### PR TITLE
Fix for creating/updating comments for issue

### DIFF
--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -82,7 +82,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(newComment, "newComment");
 
-            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(owner, name, number), newComment);
+            return ApiConnection.Post<IssueComment>(ApiUrls.IssueComments(owner, name, number), new BodyWrapper(newComment));
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
-            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, number), commentUpdate);
+            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, number), new BodyWrapper(commentUpdate));
         }
     }
 }


### PR DESCRIPTION
Attempt to create a comment for issue results in "400 Bad Request" (Problems parsing JSON) because request contains the comment body as plain text.

In order to resolve the issue the Create and Update methods has been changed to use BodyWrapper.
