### PR TITLE
Convert bools to lowercase in ToParametersDictionary. Fixes #639

### DIFF
--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -81,6 +81,13 @@ namespace Octokit
                 };
             }
 
+            if (typeof(bool).IsAssignableFrom(propertyType))
+            {
+                // GitHub does not recognize title-case boolean values as arguments.
+                // We need to convert them to lowercase.
+                return (prop, value) => value != null ? value.ToString().ToLowerInvariant() : null;
+            }
+
             return (prop, value) => value != null
                 ? value.ToString()
                 : null;


### PR DESCRIPTION
Fixes boolean type parameters by converting their string representation to lowercase - which GitHub understands. Could have probably just overloaded the return lambda right below this but I thought I might as well make it look like the other type exceptions above.
