### PR TITLE
Add code analysis to Release build

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -36,6 +36,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Octokit.Reactive/Properties/AssemblyInfo.cs
+++ b/Octokit.Reactive/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System.Reflection;
+using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Octokit.Reactive")]
 [assembly: AssemblyDescription("An IObservable based GitHub API client library for .NET using Reactive Extensions")]
+[assembly: ComVisible(false)]

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -24,6 +24,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +35,8 @@
     <DefineConstants>TRACE;NETFX_CORE;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -37,6 +37,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Octokit/Properties/AssemblyInfo.cs
+++ b/Octokit/Properties/AssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Octokit")]
 [assembly: AssemblyDescription("An async-based GitHub API client library for .NET")]
+[assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("Octokit.Tests")]
 [assembly: InternalsVisibleTo("Octokit.Tests-NetCore45")]

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 [assembly: AssemblyProductAttribute("Octokit")]
 [assembly: AssemblyVersionAttribute("0.1.2")]
 [assembly: AssemblyFileVersionAttribute("0.1.2")]
-
-class AssemblyVersionInformation { public const string Version = "0.1.2"; }
-
+namespace System {
+    internal static class AssemblyVersionInformation {
+        internal const string Version = "0.1.2";
+    }
+}


### PR DESCRIPTION
This should make it so code analysis build runs on the CI server.
Previously, it was only set for Debug builds.
