### PR TITLE
Ensure SimpleJson is not specified as a dependency when packing

### DIFF
--- a/Octokit/packages.config
+++ b/Octokit/packages.config
@@ -8,5 +8,5 @@
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Main" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-PlatformServices" version="2.1.30214.0" targetFramework="net40" />
-  <package id="SimpleJson" version="0.28.0" targetFramework="net40" />
+  <package id="SimpleJson" version="0.28.0" targetFramework="net40" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
There's a different headache with the main GitHub project (because submodules are awesome) but I think this is more important.

@Haacked @half-ogre did we want to setup NuGet specs for these projects at some stage?
