### PR TITLE
Creates constructors for all Models.Response.

### DIFF
--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -146,10 +146,7 @@ public class ReleasesClientTests
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
-            var newAsset = new ReleaseAssetUpload
-            {
-                ContentType = "text/plain", FileName = "hello-world.txt", RawData = stream
-            };
+            var newAsset = new ReleaseAssetUpload("hello-world.txt", "text/plain", stream, null);
 
             var result = await _releaseClient.UploadAsset(release, newAsset);
 
@@ -172,12 +169,7 @@ public class ReleasesClientTests
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
-            var newAsset = new ReleaseAssetUpload
-            {
-                ContentType = "text/plain",
-                FileName = "hello-world.txt",
-                RawData = stream
-            };
+            var newAsset = new ReleaseAssetUpload("hello-world.txt", "text/plain", stream, null);
 
             var result = await _releaseClient.UploadAsset(release, newAsset);
             var asset = await _releaseClient.GetAsset(_repositoryOwner, _repositoryName, result.Id);
@@ -198,12 +190,7 @@ public class ReleasesClientTests
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
-            var newAsset = new ReleaseAssetUpload
-            {
-                ContentType = "text/plain",
-                FileName = "hello-world.txt",
-                RawData = stream
-            };
+            var newAsset = new ReleaseAssetUpload("hello-world.txt", "text/plain", stream, null);
 
             var result = await _releaseClient.UploadAsset(release, newAsset);
 

--- a/Octokit.Tests/Clients/OauthClientTests.cs
+++ b/Octokit.Tests/Clients/OauthClientTests.cs
@@ -54,7 +54,7 @@ public class OauthClientTests
         [Fact]
         public async Task PostsWithCorrectBodyAndContentType()
         {
-            var responseToken = new OauthToken();
+            var responseToken = new OauthToken(null, null, null);
             var response = Substitute.For<IResponse<OauthToken>>();
             response.BodyAsObject.Returns(responseToken);
             var connection = Substitute.For<IConnection>();

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -181,7 +181,7 @@ namespace Octokit.Tests.Clients
                 var releasesClient = new ReleasesClient(client);
                 var release = new Release("https://uploads.test.dev/does/not/matter/releases/1/assets{?name}");
                 var rawData = Substitute.For<Stream>();
-                var upload = new ReleaseAssetUpload { FileName = "example.zip", ContentType = "application/zip", RawData = rawData };
+                var upload = new ReleaseAssetUpload("example.zip", "application/zip", rawData, null);
 
                 releasesClient.UploadAsset(release, upload);
 
@@ -198,7 +198,7 @@ namespace Octokit.Tests.Clients
                 var releasesClient = new ReleasesClient(Substitute.For<IApiConnection>());
 
                 var release = new Release("https://uploads.github.com/anything");
-                var uploadData = new ReleaseAssetUpload { FileName = "good", ContentType = "good/good", RawData = Stream.Null };
+                var uploadData = new ReleaseAssetUpload("good", "good/good", Stream.Null, null);
                 await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.UploadAsset(null, uploadData));
                 await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.UploadAsset(release, null));
             }
@@ -213,7 +213,7 @@ namespace Octokit.Tests.Clients
                 var fixture = new ReleasesClient(apiConnection);
 
                 var release = new Release("https://uploads.github.com/anything");
-                var uploadData = new ReleaseAssetUpload { FileName = "good", ContentType = "good/good", RawData = Stream.Null, Timeout = newTimeout };
+                var uploadData = new ReleaseAssetUpload("good", "good/good", Stream.Null, newTimeout);
 
                 await fixture.UploadAsset(release, uploadData);
 

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -14,14 +14,12 @@ namespace Octokit.Tests.Clients
             public async Task ReturnsReadme()
             {
                 string encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
-                var readmeInfo = new ReadmeResponse
-                {
-                    Content = encodedContent,
-                    Encoding = "base64",
-                    Name = "README.md",
-                    Url = "https://github.example.com/readme.md",
-                    HtmlUrl = "https://github.example.com/readme"
-                };
+                var readmeInfo = new ReadmeResponse(
+                    encodedContent,
+                    "README.md",
+                    "https://github.example.com/readme",
+                    "https://github.example.com/readme.md",
+                    "base64");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Get<ReadmeResponse>(Args.Uri, null).Returns(Task.FromResult(readmeInfo));
                 connection.GetHtml(Args.Uri, null).Returns(Task.FromResult("<html>README</html>"));

--- a/Octokit.Tests/Clients/WatchedClientTests.cs
+++ b/Octokit.Tests/Clients/WatchedClientTests.cs
@@ -63,7 +63,7 @@ namespace Octokit.Tests.Clients
                 var endpoint = new Uri("repos/fight/club/subscription", UriKind.Relative);
 
                 var connection = Substitute.For<IApiConnection>();
-                connection.Get<Subscription>(endpoint).Returns(Task.FromResult(new Subscription()));
+                connection.Get<Subscription>(endpoint).Returns(Task.FromResult(new Subscription(false, false, null, default(DateTimeOffset), null, null)));
 
                 var client = new WatchedClient(connection);
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -277,7 +277,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task FetchesAllCommitsForPullRequest()
             {
-                var commit = new PullRequestCommit();
+                var commit = new PullRequestCommit(null, null, null, null, null, null, null, null);
                 var expectedUrl = string.Format("repos/fake/repo/pulls/42/commits");
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var connection = Substitute.For<IConnection>();

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -182,7 +182,7 @@ namespace Octokit.Tests.Reactive
                 var releasesClient = new ObservableReleasesClient(gitHubClient);
                 var release = new Release("https://uploads.test.dev/does/not/matter/releases/1/assets{?name}");
                 var rawData = Substitute.For<Stream>();
-                var upload = new ReleaseAssetUpload { FileName = "example.zip", ContentType = "application/zip", RawData = rawData };
+                var upload = new ReleaseAssetUpload("example.zip", "application/zip", rawData, null);
 
                 releasesClient.UploadAsset(release, upload);
 
@@ -195,7 +195,7 @@ namespace Octokit.Tests.Reactive
                 var releasesClient = new ObservableReleasesClient(Substitute.For<IGitHubClient>());
 
                 var release = new Release("https://uploads.github.com/anything");
-                var uploadData = new ReleaseAssetUpload { FileName = "good", ContentType = "good/good", RawData = Stream.Null };
+                var uploadData = new ReleaseAssetUpload("good", "good/good", Stream.Null, null);
 
                 Assert.Throws<ArgumentNullException>(() => releasesClient.UploadAsset(null, uploadData));
                 Assert.Throws<ArgumentNullException>(() => releasesClient.UploadAsset(release, null));

--- a/Octokit.ruleset
+++ b/Octokit.ruleset
@@ -8,5 +8,6 @@
     <Rule Id="CA1056" Action="None" />
     <Rule Id="CA1726" Action="None" />
     <Rule Id="CA2210" Action="None" />
+    <Rule Id="CA1054" Action="None" />
   </Rules>
 </RuleSet>

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -7,6 +7,35 @@ namespace Octokit
     /// </summary>
     public abstract class Account
     {
+        protected Account() { }
+
+        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url)
+        {
+            AvatarUrl = avatarUrl;
+            Bio = bio;
+            Blog = blog;
+            Collaborators = collaborators;
+            Company = company;
+            CreatedAt = createdAt;
+            DiskUsage = diskUsage;
+            Email = email;
+            Followers = followers;
+            Following = following;
+            Hireable = hireable;
+            HtmlUrl = htmlUrl;
+            TotalPrivateRepos = totalPrivateRepos;
+            Id = id;
+            Location = location;
+            Login = login;
+            Name = name;
+            OwnedPrivateRepos = ownedPrivateRepos;
+            Plan = plan;
+            PrivateGists = privateGists;
+            PublicGists = publicGists;
+            PublicRepos = publicRepos;
+            Url = url;
+        }
+
         /// <summary>
         /// URL of the account's avatar.
         /// </summary>

--- a/Octokit/Models/Response/Activity.cs
+++ b/Octokit/Models/Response/Activity.cs
@@ -11,6 +11,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Activity
     {
+        public Activity() { }
+
+        public Activity(string type, bool @public, Repository repo, User actor, Organization org, DateTimeOffset createdAt, string id)
+        {
+            Type = type;
+            Public = @public;
+            Repo = repo;
+            Actor = actor;
+            Org = org;
+            CreatedAt = createdAt;
+            Id = id;
+        }
+
         /// <summary>
         /// The type of the activity.
         /// </summary>

--- a/Octokit/Models/Response/AdditionsAndDeletions.cs
+++ b/Octokit/Models/Response/AdditionsAndDeletions.cs
@@ -12,6 +12,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class AdditionsAndDeletions
     {
+        public AdditionsAndDeletions() { }
+
+        public AdditionsAndDeletions(DateTimeOffset timestamp, int additions, int deletions)
+        {
+            Timestamp = timestamp;
+            Additions = additions;
+            Deletions = deletions;
+        }
+
         /// <summary>
         /// Construct an instance of AdditionsAndDeletions
         /// </summary>

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -11,13 +11,18 @@ namespace Octokit
 #endif
     public class ApiError
     {
-        public ApiError()
-        {
-        }
+        public ApiError() { }
 
         public ApiError(string message)
         {
             Message = message;
+        }
+
+        public ApiError(string message, string documentationUrl, IReadOnlyList<ApiErrorDetail> errors)
+        {
+            Message = message;
+            DocumentationUrl = documentationUrl;
+            Errors = errors;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/ApiErrorDetail.cs
+++ b/Octokit/Models/Response/ApiErrorDetail.cs
@@ -7,6 +7,16 @@ namespace Octokit
 #endif
     public class ApiErrorDetail
     {
+        public ApiErrorDetail() { }
+
+        public ApiErrorDetail(string message, string code, string field, string resource)
+        {
+            Message = message;
+            Code = code;
+            Field = field;
+            Resource = resource;
+        }
+
         public string Message { get; protected set; }
 
         public string Code { get; protected set; }

--- a/Octokit/Models/Response/Application.cs
+++ b/Octokit/Models/Response/Application.cs
@@ -10,6 +10,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Application
     {
+        public Application() { }
+
+        public Application(string name, string url)
+        {
+            Name = name;
+            Url = url;
+        }
+
         /// <summary>
         /// <see cref="Application"/> Name.
         /// </summary>

--- a/Octokit/Models/Response/Author.cs
+++ b/Octokit/Models/Response/Author.cs
@@ -8,20 +8,33 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Author
     {
+        public Author() { }
+
+        public Author(string login, int id, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
+        {
+            Login = login;
+            Id = id;
+            AvatarUrl = avatarUrl;
+            Url = url;
+            HtmlUrl = htmlUrl;
+            FollowersUrl = followersUrl;
+            FollowingUrl = followingUrl;
+            GistsUrl = gistsUrl;
+            Type = type;
+            StarredUrl = starredUrl;
+            SubscriptionsUrl = subscriptionsUrl;
+            OrganizationsUrl = organizationsUrl;
+            ReposUrl = reposUrl;
+            EventsUrl = eventsUrl;
+            ReceivedEventsUrl = receivedEventsUrl;
+            SiteAdmin = siteAdmin;
+        }
+
         public string Login { get; protected set; }
 
         public int Id { get; protected set; }
 
         public string AvatarUrl { get; protected set; }
-
-        /// <summary>
-        /// Hex Gravatar identifier, now obsolete
-        /// </summary>
-        /// <remarks>
-        /// For more details: https://developer.github.com/changes/2014-09-05-removing-gravatar-id/
-        /// </remarks>
-        [Obsolete("This property is now obsolete, use AvatarUrl instead")]
-        public string GravatarId { get; protected set; }
 
         public string Url { get; protected set; }
 

--- a/Octokit/Models/Response/Authorization.cs
+++ b/Octokit/Models/Response/Authorization.cs
@@ -11,14 +11,25 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Authorization
     {
-        public Authorization()
-        {
-        }
+        public Authorization() { }
 
         public Authorization(string token)
         {
             Ensure.ArgumentNotNullOrEmptyString(token, "token");
             Token = token;
+        }
+
+        public Authorization(int id, string url, Application application, string token, string note, string noteUrl, DateTimeOffset createdAt, DateTimeOffset updateAt, string[] scopes)
+        {
+            Id = id;
+            Url = url;
+            Application = application;
+            Token = token;
+            Note = note;
+            NoteUrl = noteUrl;
+            CreatedAt = createdAt;
+            UpdateAt = updateAt;
+            Scopes = scopes;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/Blob.cs
+++ b/Octokit/Models/Response/Blob.cs
@@ -7,6 +7,16 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Blob
     {
+        public Blob() { }
+
+        public Blob(string content, EncodingType encoding, string sha, int size)
+        {
+            Content = content;
+            Encoding = encoding;
+            Sha = sha;
+            Size = size;
+        }
+
         /// <summary>
         /// The content of the blob.
         /// </summary>

--- a/Octokit/Models/Response/BlobReference.cs
+++ b/Octokit/Models/Response/BlobReference.cs
@@ -7,6 +7,13 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class BlobReference
     {
+        public BlobReference() { }
+
+        public BlobReference(string sha)
+        {
+            Sha = sha;
+        }
+
         /// <summary>
         /// The SHA of the blob.
         /// </summary>

--- a/Octokit/Models/Response/Branch.cs
+++ b/Octokit/Models/Response/Branch.cs
@@ -7,6 +7,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Branch
     {
+        public Branch() { }
+
+        public Branch(string name, GitReference commit)
+        {
+            Name = name;
+            Commit = commit;
+        }
+
         /// <summary>
         /// Name of this <see cref="Branch"/>.
         /// </summary>

--- a/Octokit/Models/Response/CodeFrequency.cs
+++ b/Octokit/Models/Response/CodeFrequency.cs
@@ -12,6 +12,13 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CodeFrequency
     {
+        public CodeFrequency() { }
+
+        public CodeFrequency(IEnumerable<AdditionsAndDeletions> additionsAndDeletionsByWeek)
+        {
+            AdditionsAndDeletionsByWeek = additionsAndDeletionsByWeek;
+        }
+
         /// <summary>
         /// Construct an instance of CodeFrequency
         /// </summary>

--- a/Octokit/Models/Response/CombinedCommitStatus.cs
+++ b/Octokit/Models/Response/CombinedCommitStatus.cs
@@ -7,6 +7,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CombinedCommitStatus
     {
+        public CombinedCommitStatus() { }
+
+        public CombinedCommitStatus(CommitState state, string sha, int totalCount, IReadOnlyList<CommitStatus> statuses, Repository repository)
+        {
+            State = state;
+            Sha = sha;
+            TotalCount = totalCount;
+            Statuses = statuses;
+            Repository = repository;
+        }
+
         /// <summary>
         /// The combined state of the commits.
         /// </summary>

--- a/Octokit/Models/Response/Commit.cs
+++ b/Octokit/Models/Response/Commit.cs
@@ -6,6 +6,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Commit : GitReference
     {
+        public Commit() { }
+
+        public Commit(string url, string label, string @ref, string sha, User user, Repository repository, string message, SignatureResponse author, SignatureResponse committer, GitReference tree, IEnumerable<GitReference> parents, int commentCount)
+            : base(url, label, @ref, sha, user, repository)
+        {
+            Message = message;
+            Author = author;
+            Committer = committer;
+            Tree = tree;
+            Parents = parents;
+            CommentCount = commentCount;
+        }
+
         public string Message { get; protected set; }
 
         public SignatureResponse Author { get; protected set; }

--- a/Octokit/Models/Response/CommitActivity.cs
+++ b/Octokit/Models/Response/CommitActivity.cs
@@ -9,6 +9,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CommitActivity
     {
+        public CommitActivity() { }
+
         public CommitActivity(IEnumerable<WeeklyCommitActivity> activity)
         {
             Activity = activity;

--- a/Octokit/Models/Response/CommitComment.cs
+++ b/Octokit/Models/Response/CommitComment.cs
@@ -11,6 +11,23 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]    
     public class CommitComment
     {
+        public CommitComment() { }
+
+        public CommitComment(int id, Uri url, Uri htmlUrl, string body, string path, int position, int? line, string commitId, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        {
+            Id = id;
+            Url = url;
+            HtmlUrl = htmlUrl;
+            Body = body;
+            Path = path;
+            Position = position;
+            Line = line;
+            CommitId = commitId;
+            User = user;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+        }
+
         /// <summary>
         /// The issue comment Id.
         /// </summary>

--- a/Octokit/Models/Response/CommitContent.cs
+++ b/Octokit/Models/Response/CommitContent.cs
@@ -11,6 +11,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryContentInfo
     {
+        public RepositoryContentInfo() { }
+
+        public RepositoryContentInfo(string name, string path, string sha, int size, ContentType type, Uri downloadUrl, Uri url, Uri gitUrl, Uri htmlUrl)
+        {
+            Name = name;
+            Path = path;
+            Sha = sha;
+            Size = size;
+            Type = type;
+            DownloadUrl = downloadUrl;
+            Url = url;
+            GitUrl = gitUrl;
+            HtmlUrl = htmlUrl;
+        }
+
         /// <summary>
         /// Name of the content.
         /// </summary>

--- a/Octokit/Models/Response/CommitStatus.cs
+++ b/Octokit/Models/Response/CommitStatus.cs
@@ -7,6 +7,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CommitStatus
     {
+        public CommitStatus() { }
+
+        public CommitStatus(DateTimeOffset createdAt, DateTimeOffset updatedAt, CommitState state, Uri targetUrl, string description, string context, int id, Uri url, User creator)
+        {
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            State = state;
+            TargetUrl = targetUrl;
+            Description = description;
+            Context = context;
+            Id = id;
+            Url = url;
+            Creator = creator;
+        }
+
         /// <summary>
         /// The date the commit status was created.
         /// </summary>

--- a/Octokit/Models/Response/CompareResult.cs
+++ b/Octokit/Models/Response/CompareResult.cs
@@ -8,6 +8,24 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CompareResult
     {
+        public CompareResult() { }
+
+        public CompareResult(string url, string htmlUrl, string permalinkUrl, string diffUrl, string patchUrl, GitHubCommit baseCommit, GitHubCommit mergedBaseCommit, string status, int aheadBy, int behindBy, int totalCommits, IReadOnlyList<GitHubCommit> commits)
+        {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            PermalinkUrl = permalinkUrl;
+            DiffUrl = diffUrl;
+            PatchUrl = patchUrl;
+            BaseCommit = baseCommit;
+            MergedBaseCommit = mergedBaseCommit;
+            Status = status;
+            AheadBy = aheadBy;
+            BehindBy = behindBy;
+            TotalCommits = totalCommits;
+            Commits = commits;
+        }
+
         public string Url { get; protected set; }
         public string HtmlUrl { get; protected set; }
         public string PermalinkUrl { get; protected set; }

--- a/Octokit/Models/Response/Contributor.cs
+++ b/Octokit/Models/Response/Contributor.cs
@@ -11,6 +11,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Contributor
     {
+        public Contributor() { }
+
+        public Contributor(Author author, int total, IReadOnlyList<WeeklyHash> weeks)
+        {
+            Author = author;
+            Total = total;
+            Weeks = weeks;
+        }
+
         public Author Author { get; protected set; }
 
         public int Total { get; protected set; }

--- a/Octokit/Models/Response/DeployKey.cs
+++ b/Octokit/Models/Response/DeployKey.cs
@@ -11,6 +11,16 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class DeployKey
     {
+        public DeployKey() { }
+
+        public DeployKey(int id, string key, string url, string title)
+        {
+            Id = id;
+            Key = key;
+            Url = url;
+            Title = title;
+        }
+
         public int Id { get; protected set; } 
         public string Key { get; protected set; }
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -11,6 +11,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Deployment
     {
+        public Deployment() { }
+
+        public Deployment(int id, string sha, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl)
+        {
+            Id = id;
+            Sha = sha;
+            Url = url;
+            Creator = creator;
+            Payload = payload;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Description = description;
+            StatusesUrl = statusesUrl;
+        }
+
         /// <summary>
         /// Id of this deployment.
         /// </summary>

--- a/Octokit/Models/Response/DeploymentStatus.cs
+++ b/Octokit/Models/Response/DeploymentStatus.cs
@@ -8,6 +8,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class DeploymentStatus
     {
+        public DeploymentStatus() { }
+
+        public DeploymentStatus(int id, string url, DeploymentState state, User creator, IReadOnlyDictionary<string, string> payload, string targetUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description)
+        {
+            Id = id;
+            Url = url;
+            State = state;
+            Creator = creator;
+            Payload = payload;
+            TargetUrl = targetUrl;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Description = description;
+        }
+
         /// <summary>
         /// Id of this deployment status.
         /// </summary>

--- a/Octokit/Models/Response/EmailAddress.cs
+++ b/Octokit/Models/Response/EmailAddress.cs
@@ -11,6 +11,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class EmailAddress
     {
+        public EmailAddress() { }
+
+        public EmailAddress(string email, bool verified, bool primary)
+        {
+            Email = email;
+            Verified = verified;
+            Primary = primary;
+        }
+
         /// <summary>
         /// The email address
         /// </summary>

--- a/Octokit/Models/Response/Emoji.cs
+++ b/Octokit/Models/Response/Emoji.cs
@@ -7,6 +7,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Emoji
     {
+        public Emoji() { }
+
         public Emoji(string name, Uri url)
         {
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -8,6 +8,20 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class EventInfo
     {
+        public EventInfo() { }
+
+        public EventInfo(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt)
+        {
+            Id = id;
+            Url = url;
+            Actor = actor;
+            Assignee = assignee;
+            Label = label;
+            Event = @event;
+            CommitId = commitId;
+            CreatedAt = createdAt;
+        }
+
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>

--- a/Octokit/Models/Response/Feed.cs
+++ b/Octokit/Models/Response/Feed.cs
@@ -13,6 +13,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Feed
     {
+        public Feed() { }
+
+        public Feed(string timelineUrl, string userUrl, string currentUserPublicUrl, string currentUserUrl, string currentUserActorUrl, string currentUserOrganizationUrl, FeedLinks links)
+        {
+            TimelineUrl = timelineUrl;
+            UserUrl = userUrl;
+            CurrentUserPublicUrl = currentUserPublicUrl;
+            CurrentUserUrl = currentUserUrl;
+            CurrentUserActorUrl = currentUserActorUrl;
+            CurrentUserOrganizationUrl = currentUserOrganizationUrl;
+            Links = links;
+        }
+
         /// <summary>
         /// The GitHub global public timeline
         /// </summary>

--- a/Octokit/Models/Response/FeedLink.cs
+++ b/Octokit/Models/Response/FeedLink.cs
@@ -10,6 +10,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class FeedLinks
     {
+        public FeedLinks() { }
+
+        public FeedLinks(FeedLink timeline, FeedLink user, FeedLink currentUserPublic, FeedLink currentUser, FeedLink currentUserActor, FeedLink currentUserOrganization)
+        {
+            Timeline = timeline;
+            User = user;
+            CurrentUserPublic = currentUserPublic;
+            CurrentUser = currentUser;
+            CurrentUserActor = currentUserActor;
+            CurrentUserOrganization = currentUserOrganization;
+        }
+
         /// <summary>
         /// The GitHub global public timeline
         /// </summary>
@@ -52,6 +64,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class FeedLink
     {
+        public FeedLink() { }
+
+        public FeedLink(string href, string type)
+        {
+            Href = href;
+            Type = type;
+        }
+
         /// <summary>
         /// Link to feed
         /// </summary>

--- a/Octokit/Models/Response/Gist.cs
+++ b/Octokit/Models/Response/Gist.cs
@@ -8,6 +8,27 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Gist
     {
+        public Gist() { }
+
+        public Gist(string url, string id, string description, bool @public, User owner, IReadOnlyDictionary<string, GistFile> files, int comments, string commentsUrl, string htmlUrl, string gitPullUrl, string gitPushUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, IReadOnlyList<GistFork> forks, IReadOnlyList<GistHistory> history)
+        {
+            Url = url;
+            Id = id;
+            Description = description;
+            Public = @public;
+            Owner = owner;
+            Files = files;
+            Comments = comments;
+            CommentsUrl = commentsUrl;
+            HtmlUrl = htmlUrl;
+            GitPullUrl = gitPullUrl;
+            GitPushUrl = gitPushUrl;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Forks = forks;
+            History = history;
+        }
+
         /// <summary>
         /// The API URL for this <see cref="Gist"/>.
         /// </summary>

--- a/Octokit/Models/Response/GistChangeStatus.cs
+++ b/Octokit/Models/Response/GistChangeStatus.cs
@@ -10,6 +10,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistChangeStatus
     {
+        public GistChangeStatus() { }
+
+        public GistChangeStatus(int deletions, int additions, int total)
+        {
+            Deletions = deletions;
+            Additions = additions;
+            Total = total;
+        }
+
         /// <summary>
         /// The number of deletions that occurred as part of this change.
         /// </summary>

--- a/Octokit/Models/Response/GistComment.cs
+++ b/Octokit/Models/Response/GistComment.cs
@@ -7,6 +7,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistComment
     {
+        public GistComment() { }
+
+        public GistComment(int id, Uri url, string body, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        {
+            Id = id;
+            Url = url;
+            Body = body;
+            User = user;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+        }
+
         /// <summary>
         /// The gist comment id.
         /// </summary>

--- a/Octokit/Models/Response/GistFile.cs
+++ b/Octokit/Models/Response/GistFile.cs
@@ -8,6 +8,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistFile
     {
+        public GistFile() { }
+
+        [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
+        public GistFile(int size, string filename, string type, string language, string content, string rawUrl)
+        {
+            Size = size;
+            Filename = filename;
+            Type = type;
+            Language = language;
+            Content = content;
+            RawUrl = rawUrl;
+        }
+
         /// <summary>
         /// The size in bytes of the file.
         /// </summary>

--- a/Octokit/Models/Response/GistFork.cs
+++ b/Octokit/Models/Response/GistFork.cs
@@ -7,6 +7,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistFork
     {
+        public GistFork() { }
+
+        public GistFork(User user, string url, DateTimeOffset createdAt)
+        {
+            User = user;
+            Url = url;
+            CreatedAt = createdAt;
+        }
+
         /// <summary>
         /// The <see cref="User"/> that created this <see cref="GistFork"/>
         /// </summary>

--- a/Octokit/Models/Response/GistHistory.cs
+++ b/Octokit/Models/Response/GistHistory.cs
@@ -10,6 +10,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistHistory
     {
+        public GistHistory() { }
+
+        public GistHistory(string url, string version, User user, GistChangeStatus changeStatus, DateTimeOffset committedAt)
+        {
+            Url = url;
+            Version = version;
+            User = user;
+            ChangeStatus = changeStatus;
+            CommittedAt = committedAt;
+        }
+
         /// <summary>
         /// The url that can be used by the API to retrieve this version of the <see cref="Gist"/>.
         /// </summary>

--- a/Octokit/Models/Response/GitHubCommit.cs
+++ b/Octokit/Models/Response/GitHubCommit.cs
@@ -9,6 +9,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GitHubCommit : GitReference
     {
+        public GitHubCommit() { }
+
+        public GitHubCommit(string url, string label, string @ref, string sha, User user, Repository repository, Author author, string commentsUrl, Commit commit, Author committer, string htmlUrl, GitHubCommitStats stats, IReadOnlyList<GitReference> parents, IReadOnlyList<GitHubCommitFile> files)
+            : base(url, label, @ref, sha, user, repository)
+        {
+            Author = author;
+            CommentsUrl = commentsUrl;
+            Commit = commit;
+            Committer = committer;
+            HtmlUrl = htmlUrl;
+            Stats = stats;
+            Parents = parents;
+            Files = files;
+        }
+
         public Author Author { get; protected set; }
 
         public string CommentsUrl { get; protected set; }

--- a/Octokit/Models/Response/GitHubCommitFile.cs
+++ b/Octokit/Models/Response/GitHubCommitFile.cs
@@ -11,6 +11,23 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GitHubCommitFile
     {
+        public GitHubCommitFile() { }
+
+        [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
+        public GitHubCommitFile(string filename, int additions, int deletions, int changes, string status, string blobUrl, string contentsUrl, string rawUrl, string sha, string patch)
+        {
+            Filename = filename;
+            Additions = additions;
+            Deletions = deletions;
+            Changes = changes;
+            Status = status;
+            BlobUrl = blobUrl;
+            ContentsUrl = contentsUrl;
+            RawUrl = rawUrl;
+            Sha = sha;
+            Patch = patch;
+        }
+
         /// <summary>
         /// The name of the file
         /// </summary>

--- a/Octokit/Models/Response/GitHubCommitStats.cs
+++ b/Octokit/Models/Response/GitHubCommitStats.cs
@@ -10,6 +10,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GitHubCommitStats
     {
+        public GitHubCommitStats() { }
+
+        public GitHubCommitStats(int additions, int deletions, int total)
+        {
+            Additions = additions;
+            Deletions = deletions;
+            Total = total;
+        }
+
         /// <summary>
         /// The number of additions made within the commit
         /// </summary>

--- a/Octokit/Models/Response/GitReference.cs
+++ b/Octokit/Models/Response/GitReference.cs
@@ -8,6 +8,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GitReference
     {
+        public GitReference() { }
+
+        public GitReference(string url, string label, string @ref, string sha, User user, Repository repository)
+        {
+            Url = url;
+            Label = label;
+            Ref = @ref;
+            Sha = sha;
+            User = user;
+            Repository = repository;
+        }
+
         /// <summary>
         /// The URL associated with this reference.
         /// </summary>

--- a/Octokit/Models/Response/GitTag.cs
+++ b/Octokit/Models/Response/GitTag.cs
@@ -5,6 +5,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GitTag : GitReference
     {
+        public GitTag() { }
+
+        public GitTag(string url, string label, string @ref, string sha, User user, Repository repository, string tag, string message, SignatureResponse tagger, TagObject objectVar)
+            : base(url, label, @ref, sha, user, repository)
+        {
+            Tag = tag;
+            Message = message;
+            Tagger = tagger;
+            Object = objectVar;
+        }
+
         public string Tag { get; protected set; }
 
         public string Message { get; protected set; }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -10,6 +10,27 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Issue
     {
+        public Issue() { }
+
+        public Issue(Uri url, Uri htmlUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            Number = number;
+            State = state;
+            Title = title;
+            Body = body;
+            User = user;
+            Labels = labels;
+            Assignee = assignee;
+            Milestone = milestone;
+            Comments = comments;
+            PullRequest = pullRequest;
+            ClosedAt = closedAt;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+        }
+
         /// <summary>
         /// The URL for this milestone.
         /// </summary>

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -7,6 +7,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueComment
     {
+        public IssueComment() { }
+
+        public IssueComment(int id, Uri url, Uri htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user)
+        {
+            Id = id;
+            Url = url;
+            HtmlUrl = htmlUrl;
+            Body = body;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            User = user;
+        }
+
         /// <summary>
         /// The issue comment Id.
         /// </summary>

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -7,6 +7,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueEvent
     {
+        public IssueEvent() { }
+
+        public IssueEvent(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue)
+        {
+            Id = id;
+            Url = url;
+            Actor = actor;
+            Assignee = assignee;
+            Label = label;
+            Event = @event;
+            CommitId = commitId;
+            CreatedAt = createdAt;
+            Issue = issue;
+        }
+
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>

--- a/Octokit/Models/Response/Label.cs
+++ b/Octokit/Models/Response/Label.cs
@@ -7,6 +7,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Label
     {
+        public Label() { }
+
+        public Label(Uri url, string name, string color)
+        {
+            Url = url;
+            Name = name;
+            Color = color;
+        }
+
         /// <summary>
         /// Url of the label
         /// </summary>

--- a/Octokit/Models/Response/Milestone.cs
+++ b/Octokit/Models/Response/Milestone.cs
@@ -7,13 +7,25 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Milestone
     {
-        public Milestone()
-        {
-        }
+        public Milestone() { }
 
         public Milestone(int number)
         {
             Number = number;
+        }
+
+        public Milestone(Uri url, int number, ItemState state, string title, string description, User creator, int openIssues, int closedIssues, DateTimeOffset createdAt, DateTimeOffset? dueOn)
+        {
+            Url = url;
+            Number = number;
+            State = state;
+            Title = title;
+            Description = description;
+            Creator = creator;
+            OpenIssues = openIssues;
+            ClosedIssues = closedIssues;
+            CreatedAt = createdAt;
+            DueOn = dueOn;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/Notification.cs
+++ b/Octokit/Models/Response/Notification.cs
@@ -7,6 +7,20 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Notification
     {
+        public Notification() { }
+
+        public Notification(string id, Repository repository, NotificationInfo subject, string reason, bool unread, string updatedAt, string lastReadAt, string url)
+        {
+            Id = id;
+            Repository = repository;
+            Subject = subject;
+            Reason = reason;
+            Unread = unread;
+            UpdatedAt = updatedAt;
+            LastReadAt = lastReadAt;
+            Url = url;
+        }
+
         public string Id { get; protected set; } // NB: API currently returns this as string which is Weird
 
         public Repository Repository { get; protected set; }

--- a/Octokit/Models/Response/NotificationInfo.cs
+++ b/Octokit/Models/Response/NotificationInfo.cs
@@ -8,6 +8,16 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NotificationInfo
     {
+        public NotificationInfo() { }
+
+        public NotificationInfo(string title, string url, string latestCommentUrl, string type)
+        {
+            Title = title;
+            Url = url;
+            LatestCommentUrl = latestCommentUrl;
+            Type = type;
+        }
+
         public string Title { get; protected set; }
 
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/OauthToken.cs
+++ b/Octokit/Models/Response/OauthToken.cs
@@ -8,6 +8,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class OauthToken
     {
+        public OauthToken() { }
+
+        public OauthToken(string tokenType, string accessToken, IReadOnlyList<string> scope)
+        {
+            TokenType = tokenType;
+            AccessToken = accessToken;
+            Scope = scope;
+        }
+
         /// <summary>
         /// The type of OAuth token
         /// </summary>

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -7,6 +7,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Organization : Account
     {
+        public Organization() { }
+
+        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, url)
+        {
+            BillingAddress = billingAddress;
+        }
+
         /// <summary>
         /// The billing address for an organization. This is only returned when updating 
         /// an organization.

--- a/Octokit/Models/Response/Participation.cs
+++ b/Octokit/Models/Response/Participation.cs
@@ -12,6 +12,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Participation
     {
+        public Participation() { }
+
+        public Participation(IEnumerable<int> all, IEnumerable<int> owner)
+        {
+            All = all;
+            Owner = owner;
+        }
+
         /// <summary>
         /// Returns the commit counts made each week, for the last 52 weeks
         /// </summary>

--- a/Octokit/Models/Response/Plan.cs
+++ b/Octokit/Models/Response/Plan.cs
@@ -10,6 +10,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Plan
     {
+        public Plan() { }
+
+        public Plan(long collaborators, string name, long privateRepos, long space, string billingEmail)
+        {
+            Collaborators = collaborators;
+            Name = name;
+            PrivateRepos = privateRepos;
+            Space = space;
+            BillingEmail = billingEmail;
+        }
+
         /// <summary>
         /// The number of collaborators allowed with this plan.
         /// </summary>

--- a/Octokit/Models/Response/PublicKey.cs
+++ b/Octokit/Models/Response/PublicKey.cs
@@ -7,6 +7,16 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PublicKey
     {
+        public PublicKey() { }
+
+        public PublicKey(int id, string key, string url, string title)
+        {
+            Id = id;
+            Key = key;
+            Url = url;
+            Title = title;
+        }
+
         public int Id { get; protected set; }
 
         public string Key { get; protected set; }

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -7,13 +7,41 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequest
     {
-        public PullRequest()
-        {
-        }
+        public PullRequest() { }
 
         public PullRequest(int number)
         {
             Number = number;
+        }
+
+        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, string mergeCommitSha, bool merged, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles)
+        {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            DiffUrl = diffUrl;
+            PatchUrl = patchUrl;
+            IssueUrl = issueUrl;
+            StatusesUrl = statusesUrl;
+            Number = number;
+            State = state;
+            Title = title;
+            Body = body;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            ClosedAt = closedAt;
+            MergedAt = mergedAt;
+            Head = head;
+            Base = @base;
+            User = user;
+            MergeCommitSha = mergeCommitSha;
+            Merged = merged;
+            Mergeable = mergeable;
+            MergedBy = mergedBy;
+            Comments = comments;
+            Commits = commits;
+            Additions = additions;
+            Deletions = deletions;
+            ChangedFiles = changedFiles;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/PullRequestCommit.cs
+++ b/Octokit/Models/Response/PullRequestCommit.cs
@@ -8,6 +8,20 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestCommit
     {
+        public PullRequestCommit() { }
+
+        public PullRequestCommit(SignatureResponse author, Uri commentsUrl, Commit commit, SignatureResponse committer, Uri htmlUrl, IEnumerable<GitReference> parents, string sha, Uri url)
+        {
+            Author = author;
+            CommentsUrl = commentsUrl;
+            Commit = commit;
+            Committer = committer;
+            HtmlUrl = htmlUrl;
+            Parents = parents;
+            Sha = sha;
+            Url = url;
+        }
+
         public SignatureResponse Author { get; protected set; }
 
         public Uri CommentsUrl { get; protected set; }

--- a/Octokit/Models/Response/PullRequestMerge.cs
+++ b/Octokit/Models/Response/PullRequestMerge.cs
@@ -7,6 +7,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestMerge
     {
+        public PullRequestMerge() { }
+
+        public PullRequestMerge(string sha, bool merged, string message)
+        {
+            Sha = sha;
+            Merged = merged;
+            Message = message;
+        }
+
         /// <summary>
         /// The sha reference of the commit.
         /// </summary>

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -7,13 +7,29 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewComment
     {
-        public PullRequestReviewComment()
-        {
-        }
+        public PullRequestReviewComment() { }
 
         public PullRequestReviewComment(int id)
         {
             Id = id;
+        }
+
+        public PullRequestReviewComment(Uri url, int id, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, Uri htmlUrl, Uri pullRequestUrl)
+        {
+            Url = url;
+            Id = id;
+            DiffHunk = diffHunk;
+            Path = path;
+            Position = position;
+            OriginalPosition = originalPosition;
+            CommitId = commitId;
+            OriginalCommitId = originalCommitId;
+            User = user;
+            Body = body;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            HtmlUrl = htmlUrl;
+            PullRequestUrl = pullRequestUrl;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/PunchCardPoint.cs
+++ b/Octokit/Models/Response/PunchCardPoint.cs
@@ -8,6 +8,8 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PunchCardPoint
     {
+        public PunchCardPoint() { }
+
         public PunchCardPoint(IList<int> punchPoint)
         {
             Ensure.ArgumentNotNull(punchPoint, "punchPoint");
@@ -18,6 +20,13 @@ namespace Octokit
             DayOfWeek = (DayOfWeek)punchPoint[0];
             HourOfTheDay = punchPoint[1];
             CommitCount = punchPoint[2];
+        }
+
+        public PunchCardPoint(DayOfWeek dayOfWeek, int hourOfTheDay, int commitCount)
+        {
+            DayOfWeek = dayOfWeek;
+            HourOfTheDay = hourOfTheDay;
+            CommitCount = commitCount;
         }
 
         public DayOfWeek DayOfWeek { get; private set; }

--- a/Octokit/Models/Response/Readme.cs
+++ b/Octokit/Models/Response/Readme.cs
@@ -12,6 +12,8 @@ namespace Octokit
     {
         readonly Lazy<Task<string>> htmlContent;
 
+        public Readme() { }
+
         internal Readme(ReadmeResponse response, IApiConnection client)
         {
             Ensure.ArgumentNotNull(response, "response");
@@ -26,6 +28,15 @@ namespace Octokit
                 Content = Encoding.UTF8.GetString(contentAsBytes, 0, contentAsBytes.Length);
             }
             htmlContent = new Lazy<Task<string>>(async () => await client.GetHtml(Url).ConfigureAwait(false));
+        }
+
+        public Readme(Lazy<Task<string>> htmlContent, string content, string name, Uri htmlUrl, Uri url)
+        {
+            this.htmlContent = htmlContent;
+            Content = content;
+            Name = name;
+            HtmlUrl = htmlUrl;
+            Url = url;
         }
 
         public string Content { get; private set; }

--- a/Octokit/Models/Response/ReadmeResponse.cs
+++ b/Octokit/Models/Response/ReadmeResponse.cs
@@ -2,10 +2,21 @@ namespace Octokit
 {
     internal class ReadmeResponse
     {
-        public string Content { get; set; }
-        public string Name { get; set; }
-        public string HtmlUrl { get; set; }
-        public string Url { get; set; }
-        public string Encoding { get; set; }
+        public ReadmeResponse() { }
+
+        public ReadmeResponse(string content, string name, string htmlUrl, string url, string encoding)
+        {
+            Content = content;
+            Name = name;
+            HtmlUrl = htmlUrl;
+            Url = url;
+            Encoding = encoding;
+        }
+
+        public string Content { get; protected set; }
+        public string Name { get; protected set; }
+        public string HtmlUrl { get; protected set; }
+        public string Url { get; protected set; }
+        public string Encoding { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/Reference.cs
+++ b/Octokit/Models/Response/Reference.cs
@@ -7,6 +7,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Reference
     {
+        public Reference() { }
+
+        public Reference(string @ref, string url, TagObject objectVar)
+        {
+            Ref = @ref;
+            Url = url;
+            Object = objectVar;
+        }
+
         public string Ref { get; protected set; }
 
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/Release.cs
+++ b/Octokit/Models/Response/Release.cs
@@ -8,8 +8,23 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Release
     {
-        public Release()
+        public Release() { }
+
+        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, int id, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt)
         {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            AssetsUrl = assetsUrl;
+            UploadUrl = uploadUrl;
+            Id = id;
+            TagName = tagName;
+            TargetCommitish = targetCommitish;
+            Name = name;
+            Body = body;
+            Draft = draft;
+            Prerelease = prerelease;
+            CreatedAt = createdAt;
+            PublishedAt = publishedAt;
         }
 
         [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#")]

--- a/Octokit/Models/Response/ReleaseAsset.cs
+++ b/Octokit/Models/Response/ReleaseAsset.cs
@@ -7,6 +7,23 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseAsset
     {
+        public ReleaseAsset() { }
+
+        public ReleaseAsset(string url, int id, string name, string label, string state, string contentType, int size, int downloadCount, DateTimeOffset createdAt, DateTimeOffset updatedAt, string browserDownloadUrl)
+        {
+            Url = url;
+            Id = id;
+            Name = name;
+            Label = label;
+            State = state;
+            ContentType = contentType;
+            Size = size;
+            DownloadCount = downloadCount;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            BrowserDownloadUrl = browserDownloadUrl;
+        }
+
         public string Url { get; protected set; }
 
         public int Id { get; protected set; }

--- a/Octokit/Models/Response/ReleaseAssetUpload.cs
+++ b/Octokit/Models/Response/ReleaseAssetUpload.cs
@@ -8,10 +8,20 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseAssetUpload
     {
-        public string FileName { get; set; }
-        public string ContentType { get; set; }
-        public Stream RawData { get; set; }
-        public TimeSpan? Timeout { get; set; }
+        public ReleaseAssetUpload() { }
+
+        public ReleaseAssetUpload(string fileName, string contentType, Stream rawData, TimeSpan? timeout)
+        {
+            FileName = fileName;
+            ContentType = contentType;
+            RawData = rawData;
+            Timeout = timeout;
+        }
+
+        public string FileName { get; protected set; }
+        public string ContentType { get; protected set; }
+        public Stream RawData { get; protected set; }
+        public TimeSpan? Timeout { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -7,13 +7,47 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Repository
     {
-        public Repository()
-        {
-        }
+        public Repository() { }
 
         public Repository(int id)
         {
             Id = id;
+        }
+
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, int id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, int watchersCount, int subscribersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, User organization, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads)
+        {
+            Url = url;
+            HtmlUrl = htmlUrl;
+            CloneUrl = cloneUrl;
+            GitUrl = gitUrl;
+            SshUrl = sshUrl;
+            SvnUrl = svnUrl;
+            MirrorUrl = mirrorUrl;
+            Id = id;
+            Owner = owner;
+            Name = name;
+            FullName = fullName;
+            Description = description;
+            Homepage = homepage;
+            Language = language;
+            Private = @private;
+            Fork = fork;
+            ForksCount = forksCount;
+            StargazersCount = stargazersCount;
+            WatchersCount = watchersCount;
+            SubscribersCount = subscribersCount;
+            DefaultBranch = defaultBranch;
+            OpenIssuesCount = openIssuesCount;
+            PushedAt = pushedAt;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Permissions = permissions;
+            Organization = organization;
+            Parent = parent;
+            Source = source;
+            HasIssues = hasIssues;
+            HasWiki = hasWiki;
+            HasDownloads = hasDownloads;
         }
 
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/RepositoryContent.cs
+++ b/Octokit/Models/Response/RepositoryContent.cs
@@ -11,6 +11,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryContent : RepositoryContentInfo
     {
+        public RepositoryContent() { }
+
+        public RepositoryContent(string name, string path, string sha, int size, ContentType type, Uri downloadUrl, Uri url, Uri gitUrl, Uri htmlUrl, string encoding, string encodedContent, string target, Uri submoduleGitUrl)
+            : base(name, path, sha, size, type, downloadUrl, url, gitUrl, htmlUrl)
+        {
+            Encoding = encoding;
+            EncodedContent = encodedContent;
+            Target = target;
+            SubmoduleGitUrl = submoduleGitUrl;
+        }
+
         /// <summary>
         /// The encoding of the content if this is a file. Typically "base64". Otherwise it's null.
         /// </summary>

--- a/Octokit/Models/Response/RepositoryContentChangeSet.cs
+++ b/Octokit/Models/Response/RepositoryContentChangeSet.cs
@@ -10,6 +10,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryContentChangeSet
     {
+        public RepositoryContentChangeSet() { }
+
+        public RepositoryContentChangeSet(RepositoryContentInfo content, Commit commit)
+        {
+            Content = content;
+            Commit = commit;
+        }
+
         /// <summary>
         /// The content of the response.
         /// </summary>

--- a/Octokit/Models/Response/RepositoryContributor.cs
+++ b/Octokit/Models/Response/RepositoryContributor.cs
@@ -10,6 +10,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryContributor : Author
     {
+        public RepositoryContributor() { }
+
+        public RepositoryContributor(string login, int id, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, int contributions)
+            : base(login, id, avatarUrl, url, htmlUrl, followersUrl, followingUrl, gistsUrl, type, starredUrl, subscriptionsUrl, organizationsUrl, reposUrl, eventsUrl, receivedEventsUrl, siteAdmin)
+        {
+            Contributions = contributions;
+        }
+
         public int Contributions { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/RepositoryPermissions.cs
+++ b/Octokit/Models/Response/RepositoryPermissions.cs
@@ -7,6 +7,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryPermissions
     {
+        public RepositoryPermissions() { }
+
+        public RepositoryPermissions(bool admin, bool push, bool pull)
+        {
+            Admin = admin;
+            Push = push;
+            Pull = pull;
+        }
+
         /// <summary>
         /// Whether the current user has administrative permissions
         /// </summary>

--- a/Octokit/Models/Response/RepositoryTag.cs
+++ b/Octokit/Models/Response/RepositoryTag.cs
@@ -8,6 +8,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryTag
     {
+        public RepositoryTag() { }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "tarball")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "zipball")]
+        public RepositoryTag(string name, GitReference commit, string zipballUrl, string tarballUrl)
+        {
+            Name = name;
+            Commit = commit;
+            ZipballUrl = zipballUrl;
+            TarballUrl = tarballUrl;
+        }
+
         public string Name { get; protected set; }
 
         public GitReference Commit { get; protected set; }

--- a/Octokit/Models/Response/SearchCode.cs
+++ b/Octokit/Models/Response/SearchCode.cs
@@ -7,6 +7,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchCode
     {
+        public SearchCode() { }
+
+        public SearchCode(string name, string path, string sha, Uri url, Uri gitUrl, Uri htmlUrl, Repository repository)
+        {
+            Name = name;
+            Path = path;
+            Sha = sha;
+            Url = url;
+            GitUrl = gitUrl;
+            HtmlUrl = htmlUrl;
+            Repository = repository;
+        }
+
         /// <summary>
         /// file name
         /// </summary>

--- a/Octokit/Models/Response/SearchCodeResult.cs
+++ b/Octokit/Models/Response/SearchCodeResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Octokit.Internal;
 
 namespace Octokit
@@ -6,5 +7,11 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchCodeResult : SearchResult<SearchCode>
     {
+        public SearchCodeResult() { }
+
+        public SearchCodeResult(int totalCount, bool incompleteResults, IReadOnlyList<SearchCode> items)
+            : base(totalCount, incompleteResults, items)
+        {
+        }
     }
 }

--- a/Octokit/Models/Response/SearchIssuesResult.cs
+++ b/Octokit/Models/Response/SearchIssuesResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Octokit.Internal;
 
@@ -7,5 +7,11 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchIssuesResult : SearchResult<Issue>
     {
+        public SearchIssuesResult() { }
+
+        public SearchIssuesResult(int totalCount, bool incompleteResults, IReadOnlyList<Issue> items)
+            : base(totalCount, incompleteResults, items)
+        {
+        }
     }
 }

--- a/Octokit/Models/Response/SearchRepositoryResult.cs
+++ b/Octokit/Models/Response/SearchRepositoryResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Octokit.Internal;
 
 namespace Octokit
@@ -6,5 +7,11 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchRepositoryResult : SearchResult<Repository>
     {
+        public SearchRepositoryResult() { }
+
+        public SearchRepositoryResult(int totalCount, bool incompleteResults, IReadOnlyList<Repository> items)
+            : base(totalCount, incompleteResults, items)
+        {
+        }
     }
 }

--- a/Octokit/Models/Response/SearchResult.cs
+++ b/Octokit/Models/Response/SearchResult.cs
@@ -7,6 +7,15 @@ namespace Octokit.Internal
 {
     public abstract class SearchResult<T>
     {
+        protected SearchResult() { }
+
+        protected SearchResult(int totalCount, bool incompleteResults, IReadOnlyList<T> items)
+        {
+            TotalCount = totalCount;
+            IncompleteResults = incompleteResults;
+            Items = items;
+        }
+
         /// <summary>
         /// Total number of matching items.
         /// </summary>

--- a/Octokit/Models/Response/SearchUsersResult.cs
+++ b/Octokit/Models/Response/SearchUsersResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Octokit.Internal;
 
 namespace Octokit
@@ -6,5 +7,11 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchUsersResult : SearchResult<User>
     {
+        public SearchUsersResult() { }
+
+        public SearchUsersResult(int totalCount, bool incompleteResults, IReadOnlyList<User> items)
+            : base(totalCount, incompleteResults, items)
+        {
+        }
     }
 }

--- a/Octokit/Models/Response/SignatureResponse.cs
+++ b/Octokit/Models/Response/SignatureResponse.cs
@@ -7,9 +7,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SignatureResponse
     {
-        public SignatureResponse()
-        {
-        }
+        public SignatureResponse() { }
 
         public SignatureResponse(string name, string email, DateTimeOffset date)
         {

--- a/Octokit/Models/Response/SshKey.cs
+++ b/Octokit/Models/Response/SshKey.cs
@@ -22,6 +22,14 @@ namespace Octokit
             Title = title;
         }
 
+        protected SshKey(int id, string key, string title, string url)
+        {
+            Id = id;
+            Key = key;
+            Title = title;
+            Url = url;
+        }
+
         /// <summary>
         /// The system-wide unique Id for this user.
         /// </summary>

--- a/Octokit/Models/Response/Subscription.cs
+++ b/Octokit/Models/Response/Subscription.cs
@@ -7,6 +7,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Subscription
     {
+        public Subscription() { }
+
+        public Subscription(bool subscribed, bool ignored, string reason, DateTimeOffset createdAt, Uri url, Uri repositoryUrl)
+        {
+            Subscribed = subscribed;
+            Ignored = ignored;
+            Reason = reason;
+            CreatedAt = createdAt;
+            Url = url;
+            RepositoryUrl = repositoryUrl;
+        }
+
         /// <summary>
         /// Determines if notifications should be received from this repository.
         /// </summary>

--- a/Octokit/Models/Response/TagObject.cs
+++ b/Octokit/Models/Response/TagObject.cs
@@ -6,6 +6,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TagObject : GitReference
     {
+        public TagObject() { }
+
+        public TagObject(string url, string label, string @ref, string sha, User user, Repository repository, TaggedType type)
+            : base(url, label, @ref, sha, user, repository)
+        {
+            Type = type;
+        }
+
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", 
             Justification = "Name defined by web api and required for deserialisation")]
         public TaggedType Type { get; protected set; }

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -10,6 +10,19 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Team
     {
+        public Team() { }
+
+        public Team(Uri url, int id, string name, Permission permission, int membersCount, int reposCount, Organization organization)
+        {
+            Url = url;
+            Id = id;
+            Name = name;
+            Permission = permission;
+            MembersCount = membersCount;
+            ReposCount = reposCount;
+            Organization = organization;
+        }
+
         /// <summary>
         /// url for this team
         /// </summary>

--- a/Octokit/Models/Response/ThreadSubscription.cs
+++ b/Octokit/Models/Response/ThreadSubscription.cs
@@ -7,6 +7,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ThreadSubscription
     {
+        public ThreadSubscription() { }
+
+        public ThreadSubscription(bool subscribed, bool ignored, string reason, DateTimeOffset createdAt, Uri url, Uri threadUrl)
+        {
+            Subscribed = subscribed;
+            Ignored = ignored;
+            Reason = reason;
+            CreatedAt = createdAt;
+            Url = url;
+            ThreadUrl = threadUrl;
+        }
+
         /// <summary>
         /// Determines if notifications should be received from this repository.
         /// </summary>

--- a/Octokit/Models/Response/TreeItem.cs
+++ b/Octokit/Models/Response/TreeItem.cs
@@ -8,6 +8,18 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TreeItem
     {
+        public TreeItem() { }
+
+        public TreeItem(string path, string mode, TreeType type, int size, string sha, Uri url)
+        {
+            Path = path;
+            Mode = mode;
+            Type = type;
+            Size = size;
+            Sha = sha;
+            Url = url;
+        }
+
         /// <summary>
         /// The path for this Tree Item.
         /// </summary>

--- a/Octokit/Models/Response/TreeResponse.cs
+++ b/Octokit/Models/Response/TreeResponse.cs
@@ -9,6 +9,16 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TreeResponse
     {
+        public TreeResponse() { }
+
+        public TreeResponse(string sha, Uri url, IReadOnlyList<TreeItem> tree, bool truncated)
+        {
+            Sha = sha;
+            Url = url;
+            Tree = tree;
+            Truncated = truncated;
+        }
+
         /// <summary>
         /// The SHA for this Tree response.
         /// </summary>

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -10,14 +10,13 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class User : Account
     {
-        /// <summary>
-        /// Hex Gravatar identifier, now obsolete
-        /// </summary>
-        /// <remarks>
-        /// For more details: https://developer.github.com/changes/2014-09-05-removing-gravatar-id/
-        /// </remarks>
-        [Obsolete("This property is now obsolete, use AvatarUrl instead")]
-        public string GravatarId { get; protected set; }
+        public User() { }
+
+        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, bool siteAdmin)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, url)
+        {
+            SiteAdmin = siteAdmin;
+        }
 
         /// <summary>
         /// Whether or not the user is an administrator of the site

--- a/Octokit/Models/Response/WeeklyCommitActivity.cs
+++ b/Octokit/Models/Response/WeeklyCommitActivity.cs
@@ -10,6 +10,15 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class WeeklyCommitActivity
     {
+        public WeeklyCommitActivity() { }
+
+        public WeeklyCommitActivity(IEnumerable<int> days, int total, long week)
+        {
+            Days = days;
+            Total = total;
+            Week = week;
+        }
+
         /// <summary>
         /// The days array is a group of commits per day, starting on Sunday.
         /// </summary>

--- a/Octokit/Models/Response/WeeklyHash.cs
+++ b/Octokit/Models/Response/WeeklyHash.cs
@@ -9,6 +9,20 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class WeeklyHash
     {
+        public WeeklyHash() { }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "w")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "a")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "d")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "c")]
+        public WeeklyHash(long w, int a, int d, int c)
+        {
+            W = w;
+            A = a;
+            D = d;
+            C = c;
+        }
+
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "W")]
         public long W { get; protected set; }
 


### PR DESCRIPTION
Resolves https://github.com/octokit/octokit.net/issues/677.

There are a lot of code analysis warnings about URIs as Strings.  Let me know what the preferred way to resolve this is and I'll apply the fix across the board in this PR.

Also, this doesn't build currently due to the usage of obsolete properties.  An example is User.cs which has an Obsolete GravatarId.  The constructor assigns it, which causes an obsolete usage warning at compile time.  What is the preferred way to deal with this situation?