### PR TITLE
There is only 1 commit

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -211,7 +211,7 @@ public class PullRequestsClientTests : IDisposable
 
         var result = await _fixture.Commits(Helper.UserName, _repository.Name, pullRequest.Number);
 
-        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result.Count);
         Assert.Equal("this is the commit to merge into the pull request", result[0].Commit.Message);
         Assert.Equal(0, result[0].Commit.CommentCount);
         Assert.Equal(commitMessage, result[1].Commit.Message);


### PR DESCRIPTION
Related to https://github.com/octokit/octokit.net/pull/556#issuecomment-52350752

Integration test was failing, there is only 1 commit in the collection and we are expecting 2.
