### PR TITLE
[WIP] Add List support for References Get #439

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 
@@ -18,7 +19,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<Reference> Get(string owner, string name, string reference);
+        IObservable<IReadOnlyList<Reference>> Get(string owner, string name, string reference);
 
         /// <summary>
         /// Gets all references for a given repository

--- a/Octokit.Reactive/Clients/ObservableFollowersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableFollowersClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
         public IObservable<User> GetAllForCurrent()
         {
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers());
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
         public IObservable<User> GetAll(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
         public IObservable<User> GetFollowingForCurrent()
         {
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following());
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
         public IObservable<User> GetFollowing(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reactive;
 using System.Reactive.Threading.Tasks;
 using Octokit.Reactive.Internal;
@@ -28,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public IObservable<Reference> Get(string owner, string name, string reference)
+        public IObservable<IReadOnlyList<Reference>> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -168,7 +168,7 @@ public class PullRequestsClientTests : IDisposable
 
         var master = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/master");
 
-        Assert.Equal(result.Sha, master.Object.Sha);
+        Assert.Equal(result.Sha, master[0].Object.Sha);
     }
 
     [IntegrationTest]
@@ -191,7 +191,7 @@ public class PullRequestsClientTests : IDisposable
 
         // create new commit for master branch
         var newMasterTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World!" } });
-        var newMaster = await CreateCommit("baseline for pull request", newMasterTree.Sha, master.Object.Sha);
+        var newMaster = await CreateCommit("baseline for pull request", newMasterTree.Sha, master[0].Object.Sha);
 
         // update master
         await _client.GitDatabase.Reference.Update(Helper.UserName, _repository.Name, "heads/master", new ReferenceUpdate(newMaster.Sha));

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -32,12 +32,27 @@ public class ReferencesClientTests : IDisposable
         var @ref = await _fixture.Get("octokit", "octokit.net", "heads/master");
 
         // validate the top-level properties
-        Assert.Equal("refs/heads/master", @ref.Ref);
-        Assert.Equal("https://api.github.com/repos/octokit/octokit.net/git/refs/heads/master", @ref.Url);
+        Assert.Equal("refs/heads/master", @ref[0].Ref);
+        Assert.Equal("https://api.github.com/repos/octokit/octokit.net/git/refs/heads/master", @ref[0].Url);
 
         // validate the git reference
-        Assert.Equal(TaggedType.Commit, @ref.Object.Type);
-        Assert.False(String.IsNullOrWhiteSpace(@ref.Object.Sha));
+        Assert.Equal(TaggedType.Commit, @ref[0].Object.Type);
+        Assert.False(String.IsNullOrWhiteSpace(@ref[0].Object.Sha));
+    }
+
+    [IntegrationTest]
+    public async Task CanGetMultipleReferences()
+    {
+        var list = await _fixture.Get("octokit", "octokit.net", "heads");
+        Assert.NotEmpty(list);
+
+        // validate the top-level properties
+        Assert.True(list[0].Ref.StartsWith("refs/heads"));
+        Assert.True(list[0].Url.StartsWith("https://api.github.com/repos/octokit/octokit.net/git/refs/heads"));
+
+        // validate the git reference
+        Assert.Equal(TaggedType.Commit, list[0].Object.Type);
+        Assert.False(String.IsNullOrWhiteSpace(list[0].Object.Sha));
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -73,7 +73,7 @@ public class RepositoryCommitsClientTests : IDisposable
         var master = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/master");
         var branch = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/my-branch");
 
-        var result = await _fixture.Compare(Helper.UserName, _repository.Name, master.Object.Sha, branch.Object.Sha);
+        var result = await _fixture.Compare(Helper.UserName, _repository.Name, master[0].Object.Sha, branch[0].Object.Sha);
 
         Assert.Equal(1, result.Commits.Count);
         Assert.Equal(1, result.AheadBy);
@@ -86,7 +86,7 @@ public class RepositoryCommitsClientTests : IDisposable
 
         // create new commit for master branch
         var newMasterTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World!" } });
-        var newMaster = await CreateCommit("baseline for pull request", newMasterTree.Sha, master.Object.Sha);
+        var newMaster = await CreateCommit("baseline for pull request", newMasterTree.Sha, master[0].Object.Sha);
 
         // update master
         await _client.GitDatabase.Reference.Update(Helper.UserName, _repository.Name, "heads/master", new ReferenceUpdate(newMaster.Sha));

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Tests.Helpers;
@@ -40,7 +41,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Get("owner", "repo", "heads/develop");
 
-                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"), null);
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
             }
         }
 

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<Reference> Get(string owner, string name, string reference);
+        Task<IReadOnlyList<Reference>> Get(string owner, string name, string reference);
 
         /// <summary>
         /// Gets all references for a given repository

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -30,13 +30,13 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public Task<Reference> Get(string owner, string name, string reference)
+        public Task<IReadOnlyList<Reference>> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return ApiConnection.Get<Reference>(ApiUrls.Reference(owner, name, reference));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, reference));
         }
 
         /// <summary>

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1407,6 +1407,16 @@ namespace Octokit
 
                         obj = dict;
                     }
+                    if (ReflectionUtils.IsTypeGenericeCollectionInterface(type) || ReflectionUtils.IsAssignableFrom(typeof(IList), type))
+                    {
+                        IList list = null;
+
+                        Type innerType = ReflectionUtils.GetGenericListElementType(type);
+                        list = (IList)(ConstructorCache[type] ?? ConstructorCache[typeof(List<>).MakeGenericType(innerType)])(jsonObject.Count);
+                        list.Add(DeserializeObject(objects, innerType));
+
+                        obj = list;
+                    }
                     else
                     {
                         if (type == typeof(object))


### PR DESCRIPTION
**Commit Comments:**
Added new test for a Get call for References that returns a list of objects
Updated the related methods to return the read only list of references
Updated the tests that were looking for a single reference to use the first index position
Updated the SimpleJSON DeserializeObject method to check the if the return type is a generic collection, or assignable form one, to create the List when only a single reference is returned
This was required because the API returns a single object from the Get method without the list wrapper if it only finds one

**Discussion Notes:**
The ObservableReferences Get most likely needs to change still.  It is not being flattened like the GetAll method
Array index notation is being used to grab the first element when other places were expecting a single reference.  Perhaps those should be changed as well?
