### PR TITLE
Update octokit icon for nuget package

### DIFF
--- a/Octokit.Reactive.nuspec
+++ b/Octokit.Reactive.nuspec
@@ -8,7 +8,7 @@
     <summary>@summary@</summary>
     <licenseUrl>https://github.com/octokit/octokit.net/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/octokit/octokit.net</projectUrl>
-    <iconUrl>https://f.cloud.github.com/assets/19977/1441274/160fba8c-41a9-11e3-831d-61d88fa886f4.png</iconUrl>
+    <iconUrl>https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>@description@</description>
     <releaseNotes>@releaseNotes@</releaseNotes>


### PR DESCRIPTION
Fixes #202 

Here's how it looks at the three sizes that NuGet displays it (first 2 on nuget.org and the last one in the VS extension)

128x128
![octokit-128x128](https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png)
48x48
<img src="https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png" width="48" />
32x32
<img src="https://f.cloud.github.com/assets/19977/1510987/64af2b26-4a9d-11e3-89fc-96a185171c75.png" width="32" />
