### PR TITLE
Delete test that can't be easily automated

### DIFF
--- a/Octokit.Tests.Integration/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/RepositoriesClientTests.cs
@@ -218,23 +218,6 @@ namespace Octokit.Tests.Integration
             }
 
             [IntegrationTest]
-            public async Task ReturnsNeverPushedRepository()
-            {
-                var github = new GitHubClient("Test Runner User Agent")
-                {
-                    Credentials = AutomationSettings.Current.GitHubCredentials
-                };
-
-                var repository = await github.Repository.Get("Test-Octowin", "PrivateTestRepository");
-
-                Assert.Equal("https://github.com/Test-Octowin/PrivateTestRepository.git", repository.CloneUrl);
-                Assert.True(repository.Private);
-                Assert.False(repository.Fork);
-                Assert.Equal(3709146, repository.Id);
-                Assert.Null(repository.PushedAt);
-            }
-
-            [IntegrationTest]
             public async Task ReturnsForkedRepository()
             {
                 var github = new GitHubClient("Test Runner User Agent")


### PR DESCRIPTION
This deletes a test I can't re-create via the API, because pushed date is never null. @Haacked, you mentioned you added this test because of a problem deserializing null? If so, we now have other tests that do this, so I think we're good to delete this test. Once this test is gone, I can add running integration tests to CI.
