### PR TITLE
Added missing fields to GitHubCommit

### DIFF
--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -87,7 +87,7 @@ public class TagsClientTests
                 {
                     Name = "tagger-name",
                     Email = "tagger-email",
-                    Date = new DateTime(2013, 09, 03, 13, 42, 52, DateTimeKind.Utc)
+                    Date = DateTimeOffset.Parse("2013-09-03T13:42:52Z")
                 }
             };
 

--- a/Octokit.Tests/Http/JsonHttpPipelineTests.cs
+++ b/Octokit.Tests/Http/JsonHttpPipelineTests.cs
@@ -169,7 +169,7 @@ namespace Octokit.Tests.Http
                 Assert.Equal("tagger-name", response.BodyAsObject.Tagger.Name);
                 Assert.Equal("tagger-email", response.BodyAsObject.Tagger.Email);
                 //Adjust expected date for time zone adjustment
-                Assert.Equal(new DateTime(2011, 06, 17, 21, 53, 35), response.BodyAsObject.Tagger.Date);
+                Assert.Equal(DateTimeOffset.Parse("2011-06-17T14:53:35-07:00"), response.BodyAsObject.Tagger.Date);
                 Assert.Equal(TaggedType.Commit, response.BodyAsObject.Object.Type);
                 Assert.Equal("object-sha", response.BodyAsObject.Object.Sha);
                 Assert.Equal("object-url", response.BodyAsObject.Object.Url);

--- a/Octokit.Tests/Models/CommitTests.cs
+++ b/Octokit.Tests/Models/CommitTests.cs
@@ -18,13 +18,13 @@ public class CommitTests
             {
                 Name = "author-name", 
                 Email = "author-email", 
-                Date = new DateTime(2013, 10, 15, 13, 40, 14, DateTimeKind.Utc)
+                Date = DateTimeOffset.Parse("2013-10-15T13:40:14Z")
             };
             
             var committer = new Signature { 
                 Name = "committer-name", 
                 Email = "committer-email",
-                Date = new DateTime(2013, 06, 29, 10, 12, 50, DateTimeKind.Utc)
+                Date = DateTimeOffset.Parse("2013-06-29T10:12:50Z")
             };
 
             var commit = new Commit

--- a/Octokit/Models/Response/GitHubCommit.cs
+++ b/Octokit/Models/Response/GitHubCommit.cs
@@ -14,6 +14,7 @@ namespace Octokit
         public Commit Commit { get; set; }
         public Author Committer { get; set; }
         public string HtmlUrl { get; set; }
+        public GitHubCommitStats Stats { get; set; }
         public IReadOnlyList<GitReference> Parents { get; set; }
         public IReadOnlyList<GitHubCommitFile> Files {  get; set; }
     }

--- a/Octokit/Models/Response/GitHubCommitFile.cs
+++ b/Octokit/Models/Response/GitHubCommitFile.cs
@@ -57,6 +57,11 @@ namespace Octokit
         /// </summary>
         public string Sha { get; set; }
 
+        /// <summary>
+        /// The patch associated with the commit
+        /// </summary>
+        public string Patch { get; set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Response/GitHubCommitStats.cs
+++ b/Octokit/Models/Response/GitHubCommitStats.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// An enhanced git commit containing links to additional resources
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class GitHubCommitStats
+    {
+        /// <summary>
+        /// The number of additions made within the commit
+        /// </summary>
+        public int Additions { get; set; }
+
+        /// <summary>
+        /// The number of deletions made within the commit
+        /// </summary>
+        public int Deletions { get; set; }
+
+        /// <summary>
+        /// The total number of modifications within the commit
+        /// </summary>
+        public int Total { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "Stats: +{0} -{1} ={2}", Additions, Deletions, Total);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/Signature.cs
+++ b/Octokit/Models/Response/Signature.cs
@@ -6,6 +6,6 @@ namespace Octokit
     {
         public string Name { get; set; }
         public string Email { get; set; }
-        public DateTime Date { get; set; }
+        public DateTimeOffset Date { get; set; }
     }
 }

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -324,6 +324,7 @@
     <Compile Include="Clients\IRepositoryCommitsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Helpers\ConcurrentCache.cs" />
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -334,6 +334,7 @@
     <Compile Include="Clients\IRepositoryCommitsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Helpers\ConcurrentCache.cs" />
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Clients\IRepositoryCommitsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Helpers\ConcurrentCache.cs" />
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Models\Response\CompareResult.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />
     <Compile Include="Models\Request\OauthLoginRequest.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -326,6 +326,7 @@
     <Compile Include="Clients\IRepositoryCommitsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Helpers\ConcurrentCache.cs" />
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Models\Request\OauthLoginRequest.cs" />
     <Compile Include="Models\Request\OauthTokenRequest.cs" />
     <Compile Include="Models\Response\GitHubCommit.cs" />
+    <Compile Include="Models\Response\GitHubCommitStats.cs" />
     <Compile Include="Models\Response\CompareResult.cs" />
     <Compile Include="Models\Request\NewCommitComment.cs" />
     <Compile Include="Models\Response\CommitComment.cs" />


### PR DESCRIPTION
Added `Stats` and `Patch` fields to `GitHubCommit` and `GitHubCommitFile`, repectively. Also, modified the type for the `Signature.Date` field since it was `DateTime` and everywhere else in the project uses `DateTimeOffset`. 

PS. My stupid Mac or stupid Xamarin instance won't build the test projects for some reason I have yet to run the tests at all so don't be surprised if I fail the continous integration build :sunglasses: 