### PR TITLE
Do not block the build script from finishing

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -31,13 +31,5 @@ if defined TEAMCITY_PROJECT_NAME goto Quit
 rem Bail if we're running a MyGet build.
 if /i "%BuildRunner%"=="MyGet" goto Quit
 
-rem Loop the build script.
-set CHOICE=nothing
-echo (Q)uit, (Enter) runs the build again
-set /P CHOICE= 
-if /i "%CHOICE%"=="Q" goto :Quit
-
-GOTO Build
-
 :Quit
 exit /b %errorlevel%


### PR DESCRIPTION
Pretty simple, let's just finish up when the script is done.
- [x] resolve upstream issue with generated file
