### PR TITLE
And then there was QED

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -12,6 +12,19 @@ IF NOT [%1]==[] (set TARGET="%1")
 SET BUILDMODE="Release"
 IF NOT [%2]==[] (set BUILDMODE="%2")
 
+:: because we want to run specific steps inline on qed
+:: we need to break the dependency chain
+:: this ensures we do a build before running any tests
+
+if TARGET=="Default" (SET RunBuild=1)
+if TARGET=="RunUnitTests" (SET RunBuild=1)
+if TARGET=="RunIntegrationTests" (SET RunBuild=1)
+if TARGET=="CreatePackages" (SET RunBuild=1)
+
+if "%RunBuild%"=="" (
+"tools\FAKE.Core\tools\Fake.exe" "build.fsx" "target=BuildApp" "buildMode=%BUILDMODE%"
+)
+
 "tools\FAKE.Core\tools\Fake.exe" "build.fsx" "target=%TARGET%" "buildMode=%BUILDMODE%"
 
 rem Bail if we're running a TeamCity build.

--- a/build.fsx
+++ b/build.fsx
@@ -131,14 +131,21 @@ Target "CreateOctokitReactivePackage" (fun _ ->
 
 Target "Default" DoNothing
 
+Target "CreatePackages" DoNothing
+
 "Clean"
    ==> "AssemblyInfo"
    ==> "CheckProjects"
-   ==> "BuildApp"
-   ==> "UnitTests"
-   ==> "IntegrationTests"
-   ==> "CreateOctokitPackage"
-   ==> "CreateOctokitReactivePackage"
+       ==> "BuildApp"
+
+"UnitTests"
    ==> "Default"
+
+"IntegrationTests"
+   ==> "Default"
+
+"CreateOctokitPackage"
+"CreateOctokitReactivePackage"
+   ==> "CreatePackages"
 
 RunTargetOrDefault "Default"

--- a/script/cibuild.ps1
+++ b/script/cibuild.ps1
@@ -35,6 +35,17 @@ function Die-WithOutput($exitCode, $output) {
     exit $exitCode
 }
 
+function Dump-Error($output) {
+    $exitCode = $LastExitCode
+
+    $errors = $output | Select-String ": error"
+    if ($errors) {
+        $output = "Likely errors:", $errors, "", "Full output:", $output
+    }
+
+    Die-WithOutput $exitCode $output
+}
+
 function Run-Command([scriptblock]$Command, [switch]$Fatal, [switch]$Quiet) {
     $output = ""
     if ($Quiet) {
@@ -81,16 +92,34 @@ else {
 
 Write-Output "Building Octokit..."
 Write-Output ""
-$output = .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=Default" "buildMode=Release"
+$output = & .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=BuildApp" "buildMode=Release" 2>&1
 if ($LastExitCode -ne 0) {
-    $exitCode = $LastExitCode
+    Dump-Error($output)
+}
 
-    $errors = $output | Select-String ": error"
-    if ($errors) {
-        $output = "Likely errors:", $errors, "", "Full output:", $output
-    }
+Write-Output "Running unit tests..."
+Write-Output ""
+$output = & .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=UnitTests" "buildMode=Release" 2>&1
+if ($LastExitCode -ne 0) {
+    Dump-Error($output)
+}
 
-    Die-WithOutput $exitCode $output
+Write-Output "Running integration tests..."
+Write-Output ""
+$output = & .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=IntegrationTests" "buildMode=Release" 2>&1
+if ($LastExitCode -ne 0) {
+    Dump-Error($output)
+}
+
+Write-Output "Creating NuGet packages..."
+Write-Output ""
+$output = & .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=CreateOctokitPackage" "buildMode=Release" 2>&1
+if ($LastExitCode -ne 0) {
+    Dump-Error($output)
+}
+$output = & .\tools\FAKE.Core\tools\Fake.exe "build.fsx" "target=CreateOctokitReactivePackage" "buildMode=Release" 2>&1
+if ($LastExitCode -ne 0) {
+    Dump-Error($output)
 }
 
 $exitCode = 0


### PR DESCRIPTION
As part of transitioning to using QED for our build server...

That's right:

![ron-paul](https://f.cloud.github.com/assets/359239/1627150/9a3fddac-56ec-11e3-8e94-7081b767dbfc.gif)

This resolves #119. Prepare yourselves.

But first, there's some housekeeping we need to work through:
- [x] build script changes

Currently we have a monolithic `build.fsx` that does everything we need. I had to break this up a bit because of how we wanted the build scripts to run on the build server.

So developers will still have the `.\build.cmd` script for their local testing. I've dropped creating NuGet packages as part of this build, because you probably don't care about that.

For QED we'll point it at `.\script\cibuild.ps1` which will run each these step incrementally:
- build
- unit tests
- integration tests
- create packaages

And get a clean output if All Is Well.
