### PR TITLE
Use FAKE 2.2 for build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,17 +1,6 @@
 @echo off
 
-SET MinimalFAKEVersion=639
-SET FAKEVersion=1
-cls
-
-if exist tools\FAKE.Core\tools\PatchVersion.txt ( 
-    FOR /F "tokens=*" %%i in (tools\FAKE.Core\tools\PatchVersion.txt) DO (SET FAKEVersion=%%i)    
-)
-
-if %MinimalFAKEVersion% lss %FAKEVersion% goto Build
-if %MinimalFAKEVersion%==%FAKEVersion% goto Build
-
-"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-Prerelease"
+"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.2.0"
 
 :Build
 cls

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -76,7 +76,7 @@ if (Test-Path tools\FAKE.Core\tools\Fake.exe) {
 else {
     Write-Output "Installing FAKE..."
     Write-Output ""
-    .\tools\nuget\nuget.exe "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-Prerelease"
+    .\tools\nuget\nuget.exe "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-Version" "2.2.0"
 }
 
 Write-Output "Building Octokit..."


### PR DESCRIPTION
Hi,

I released FAKE 2.2 (see http://www.navision-blog.de/blog/2013/11/22/fake_2_released/) and I think it's a good idea to move Octokit to a stable version.

Cheers,
Steffen
