### PR TITLE
[WIP] Pull Request Commits have this neat comment_count property

### DIFF
--- a/Octokit/Models/Response/Commit.cs
+++ b/Octokit/Models/Response/Commit.cs
@@ -11,5 +11,6 @@ namespace Octokit
         public Signature Committer { get; set; }
         public GitReference Tree { get; set; }
         public IEnumerable<GitReference> Parents { get; set; }
+        public int CommentCount { get; set; }
     }
 }

--- a/Octokit/Models/Response/CommitComment.cs
+++ b/Octokit/Models/Response/CommitComment.cs
@@ -44,7 +44,7 @@ namespace Octokit
         /// <summary>
         /// The line number in the file that was commented on.
         /// </summary>
-        public int Line { get; set; }
+        public int? Line { get; set; }
 
         /// <summary>
         /// The commit 


### PR DESCRIPTION
Added the comment_count property and an integration test to ensure it's read properly from the API.

Line is now [deprecated](https://developer.github.com/v3/repos/comments/#create-a-commit-comment) for CommentCommit so I made the property nullable.

issue #374
