### PR TITLE
Fix up URLs for individual assets

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -105,10 +105,9 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <returns>The <see cref="ReleaseAsset"/> specified by the asset id.</returns>
-        IObservable<ReleaseAsset> GetAsset(string owner, string name, int releaseId, int assetId);
+        IObservable<ReleaseAsset> GetAsset(string owner, string name, int assetId);
 
         /// <summary>
         /// Edits the <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -118,11 +117,10 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
         /// <returns>The edited <see cref="ReleaseAsset"/>.</returns>
-        IObservable<ReleaseAsset> EditAsset(string owner, string name, int releaseId, int assetId, ReleaseAssetUpdate data);
+        IObservable<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository

--- a/Octokit.Reactive/Clients/ObservableFollowersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableFollowersClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
         public IObservable<User> GetAllForCurrent()
         {
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers());
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
         public IObservable<User> GetAll(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
         public IObservable<User> GetFollowingForCurrent()
         {
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following());
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="System.Collections.Generic.IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
         public IObservable<User> GetFollowing(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -142,17 +142,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <returns>The <see cref="ReleaseAsset"/> specified by the asset id.</returns>
-        public IObservable<ReleaseAsset> GetAsset(string owner, string name, int releaseId, int assetId)
+        public IObservable<ReleaseAsset> GetAsset(string owner, string name, int assetId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(releaseId, "releaseId");
             Ensure.ArgumentNotNull(assetId, "assetId");
 
-            return _client.GetAsset(owner, name, releaseId, assetId).ToObservable();
+            return _client.GetAsset(owner, name, assetId).ToObservable();
         }
 
         /// <summary>
@@ -181,19 +179,17 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
         /// <returns>The edited <see cref="ReleaseAsset"/>.</returns>
-        public IObservable<ReleaseAsset> EditAsset(string owner, string name, int releaseId, int assetId, ReleaseAssetUpdate data)
+        public IObservable<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(releaseId, "releaseId");
             Ensure.ArgumentNotNull(assetId, "assetId");
             Ensure.ArgumentNotNull(data, "data");
 
-            return _client.EditAsset(owner, name, releaseId, assetId, data).ToObservable();
+            return _client.EditAsset(owner, name, assetId, data).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -211,7 +211,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.GetAsset("fake", "repo", 1, 1);
+                client.GetAsset("fake", "repo", 1);
 
                 connection.Received().Get<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets/1"), null);
             }
@@ -221,10 +221,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReleasesClient(Substitute.For<IApiConnection>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAsset(null, "name", 1, 1));
-                Assert.Throws<ArgumentException>(() => client.GetAsset("", "name", 1, 1));
-                Assert.Throws<ArgumentNullException>(() => client.GetAsset("owner", null, 1, 1));
-                Assert.Throws<ArgumentException>(() => client.GetAsset("owner", "", 1, 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAsset(null, "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAsset("", "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAsset("owner", null, 1));
+                Assert.Throws<ArgumentException>(() => client.GetAsset("owner", "", 1));
             }
         }
 
@@ -237,9 +237,9 @@ namespace Octokit.Tests.Clients
                 var client = new ReleasesClient(connection);
                 var data = new ReleaseAssetUpdate("asset");
 
-                client.EditAsset("fake", "repo", 1, 1, data);
+                client.EditAsset("fake", "repo", 1, data);
 
-                connection.Received().Patch<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets/1"),
+                connection.Received().Patch<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"),
                     data);
             }
 
@@ -248,11 +248,11 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReleasesClient(Substitute.For<IApiConnection>());
 
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset(null, "name", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentException>(() => client.EditAsset("", "name", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", null, 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentException>(() => client.EditAsset("owner", "", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", "name", 1, 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset(null, "name", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentException>(() => client.EditAsset("", "name", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", null, 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentException>(() => client.EditAsset("owner", "", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", "name", 1, null));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -213,9 +210,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableReleasesClient(gitHubClient);
 
-                client.GetAsset("fake", "repo", 1, 1);
+                client.GetAsset("fake", "repo", 1);
 
-                gitHubClient.Release.Received(1).GetAsset("fake", "repo", 1, 1);
+                gitHubClient.Release.Received(1).GetAsset("fake", "repo", 1);
             }
 
             [Fact]
@@ -223,10 +220,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableReleasesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAsset(null, "name", 1, 1));
-                Assert.Throws<ArgumentException>(() => client.GetAsset("", "name", 1, 1));
-                Assert.Throws<ArgumentNullException>(() => client.GetAsset("owner", null, 1, 1));
-                Assert.Throws<ArgumentException>(() => client.GetAsset("owner", "", 1, 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAsset(null, "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAsset("", "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAsset("owner", null, 1));
+                Assert.Throws<ArgumentException>(() => client.GetAsset("owner", "", 1));
             }
         }
 
@@ -239,9 +236,9 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableReleasesClient(gitHubClient);
                 var data = new ReleaseAssetUpdate("asset");
 
-                client.EditAsset("fake", "repo", 1, 1, data);
+                client.EditAsset("fake", "repo", 1, data);
 
-                gitHubClient.Release.Received(1).EditAsset("fake", "repo", 1, 1, data);
+                gitHubClient.Release.Received(1).EditAsset("fake", "repo", 1, data);
             }
 
             [Fact]
@@ -249,11 +246,11 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableReleasesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset(null, "name", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentException>(() => client.EditAsset("", "name", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", null, 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentException>(() => client.EditAsset("owner", "", 1, 1, new ReleaseAssetUpdate("name")));
-                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", "name", 1, 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset(null, "name", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentException>(() => client.EditAsset("", "name", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", null, 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentException>(() => client.EditAsset("owner", "", 1, new ReleaseAssetUpdate("name")));
+                Assert.Throws<ArgumentNullException>(() => client.EditAsset("owner", "name", 1, null));
             }
         }
 

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -113,10 +113,9 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <returns>The <see cref="ReleaseAsset"/> specified by the asset id.</returns>
-        Task<ReleaseAsset> GetAsset(string owner, string name, int releaseId, int assetId);
+        Task<ReleaseAsset> GetAsset(string owner, string name, int assetId);
 
         /// <summary>
         /// Edits the <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -126,11 +125,10 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
         /// <returns>The edited <see cref="ReleaseAsset"/>.</returns>
-        Task<ReleaseAsset> EditAsset(string owner, string name, int releaseId, int assetId, ReleaseAssetUpdate data);
+        Task<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -174,15 +174,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <returns>The <see cref="ReleaseAsset"/> specified by the asset id.</returns>
-        public Task<ReleaseAsset> GetAsset(string owner, string name, int releaseId, int assetId)
+        public Task<ReleaseAsset> GetAsset(string owner, string name, int assetId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            var endpoint = ApiUrls.ReleaseAssets(owner, name, releaseId, assetId);
+            var endpoint = ApiUrls.Asset(owner, name, assetId);
             return ApiConnection.Get<ReleaseAsset>(endpoint);
         }
 
@@ -194,17 +193,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
-        /// <param name="releaseId">The id of the <see cref="Release"/></param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
         /// <returns>The edited <see cref="ReleaseAsset"/>.</returns>
-        public Task<ReleaseAsset> EditAsset(string owner, string name, int releaseId, int assetId, ReleaseAssetUpdate data)
+        public Task<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(data, "data");
 
-            var endpoint = ApiUrls.ReleaseAssets(owner, name, releaseId, assetId);
+            var endpoint = ApiUrls.Asset(owner, name, assetId);
             return ApiConnection.Patch<ReleaseAsset>(endpoint, data);
         }
 
@@ -223,7 +221,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            var endpoint = ApiUrls.Assets(owner, name, id);
+            var endpoint = ApiUrls.Asset(owner, name, id);
             return ApiConnection.Delete(endpoint);
         }
     }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -134,26 +134,13 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> that returns a single asset for the specified release for the specified repository.
-        /// </summary>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="releaseId">The id of the release</param>
-        /// <param name="assetId">The id of the release asset</param>
-        /// <returns></returns>
-        public static Uri ReleaseAssets(string owner, string name, int releaseId, int assetId)
-        {
-            return "repos/{0}/{1}/releases/{2}/assets/{3}".FormatUri(owner, name, releaseId, assetId);
-        }
-
-        /// <summary>
-        /// Returns the <see cref="Uri"/> that returns all the assets for the specified repository.
+        /// Returns the <see cref="Uri"/> that returns the assets specified by the asset id.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The id of the release asset</param>
         /// <returns></returns>
-        public static Uri Assets(string owner, string name, int id)
+        public static Uri Asset(string owner, string name, int id)
         {
             return "repos/{0}/{1}/releases/assets/{2}".FormatUri(owner, name, id);
         }


### PR DESCRIPTION
The release id is not needed to edit or retrieve an asset.
Fixes #506
