### PR TITLE
Move more types into the Octokit namespace

### DIFF
--- a/Octokit/ApiExtensions.cs
+++ b/Octokit/ApiExtensions.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 #endif
 using System.Threading.Tasks;
-using Octokit.Internal;
 
 namespace Octokit
 {

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -2,8 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Octokit.Internal;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public class ApiConnection<T> : IApiConnection<T>
     {

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 #endif
 
-namespace Octokit.Internal
+namespace Octokit
 {
     /// <summary>
     /// Extra information returned as part of each api response.

--- a/Octokit/Http/ApiInfoExtensions.cs
+++ b/Octokit/Http/ApiInfoExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public static class ApiInfoExtensions
     {

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -4,8 +4,9 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Octokit.Internal;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     // NOTE: Every request method must go through the `RunRequest` code path. So if you need to add a new method
     //       ensure it goes through there. :)

--- a/Octokit/Http/Credentials.cs
+++ b/Octokit/Http/Credentials.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public class Credentials
     {

--- a/Octokit/Http/CredentialsExtensions.cs
+++ b/Octokit/Http/CredentialsExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Octokit.Internal
+﻿namespace Octokit
 {
     public static class CredentialsExtensions
     {

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     /// <summary>
     /// Wraps an IConnection and provides useful methods for an endpoint.

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public interface IConnection
     {

--- a/Octokit/Http/ICredentialStore.cs
+++ b/Octokit/Http/ICredentialStore.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public interface ICredentialStore
     {

--- a/Octokit/Http/IResponse.cs
+++ b/Octokit/Http/IResponse.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Octokit.Internal;
 
-namespace Octokit.Internal
+namespace Octokit
 {
     public interface IResponse<T> : IResponse
     {


### PR DESCRIPTION
This makes it so GHfW doesn't have to reference Octokit.Internal.
