### PR TITLE
New FixIt task - closes #197

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -45,6 +45,11 @@ Target "CheckProjects" (fun _ ->
     |> Fake.MSBuild.ProjectSystem.CompareProjectsTo "./Octokit/Octokit.csproj"
 )
 
+Target "FixProjects" (fun _ ->
+    !! "./Octokit/Octokit*.csproj"
+    |> Fake.MSBuild.ProjectSystem.FixMissingFiles "./Octokit/Octokit.csproj"
+)
+
 Target "BuildApp" (fun _ ->
     MSBuild null "Build" ["Configuration", buildMode] ["./Octokit.sln"]
     |> Log "AppBuild-Output: "


### PR DESCRIPTION
Hi,

issue #197 describes the trouble with the project files.

Now use

```
.\build FixProjects
```

![image](https://f.cloud.github.com/assets/57396/1499720/e26a3918-4861-11e3-8592-369f193f0fe7.png)

and get:

![image](https://f.cloud.github.com/assets/57396/1499722/f8691d7e-4861-11e3-9858-3e887c805333.png)

Afterwards you can just run .\build

Of course we could add this to the build pipeline, but maybe it's better to have this explicit for the moment
