### PR TITLE
We removed the F# compiler from the FAKE package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ nunit-*.xml
 *.userprefs
 packaging/
 tools/FAKE.Core
+tools/FSharp.Compiler


### PR DESCRIPTION
and use it as a NuGet  package.

This reduces download size a lot since the compiler changes less frequently.

But now we should ignore the FSharp.Compiler tool as well.
