### PR TITLE
Fixed up some simple documentation typos/missing params

### DIFF
--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/releases/#create-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner.</param>
-        /// <param name="name">The repository's name.</param
+        /// <param name="name">The repository's name.</param>
         /// <param name="data">A description of the release to create.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Release"/>.</returns>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/releases/#create-a-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The repository's owner.</param>
-        /// <param name="name">The repository's name.</param
+        /// <param name="name">The repository's name.</param>
         /// <param name="data">A description of the release to create.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Release"/>.</returns>

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 namespace Octokit
 {
     /// <summary>
-    /// Describes a new issue to create via the <see cref="IIssuesClient.Create(NewIssue)"/> method.
+    /// Describes a new issue to create via the <see cref="IIssuesClient.Create(string,string,NewIssue)"/> method.
     /// </summary>
     public class NewIssue
     {

--- a/Octokit/Models/Request/NewMilestone.cs
+++ b/Octokit/Models/Request/NewMilestone.cs
@@ -3,7 +3,7 @@
 namespace Octokit
 {
     /// <summary>
-    /// Describes a new milestone to create via the <see cref="IMilestonesClient.Create(NewMilestone)"/> method.
+    /// Describes a new milestone to create via the <see cref="IMilestonesClient.Create(string,string,NewMilestone)"/> method.
     /// </summary>
     public class NewMilestone
     {


### PR DESCRIPTION
Patching up a few issues I came across with the documentation while working on the Pull Request Comments API.
