### PR TITLE
Deprecate IGitHubClient.Blob

### DIFF
--- a/Octokit.Reactive/Clients/ObservableBlobClient.cs
+++ b/Octokit.Reactive/Clients/ObservableBlobClient.cs
@@ -11,7 +11,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(client, "client");
 
-            _client = client.Blob;
+            _client = client.GitDatabase.Blob;
         }
 
         /// <summary>

--- a/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Get("fake", "repo", "123456ABCD");
 
-                gitHubClient.Blob.Received().Get("fake", "repo", "123456ABCD");
+                gitHubClient.GitDatabase.Blob.Received().Get("fake", "repo", "123456ABCD");
             }
 
             [Fact]
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Create("fake", "repo", newBlob);
 
-                gitHubClient.Blob.Received().Create("fake", "repo", newBlob);
+                gitHubClient.GitDatabase.Blob.Received().Create("fake", "repo", newBlob);
             }
 
             [Fact]

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -81,7 +81,6 @@ namespace Octokit
             var apiConnection = new ApiConnection(connection);
             Authorization = new AuthorizationsClient(apiConnection);
             Activity = new ActivitiesClient(apiConnection);
-            Blob = new BlobsClient(apiConnection);
             Issue = new IssuesClient(apiConnection);
             Miscellaneous = new MiscellaneousClient(connection);
             Notification = new NotificationsClient(apiConnection);
@@ -132,7 +131,6 @@ namespace Octokit
 
         public IAuthorizationsClient Authorization { get; private set; }
         public IActivitiesClient Activity { get; private set; }
-        public IBlobsClient Blob { get; private set; }
         public IIssuesClient Issue { get; private set; }
         public IMiscellaneousClient Miscellaneous { get; private set; }
         public IOrganizationsClient Organization { get; private set; }

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -11,7 +11,6 @@ namespace Octokit
 
         IAuthorizationsClient Authorization { get; }
         IActivitiesClient Activity { get; }
-        IBlobsClient Blob { get; }
         IIssuesClient Issue { get; }
         IMiscellaneousClient Miscellaneous { get; }
         IOrganizationsClient Organization { get; }


### PR DESCRIPTION
It's not necessary in both places and is confusing.

Resolves #303 
