### PR TITLE
Fix a few documentation typos in NewRepository

### DIFF
--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -22,17 +22,17 @@ namespace Octokit
         public string Description { get; set; }
 
         /// <summary>s
-        /// Optional. Gets or sets whether to the enable downloads for the new repository. The default is true.
+        /// Optional. Gets or sets whether to enable downloads for the new repository. The default is true.
         /// </summary>
         public bool? HasDownloads { get; set; }
 
         /// <summary>s
-        /// Optional. Gets or sets whether to the enable issues for the new repository. The default is true.
+        /// Optional. Gets or sets whether to enable issues for the new repository. The default is true.
         /// </summary>
         public bool? HasIssues { get; set; }
 
         /// <summary>s
-        /// Optional. Gets or sets whether to the enable the wiki for the new repository. The default is true.
+        /// Optional. Gets or sets whether to enable the wiki for the new repository. The default is true.
         /// </summary>
         public bool? HasWiki { get; set; }
 


### PR DESCRIPTION
Fix some copy/paste typos in doc strings
