### PR TITLE
[WIP] #373 added more specific exception when PR is not mergeable

### DIFF
--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -105,13 +105,19 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
-        public Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest) 
+        public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest) 
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
 
-            return ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest);
+            var response = await Connection.PutAsync<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.MethodNotAllowed)
+            {
+                throw new PullRequestNotMergeableException();
+            }
+            
+            return response.BodyAsObject;
         }
 
         /// <summary>

--- a/Octokit/Exceptions/PullRequestNotMergeableException.cs
+++ b/Octokit/Exceptions/PullRequestNotMergeableException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class PullRequestNotMergeableException : ApiValidationException
+    {
+        public PullRequestNotMergeableException()
+        {
+        }
+
+        public override string Message
+        {
+            get
+            {
+                return "The pull request is not mergeable.";
+            }
+        }
+
+#if !NETFX_CORE
+        protected PullRequestNotMergeableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Clients\FeedsClient.cs" />
     <Compile Include="Clients\IFeedsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
+    <Compile Include="Exceptions\PullRequestNotMergeableException.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />
     <Compile Include="Exceptions\RepositoryExistsException.cs" />
     <Compile Include="Helpers\ApiErrorExtensions.cs" />


### PR DESCRIPTION
Marked as WIP. Re #373.

So to shed a little light: I sent this PR (somewhat hurriedly) during my talk this evening (http://www.meetup.com/Zurich-Developers-NET-User-Group/events/166898202/) as a demo of OSS contribution. Still a few things outstanding:
- [ ] tests
- [ ] reconsideration of the design of `PullRequestNotMergeableException` (I simply copied `PrivateRepositoryQuotaExceededException` and just made the minimum alterations to get it compiling)
- [ ] inclusion of the new exception in the Mono, NetCore45 and Portable projects (skipped to save time)
- [ ] XML docs for `PullRequestNotMergeableException` (I just ripped out the existing ones since they didn't make sense on the new type)

Have I taken the correct approach in `PullRequestsClient.Merge()`?
