### PR TITLE
s/description/body

### DIFF
--- a/Octokit/Models/Request/ReleaseUpdate.cs
+++ b/Octokit/Models/Request/ReleaseUpdate.cs
@@ -14,7 +14,7 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Commitish")]
         public string TargetCommitish { get; set; }
         public string Name { get; set; }
-        public string Description { get; set; }
+        public string Body { get; set; }
         public bool Draft { get; set; }
         public bool Prerelease { get; set; }
     }


### PR DESCRIPTION
I was fooled by the example (fixed in github/developer.github.com#345), and this unfools octokit.net.

Since this changes a public type, is there anything special I need to do for backwards compatibility? I lean towards "no". Octokit.net is new, and the releases API is new and experimental. I don't think there's a big impact to this change.
