### PR TITLE
Return a more helpful error message if an invalid refs path is provided

### DIFF
--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -62,11 +62,16 @@ public class ReferencesClientTests : IDisposable
         Assert.NotEmpty(list);
     }
 
-    [IntegrationTest(Skip = "See https://github.com/octokit/octokit.net/issues/242 and https://github.com/octokit/octokit.net/issues/238 for the relevant issues we need to address")]
+    [IntegrationTest]
     public async Task CanGetErrorForInvalidNamespace()
     {
-        await AssertEx.Throws<NotFoundException>(
-            async () => { await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "666"); });
+        var owner = "octokit";
+        var repo = "octokit.net";
+        var subNamespace = "666";
+
+        var result = await AssertEx.Throws<NotFoundException>(
+            async () => { await _fixture.GetAllForSubNamespace(owner, repo, subNamespace); });
+        Assert.Equal(string.Format("{0} was not found.", ApiUrls.Reference(owner, repo, subNamespace)), result.Message);
     }
 
     [IntegrationTest]

--- a/Octokit/Helpers/IApiPagination.cs
+++ b/Octokit/Helpers/IApiPagination.cs
@@ -14,6 +14,6 @@ namespace Octokit
     /// </remarks>
     public interface IApiPagination
     {
-        Task<IReadOnlyList<T>> GetAllPages<T>(Func<Task<IReadOnlyPagedCollection<T>>> getFirstPage);
+        Task<IReadOnlyList<T>> GetAllPages<T>(Func<Task<IReadOnlyPagedCollection<T>>> getFirstPage, Uri uri);
     }
 }

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -110,7 +110,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(uri, "uri");
 
             return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts)
-                                                                 .ConfigureAwait(false));
+                                                                 .ConfigureAwait(false), uri);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #240 and #242
