### PR TITLE
Fix for mergeable property returning always false when getting pull request details

### DIFF
--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -105,7 +105,7 @@ namespace Octokit
         /// <summary>
         /// Whether or not the pull request can be merged.
         /// </summary>
-        public bool Mergable { get; set; }
+        public bool Mergeable { get; set; }
 
         /// <summary>
         /// The user who merged the pull request.


### PR DESCRIPTION
In class PullRequest the property Mergable is misspelled. Because of that, when getting PR details, the property always return false regardless if the PR is mergeable or not.
