### PR TITLE
RateLimit class encapsulates rate limit headers

### DIFF
--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Clients
                 var scopes = new List<string>();
                 IResponse<string> response = new ApiResponse<string>
                 {
-                    ApiInfo = new ApiInfo(links, scopes, scopes, "", 1, 1),
+                    ApiInfo = new ApiInfo(links, scopes, scopes, "", new RateLimit(new Dictionary<string, string>())),
                     Body = "<strong>Test</strong>"
                 };
                 var connection = Substitute.For<IConnection>();
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Clients
                 var scopes = new List<string>();
                 IResponse<Dictionary<string, string>> response = new ApiResponse<Dictionary<string, string>>
                 {
-                    ApiInfo = new ApiInfo(links, scopes, scopes, "", 1, 1),
+                    ApiInfo = new ApiInfo(links, scopes, scopes, "", new RateLimit(new Dictionary<string, string>())),
                     BodyAsObject = new Dictionary<string, string>
                     {
                         { "foo", "http://example.com/foo.gif" },

--- a/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -19,6 +20,7 @@ namespace Octokit.Tests.Exceptions
                 response.Headers.Add("X-RateLimit-Limit", "100");
                 response.Headers.Add("X-RateLimit-Remaining", "42");
                 response.Headers.Add("X-RateLimit-Reset", "1372700873");
+                response.ApiInfo = CreateApiInfo(response);
                 var exception = new RateLimitExceededException(response);
 
                 Assert.Equal(HttpStatusCode.Forbidden, exception.StatusCode);
@@ -40,6 +42,7 @@ namespace Octokit.Tests.Exceptions
                 response.Headers.Add("X-RateLimit-Limit", "XXX");
                 response.Headers.Add("X-RateLimit-Remaining", "XXXX");
                 response.Headers.Add("X-RateLimit-Reset", "XXXX");
+                response.ApiInfo = CreateApiInfo(response);
                 var exception = new RateLimitExceededException(response);
 
                 Assert.Equal(HttpStatusCode.Forbidden, exception.StatusCode);
@@ -55,7 +58,11 @@ namespace Octokit.Tests.Exceptions
             [Fact]
             public void HandlesMissingHeaderValues()
             {
-                var response = new ApiResponse<object> { StatusCode = HttpStatusCode.Forbidden };
+                var response = new ApiResponse<object>
+                {
+                    StatusCode = HttpStatusCode.Forbidden
+                };
+                response.ApiInfo = CreateApiInfo(response);
                 var exception = new RateLimitExceededException(response);
 
                 Assert.Equal(HttpStatusCode.Forbidden, exception.StatusCode);
@@ -76,6 +83,7 @@ namespace Octokit.Tests.Exceptions
                 response.Headers.Add("X-RateLimit-Limit", "100");
                 response.Headers.Add("X-RateLimit-Remaining", "42");
                 response.Headers.Add("X-RateLimit-Reset", "1372700873");
+                response.ApiInfo = CreateApiInfo(response);
 
                 var exception = new RateLimitExceededException(response);
 
@@ -97,6 +105,11 @@ namespace Octokit.Tests.Exceptions
                 }
             }
 #endif
+        }
+
+        static ApiInfo CreateApiInfo(IResponse response)
+        {
+            return new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit(response.Headers) );
         }
     }
 }

--- a/Octokit.Tests/Http/ApiConnectionTests.cs
+++ b/Octokit.Tests/Http/ApiConnectionTests.cs
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Http
                 var scopes = new List<string>();
                 IResponse<List<object>> response = new ApiResponse<List<object>>
                 {
-                    ApiInfo = new ApiInfo(links, scopes, scopes, "etag", 1, 1),
+                    ApiInfo = new ApiInfo(links, scopes, scopes, "etag", new RateLimit(new Dictionary<string, string>())),
                     BodyAsObject = new List<object> {new object(), new object()}
                 };
                 var connection = Substitute.For<IConnection>();

--- a/Octokit.Tests/Http/ApiInfoParserTests.cs
+++ b/Octokit.Tests/Http/ApiInfoParserTests.cs
@@ -25,16 +25,15 @@ namespace Octokit.Tests
                         { "ETag", "5634b0b187fd2e91e3126a75006cc4fa" }
                     }
                 };
-                var parser = new ApiInfoParser();
 
-                parser.ParseApiHttpHeaders(response);
+                ApiInfoParser.ParseApiHttpHeaders(response);
 
                 var apiInfo = response.ApiInfo;
                 Assert.NotNull(apiInfo);
                 Assert.Equal(new[] { "user" }, apiInfo.AcceptedOauthScopes.ToArray());
                 Assert.Equal(new[] { "user", "public_repo", "repo", "gist" }, apiInfo.OauthScopes.ToArray());
-                Assert.Equal(5000, apiInfo.RateLimit);
-                Assert.Equal(4997, apiInfo.RateLimitRemaining);
+                Assert.Equal(5000, apiInfo.RateLimit.Limit);
+                Assert.Equal(4997, apiInfo.RateLimit.Remaining);
                 Assert.Equal("5634b0b187fd2e91e3126a75006cc4fa", apiInfo.Etag);
             }
 
@@ -52,9 +51,8 @@ namespace Octokit.Tests
                         }
                     }
                 };
-                var parser = new ApiInfoParser();
 
-                parser.ParseApiHttpHeaders(response);
+                ApiInfoParser.ParseApiHttpHeaders(response);
 
                 var apiInfo = response.ApiInfo;
                 Assert.NotNull(apiInfo);
@@ -77,9 +75,8 @@ namespace Octokit.Tests
                         }
                     }
                 };
-                var parser = new ApiInfoParser();
 
-                parser.ParseApiHttpHeaders(response);
+                ApiInfoParser.ParseApiHttpHeaders(response);
 
                 var apiInfo = response.ApiInfo;
                 Assert.NotNull(apiInfo);
@@ -138,7 +135,7 @@ namespace Octokit.Tests
 
             static ApiInfo BuildApiInfo(IDictionary<string, Uri> links)
             {
-                return new ApiInfo(links, new List<string>(), new List<string>(), "etag", 0, 0);
+                return new ApiInfo(links, new List<string>(), new List<string>(), "etag", new RateLimit(new Dictionary<string, string>()));
             }
         }
     }

--- a/Octokit.Tests/Http/RateLimitTests.cs
+++ b/Octokit.Tests/Http/RateLimitTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace Octokit.Tests.Http
+{
+    public class RateLimitTests
+    {
+        public class TheConstructor
+        {
+            public void Foo()
+            {
+                Console.WriteLine(new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).Ticks);
+            }
+
+            [Fact]
+            public void ParsesRateLimitsFromHeaders()
+            {
+                var headers = new Dictionary<string, string> 
+                {
+                    { "X-RateLimit-Limit", "100" },
+                    { "X-RateLimit-Remaining", "42" },
+                    { "X-RateLimit-Reset", "1372700873" }
+                };
+
+                var rateLimit = new RateLimit(headers);
+
+                Assert.Equal(100, rateLimit.Limit);
+                Assert.Equal(42, rateLimit.Remaining);
+                var expectedReset = DateTimeOffset.ParseExact(
+                    "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, rateLimit.Reset);
+            }
+
+            [Fact]
+            public void HandlesInvalidHeaderValues()
+            {
+                var headers = new Dictionary<string, string> 
+                {
+                    { "X-RateLimit-Limit", "1234scoobysnacks1234" },
+                    { "X-RateLimit-Remaining", "xanadu" },
+                    { "X-RateLimit-Reset", "garbage" }
+                };
+
+                var rateLimit = new RateLimit(headers);
+
+                Assert.Equal(0, rateLimit.Limit);
+                Assert.Equal(0, rateLimit.Remaining);
+                var expectedReset = DateTimeOffset.ParseExact(
+                    "Thu 01 Jan 1970 0:00:00 AM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, rateLimit.Reset);
+            }
+
+            [Fact]
+            public void HandlesMissingHeaderValues()
+            {
+                var headers = new Dictionary<string, string>();
+
+                var rateLimit = new RateLimit(headers);
+
+                Assert.Equal(0, rateLimit.Limit);
+                Assert.Equal(0, rateLimit.Remaining);
+                var expectedReset = DateTimeOffset.ParseExact(
+                    "Thu 01 Jan 1970 0:00:00 AM -00:00",
+                    "ddd dd MMM yyyy h:mm:ss tt zzz",
+                    CultureInfo.InvariantCulture);
+                Assert.Equal(expectedReset, rateLimit.Reset);
+            }
+
+#if !NETFX_CORE
+            [Fact]
+            public void CanPopulateObjectFromSerializedData()
+            {
+                var headers = new Dictionary<string, string> 
+                {
+                    { "X-RateLimit-Limit", "100" },
+                    { "X-RateLimit-Remaining", "42" },
+                    { "X-RateLimit-Reset", "1372700873" }
+                };
+
+                var rateLimit = new RateLimit(headers);
+
+                using (var stream = new MemoryStream())
+                {
+                    var formatter = new BinaryFormatter();
+                    formatter.Serialize(stream, rateLimit);
+                    stream.Position = 0;
+                    var deserialized = (RateLimit) formatter.Deserialize(stream);
+
+                    Assert.Equal(100, deserialized.Limit);
+                    Assert.Equal(42, deserialized.Remaining);
+                    var expectedReset = DateTimeOffset.ParseExact(
+                        "Mon 01 Jul 2013 5:47:53 PM -00:00",
+                        "ddd dd MMM yyyy h:mm:ss tt zzz",
+                        CultureInfo.InvariantCulture);
+                    Assert.Equal(expectedReset, deserialized.Reset);
+                }
+            }
+#endif
+            [Fact]
+            public void EnsuresHeadersNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => new RateLimit(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
+++ b/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
@@ -23,7 +23,7 @@ namespace Octokit.Tests.Models
                 var response = new ApiResponse<List<object>>
                 {
                     BodyAsObject = new List<object>(),
-                    ApiInfo = new ApiInfo(links, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = new ApiInfo(links, scopes, scopes, "etag", new RateLimit(new Dictionary<string, string>()))
                 };
                 var connection = Substitute.For<IConnection>();
                 connection.GetAsync<List<object>>(nextPageUrl, null, null).Returns(nextPageResponse);

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="GitHubClientTests.cs" />
     <Compile Include="Authentication\TokenAuthenticatorTests.cs" />
     <Compile Include="Http\ConnectionTests.cs" />
+    <Compile Include="Http\RateLimitTests.cs" />
     <Compile Include="Http\ResponseTests.cs" />
     <Compile Include="Http\RequestTests.cs" />
     <Compile Include="Models\ModelExtensionsTests.cs" />

--- a/Octokit.Tests/OctokitRT.Tests.csproj
+++ b/Octokit.Tests/OctokitRT.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="GitHubClientTests.cs" />
     <Compile Include="Authentication\TokenAuthenticatorTests.cs" />
     <Compile Include="Http\ConnectionTests.cs" />
+    <Compile Include="Http\RateLimitTests.cs" />
     <Compile Include="Http\ResponseTests.cs" />
     <Compile Include="Http\RequestTests.cs" />
     <Compile Include="Models\ModelExtensionsTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -48,7 +48,6 @@ namespace Octokit.Tests.Reactive
                 var firstPageUrl = new Uri("user/repos", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> {{"next", secondPageUrl}};
-                var scopes = new List<string>();
                 var firstPageResponse = new ApiResponse<List<Repository>>
                 {
                     BodyAsObject = new List<Repository>
@@ -57,7 +56,7 @@ namespace Octokit.Tests.Reactive
                         new Repository {Id = 2},
                         new Repository {Id = 3}
                     },
-                    ApiInfo = new ApiInfo(firstPageLinks, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(firstPageLinks)
                 };
                 var thirdPageUrl = new Uri("https://example.com/page/3");
                 var secondPageLinks = new Dictionary<string, Uri> {{"next", thirdPageUrl}};
@@ -69,7 +68,7 @@ namespace Octokit.Tests.Reactive
                         new Repository {Id = 5},
                         new Repository {Id = 6}
                     },
-                    ApiInfo = new ApiInfo(secondPageLinks, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(secondPageLinks)
                 };
                 var lastPageResponse = new ApiResponse<List<Repository>>
                 {
@@ -77,7 +76,7 @@ namespace Octokit.Tests.Reactive
                     {
                         new Repository {Id = 7}
                     },
-                    ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(new Dictionary<string, Uri>())
                 };
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.GetAsync<List<Repository>>(firstPageUrl)
@@ -102,7 +101,6 @@ namespace Octokit.Tests.Reactive
                 var firstPageUrl = new Uri("user/repos", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
-                var scopes = new List<string>();
                 var firstPageResponse = new ApiResponse<List<Repository>>
                 {
                     BodyAsObject = new List<Repository>
@@ -111,7 +109,7 @@ namespace Octokit.Tests.Reactive
                         new Repository {Id = 2},
                         new Repository {Id = 3}
                     },
-                    ApiInfo = new ApiInfo(firstPageLinks, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(firstPageLinks)
                 };
                 var thirdPageUrl = new Uri("https://example.com/page/3");
                 var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
@@ -123,7 +121,7 @@ namespace Octokit.Tests.Reactive
                         new Repository {Id = 5},
                         new Repository {Id = 6}
                     },
-                    ApiInfo = new ApiInfo(secondPageLinks, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(secondPageLinks)
                 };
                 var fourthPageUrl = new Uri("https://example.com/page/4");
                 var thirdPageLinks = new Dictionary<string, Uri> { { "next", fourthPageUrl } };
@@ -133,7 +131,7 @@ namespace Octokit.Tests.Reactive
                     {
                         new Repository {Id = 7}
                     },
-                    ApiInfo = new ApiInfo(thirdPageLinks, scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(thirdPageLinks)
                 };
                 var lastPageResponse = new ApiResponse<List<Repository>>
                 {
@@ -141,7 +139,7 @@ namespace Octokit.Tests.Reactive
                     {
                         new Repository {Id = 8}
                     },
-                    ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), scopes, scopes, "etag", 100, 100)
+                    ApiInfo = CreateApiInfo(new Dictionary<string, Uri>())
                 };
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.GetAsync<List<Repository>>(firstPageUrl)
@@ -162,6 +160,11 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(0).GetAsync<List<Repository>>(thirdPageUrl, null, null);
                 gitHubClient.Connection.Received(0).GetAsync<List<Repository>>(fourthPageUrl, null, null);
             }
+        }
+
+        static ApiInfo CreateApiInfo(IDictionary<string, Uri> links)
+        {
+            return new ApiInfo(links, new List<string>(), new List<string>(), "etag", new RateLimit(new Dictionary<string, string>()));
         }
     }
 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -15,8 +15,7 @@ namespace Octokit
             IList<string> oauthScopes,
             IList<string> acceptedOauthScopes,
             string etag,
-            int rateLimit,
-            int rateLimitRemaining)
+            RateLimit rateLimit)
         {
             Ensure.ArgumentNotNull(links, "links");
             Ensure.ArgumentNotNull(oauthScopes, "ouathScopes");
@@ -26,7 +25,6 @@ namespace Octokit
             AcceptedOauthScopes = new ReadOnlyCollection<string>(acceptedOauthScopes);
             Etag = etag;
             RateLimit = rateLimit;
-            RateLimitRemaining = rateLimitRemaining;
         }
 
         /// <summary>
@@ -45,18 +43,13 @@ namespace Octokit
         public string Etag { get; private set; }
 
         /// <summary>
-        /// Rate limit in requests/hr.
-        /// </summary>
-        public int RateLimit { get; private set; }
-
-        /// <summary>
-        /// Number of calls remaining before hitting the rate limit.
-        /// </summary>
-        public int RateLimitRemaining { get; private set; }
-
-        /// <summary>
         /// Links to things like next/previous pages
         /// </summary>
         public IReadOnlyDictionary<string, Uri> Links { get; private set; }
+
+        /// <summary>
+        /// Information about the API rate limit
+        /// </summary>
+        public RateLimit RateLimit { get; private set; }
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -19,7 +19,6 @@ namespace Octokit
         readonly Authenticator _authenticator;
         readonly IHttpClient _httpClient;
         readonly JsonHttpPipeline _jsonPipeline;
-        readonly ApiInfoParser _apiInfoParser;
 
         public Connection(string userAgent) : this(userAgent, _defaultGitHubApiUrl, _anonymousCredentials)
         {
@@ -67,7 +66,6 @@ namespace Octokit
             _authenticator = new Authenticator(credentialStore);
             _httpClient = httpClient;
             _jsonPipeline = new JsonHttpPipeline();
-            _apiInfoParser = new ApiInfoParser();
         }
 
         public async Task<IResponse<T>> GetAsync<T>(Uri uri, IDictionary<string, string> parameters, string accepts)
@@ -224,7 +222,7 @@ namespace Octokit
             request.Headers.Add("User-Agent", UserAgent);
             await _authenticator.Apply(request);
             var response = await _httpClient.Send<T>(request);
-            _apiInfoParser.ParseApiHttpHeaders(response);
+            ApiInfoParser.ParseApiHttpHeaders(response);
             HandleErrors(response);
             return response;
         }

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Octokit
+{
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    public class RateLimit
+#if !NETFX_CORE
+        : ISerializable
+#endif
+    {
+        const long _unixEpochTicks = 621355968000000000; // Unix Epoch is January 1, 1970 00:00 -0:00
+
+        public RateLimit(IDictionary<string, string> responseHeaders)
+        {
+            Ensure.ArgumentNotNull(responseHeaders, "responseHeaders");
+
+            Limit = (int) GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Limit");
+            Remaining = (int) GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Remaining");
+            Reset = FromUnixTime(GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Reset"));
+        }
+
+        /// <summary>
+        /// The maximum number of requests that the consumer is permitted to make per hour.
+        /// </summary>
+        public int Limit { get; private set; }
+
+        /// <summary>
+        /// The number of requests remaining in the current rate limit window.
+        /// </summary>
+        public int Remaining { get; private set; }
+
+        /// <summary>
+        /// The date and time at which the current rate limit window resets
+        /// </summary>
+        public DateTimeOffset Reset { get; private set; }
+
+        static long GetHeaderValueAsInt32Safe(IDictionary<string, string> responseHeaders, string key)
+        {
+            string value;
+            long result;
+            return !responseHeaders.TryGetValue(key, out value) || value == null || !long.TryParse(value, out result)
+                ? 0
+                : result;
+        }
+
+        static DateTimeOffset FromUnixTime(long unixTime)
+        {
+            return new DateTimeOffset(unixTime*TimeSpan.TicksPerSecond + _unixEpochTicks, TimeSpan.Zero);
+        }
+
+#if !NETFX_CORE
+        protected RateLimit(SerializationInfo info, StreamingContext context)
+        {
+            Ensure.ArgumentNotNull(info, "info");
+
+            Limit = info.GetInt32("Limit");
+            Remaining = info.GetInt32("Remaining");
+            Reset = new DateTimeOffset(info.GetInt64("Reset"), TimeSpan.Zero);
+        }
+
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            Ensure.ArgumentNotNull(info, "info");
+
+            info.AddValue("Limit", Limit);
+            info.AddValue("Remaining", Remaining);
+            info.AddValue("Reset", Reset.Ticks);
+        }
+#endif
+    }
+}

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Helpers\ApiUrls.cs" />
     <Compile Include="Helpers\AuthorizationExtensions.cs" />
     <Compile Include="Helpers\TwoFactorChallengeResult.cs" />
+    <Compile Include="Http\RateLimit.cs" />
     <Compile Include="Models\Account.cs" />
     <Compile Include="Models\ApiError.cs" />
     <Compile Include="Models\ApiErrorDetail.cs" />

--- a/Octokit/OctokitRT.csproj
+++ b/Octokit/OctokitRT.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Http\IHttpClient.cs" />
     <Compile Include="Http\InMemoryCredentialStore.cs" />
     <Compile Include="Http\JsonHttpPipeline.cs" />
+    <Compile Include="Http\RateLimit.cs" />
     <Compile Include="Http\ReadOnlyPagedCollection.cs" />
     <Compile Include="IApiPagination.cs" />
     <Compile Include="IAuthorizationsClient.cs" />


### PR DESCRIPTION
Added a RateLimit class to encapsulate pulling rate limit information
from the headers. This is now exposed by `ApiInfo` as well as the
`RateLimitExceeededException`. That way these two classes are not grabbing
the same information in different ways which we were doing before.
