### PR TITLE
Support requests with HttpContent body

### DIFF
--- a/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using NSubstitute;
-using Octokit.Internal;
 using Xunit;
 using Xunit.Extensions;
 

--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -55,6 +56,23 @@ namespace Octokit.Tests.Http
 
                 Assert.NotNull(requestMessage.Content);
                 Assert.Equal("text/plain", requestMessage.Content.Headers.ContentType.MediaType);
+            }
+
+            [Fact]
+            public void SetsHttpContentBody()
+            {
+                var request = new Request
+                {
+                    Method = HttpMethod.Post,
+                    Body = new FormUrlEncodedContent(new Dictionary<string, string> {{"foo", "bar"}})
+                };
+                var tester = new HttpClientAdapterTester();
+
+                var requestMessage = tester.BuildRequestMessageTester(request);
+
+                Assert.NotNull(requestMessage.Content);
+                Assert.IsType<FormUrlEncodedContent>(requestMessage.Content);
+                Assert.Equal("application/x-www-form-urlencoded", requestMessage.Content.Headers.ContentType.MediaType);
             }
 
             [Fact]

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -68,13 +69,19 @@ namespace Octokit.Internal
                 {
                     requestMessage.Headers.Add(header.Key, header.Value);
                 }
+                var httpContent = request.Body as HttpContent;
+                if (httpContent != null)
+                {
+                    requestMessage.Content = httpContent;
+                }
 
                 var body = request.Body as string;
                 if (body != null)
                 {
                     requestMessage.Content = new StringContent(body, Encoding.UTF8, request.ContentType);
                 }
-                var bodyStream = request.Body as System.IO.Stream;
+
+                var bodyStream = request.Body as Stream;
                 if (bodyStream != null)
                 {
                     requestMessage.Content = new StreamContent(bodyStream);


### PR DESCRIPTION
If a 3rd party client needs to provide a specific HttpContent, we should allow that in the adapter. Our clients probably shouldn't do this as it would break encapsulation.
