### PR TITLE
Build user agent from user supplied product info

### DIFF
--- a/Octokit.Tests.Integration/AssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/AssigneesClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -12,7 +13,7 @@ public class AssigneesClientTests
 
     public AssigneesClientTests()
     {
-        _gitHubClient = new GitHubClient("Test Runner User Agent")
+        _gitHubClient = new GitHubClient(new ProductHeaderValue("OctokitTests"))
         {
             Credentials = Helper.Credentials
         };

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http.Headers;
 
 namespace Octokit.Tests.Integration
 {
@@ -24,7 +25,7 @@ namespace Octokit.Tests.Integration
         
         public static void DeleteRepo(string owner, string name)
         {
-            var api = new GitHubClient("Integration Test Runner") { Credentials = Credentials };
+            var api = new GitHubClient(new ProductHeaderValue("OctokitTests")) { Credentials = Credentials };
             try
             {
                 api.Repository.Delete(owner, name);

--- a/Octokit.Tests.Integration/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/IssuesClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
@@ -15,7 +16,7 @@ public class IssuesClientTests : IDisposable
 
     public IssuesClientTests()
     {
-        _gitHubClient = new GitHubClient("Test Runner User Agent")
+        _gitHubClient = new GitHubClient(new ProductHeaderValue("OctokitTests"))
         {
             Credentials = Helper.Credentials
         };

--- a/Octokit.Tests.Integration/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/MilestonesClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -15,7 +16,7 @@ public class MilestonesClientTests : IDisposable
 
     public MilestonesClientTests()
     {
-        _gitHubClient = new GitHubClient("Test Runner User Agent")
+        _gitHubClient = new GitHubClient(new ProductHeaderValue("OctokitTests"))
         {
             Credentials = Helper.Credentials
         };

--- a/Octokit.Tests.Integration/MiscellaneousClientTests.cs
+++ b/Octokit.Tests.Integration/MiscellaneousClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Integration
@@ -10,7 +11,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task GetsAllTheEmojis()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -26,7 +27,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CanRenderGitHubFlavoredMarkdown()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System.Net.Http.Headers;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit.Reactive;
 using Xunit;
@@ -12,7 +13,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsSpecifiedRepository()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };

--- a/Octokit.Tests.Integration/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/ReleasesClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsReleases()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };

--- a/Octokit.Tests.Integration/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/RepositoriesClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Integration
@@ -10,7 +11,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesANewPublicRepository()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -42,7 +43,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesANewPrivateRepository()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -69,7 +70,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithoutDownloads()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -96,7 +97,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithoutIssues()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -123,7 +124,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithoutAWiki()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -150,7 +151,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithADescription()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -177,7 +178,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithAHomepage()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -204,7 +205,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithAutoInit()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -232,7 +233,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesARepositoryWithAGitignoreTemplate()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -264,7 +265,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task CreatesANewPublicRepository()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -303,7 +304,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task DeletesRepository()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -319,7 +320,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsSpecifiedRepository()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -334,7 +335,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsForkedRepository()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -351,7 +352,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsAllRepositoriesForOrganization()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -367,7 +368,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsReadmeForSeeGit()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -383,7 +384,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsReadmeHtmlForSeeGit()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };

--- a/Octokit.Tests.Integration/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/UsersClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Net.Http.Headers;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit.Internal;
@@ -14,7 +15,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsSpecifiedUser()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -28,7 +29,8 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsSpecifiedUserUsingAwaitableCredentialProvider()
             {
-                var github = new GitHubClient("Octokit Test Runner", new ObservableCredentialProvider());
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"),
+                    new ObservableCredentialProvider());
 
                 // Get a user by username
                 var user = await github.User.Get("tclem");
@@ -50,7 +52,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task ReturnsSpecifiedUser()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };
@@ -66,7 +68,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task FailsWhenNotAuthenticated()
             {
-                var github = new GitHubClient("Octokit Test Runner");
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"));
                 var userUpdate = new UserUpdate
                 {
                     Name = Helper.Credentials.Login,
@@ -81,7 +83,7 @@ namespace Octokit.Tests.Integration
             [IntegrationTest]
             public async Task FailsWhenAuthenticatedWithBadCredentials()
             {
-                var github = new GitHubClient("Octokit Test Runner")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = new Credentials(Helper.Credentials.Login, "bad-password")
                 };
@@ -101,7 +103,7 @@ namespace Octokit.Tests.Integration
         {
             public async Task RetrievesEmailsForUser()
             {
-                var github = new GitHubClient("Test Runner User Agent")
+                var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
                 {
                     Credentials = Helper.Credentials
                 };

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
@@ -13,7 +14,7 @@ namespace Octokit.Tests
             [Fact]
             public void CreatesAnonymousClientByDefault()
             {
-                var client = new GitHubClient("Test Runner User Agent");
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests", "1.0"));
 
                 Assert.Equal(AuthenticationType.Anonymous, client.Credentials.AuthenticationType);
             }
@@ -21,7 +22,10 @@ namespace Octokit.Tests
             [Fact]
             public void CanCreateBasicAuthClient()
             {
-                var client = new GitHubClient("Test Runner") { Credentials = new Credentials("tclem", "pwd") };
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests", "1.0"))
+                {
+                    Credentials = new Credentials("tclem", "pwd")
+                };
 
                 Assert.Equal(AuthenticationType.Basic, client.Credentials.AuthenticationType);
             }
@@ -29,7 +33,10 @@ namespace Octokit.Tests
             [Fact]
             public void CanCreateOauthClient()
             {
-                var client = new GitHubClient("Test Runner") { Credentials = new Credentials("token") };
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests"))
+                {
+                    Credentials = new Credentials("token")
+                };
 
                 Assert.Equal(AuthenticationType.Oauth, client.Credentials.AuthenticationType);
             }
@@ -40,7 +47,7 @@ namespace Octokit.Tests
             [Fact]
             public void IsSetToGitHubApiV3()
             {
-                var client = new GitHubClient("Test Runner");
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests", "1.0"));
 
                 Assert.Equal(new Uri("https://api.github.com"), client.BaseAddress);
             }
@@ -51,7 +58,7 @@ namespace Octokit.Tests
             [Fact]
             public void DefaultsToAnonymous()
             {
-                var client = new GitHubClient("Test Runner");
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests", "1.0"));
                 Assert.Same(Credentials.Anonymous, client.Credentials);
             }
 
@@ -59,7 +66,8 @@ namespace Octokit.Tests
             public void WhenSetCreatesInMemoryStoreThatReturnsSpecifiedCredentials()
             {
                 var credentials = new Credentials("Peter", "Griffin");
-                var client = new GitHubClient("Test Runner", Substitute.For<ICredentialStore>())
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests"),
+                    Substitute.For<ICredentialStore>())
                 {
                     Credentials = credentials
                 };
@@ -73,7 +81,7 @@ namespace Octokit.Tests
             {
                 var credentialStore = Substitute.For<ICredentialStore>();
                 credentialStore.GetCredentials().Returns(Task.Factory.StartNew(() => new Credentials("foo", "bar")));
-                var client = new GitHubClient("Test Runner", credentialStore);
+                var client = new GitHubClient(new ProductHeaderValue("OctokitTests"), credentialStore);
 
                 Assert.Equal("foo", client.Credentials.Login);
                 Assert.Equal("bar", client.Credentials.Password);

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
@@ -25,7 +26,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -47,7 +48,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -76,7 +77,7 @@ namespace Octokit.Tests.Http
                 };
 
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -93,7 +94,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string> { StatusCode = HttpStatusCode.Unauthorized};
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent", 
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"), 
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -117,7 +118,7 @@ namespace Octokit.Tests.Http
                 IResponse<string> response = new ApiResponse<string> { StatusCode = HttpStatusCode.Unauthorized };
                 response.Headers[headerKey] = otpHeaderValue;
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -147,7 +148,7 @@ namespace Octokit.Tests.Http
                 };
                 response.Headers[headerKey] = otpHeaderValue;
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -170,7 +171,7 @@ namespace Octokit.Tests.Http
                         @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}"
                 };
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -194,7 +195,7 @@ namespace Octokit.Tests.Http
                            "See http://developer.github.com/v3/#rate-limiting for details.\"}"
                 };
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -218,7 +219,7 @@ namespace Octokit.Tests.Http
                            "\"documentation_url\":\"http://developer.github.com/v3\"}"
                 };
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -241,7 +242,7 @@ namespace Octokit.Tests.Http
                     Body = "GONE BYE BYE!"
                 };
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -263,7 +264,7 @@ namespace Octokit.Tests.Http
                     Body = "YOU SHALL NOT PASS!"
                 };
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -284,7 +285,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -311,7 +312,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -337,7 +338,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -360,7 +361,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -387,7 +388,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -409,7 +410,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -437,7 +438,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<string> response = new ApiResponse<string>();
                 httpClient.Send<string>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner User Agent",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -464,7 +465,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse<object> response = new ApiResponse<object>();
                 httpClient.Send<object>(Args.Request).Returns(Task.FromResult(response));
-                var connection = new Connection("Test Runner",
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     ExampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -486,8 +487,8 @@ namespace Octokit.Tests.Http
             [Fact]
             public void EnsuresAbsoluteBaseAddress()
             {
-                Assert.Throws<ArgumentException>(() => new Connection("Test Runner", new Uri("/foo", UriKind.Relative)));
-                Assert.Throws<ArgumentException>(() => new Connection("Test Runner", new Uri("/foo", UriKind.RelativeOrAbsolute)));
+                Assert.Throws<ArgumentException>(() => new Connection(new ProductHeaderValue("TestRunner"), new Uri("/foo", UriKind.Relative)));
+                Assert.Throws<ArgumentException>(() => new Connection(new ProductHeaderValue("TestRunner"), new Uri("/foo", UriKind.RelativeOrAbsolute)));
             }
 
             [Fact]
@@ -495,55 +496,44 @@ namespace Octokit.Tests.Http
             {
                 // 1 arg
                 Assert.Throws<ArgumentNullException>(() => new Connection(null));
-                Assert.Throws<ArgumentException>(() => new Connection(""));
-
                 
                 // 2 args
                 Assert.Throws<ArgumentNullException>(() => new Connection(null, new Uri("https://example.com"))); 
-                Assert.Throws<ArgumentException>(() => new Connection("", new Uri("https://example.com")));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo", (Uri)null));
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("test"), (Uri)null));
 
                 // 3 args
-                Assert.Throws<ArgumentException>(() => new Connection("",
-                    new Uri("https://example.com"),
-                    Substitute.For<ICredentialStore>())); 
                 Assert.Throws<ArgumentNullException>(() => new Connection(null,
                     new Uri("https://example.com"),
                     Substitute.For<ICredentialStore>()));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     null,
                     Substitute.For<ICredentialStore>()));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     new Uri("https://example.com"),
                     null));
 
                 // 5 Args
-                Assert.Throws<ArgumentException>(() => new Connection(""
-                    , new Uri("https://example.com"),
-                    Substitute.For<ICredentialStore>(),
-                    Substitute.For<IHttpClient>(),
-                    Substitute.For<IJsonSerializer>())); 
                 Assert.Throws<ArgumentNullException>(() => new Connection(null
                     , new Uri("https://example.com"),
                     Substitute.For<ICredentialStore>(),
                     Substitute.For<IHttpClient>(),
-                    Substitute.For<IJsonSerializer>())); 
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                    Substitute.For<IJsonSerializer>()));
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     new Uri("https://example.com"),
                     Substitute.For<ICredentialStore>(),
                     Substitute.For<IHttpClient>(),
                     null));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     new Uri("https://example.com"),
                     Substitute.For<ICredentialStore>(),
                     null,
                     Substitute.For<IJsonSerializer>()));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     new Uri("https://example.com"),
                     null,
                     Substitute.For<IHttpClient>(),
                     Substitute.For<IJsonSerializer>()));
-                Assert.Throws<ArgumentNullException>(() => new Connection("foo",
+                Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("foo"),
                     null,
                     Substitute.For<ICredentialStore>(),
                     Substitute.For<IHttpClient>(),
@@ -553,10 +543,10 @@ namespace Octokit.Tests.Http
             [Fact]
             public void CreatesConnectionWithBaseAddress()
             {
-                var connection = new Connection("Test Runner User Agent", new Uri("https://github.com/"));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"), new Uri("https://github.com/"));
 
                 Assert.Equal(new Uri("https://github.com/"), connection.BaseAddress);
-                Assert.Equal("Test Runner User Agent", connection.UserAgent);
+                Assert.True(connection.UserAgent.StartsWith("OctokitTests ("));
             }
         }
     }

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http.Headers;
 using Octokit.Internal;
 
 namespace Octokit
@@ -12,23 +13,64 @@ namespace Octokit
         /// Create a new instance of the GitHub API v3 client pointing to 
         /// https://api.github.com/
         /// </summary>
-        public GitHubClient(string userAgent) : this(new Connection(userAgent))
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        public GitHubClient(ProductHeaderValue productInformation)
+            : this(new Connection(productInformation))
         {
         }
 
-        public GitHubClient(string userAgent, ICredentialStore credentialStore) : this(new Connection(userAgent, credentialStore))
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to 
+        /// https://api.github.com/
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore)
+            : this(new Connection(productInformation, credentialStore))
         {
         }
 
-        public GitHubClient(string userAgent, Uri baseAddress) : this(new Connection(userAgent, baseAddress))
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="baseAddress">
+        /// The address to point this client to. Typically used for GitHub Enterprise 
+        /// instances</param>
+        public GitHubClient(ProductHeaderValue productInformation, Uri baseAddress)
+            : this(new Connection(productInformation, baseAddress))
         {
         }
 
-        public GitHubClient(string userAgent, ICredentialStore credentialStore, Uri baseAddress)
-            : this(new Connection(userAgent, baseAddress, credentialStore))
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        /// <param name="baseAddress">
+        /// The address to point this client to. Typically used for GitHub Enterprise 
+        /// instances</param>
+        public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore, Uri baseAddress)
+            : this(new Connection(productInformation, baseAddress, credentialStore))
         {
         }
 
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client using the specified connection.
+        /// </summary>
+        /// <param name="connection">The underlying <seealso cref="IConnection"/> used to make requests.</param>
         public GitHubClient(IConnection connection)
         {
             Ensure.ArgumentNotNull(connection, "connection");

--- a/clean-up-after-tests/Program.cs
+++ b/clean-up-after-tests/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Octokit;
@@ -31,7 +32,7 @@ namespace clean_up_after_tests
 
         static async Task DeleteRepos()
         {
-            var api = new GitHubClient("Octokit.net/clean-up-after-test.exe")
+            var api = new GitHubClient(new ProductHeaderValue("Octokit.net", "clean-up-after-test.exe"))
             {
                 Credentials = Helper.Credentials
             };

--- a/clean-up-after-tests/clean-up-after-tests.csproj
+++ b/clean-up-after-tests/clean-up-after-tests.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Rather than create a default user agent, we'll build the user agent for
the user of the library. We only require that the user provide us
product information.

fixes #61
