### PR TITLE
Remove public api for getting a page of data

### DIFF
--- a/Octopi.Tests.Integration/RepositoriesEndpointTests.cs
+++ b/Octopi.Tests.Integration/RepositoriesEndpointTests.cs
@@ -23,38 +23,6 @@ namespace Octopi.Tests.Integration
             }
         }
 
-        public class TheGetPageForCurrentMethod
-        {
-            [Fact]
-            public async Task ReturnsRepositoriesForTheCurrentUser()
-            {
-                var github = new GitHubClient
-                {
-                    Credentials = new Credentials("xapitestaccountx", "octocat11")
-                };
-
-                var repos = await github.Repository.GetPageForCurrent();
-
-                repos.Count.Should().Be(0);
-            }
-        }
-
-        public class TheGetPageForUserMethod
-        {
-            [Fact]
-            public async Task ReturnsAPageOfRepositoriesForUser()
-            {
-                var github = new GitHubClient
-                {
-                    Credentials = new Credentials("xapitestaccountx", "octocat11")
-                };
-
-                var repositories = await github.Repository.GetPageForUser("github");
-
-                repositories.Count.Should().Be(30);
-            }
-        }
-
         public class TheGetAllForOrgMethod
         {
             [Fact]

--- a/Octopi/Endpoints/RepositoriesEndpoint.cs
+++ b/Octopi/Endpoints/RepositoriesEndpoint.cs
@@ -31,7 +31,7 @@ namespace Octopi.Endpoints
             return res.BodyAsObject;
         }
 
-        public async Task<IReadOnlyPagedCollection<Repository>> GetPageForOrg(string organization)
+        async Task<IReadOnlyPagedCollection<Repository>> GetPageForOrg(string organization)
         {
             var endpoint = new Uri(string.Format(CultureInfo.InvariantCulture, "/orgs/{0}/repos", organization),
                 UriKind.Relative);
@@ -39,14 +39,14 @@ namespace Octopi.Endpoints
             return new ReadOnlyPagedCollection<Repository>(response, connection);
         }
 
-        public async Task<IReadOnlyPagedCollection<Repository>> GetPageForCurrent()
+        async Task<IReadOnlyPagedCollection<Repository>> GetPageForCurrent()
         {
             var endpoint = new Uri("user/repos", UriKind.Relative);
             var response = await connection.GetAsync<List<Repository>>(endpoint);
             return new ReadOnlyPagedCollection<Repository>(response, connection);
         }
 
-        public async Task<IReadOnlyPagedCollection<Repository>> GetPageForUser(string login)
+        async Task<IReadOnlyPagedCollection<Repository>> GetPageForUser(string login)
         {
             var endpoint = new Uri(string.Format(CultureInfo.InvariantCulture, "/users/{0}/repos", login),
                 UriKind.Relative);

--- a/Octopi/IRepositoriesEndpoint.cs
+++ b/Octopi/IRepositoriesEndpoint.cs
@@ -16,38 +16,6 @@ namespace Octopi
         Task<Repository> Get(string owner, string name);
         
         /// <summary>
-        /// Retrieves a page of <see cref="Repository"/> instances that belong to the current user.
-        /// </summary>
-        /// <remarks>
-        /// The default page size on GitHub.com is 30.
-        /// </remarks>
-        /// <exception cref="AuthenticationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
-            Justification = "Makes a network request")]
-        Task<IReadOnlyPagedCollection<Repository>> GetPageForCurrent();
-
-        /// <summary>
-        /// Retrieves a page of <see cref="Repository"/> instances that belong to the specified owner.
-        /// </summary>
-        /// <remarks>
-        /// The default page size on GitHub.com is 30.
-        /// </remarks>
-        /// <param name="login">The owner of the repositories.</param>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        Task<IReadOnlyPagedCollection<Repository>> GetPageForUser(string login);
-
-        /// <summary>
-        /// Retrieves a page of <see cref="Repository"/> instances that belong to the specified org.
-        /// </summary>
-        /// <remarks>
-        /// The default page size on GitHub.com is 30.
-        /// </remarks>
-        /// <param name="organization">The owner of the repositories.</param>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        Task<IReadOnlyPagedCollection<Repository>> GetPageForOrg(string organization);
-
-        /// <summary>
         /// Retrieves every <see cref="Repository"/> that belongs to the current user.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Let's get serious about driving the design from our actual application
requirements. I bet we'll eventually add those things back in. But let's
do it when we need it.

@half-ogre: this is in response to your code review comments earlier. :thumbsup:
