### PR TITLE
"_links" JSON field serialization convention fix

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -91,6 +91,16 @@ namespace Octokit.Tests
                 Assert.Equal("commit-url", result.Url);
                 Assert.Equal("commit-message", result.Message);
             }
+
+            [Fact]
+            public void IgnoresUnderscore()
+            {
+                const string json = "{\"_links\":\"blah\"}";
+
+                var result = new SimpleJsonSerializer().Deserialize<Sample>(json);
+
+                Assert.Equal("blah", result.Links);
+            }
         }
 
         public class Sample
@@ -99,6 +109,7 @@ namespace Octokit.Tests
             public string FirstName { get; set; }
             public bool IsSomething { get; set; }
             public bool Private { get; set; }
+            public string Links { get; set; }
         }
     }
 }

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -23,7 +23,9 @@ namespace Octokit.Internal
         {
             protected override string MapClrMemberNameToJsonFieldName(string clrPropertyName)
             {
-                return clrPropertyName.ToRubyCase();
+                var rubyCased = clrPropertyName.ToRubyCase();
+                if (rubyCased == "links") return "_links"; // Special case for GitHub API
+                return rubyCased;
             }
 
             // This is overridden so that null values are omitted from serialized objects.


### PR DESCRIPTION
Special case JSON _links property.

```
For some reason, the List Feeds http://developer.github.com/v3/activity/feeds/#list-feeds
API response has a field that starts with an underscore. This also occurs in
the Review Comments API: http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository
and in the Contents API. http://developer.github.com/v3/repos/contents/#get-the-readme

This commit special cases that one field so we can use the expected CLR
property name. I couldn't find a case where a
JSON response doesn't prefix "links" with an underscore.

Related to #386
```
