### PR TITLE
Port ssh key helpers from GHfW

### DIFF
--- a/Octokit.Tests/Models/ModelExtensionsTests.cs
+++ b/Octokit.Tests/Models/ModelExtensionsTests.cs
@@ -1,0 +1,66 @@
+﻿using Xunit;
+using Xunit.Extensions;
+
+namespace Octokit.Tests.Models
+{
+    public class ModelExtensionsTests
+    {
+        public class TheGetKeyDataAndNameMethod
+        {
+            [Theory]
+            [InlineData("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAA timothy.clem@gmail.com", "AAAAB3NzaC1yc2EAAAABIwAA", "timothy.clem@gmail.com")]
+            [InlineData("ssh-rsa AAAAB3NzaC1yc2EAAAABIwAA", "AAAAB3NzaC1yc2EAAAABIwAA", "")]
+            [InlineData("ssh-dss AAAAB3NzaC1yc2EAAAABIwAA", "AAAAB3NzaC1yc2EAAAABIwAA", "")]
+            [InlineData("ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA", "AAAAB3NzaC1yc2EAAAABIwAA", "")]
+            public void CanParseKeyData(string raw, string data, string name)
+            {
+                var key = new SshKey { Key = raw };
+
+                SshKeyInfo keyInfo = key.GetKeyDataAndName();
+                Assert.Equal(data, keyInfo.Data);
+                Assert.Equal(name, keyInfo.Name);
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            [InlineData("apsdfoihat")]
+            public void ParsingBadDataReturnsNull(string key)
+            {
+                Assert.Null(new SshKey { Key = key }.GetKeyDataAndName());
+            }
+        }
+
+        public class TheHasSameDataAsMethod
+        {
+            [Fact]
+            public void ReturnsTrueWhenTwoKeysHaveTheSameData()
+            {
+                var key = new SshKey { Key = "ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA", Title = "somekey" };
+                var anotherKey = new SshKey { Key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAA", Title = "whatever" };
+
+                Assert.True(key.HasSameDataAs(anotherKey));
+            }
+
+            [Fact]
+            public void ReturnsFalseWhenCompareKeyIsNull()
+            {
+                var key = new SshKey { Key = "ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA", Title = "somekey" };
+
+                Assert.False(key.HasSameDataAs(null));
+            }
+
+            [Theory]
+            [InlineData(null, "ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA")]
+            [InlineData("ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA", null)]
+            [InlineData("ssh-dsa AAAAB3NzaC1yc2EAAAABIwAA", "ssh-dsa AAAAB3NzaC1yc2EAAAABIwAB")]
+            public void ReturnsFalseWhenTwoKeysHaveDifferentData(string firstKey, string secondKey)
+            {
+                var key = new SshKey { Key = firstKey, Title = "somekey" };
+                var anotherKey = new SshKey { Key = secondKey, Title = "whatever" };
+
+                Assert.False(key.HasSameDataAs(anotherKey));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Http\ConnectionTests.cs" />
     <Compile Include="Http\ResponseTests.cs" />
     <Compile Include="Http\RequestTests.cs" />
+    <Compile Include="Models\ModelExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\StringExtensionsTests.cs" />
     <Compile Include="Clients\RepositoriesClientTests.cs" />

--- a/Octokit/GitHubModels.cs
+++ b/Octokit/GitHubModels.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Octokit.Http;
 
@@ -353,6 +354,24 @@ namespace Octokit
         /// The api URL for this organization.
         /// </summary>
         public string Url { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the data and name parsed from the Ssh key.
+    /// </summary>
+    public class SshKeyInfo
+    {
+        public SshKeyInfo(string data, string name)
+        {
+            Ensure.ArgumentNotNull(data, "data");
+            Ensure.ArgumentNotNull(name, "name");
+
+            Data = data;
+            Name = name;
+        }
+
+        public string Data { get; private set; }
+        public string Name { get; private set; }
     }
 
     public class SshKeyUpdate

--- a/Octokit/ModelExtensions.cs
+++ b/Octokit/ModelExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Octokit
+{
+    public static class ModelExtensions
+    {
+        static readonly Regex sshKeyRegex = new Regex(@"ssh-[rd]s[as] (?<data>\S+) ?(?<name>.*)$", RegexOptions.Compiled);
+
+        public static SshKeyInfo GetKeyDataAndName(this SshKey sshKey)
+        {
+            Ensure.ArgumentNotNull(sshKey, "sshKey");
+
+            var key = sshKey.Key;
+            if (key == null) return null;
+            var match = sshKeyRegex.Match(key);
+            return (match.Success ? new SshKeyInfo(match.Groups["data"].Value, match.Groups["name"].Value) : null);
+        }
+
+        public static bool HasSameDataAs(this SshKey key, SshKey otherKey)
+        {
+            Ensure.ArgumentNotNull(key, "key");
+
+            if (otherKey == null) return false;
+            var keyData = key.GetKeyData();
+            return keyData != null && keyData == otherKey.GetKeyData();
+        }
+
+        static string GetKeyData(this SshKey key)
+        {
+            var keyInfo = key.GetKeyDataAndName();
+            return keyInfo == null ? null : keyInfo.Data;
+        }
+    }
+}

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Http\IRequest.cs" />
     <Compile Include="Http\IResponse.cs" />
     <Compile Include="Http\Request.cs" />
+    <Compile Include="ModelExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\StringExtensions.cs" />
     <Compile Include="Clients\RepositoriesClient.cs" />


### PR DESCRIPTION
These extension methods are ported straight over from the GitHub for Windows code. These are pretty essential for doing SSH related stuff.
