### PR TITLE
Fixing some `AssertEx.Throws` that were not

### DIFF
--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -18,8 +18,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
-            Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+            await AssertEx.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
+            await AssertEx.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
         }
 
         [Fact]
@@ -27,8 +27,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
-            Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+            await AssertEx.Throws<ArgumentException>(() => client.GetAll("", "name"));
+            await AssertEx.Throws<ArgumentException>(() => client.GetAll("owner", ""));
         }
 
         [Theory]
@@ -76,22 +76,22 @@ public class DeploymentsClientTests
         readonly NewDeployment newDeployment = new NewDeployment { Ref = "aRef" };
 
         [Fact]
-        public void EnsuresNonNullArguments()
+        public async Task EnsuresNonNullArguments()
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            AssertEx.Throws<ArgumentNullException>(() => client.Create(null, "name", newDeployment));
-            AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", null, newDeployment));
-            AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+            await AssertEx.Throws<ArgumentNullException>(() => client.Create(null, "name", newDeployment));
+            await AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", null, newDeployment));
+            await AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
         }
 
         [Fact]
-        public void EnsuresNonEmptyArguments()
+        public async Task EnsuresNonEmptyArguments()
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            Assert.Throws<ArgumentException>(() => client.Create("", "name", newDeployment));
-            Assert.Throws<ArgumentException>(() => client.Create("owner", "", newDeployment));
+            await AssertEx.Throws<ArgumentException>(() => client.Create("", "name", newDeployment));
+            await AssertEx.Throws<ArgumentException>(() => client.Create("owner", "", newDeployment));
         }
 
         [Theory]
@@ -100,12 +100,12 @@ public class DeploymentsClientTests
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData("\n\r")]
-        public void EnsuresNonWhitespaceArguments(string whitespace)
+        public async Task EnsuresNonWhitespaceArguments(string whitespace)
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            Assert.Throws<ArgumentException>(() => client.Create(whitespace, "name", newDeployment));
-            Assert.Throws<ArgumentException>(() => client.Create("owner", whitespace, newDeployment));
+            await AssertEx.Throws<ArgumentException>(() => client.Create(whitespace, "name", newDeployment));
+            await AssertEx.Throws<ArgumentException>(() => client.Create("owner", whitespace, newDeployment));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -28,10 +28,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new PullRequestsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", null, 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Get("owner", null, 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Get(null, "", 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Get("", null, 1));
             }
         }
 
@@ -86,15 +86,15 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                await AssertEx.Throws<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                await AssertEx.Throws<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -120,15 +120,15 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                await AssertEx.Throws<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                await AssertEx.Throws<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -154,11 +154,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Merge(null, "name", 42, new MergePullRequest("message")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Merge("owner", null, 42, new MergePullRequest("message")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                await AssertEx.Throws<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }
         }
@@ -185,10 +185,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Merged(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Merged("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Merged(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Merged("", null, 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Merged(null, "name", 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Merged("owner", null, 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Merged(null, "", 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Merged("", null, 1));
             }
         }
 
@@ -211,10 +211,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Commits(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Commits("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Commits(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Commits("", null, 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Commits(null, "name", 1));
+                await AssertEx.Throws<ArgumentNullException>(() => client.Commits("owner", null, 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Commits(null, "", 1));
+                await AssertEx.Throws<ArgumentException>(() => client.Commits("", null, 1));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -170,15 +170,15 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                Assert.Throws<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                Assert.Throws<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -203,15 +203,15 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                Assert.Throws<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                Assert.Throws<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -236,11 +236,11 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Merge(null, "name", 42, new MergePullRequest("message")));
-                AssertEx.Throws<ArgumentException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Merge("owner", null, 42, new MergePullRequest("message")));
-                AssertEx.Throws<ArgumentNullException>(async () => await
+                Assert.Throws<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }
         }


### PR DESCRIPTION
awaited by awaiting them. Also removed `async`/`await` from the test lambdas of those `Throws<T>` calls.
