### PR TITLE
IssueEvent & EventInfo Field/Enum Updates

### DIFF
--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -45,7 +45,7 @@ public class IssuesEventsClientTests : IDisposable
         issueEventInfo = await _issuesEventsClientClient.GetForIssue(_repositoryOwner, _repositoryName, issue.Number);
         
         Assert.Equal(1, issueEventInfo.Count);
-        Assert.Equal(EventInfoState.Closed, issueEventInfo[0].InfoState);
+        Assert.Equal(EventInfoState.Closed, issueEventInfo[0].Event);
     }
 
     [IntegrationTest]
@@ -93,7 +93,7 @@ public class IssuesEventsClientTests : IDisposable
         var issueEventLookupById = await _issuesEventsClientClient.Get(_repositoryOwner, _repositoryName, issueEventId);
 
         Assert.Equal(issueEventId, issueEventLookupById.Id);
-        Assert.Equal(issueEvents[0].InfoState, issueEventLookupById.InfoState);
+        Assert.Equal(issueEvents[0].Event, issueEventLookupById.Event);
     }
 
     public void Dispose()

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit
 {
@@ -23,9 +24,19 @@ namespace Octokit
         public User Actor { get; set; }
 
         /// <summary>
+        /// The user that was assigned, if the event was 'Assigned'.
+        /// </summary>
+        public User Assignee { get; set; }
+
+        /// <summary>
+        /// The label that was assigned, if the event was 'Labeled'
+        /// </summary>
+        public Label Label { get; set; }
+
+        /// <summary>
         /// Identifies the actual type of Event that occurred.
         /// </summary>
-        public EventInfoState InfoState { get; set; }
+        public EventInfoState Event { get; set; }
 
         /// <summary>
         /// The String SHA of a commit that referenced this Issue.
@@ -83,6 +94,58 @@ namespace Octokit
         /// <summary>
         /// The issue was assigned to the actor.
         /// </summary>
-        Assigned
+        Assigned,
+
+        /// <summary>
+        /// The issue was unassigned to the actor.
+        /// </summary>
+        Unassigned,
+
+        /// <summary>
+        /// A label was added to the issue.
+        /// </summary>
+        Labeled,
+
+        /// <summary>
+        /// A label was removed from the issue.
+        /// </summary>
+        Unlabeled,
+
+        /// <summary>
+        /// The issue was added to a milestone.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Milestoned")]
+        Milestoned,
+
+        /// <summary>
+        /// The issue was removed from a milestone.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Demilestoned")]
+        Demilestoned,
+
+        /// <summary>
+        /// The issue title was changed.
+        /// </summary>
+        Renamed,
+
+        /// <summary>
+        /// The issue was locked by the actor.
+        /// </summary>
+        Locked,
+
+        /// <summary>
+        /// The issue was unlocked by the actor.
+        /// </summary>
+        Unlocked,
+
+        /// <summary>
+        /// The pull request’s branch was deleted.
+        /// </summary>
+        HeadRefDeleted,
+
+        /// <summary>
+        /// The pull request’s branch was restored.
+        /// </summary>
+        HeadRefRestored,
     }
 }

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -23,9 +23,19 @@ namespace Octokit
         public User Actor { get; set; }
 
         /// <summary>
+        /// The user that was assigned, if the event was 'Assigned'.
+        /// </summary>
+        public User Assignee { get; set; }
+
+        /// <summary>
+        /// The label that was assigned, if the event was 'Labeled'
+        /// </summary>
+        public Label Label { get; set; }
+
+        /// <summary>
         /// Identifies the actual type of Event that occurred.
         /// </summary>
-        public EventInfoState InfoState { get; set; }
+        public EventInfoState Event { get; set; }
 
         /// <summary>
         /// The String SHA of a commit that referenced this Issue.


### PR DESCRIPTION
Fixes #642.
- Updated the EventInfoState enum to reflect the current standing in the API docs.
- Added `Assignee` and `Label` properties to allow for them to be populated on `Assignee` and `Labeled` events, respectively.
