### PR TITLE
Fix serialization error with null PushedAt

### DIFF
--- a/Octokit.Tests.Integration/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/RepositoriesClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Integration
@@ -20,6 +21,23 @@ namespace Octokit.Tests.Integration
                 Assert.Equal("https://github.com/Haacked/SeeGit.git", repository.CloneUrl);
                 Assert.False(repository.Private);
                 Assert.False(repository.Fork);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsNeverPushedRepository()
+            {
+                var github = new GitHubClient
+                {
+                    Credentials = AutomationSettings.Current.GitHubCredentials
+                };
+
+                var repository = await github.Repository.Get("Test-Octowin", "PrivateTestRepository");
+
+                Assert.Equal("https://github.com/Test-Octowin/PrivateTestRepository.git", repository.CloneUrl);
+                Assert.True(repository.Private);
+                Assert.False(repository.Fork);
+                Assert.Equal(3709146, repository.Id);
+                Assert.Null(repository.PushedAt);
             }
 
             [IntegrationTest]

--- a/Octokit/GitHubModels.cs
+++ b/Octokit/GitHubModels.cs
@@ -432,7 +432,7 @@ namespace Octokit
         public int WatchersCount { get; set; }
         public string MasterBranch { get; set; }
         public int OpenIssuesCount { get; set; }
-        public DateTimeOffset PushedAt { get; set; }
+        public DateTimeOffset? PushedAt { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
 


### PR DESCRIPTION
It's possible for a repository to have a null value for the `pushed_at` field. For example, if it's been created
online and never pushed to via git.

This fixes that and adds an integration test.

NOTE TO @half-ogre: This new integration test retrieves a private repository, which I think is important to have. But it's going to fail for everybody but us even if they set the environment variables for running integration test. I think that's probably ok for now. If folks complain, we can add one more environment var. Something like `SKIP_GITHUBBER_ONLY_TESTS`
