### PR TITLE
Adds truncated attribute to TreeResponse.

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -203,6 +203,19 @@ namespace Octokit.Tests
 
                 Assert.Equal("blah", result.Links);
             }
+
+            [Fact]
+            public void DefaultsMissingParameters()
+            {
+                const string json = @"{""private"":true}";
+
+                var sample = new SimpleJsonSerializer().Deserialize<Sample>(json);
+
+                Assert.Equal(0, sample.Id);
+                Assert.Equal(null, sample.FirstName);
+                Assert.False(sample.IsSomething);
+                Assert.True(sample.Private);
+            }
         }
 
         public class Sample

--- a/Octokit/Models/Response/TreeResponse.cs
+++ b/Octokit/Models/Response/TreeResponse.cs
@@ -24,6 +24,11 @@ namespace Octokit
         /// </summary>
         public IReadOnlyList<TreeItem> Tree { get; protected set; }
 
+        /// <summary>
+        /// Whether the response was truncated due to GitHub API limits.
+        /// </summary>
+        public bool Truncated { get; protected set; }
+
         internal string DebuggerDisplay
         {
             get


### PR DESCRIPTION
See https://developer.github.com/v3/git/trees/#get-a-tree for details on the truncated attribute.

I am operating under the assumption that if a property is missing from the json object then the property will be set to its default value (false in this case).

I'm not sure how to test this.  If someone can point me at some existing tests that validate the json deserializer behaves correctly in certain scenarios (like when the property is missing) I can add some test coverage.  Though, if using an off-the-shelf deserializer then perhaps that wouldn't be testing anything meaningful in the library.