### PR TITLE
Make ObservableStarredClient accessible

### DIFF
--- a/Octokit.Reactive/Clients/IObservableActivitiesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableActivitiesClient.cs
@@ -3,5 +3,6 @@
     public interface IObservableActivitiesClient
     {
         IObservableEventsClient Events { get; }
+        IObservableStarredClient Starred { get; }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableActivitiesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableActivitiesClient.cs
@@ -7,7 +7,9 @@
             Ensure.ArgumentNotNull(client, "client");
 
             Events = new ObservableEventsClient(client);
+            Starred = new ObservableStarredClient(client);
         }
         public IObservableEventsClient Events { get; private set; }
+        public IObservableStarredClient Starred { get; private set; }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -5,7 +5,7 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
-    public class ObservableStarredClient
+    public class ObservableStarredClient : IObservableStarredClient
     {
         private IStarredClient _client;
         private IConnection _connection;


### PR DESCRIPTION
Currently the ObservableStarredClient isn't accessible through the ObservableActivitiesClient like it is in the async library.

This pull request adds IObservableStarredClient to ObservableStarredClient and references it from ObservableActivitiesClient.
