### PR TITLE
Add support for requesting raw bytes.

### DIFF
--- a/Octokit.Tests.Integration/HttpClientAdapterTests.cs
+++ b/Octokit.Tests.Integration/HttpClientAdapterTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Octokit.Internal;
+using Octokit.Tests.Integration;
+using Xunit;
+
+public class HttpClientAdapterTests
+{
+    public class TheSendAsyncMethod
+    {
+        [IntegrationTest]
+        public async Task CanDownloadImage()
+        {
+            var httpClient = new HttpClientAdapter();
+            var request = new Request
+            {
+                BaseAddress = new Uri("https://github.global.ssl.fastly.net/", UriKind.Absolute),
+                Endpoint = new Uri("/images/icons/emoji/poop.png?v=5", UriKind.RelativeOrAbsolute),
+                AllowAutoRedirect = true,
+                Method = HttpMethod.Get
+            };
+
+            var imageBytes = await httpClient.Send<byte[]>(request, CancellationToken.None);
+
+            // Spot check some of dem bytes.
+            Assert.Equal(137, imageBytes.BodyAsObject[0]);
+            Assert.Equal(80, imageBytes.BodyAsObject[1]);
+            Assert.Equal(78, imageBytes.BodyAsObject[2]);
+            Assert.Equal(130, imageBytes.BodyAsObject.Last());
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Clients\TreeClientTests.cs" />
     <Compile Include="Clients\UserEmailsClientTests.cs" />
     <Compile Include="Clients\FollowersClientTests.cs" />
+    <Compile Include="HttpClientAdapterTests.cs" />
     <Compile Include="IntegrationTestAttribute.cs" />
     <Compile Include="Clients\IssuesClientTests.cs" />
     <Compile Include="Clients\MiscellaneousClientTests.cs" />

--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -133,6 +133,23 @@ namespace Octokit.Tests.Http
                 Assert.Null(response.ContentType);
             }
 
+            [Fact]
+            public async Task BuildsByteArrayResponseFromResponseMessage()
+            {
+                var responseMessage = new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ByteArrayContent(new byte[] { 0, 1, 1, 0, 1}),
+                };
+                var tester = new HttpClientAdapterTester();
+
+                var response = await tester.BuildResponseTester<byte[]>(responseMessage);
+
+                Assert.Equal(new byte[] { 0, 1, 1, 0, 1 }, response.BodyAsObject);
+                Assert.Null(response.Body);
+                Assert.Null(response.ContentType);
+            }
+
             public async Task SetsContentType(HttpStatusCode httpStatusCode)
             {
                 var responseMessage = new HttpResponseMessage

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -63,12 +63,21 @@ namespace Octokit.Internal
             Ensure.ArgumentNotNull(responseMessage, "responseMessage");
 
             string responseBody = null;
+            object bodyAsObject = null;
             string contentType = null;
             using (var content = responseMessage.Content)
             {
                 if (content != null)
                 {
-                    responseBody = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    if (typeof(T) != typeof(byte[]))
+                    {
+                        responseBody = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        bodyAsObject = await responseMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    }
+
                     contentType = GetContentType(content);
                 }
             }
@@ -76,6 +85,7 @@ namespace Octokit.Internal
             var response = new ApiResponse<T>
             {
                 Body = responseBody,
+                BodyAsObject = (T)bodyAsObject,
                 StatusCode = responseMessage.StatusCode,
                 ContentType = contentType
             };

--- a/Octokit/Http/IResponse.cs
+++ b/Octokit/Http/IResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using Octokit.Internal;
 
 namespace Octokit
 {


### PR DESCRIPTION
People have their reasons. We're going to use the same `IHttpClient`
to request emoji images.
