### PR TITLE
Fix xml docs in `NewAuthorization`

### DIFF
--- a/Octokit/Models/Request/NewAuthorization.cs
+++ b/Octokit/Models/Request/NewAuthorization.cs
@@ -18,7 +18,7 @@ namespace Octokit
         public string Note { get; set; }
 
         /// <summary>
-        // An optional URL to remind you what app the OAuth token is for.
+        /// An optional URL to remind you what app the OAuth token is for.
         /// </summary>
         public string NoteUrl { get; set; }
     }


### PR DESCRIPTION
This puts in a missing slash that was ruining the xml doc information.
