### PR TITLE
WIP: From `Assert.Throw` to `AssertEx.Throw`

### DIFF
--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -170,15 +170,15 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentException>(() =>
+                await AssertEx.Throws<ArgumentException>(async () => await
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentException>(() =>
+                await AssertEx.Throws<ArgumentException>(async () => await
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create("owner", "name", null));
             }
         }
@@ -203,15 +203,15 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentException>(() =>
+                await AssertEx.Throws<ArgumentException>(async () => await
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentException>(() =>
+                await AssertEx.Throws<ArgumentException>(async () => await
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Create("owner", "name", null));
             }
         }
@@ -236,11 +236,11 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Merge(null, "name", 42, new MergePullRequest("message")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Merge("owner", null, 42, new MergePullRequest("message")));
-                Assert.Throws<ArgumentNullException>(() =>
+                await AssertEx.Throws<ArgumentNullException>(async () => await
                     client.Merge("owner", "name", 42, null));
             }
         }


### PR DESCRIPTION
These should have been in the previous cleanup. Premature pull request
without a WIP tag, yay!
- [x] Double check that stuff is the way it's supposed to be
