### PR TITLE
Adds TreeClient.GetRecursive method.

### DIFF
--- a/Octokit.Reactive/Clients/IObservableTreesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTreesClient.cs
@@ -18,6 +18,18 @@ namespace Octokit.Reactive
         IObservable<TreeResponse> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a Tree Response for a given SHA.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/git/trees/#get-a-tree-recursively
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The SHA that references the tree</param>
+        /// <returns>The <see cref="TreeResponse"/> for the specified Tree.</returns>
+        IObservable<TreeResponse> GetRecursive(string owner, string name, string reference);
+
+        /// <summary>
         /// Creates a new Tree in the specified repo
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableTreesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTreesClient.cs
@@ -35,6 +35,25 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a Tree Response for a given SHA.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/git/trees/#get-a-tree-recursively
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The SHA that references the tree</param>
+        /// <returns>The <see cref="TreeResponse"/> for the specified Tree.</returns>
+        public IObservable<TreeResponse> GetRecursive(string owner, string name, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.GetRecursive(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a new Tree in the specified repo
         /// </summary>
         /// <remarks>

--- a/Octokit.Tests/Clients/TreesClientTests.cs
+++ b/Octokit.Tests/Clients/TreesClientTests.cs
@@ -37,6 +37,34 @@ namespace Octokit.Tests
             }
         }
 
+        public class TheGetRecursiveMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TreesClient(connection);
+
+                client.GetRecursive("fake", "repo", "123456ABCD");
+
+                connection.Received().Get<TreeResponse>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/trees/123456ABCD?recursive=1"),
+                    null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new TreesClient(Substitute.For<IApiConnection>());
+
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive(null, "name", "123456ABCD"));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("", "name", "123456ABCD"));
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", null, "123456ABCD"));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "", "123456ABCD"));
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", "name", null));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "name", ""));
+            }
+        }
+
         public class TheCreateMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -37,6 +37,33 @@ namespace Octokit.Tests
             }
         }
         
+        public class TheGetRecursiveMethod
+        {
+            [Fact]
+            public void GetsFromClientIssueIssue()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableTreesClient(gitHubClient);
+
+                client.GetRecursive("fake", "repo", "123456ABCD");
+
+                gitHubClient.GitDatabase.Tree.Received().GetRecursive("fake", "repo", "123456ABCD");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableTreesClient(Substitute.For<IGitHubClient>());
+
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive(null, "name", "123456ABCD"));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("", "name", "123456ABCD"));
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", null, "123456ABCD"));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "", "123456ABCD"));
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", "name", null));
+                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "name", ""));
+            }
+        }
+        
         public class TheCreateMethod
         {
             [Fact]

--- a/Octokit/Clients/ITreesClient.cs
+++ b/Octokit/Clients/ITreesClient.cs
@@ -24,6 +24,18 @@ namespace Octokit
         Task<TreeResponse> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a Tree Response for a given SHA.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/git/trees/#get-a-tree-recursively
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The SHA that references the tree</param>
+        /// <returns>The <see cref="TreeResponse"/> for the specified Tree.</returns>
+        Task<TreeResponse> GetRecursive(string owner, string name, string reference);
+
+        /// <summary>
         /// Creates a new Tree in the specified repo
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/TreesClient.cs
+++ b/Octokit/Clients/TreesClient.cs
@@ -41,6 +41,25 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a Tree Response for a given SHA.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/git/trees/#get-a-tree-recursively
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The SHA that references the tree</param>
+        /// <returns>The <see cref="TreeResponse"/> for the specified Tree.</returns>
+        public Task<TreeResponse> GetRecursive(string owner, string name, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<TreeResponse>(ApiUrls.TreeRecursive(owner, name, reference));
+        }
+
+        /// <summary>
         /// Creates a new Tree in the specified repo
         /// </summary>
         /// <remarks>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1034,6 +1034,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for the specified tree.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The tree reference (SHA)</param>
+        /// <returns></returns>
+        public static Uri TreeRecursive(string owner, string name, string reference)
+        {
+            return "repos/{0}/{1}/git/trees/{2}?recursive=1".FormatUri(owner, name, reference);
+        }
+
+        /// <summary>
         /// returns the <see cref="Uri"/> for org teams 
         /// use for both Get and Create methods
         /// </summary>


### PR DESCRIPTION
Initially I implemented this as an optional boolean parameter on `TreeClient.Get` that would append `?recursive=1` to the end of the URI.  Unfortunately, code analysis complained about that (optional parameters) so I went with a set of new overloads instead.

Let me know if a different approach is preferred for adding optional query string parameters to API methods or if this is the preferred solution.  The problem with this solution is that it doesn't scale out well with multiple optional parameters.