### PR TITLE
less parallelism, less upset

### DIFF
--- a/Octokit.Tests.Integration/Properties/AssemblyInfo.cs
+++ b/Octokit.Tests.Integration/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -37,3 +38,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Prevent the default behaviour of running each test class in parallel for now.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
This is a fix that @ammeep found a few days ago for the VS test runner parallelizing all tests by default.

I've applied this to the integration tests only, as everything else has been fine. 

And here's what it looks like running non-integration tests from VS2013:

```
------ Run test started ------
[xUnit.net 00:00:00.0000040] Execution started
[xUnit.net 00:00:00.0022132] Settings: MaxParallelThreads = 0, NameDisplay = Short, ParallelizeAssemblies = False, ParallelizeTestCollections = True, ShutdownAfterRun = False
[xUnit.net 00:00:00.0053948] Discovery started
[xUnit.net 00:00:00.1806443] Discovery starting: Octokit.Tests.Conventions.dll
[xUnit.net 00:00:03.3871694] Discovery finished: Octokit.Tests.Conventions.dll (272 tests)
[xUnit.net 00:00:03.6478859] Discovery starting: Octokit.Tests.dll
[xUnit.net 00:00:16.1548200] Discovery finished: Octokit.Tests.dll (1044 tests)
[xUnit.net 00:00:16.7834971] Discovery starting: Octokit.Tests-NetCore45.dll
[xUnit.net 00:00:26.5953524] Discovery finished: Octokit.Tests-NetCore45.dll (825 tests)
[xUnit.net 00:00:27.1042509] Discovery starting: Octokit.Tests-Portable.dll
[xUnit.net 00:00:36.7624797] Discovery finished: Octokit.Tests-Portable.dll (825 tests)
[xUnit.net 00:00:37.0377275] Discovery complete
[xUnit.net 00:00:37.0377275] Execution starting: Octokit.Tests.Conventions.dll
[xUnit.net 00:00:37.0377275] Execution finished: Octokit.Tests.Conventions.dll
[xUnit.net 00:00:37.0377275] Execution starting: Octokit.Tests.dll
[xUnit.net 00:00:37.0377275] Execution finished: Octokit.Tests.dll
[xUnit.net 00:00:37.0377275] Execution starting: Octokit.Tests-NetCore45.dll
[xUnit.net 00:00:37.0377275] Execution finished: Octokit.Tests-NetCore45.dll
[xUnit.net 00:00:37.0377275] Execution starting: Octokit.Tests-Portable.dll
[xUnit.net 00:00:37.0377275] Execution finished: Octokit.Tests-Portable.dll
[xUnit.net 00:00:37.0377275] Execution complete
========== Run test finished: 2966 run (0:01:55.2127698) ==========
```