### PR TITLE
Adds roslyn temporary files to the gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ bin/**/*.pdb
 *.vspscc
 .builds
 
+# Roslyn cache directories
+*.ide/
+
 # Visual C++ cache files
 ipch/
 *.aps


### PR DESCRIPTION
The roslyn compiler creates a folder name [solutionname].sln.ide next to the solution file.  This folder is used for storing temporary files and should not be committed to source control.