### PR TITLE
Check if we are already on the right FAKE version - otherwise patch it

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,10 +1,20 @@
 @echo off
 
+SET MinimalFAKEVersion=639
+SET FAKEVersion=1
+cls
+
+if exist tools\FAKE.Core\tools\PatchVersion.txt ( 
+    FOR /F "tokens=*" %%i in (tools\FAKE.Core\tools\PatchVersion.txt) DO (SET FAKEVersion=%%i)    
+)
+
+if %MinimalFAKEVersion% lss %FAKEVersion% goto Build
+if %MinimalFAKEVersion%==%FAKEVersion% goto Build
+
+"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-Prerelease"
+
 :Build
 cls
-if not exist tools\FAKE.Core\tools\Fake.exe ( 
-	"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-Prerelease"
-)
 
 SET TARGET="Default"
 


### PR DESCRIPTION
This will allow us to specify a minimal FAKE patch version in the build.cmd.
Whenever we have to upgrade FAKE (like today) we can modify this version and everybody gets the latest FAKE version.
This will hopefully reduce the confusion with breaking build scripts and work at least until NuGet 1.8 fixes the nuget install.

/cc @haacked @shiftkey
