### PR TITLE
Overhaul of status API client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ tools/FAKE.Core
 tools/SourceLink.Fake
 tools/xunit.runners
 *.ncrunch*
+*.GhostDoc.xml
 
 # New VS Test Runner creates arbitrary folders with PDBs
 *.pdb

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -16,6 +16,17 @@ namespace Octokit.Reactive
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -32,6 +32,20 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        public IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
+        {
+            return _client.GetCombined(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference)
         {
-            return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatus(owner, name, reference));
+            return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference));
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
@@ -25,6 +25,27 @@ public class CommitStatusClientTests
         }
     }
 
+    public class TheGetCombinedMethod
+    {
+        [IntegrationTest]
+        public async Task CanRetrieveCombinedStatus()
+        {
+            var githubClient = new GitHubClient(new ProductHeaderValue("OctokitTests"))
+            {
+                Credentials = Helper.Credentials
+            };
+            var status = await githubClient.Repository.CommitStatus.GetCombined(
+            "rails",
+            "rails",
+            "94b857899506612956bb542e28e292308accb908");
+            Assert.Equal(CommitState.Failure, status.State);
+            Assert.Equal("94b857899506612956bb542e28e292308accb908", status.Sha);
+            Assert.Equal(1, status.TotalCount);
+            Assert.Equal(CommitState.Failure, status.Statuses[0].State);
+            Assert.Equal("The Travis CI build failed", status.Statuses[0].Description);
+        }
+    }
+
     public class TheCreateMethod : IDisposable
     {
         readonly IGitHubClient _client;

--- a/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -30,19 +31,17 @@ public class CommitStatusClientTests
         [IntegrationTest]
         public async Task CanRetrieveCombinedStatus()
         {
-            var githubClient = new GitHubClient(new ProductHeaderValue("OctokitTests"))
-            {
-                Credentials = Helper.Credentials
-            };
+            var githubClient = Helper.GetAuthenticatedClient();
             var status = await githubClient.Repository.CommitStatus.GetCombined(
-            "rails",
-            "rails",
-            "94b857899506612956bb542e28e292308accb908");
-            Assert.Equal(CommitState.Failure, status.State);
-            Assert.Equal("94b857899506612956bb542e28e292308accb908", status.Sha);
-            Assert.Equal(1, status.TotalCount);
-            Assert.Equal(CommitState.Failure, status.Statuses[0].State);
-            Assert.Equal("The Travis CI build failed", status.Statuses[0].Description);
+            "libgit2",
+            "libgit2sharp",
+            "f54529997b6ad841be524654d9e9074ab8e7d41d");
+            Assert.Equal(CommitState.Success, status.State);
+            Assert.Equal("f54529997b6ad841be524654d9e9074ab8e7d41d", status.Sha);
+            Assert.Equal(2, status.TotalCount);
+            Assert.Equal(2, status.Statuses.Count);
+            Assert.True(status.Statuses.All(x => x.State == CommitState.Success));
+            Assert.Equal("The Travis CI build passed", status.Statuses[0].Description);
         }
     }
 

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("fake", "repo", "sha");
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/statuses/sha"), null);
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Policy;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Tests.Helpers;
@@ -39,6 +40,40 @@ namespace Octokit.Tests.Clients
                     await client.GetAll("owner", null, "sha"));
                 await AssertEx.Throws<ArgumentNullException>(async () =>
                     await client.GetAll("owner", "name", null));
+            }
+        }
+
+        public class TheGetCombinedMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
+
+                client.GetCombined("fake", "repo", "sha");
+
+                connection.Received()
+                    .Get<CombinedCommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/status"), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new CommitStatusClient(Substitute.For<IApiConnection>());
+
+                await AssertEx.Throws<ArgumentException>(async () =>
+                    await client.GetCombined("", "name", "sha"));
+                await AssertEx.Throws<ArgumentException>(async () =>
+                    await client.GetCombined("owner", "", "sha"));
+                await AssertEx.Throws<ArgumentException>(async () =>
+                    await client.GetCombined("owner", "name", ""));
+                await AssertEx.Throws<ArgumentNullException>(async () =>
+                    await client.GetCombined(null, "name", "sha"));
+                await AssertEx.Throws<ArgumentNullException>(async () =>
+                    await client.GetCombined("owner", null, "sha"));
+                await AssertEx.Throws<ArgumentNullException>(async () =>
+                    await client.GetCombined("owner", "name", null));
             }
         }
 

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -23,7 +23,9 @@ namespace Octokit
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
-        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
@@ -34,18 +36,16 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            // This is currently a preview feature of the API and is subject to change
-            // https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-            return ApiConnection.GetAll<CommitStatus>(
-                ApiUrls.CommitStatus(owner, name, reference),
-                null);
+            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference));
         }
 
         /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
-        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
@@ -62,6 +62,9 @@ namespace Octokit
         /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#create-a-status
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
@@ -74,11 +77,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(commitStatus, "commitStatus");
 
-            // This is currently a preview feature of the API and is subject to change
-            // https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-            return ApiConnection.Post<CommitStatus>(
-                ApiUrls.CommitStatus(owner, name, reference),
-                commitStatus);
+            return ApiConnection.Post<CommitStatus>(ApiUrls.CreateCommitStatus(owner, name, reference), commitStatus);
         }
     }
 }

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -42,6 +42,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<CombinedCommitStatus>(ApiUrls.CombinedCommitStatus(owner, name, reference));
+        }
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -15,7 +15,9 @@ namespace Octokit
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
-        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
@@ -26,7 +28,9 @@ namespace Octokit
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
-        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
@@ -36,6 +40,9 @@ namespace Octokit
         /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#create-a-status
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -23,6 +23,17 @@ namespace Octokit
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -544,15 +544,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> to use when creating a commit status for the specified reference.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        public static Uri CreateCommitStatus(string owner, string name, string reference)
+        {
+            return "repos/{0}/{1}/statuses/{2}".FormatUri(owner, name, reference);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that lists the commit statuses for the specified reference.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <returns></returns>
-        public static Uri CommitStatus(string owner, string name, string reference)
+        public static Uri CommitStatuses(string owner, string name, string reference)
         {
-            return "repos/{0}/{1}/statuses/{2}".FormatUri(owner, name, reference);
+            return "repos/{0}/{1}/commits/{2}/statuses".FormatUri(owner, name, reference);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -556,6 +556,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns a combined view of commit statuses for the specified reference.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        public static Uri CombinedCommitStatus(string owner, string name, string reference)
+        {
+            return "repos/{0}/{1}/commits/{2}/status".FormatUri(owner, name, reference);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that lists the watched repositories for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -1,7 +1,35 @@
-﻿namespace Octokit
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Octokit
 {
     public class CombinedCommitStatus
     {
-         
+        /// <summary>
+        /// The combined state of the commits.
+        /// </summary>
+        public CommitState State { get; set; }
+
+        /// <summary>
+        /// The SHA of the reference.
+        /// </summary>
+        public string Sha { get; set; }
+
+        /// <summary>
+        /// The total number of statuses.
+        /// </summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>
+        /// The statuses.
+        /// </summary>
+        // TODO: This ought to be an IReadOnlyList<ApiErrorDetail> but we need to add support to SimpleJson for that.
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+        public IList<CommitStatus> Statuses { get; set; }
+
+        /// <summary>
+        /// The repository of the reference.
+        /// </summary>
+        public Repository Repository { get; set; }
     }
 }

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -1,8 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Octokit
 {
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CombinedCommitStatus
     {
         /// <summary>
@@ -31,5 +34,13 @@ namespace Octokit
         /// The repository of the reference.
         /// </summary>
         public Repository Repository { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "SHA: {0}, State: {1}, TotalCount: {2}", Sha, State, TotalCount);
+            }
+        }
     }
 }

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -1,0 +1,7 @@
+﻿namespace Octokit
+{
+    public class CombinedCommitStatus
+    {
+         
+    }
+}

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -11,29 +11,29 @@ namespace Octokit
         /// <summary>
         /// The combined state of the commits.
         /// </summary>
-        public CommitState State { get; set; }
+        public CommitState State { get; protected set; }
 
         /// <summary>
         /// The SHA of the reference.
         /// </summary>
-        public string Sha { get; set; }
+        public string Sha { get; protected set; }
 
         /// <summary>
         /// The total number of statuses.
         /// </summary>
-        public int TotalCount { get; set; }
+        public int TotalCount { get; protected set; }
 
         /// <summary>
         /// The statuses.
         /// </summary>
         // TODO: This ought to be an IReadOnlyList<ApiErrorDetail> but we need to add support to SimpleJson for that.
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public IList<CommitStatus> Statuses { get; set; }
+        public IList<CommitStatus> Statuses { get; protected set; }
 
         /// <summary>
         /// The repository of the reference.
         /// </summary>
-        public Repository Repository { get; set; }
+        public Repository Repository { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Octokit
@@ -26,9 +25,7 @@ namespace Octokit
         /// <summary>
         /// The statuses.
         /// </summary>
-        // TODO: This ought to be an IReadOnlyList<ApiErrorDetail> but we need to add support to SimpleJson for that.
-        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public IList<CommitStatus> Statuses { get; protected set; }
+        public IReadOnlyList<CommitStatus> Statuses { get; protected set; }
 
         /// <summary>
         /// The repository of the reference.

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -341,6 +341,7 @@
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Models\Response\RepositoryPermissions.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -352,6 +352,7 @@
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Models\Response\RepositoryPermissions.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -347,6 +347,7 @@
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Models\Response\RepositoryPermissions.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -341,6 +341,7 @@
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Models\Request\OrganizationUpdate.cs" />
     <Compile Include="Models\Response\RepositoryPermissions.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -343,6 +343,7 @@
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Models\Response\RepositoryPermissions.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Request\PublicKey.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
+    <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Response\CommitContent.cs" />
     <Compile Include="Models\Response\ContentType.cs" />
     <Compile Include="Models\Response\GitHubCommitFile.cs" />


### PR DESCRIPTION
Added the new endpoint for [combined commit statuses](https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref), replaced a legacy URL and added some XML docs :lipstick: 

Tell me if you want the commits squashed after a review :smile: