### PR TITLE
Implement User Emails API

### DIFF
--- a/Octokit.Tests.Integration/Clients/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UsersClientTests.cs
@@ -117,4 +117,23 @@ public class UsersClientTests
             Assert.True(email.Primary);
         }
     }
+
+    public class TheAddEmailsToCurrentMethod
+    {
+        [IntegrationTest]
+        public async Task CanAddEmailsToUser()
+        {
+            var github = new GitHubClient(new ProductHeaderValue("OctokitTests"))
+            {
+                Credentials = Helper.Credentials
+            };
+
+            var emailToAdd = string.Format("test_{0}@example.com", System.Guid.NewGuid());
+
+            await github.User.AddEmailsToCurrent(emailToAdd);
+            var emails = await github.User.GetEmails();
+
+            Assert.True(emails.Where(e => e.Email == emailToAdd).Any());
+        }
+    }
 }

--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -105,5 +105,31 @@ namespace Octokit.Tests.Clients
                 client.Received().GetAll<EmailAddress>(endpoint, null);
             }
         }
+
+        public class TheAddEmailsToCurrentMethod
+        {
+            [Fact]
+            public void ShouldThrowIfProvidedListIsEmpty()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var usersClient = new UsersClient(client);
+
+                var result = Record.Exception(() => usersClient.AddEmailsToCurrent());
+
+                Assert.IsType<ArgumentException>(result);
+                Assert.Equal("emails", ((ArgumentException)result).ParamName);
+            }
+
+            [Fact]
+            public void ShouldSkipEmptyEmailAddresses()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var usersClient = new UsersClient(client);
+
+                usersClient.AddEmailsToCurrent("foo@bar.com", "", null, "test@test.com");
+
+                client.Received().Post<string[]>(ApiUrls.Emails(), Arg.Is<string[]>(p => p.Length == 2));
+            }
+        }
     }
 }

--- a/Octokit/Clients/IUsersClient.cs
+++ b/Octokit/Clients/IUsersClient.cs
@@ -41,5 +41,12 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<EmailAddress>> GetEmails();
+
+        /// <summary>
+        /// Add email address(es) to the current user.
+        /// </summary>
+        /// <param name="emails">The email adresses to add.</param>
+        /// <returns>A read only list of the added email adresses.</returns>
+        Task<EmailAddress[]> AddEmailsToCurrent(params string[] emails);
     }
 }

--- a/Octokit/Clients/UsersClient.cs
+++ b/Octokit/Clients/UsersClient.cs
@@ -2,6 +2,7 @@
 #if NET_45
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 #endif
 using System.Threading.Tasks;
 
@@ -67,6 +68,23 @@ namespace Octokit
         public Task<IReadOnlyList<EmailAddress>> GetEmails()
         {
             return ApiConnection.GetAll<EmailAddress>(ApiUrls.Emails(), null);
+        }
+
+        /// <summary>
+        /// Add email address(es) to the current user.
+        /// </summary>
+        /// <param name="emails">The email adresses to add.</param>
+        /// <returns>A read only list of the added email adresses.</returns>
+        public Task<EmailAddress[]> AddEmailsToCurrent(params string[] emails)
+        {
+            if (emails == null || emails.Length == 0)
+            {
+                throw new ArgumentException("No email addresses provided.", "emails");
+            }
+
+            var data = emails.Where(e => !string.IsNullOrEmpty(e)).ToArray();
+
+            return ApiConnection.Post<EmailAddress[]>(ApiUrls.Emails(), data);
         }
     }
 }


### PR DESCRIPTION
I've added code, tests and integration test for adding email addresses to user accounts (#341).

If someone can clarify the API for me on how to delete email adresses (http://developer.github.com/v3/users/emails/#delete-email-addresses) then I can do that as well.
