### PR TITLE
Don't NRE on `null` JSON values.

### DIFF
--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1420,7 +1420,8 @@ namespace Octokit
                                 if (jsonObject.TryGetValue(setter.Key, out jsonValue))
                                 {
                                     jsonValue = DeserializeObject(jsonValue, setter.Value.Key);
-                                    setter.Value.Value(obj, jsonValue);
+                                    if (jsonValue != null)
+                                        setter.Value.Value(obj, jsonValue);
                                 }
                             }
                         }


### PR DESCRIPTION
This threw an NRE on null values when parsing a user on Xamarin.
