### PR TITLE
i am an idiot

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -21,7 +21,7 @@ if TARGET=="RunUnitTests" (SET RunBuild=1)
 if TARGET=="RunIntegrationTests" (SET RunBuild=1)
 if TARGET=="CreatePackages" (SET RunBuild=1)
 
-if "%RunBuild%"=="" (
+if NOT "%RunBuild%"=="" (
 "tools\FAKE.Core\tools\Fake.exe" "build.fsx" "target=BuildApp" "buildMode=%BUILDMODE%"
 )
 


### PR DESCRIPTION
I could have sworn I'd tested this, but I guess I missed it.

So when you specify a build config which depends on compilation, it's supposed to enter that first conditional and, you know, build the thing.

However I got the condition the wrong way round, and it would run when I specify a target that isn't dependent on compilation, say `FixProjects`.  And for something that was dependent on compilation, say `RunUnitTests`, it would avoid it.

![](http://replygif.net/i/906.gif)

Bravo me.

So let's do it right.
