### PR TITLE
The property GravatarId in User and Author models is marked as obsolete

### DIFF
--- a/Octokit/Models/Response/Author.cs
+++ b/Octokit/Models/Response/Author.cs
@@ -17,6 +17,9 @@ namespace Octokit
         /// <summary>
         /// Hex Gravatar identifier, now obsolete
         /// </summary>
+        /// <remarks>
+        /// For more details: https://developer.github.com/changes/2014-09-05-removing-gravatar-id/
+        /// </remarks>
         [Obsolete("This property is now obsolete, use AvatarUrl instead")]
         public string GravatarId { get; set; }
 

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -13,6 +13,9 @@ namespace Octokit
         /// <summary>
         /// Hex Gravatar identifier, now obsolete
         /// </summary>
+        /// <remarks>
+        /// For more details: https://developer.github.com/changes/2014-09-05-removing-gravatar-id/
+        /// </remarks>
         [Obsolete("This property is now obsolete, use AvatarUrl instead")]
         public string GravatarId { get; set; }
 


### PR DESCRIPTION
Alright, guys, so I marked the GravatarId of User and Author as 'obsolete' (issue #613). User derives from Account, which has the AvatarUrl property, which should be used instead and the Author has it anyway. As far as I can see, the test data in the deserialization tests already includes the avatar_url, so I guess the tests are fine as well. Is this correct? Did I miss anything?
