### PR TITLE
Fix for issues comments tests, fixes #266

### DIFF
--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -98,7 +98,8 @@ public class IssueCommentsClientTests
 
             client.Create("fake", "repo", 1, newComment);
 
-            connection.Received().Post<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/comments"), newComment);
+            connection.Received().Post<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/comments"),
+                new BodyWrapper(newComment));
         }
 
         [Fact]
@@ -127,7 +128,7 @@ public class IssueCommentsClientTests
             client.Update("fake", "repo", 42, issueCommentUpdate);
 
             connection.Received().Patch<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"),
-                issueCommentUpdate);
+                new BodyWrapper(issueCommentUpdate));
         }
 
         [Fact]


### PR DESCRIPTION
This fixes the issue with tests for creating and updating issues comments (#266) which I've introduced by fixing the methods for creating and updating issues comments (#262).
