### PR TITLE
Set code analysis culture to en-US to prevent violations on en-(other) machines

### DIFF
--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>Octokit</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This fixes code analysis errors (CA1704), which prevent my build from continuing.

I believe this only happens on en-(non-US) machines (mine is en-AU). We had [the same issues in AutoFixture](https://github.com/AutoFixture/AutoFixture/pull/200) where @adamralph kindly submitted a PR to fix it.

Here are the errors I see when running `build.cmd` from a VS2013 command prompt:

```
Build FAILED.

       "c:\My\repo\octokit.net\Octokit.sln" (Build target) (1) ->
       "c:\My\repo\octokit.net\Octokit\Octokit-NetCore45.csproj" (default target) (7) ->
       (RunCodeAnalysis target) -> 
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Catalog' in member name 'Language.GettextCatalog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit-NetCore45.csproj]
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Prolog' in member name 'Language.Prolog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit-NetCore45.csproj]
         MSBUILD : error : Code Analysis detected errors.  See Code Analysis results window or log file for details. [c:\My\repo\octokit.net\Octokit\Octokit-NetCore45.csproj]


       "c:\My\repo\octokit.net\Octokit.sln" (Build target) (1) ->
       "c:\My\repo\octokit.net\Octokit\Octokit.csproj" (default target) (2) ->
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Catalog' in member name 'Language.GettextCatalog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit.csproj]
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Prolog' in member name 'Language.Prolog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit.csproj]
         MSBUILD : error : Code Analysis detected errors.  See Code Analysis results window or log file for details. [c:\My\repo\octokit.net\Octokit\Octokit.csproj]

    0 Warning(s)
    6 Error(s)

Time Elapsed 00:00:08.40
```
