### PR TITLE
make the script run non-interactive when building on MyGet

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -18,6 +18,9 @@ IF NOT [%2]==[] (set BUILDMODE="%2")
 rem Bail if we're running a TeamCity build.
 if defined TEAMCITY_PROJECT_NAME goto Quit
 
+rem Bail if we're running a MyGet build.
+if /i "%BuildRunner%"=="MyGet" goto Quit
+
 rem Loop the build script.
 set CHOICE=nothing
 echo (Q)uit, (Enter) runs the build again


### PR DESCRIPTION
The `build.cmd` script prompts the user the quit or run the build again.

This PR checks whether the build is running on MyGet Build Services and exits properly by checking the `BuildRunner` environment variable provided by MyGet.
