### PR TITLE
Fixed CanStarAndUnstarAGist

### DIFF
--- a/Octokit.Tests.Integration/Clients/GistsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GistsClientTests.cs
@@ -1,130 +1,129 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
 using Xunit;
 
-namespace Octokit.Tests.Integration.Clients
+public class GistsClientTests
 {
-    public class GistsClientTests
+    readonly IGistsClient _fixture;
+    const string testGistId = "6305249";
+
+    public GistsClientTests()
     {
-        readonly IGistsClient _fixture;
-        const string testGistId = "6305249";
-
-        public GistsClientTests()
+        var client = new GitHubClient(new ProductHeaderValue("OctokitTests"))
         {
-            var client = new GitHubClient(new ProductHeaderValue("OctokitTests"))
-            {
-                Credentials = Helper.Credentials
-            };
+            Credentials = Helper.Credentials
+        };
 
-            _fixture = client.Gist;
-        }
+        _fixture = client.Gist;
+    }
 
-        [IntegrationTest]
-        public async Task CanGetGist()
+    [IntegrationTest]
+    public async Task CanGetGist()
+    {
+        var retrieved = await _fixture.Get(testGistId);
+        Assert.NotNull(retrieved);
+    }
+
+    [IntegrationTest]
+    public async Task CanCreateEditAndDeleteAGist()
+    {
+        var newGist = new NewGist { Description = "my new gist", Public = true };
+
+        newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
+
+        var createdGist = await _fixture.Create(newGist);
+
+        Assert.NotNull(createdGist);
+        Assert.Equal(newGist.Description, createdGist.Description);
+        Assert.Equal(newGist.Public, createdGist.Public);
+
+        var gistUpdate = new GistUpdate { Description = "my newly updated gist" };
+        var gistFileUpdate = new GistFileUpdate
         {
-            var retrieved = await _fixture.Get(testGistId);
-            Assert.NotNull(retrieved);
-        }
+            NewFileName = "myNewGistTestFile.cs",
+            Content = "new GistsClient(connection).Edit();"
+        };
 
-        [IntegrationTest]
-        public async Task CanCreateEditAndDeleteAGist()
-        {
-            var newGist = new NewGist { Description = "my new gist", Public = true };
+        gistUpdate.Files.Add("myGistTestFile.cs", gistFileUpdate);
 
-            newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
+        var updatedGist = await _fixture.Edit(createdGist.Id, gistUpdate);
 
-            var createdGist = await _fixture.Create(newGist);
+        Assert.NotNull(updatedGist);
+        Assert.Equal(updatedGist.Description, gistUpdate.Description);
 
-            Assert.NotNull(createdGist);
-            Assert.Equal(newGist.Description, createdGist.Description);
-            Assert.Equal(newGist.Public, createdGist.Public);
+        Assert.DoesNotThrow(async () => { await _fixture.Delete(createdGist.Id); });
+    }
 
-            var gistUpdate = new GistUpdate { Description = "my newly updated gist" };
-            var gistFileUpdate = new GistFileUpdate
-            {
-                NewFileName = "myNewGistTestFile.cs",
-                Content = "new GistsClient(connection).Edit();"
-            };
+    [IntegrationTest]
+    public async Task CanStarAndUnstarAGist()
+    {
+        await _fixture.Star(testGistId);
 
-            gistUpdate.Files.Add("myGistTestFile.cs", gistFileUpdate);
+        var isStarredTrue = await _fixture.IsStarred(testGistId);
+        Assert.True(isStarredTrue);
 
-            var updatedGist = await _fixture.Edit(createdGist.Id, gistUpdate);
+        await _fixture.Unstar(testGistId);
 
-            Assert.NotNull(updatedGist);
-            Assert.Equal(updatedGist.Description, gistUpdate.Description);
+        var isStarredFalse = await _fixture.IsStarred(testGistId);
+        Assert.False(isStarredFalse);
+    }
 
-            Assert.DoesNotThrow(async () => { await _fixture.Delete(createdGist.Id); });
-        }
+    [IntegrationTest]
+    public async Task CanForkAGist()
+    {
+        var forkedGist = await _fixture.Fork(testGistId);
 
-        [IntegrationTest]
-        public async Task CanStarAndUnstarAGist()
-        {
-            await _fixture.Star(testGistId);
+        Assert.NotNull(forkedGist);
 
-            var isStarredTrue = await _fixture.IsStarred(testGistId);
-            Assert.True(isStarredTrue);
+        await _fixture.Delete(forkedGist.Id);
+    }
 
-            await _fixture.Unstar(testGistId);
+    [IntegrationTest]
+    public async Task CanListGists()
+    {
+        // Time is tricky between local and remote, be lenient
+        var startTime = DateTimeOffset.Now.Subtract(TimeSpan.FromHours(1));
+        var newGist = new NewGist { Description = "my new gist", Public = true };
 
-            var isStarredFalse = await _fixture.IsStarred(testGistId);
-            Assert.False(isStarredFalse);
-        }
+        newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
 
-        [IntegrationTest]
-        public async Task CanForkAGist()
-        {
-            var forkedGist = await _fixture.Fork(testGistId);
+        var createdGist = await _fixture.Create(newGist);
 
-            Assert.NotNull(forkedGist);
+        // Test get all Gists
+        var gists = await _fixture.GetAll();
+        Assert.NotNull(gists);
 
-            await _fixture.Delete(forkedGist.Id);
-        }
+        // Test get all Gists since startTime
+        gists = await _fixture.GetAll(startTime);
 
-        [IntegrationTest]
-        public async Task CanListGists()
-        {
-            // Time is tricky between local and remote, be lenient
-            var startTime = DateTimeOffset.Now.Subtract(TimeSpan.FromHours(1));
-            var newGist = new NewGist { Description = "my new gist", Public = true };
+        Assert.NotNull(gists);
+        Assert.True(gists.Count > 0);
 
-            newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
+        // Make sure we can successfully request gists for another user
+        Assert.DoesNotThrow(async () => { await _fixture.GetAllForUser("FakeHaacked"); });
+        Assert.DoesNotThrow(async () => { await _fixture.GetAllForUser("FakeHaacked", startTime); });
 
-            var createdGist = await _fixture.Create(newGist);
+        // Test public gists
+        var publicGists = await _fixture.GetAllPublic();
+        Assert.True(publicGists.Count > 1);
 
-            // Test get all Gists
-            var gists = await _fixture.GetAll();
-            Assert.NotNull(gists);
+        var publicGistsSinceStartTime = await _fixture.GetAllPublic(startTime);
+        Assert.True(publicGistsSinceStartTime.Count > 0);
 
-            // Test get all Gists since startTime
-            gists = await _fixture.GetAll(startTime);
+        // Test starred gists
+        await _fixture.Star(createdGist.Id);
+        var starredGists = await _fixture.GetAllStarred();
 
-            Assert.NotNull(gists);
-            Assert.True(gists.Count > 0);
+        Assert.NotNull(starredGists);
+        Assert.True(starredGists.Any(x => x.Id == createdGist.Id));
 
-            // Make sure we can successfully request gists for another user
-            Assert.DoesNotThrow(async () => { await _fixture.GetAllForUser("FakeHaacked"); });
-            Assert.DoesNotThrow(async () => { await _fixture.GetAllForUser("FakeHaacked", startTime); });
+        var starredGistsSinceStartTime = await _fixture.GetAllStarred(startTime);
+        Assert.NotNull(starredGistsSinceStartTime);
+        Assert.True(starredGistsSinceStartTime.Any(x => x.Id == createdGist.Id));
 
-            // Test public gists
-            var publicGists = await _fixture.GetAllPublic();
-            Assert.True(publicGists.Count > 1);
-
-            var publicGistsSinceStartTime = await _fixture.GetAllPublic(startTime);
-            Assert.True(publicGistsSinceStartTime.Count > 0);
-
-            // Test starred gists
-            await _fixture.Star(createdGist.Id);
-            var starredGists = await _fixture.GetAllStarred();
-
-            Assert.NotNull(starredGists);
-            Assert.True(starredGists.Any(x => x.Id == createdGist.Id));
-
-            var starredGistsSinceStartTime = await _fixture.GetAllStarred(startTime);
-            Assert.NotNull(starredGistsSinceStartTime);
-            Assert.True(starredGistsSinceStartTime.Any(x => x.Id == createdGist.Id));
-
-            await _fixture.Delete(createdGist.Id);
-        }
+        await _fixture.Delete(createdGist.Id);
     }
 }


### PR DESCRIPTION
Removed the Assert.DoNotThrow as they're not needed (the test will fail if the callback throws anyway). The test then passed three times in a row.

issue #424
