### PR TITLE
Fix the namespace problem which was introduced in FAKE 2.1.537-alpha

### DIFF
--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using AssemblyInfo;
 using Octokit.Internal;
 
 namespace Octokit


### PR DESCRIPTION
see https://github.com/fsharp/FAKE/pull/215 

I hope this will help to STFU all the FxCop warnings for the generated class.

Sorry.
