### PR TITLE
Use the token authenticator.

### DIFF
--- a/Octokit/Authentication/Authenticator.cs
+++ b/Octokit/Authentication/Authenticator.cs
@@ -10,7 +10,7 @@ namespace Octokit.Internal
             {
                 { AuthenticationType.Anonymous, new AnonymousAuthenticator() },
                 { AuthenticationType.Basic, new BasicAuthenticator() },
-                { AuthenticationType.Oauth, new AnonymousAuthenticator() }
+                { AuthenticationType.Oauth, new TokenAuthenticator() }
             };
 
         public Authenticator(ICredentialStore credentialStore)


### PR DESCRIPTION
Using a token for authentication (`new Credentials(token)`) wasn't working for me. This change fixes that.
