### PR TITLE
Make Code Analysis (and build) work on en-[!US]

### DIFF
--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This was done in other project files in #426.

Before this PR, I get the following build errors:

```
Build FAILED.

       "c:\My\repo\octokit.net\Octokit.sln" (Build target) (1) ->
       "c:\My\repo\octokit.net\Octokit\Octokit-Portable.csproj" (default target) (9) ->
       (RunCodeAnalysis target) ->
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Catalog' in member name 'Language.GettextCatalog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit-Portable.csproj]
         MSBUILD : error CA1704: Microsoft.Naming : Correct the spelling of 'Prolog' in member name 'Language.Prolog' or remove it entirely if it represents any sort of Hungarian notation. [c:\My\repo\octokit.net\Octokit\Octokit-Portable.csproj]
         MSBUILD : error : Code Analysis detected errors.  See Code Analysis results window or log file for details. [c:\My\repo\octokit.net\Octokit\Octokit-Portable.csproj]
```
