### PR TITLE
Changed Gist Comment Client Id param from int to string

### DIFF
--- a/Octokit.Reactive/Clients/IObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableGistCommentsClient.cs
@@ -15,7 +15,7 @@ namespace Octokit.Reactive
         /// <returns>IObservable{GistComment}.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<GistComment> Get(int gistId, int commentId);
+        IObservable<GistComment> Get(string gistId, int commentId);
 
         /// <summary>
         /// Gets all comments for the gist with the specified id.
@@ -23,7 +23,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
         /// <param name="gistId">The id of the gist</param>
         /// <returns>IObservable{GistComment}.</returns>
-        IObservable<GistComment> GetForGist(int gistId);
+        IObservable<GistComment> GetForGist(string gistId);
 
         /// <summary>
         /// Creates a comment for the gist with the specified id.
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="gistId">The id of the gist</param>
         /// <param name="comment">The body of the comment</param>
         /// <returns>IObservable{GistComment}.</returns>
-        IObservable<GistComment> Create(int gistId, string comment);
+        IObservable<GistComment> Create(string gistId, string comment);
 
         /// <summary>
         /// Updates the comment with the specified gist- and comment id.
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="commentId">The id of the comment</param>
         /// <param name="comment">The updated body of the comment</param>
         /// <returns>IObservable{GistComment}.</returns>
-        IObservable<GistComment> Update(int gistId, int commentId, string comment);
+        IObservable<GistComment> Update(string gistId, int commentId, string comment);
 
         /// <summary>
         /// Deletes the comment with the specified gist- and comment id.
@@ -51,6 +51,6 @@ namespace Octokit.Reactive
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>IObservable{Unit}.</returns>
-        IObservable<Unit> Delete(int gistId, int commentId);
+        IObservable<Unit> Delete(string gistId, int commentId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>IObservable{GistComment}.</returns>
-        public IObservable<GistComment> Get(int gistId, int commentId)
+        public IObservable<GistComment> Get(string gistId, int commentId)
         {
             return _client.Get(gistId, commentId).ToObservable();
         }
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
         /// <param name="gistId">The id of the gist</param>
         /// <returns>IObservable{GistComment}.</returns>
-        public IObservable<GistComment> GetForGist(int gistId)
+        public IObservable<GistComment> GetForGist(string gistId)
         {
             return _connection.GetAndFlattenAllPages<GistComment>(ApiUrls.GistComments(gistId));
         }
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="gistId">The id of the gist</param>
         /// <param name="comment">The body of the comment</param>
         /// <returns>IObservable{GistComment}.</returns>
-        public IObservable<GistComment> Create(int gistId, string comment)
+        public IObservable<GistComment> Create(string gistId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, "comment");
 
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="commentId">The id of the comment</param>
         /// <param name="comment">The updated body of the comment</param>
         /// <returns>IObservable{GistComment}.</returns>
-        public IObservable<GistComment> Update(int gistId, int commentId, string comment)
+        public IObservable<GistComment> Update(string gistId, int commentId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, "comment");
 
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>IObservable{Unit}.</returns>
-        public IObservable<Unit> Delete(int gistId, int commentId)
+        public IObservable<Unit> Delete(string gistId, int commentId)
         {
             return _client.Delete(gistId, commentId).ToObservable();
         }

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -24,7 +24,7 @@ public class GistCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistCommentsClient(connection);
 
-            await client.Get(24, 1337);
+            await client.Get("24", 1337);
 
             connection.Received().Get<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"), null);
         }
@@ -38,7 +38,7 @@ public class GistCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistCommentsClient(connection);
 
-            await client.GetForGist(24);
+            await client.GetForGist("24");
 
             connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"));
         }
@@ -51,8 +51,8 @@ public class GistCommentsClientTests
         {
             var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(24, null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create(24, ""));
+            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("24", null));
+            await AssertEx.Throws<ArgumentException>(async () => await client.Create("24", ""));
         }
 
         [Fact]
@@ -62,7 +62,7 @@ public class GistCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistCommentsClient(connection);
 
-            await client.Create(24, comment);
+            await client.Create("24", comment);
 
             connection.Received().Post<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Arg.Is<BodyWrapper>(x => x.Body == comment));
         }
@@ -75,8 +75,8 @@ public class GistCommentsClientTests
         {
             var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update(24, 1337, null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update(24, 1337, ""));
+            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("24", 1337, null));
+            await AssertEx.Throws<ArgumentException>(async () => await client.Update("24", 1337, ""));
         }
 
         [Fact]
@@ -86,7 +86,7 @@ public class GistCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistCommentsClient(connection);
 
-            await client.Update(24, 1337, comment);
+            await client.Update("24", 1337, comment);
 
             connection.Received().Patch<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"), Arg.Is<BodyWrapper>(x => x.Body == comment));
         }
@@ -100,7 +100,7 @@ public class GistCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistCommentsClient(connection);
 
-            await client.Delete(24, 1337);
+            await client.Delete("24", 1337);
 
             connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
         }

--- a/Octokit/Clients/GistCommentsClient.cs
+++ b/Octokit/Clients/GistCommentsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        public Task<GistComment> Get(int gistId, int commentId)
+        public Task<GistComment> Get(string gistId, int commentId)
         {
             return ApiConnection.Get<GistComment>(ApiUrls.GistComment(gistId, commentId));
         }
@@ -37,7 +37,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
         /// <param name="gistId">The id of the gist</param>
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
-        public Task<IReadOnlyList<GistComment>> GetForGist(int gistId)
+        public Task<IReadOnlyList<GistComment>> GetForGist(string gistId)
         {
             return ApiConnection.GetAll<GistComment>(ApiUrls.GistComments(gistId));
         }
@@ -49,7 +49,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="comment">The body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        public Task<GistComment> Create(int gistId, string comment)
+        public Task<GistComment> Create(string gistId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, "comment");
 
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="commentId">The id of the comment</param>
         /// <param name="comment">The updated body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        public Task<GistComment> Update(int gistId, int commentId, string comment)
+        public Task<GistComment> Update(string gistId, int commentId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, "comment");
 
@@ -78,7 +78,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task.</returns>
-        public Task Delete(int gistId, int commentId)
+        public Task Delete(string gistId, int commentId)
         {
             return ApiConnection.Delete(ApiUrls.GistComment(gistId, commentId));
         }

--- a/Octokit/Clients/IGistCommentsClient.cs
+++ b/Octokit/Clients/IGistCommentsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <returns>Task{GistComment}.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", 
             Justification = "Method makes a network request")]
-        Task<GistComment> Get(int gistId, int commentId);
+        Task<GistComment> Get(string gistId, int commentId);
 
         /// <summary>
         /// Gets all comments for the gist with the specified id.
@@ -29,7 +29,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
         /// <param name="gistId">The id of the gist</param>
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
-        Task<IReadOnlyList<GistComment>> GetForGist(int gistId);
+        Task<IReadOnlyList<GistComment>> GetForGist(string gistId);
 
         /// <summary>
         /// Creates a comment for the gist with the specified id.
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="comment">The body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        Task<GistComment> Create(int gistId, string comment);
+        Task<GistComment> Create(string gistId, string comment);
 
         /// <summary>
         /// Updates the comment with the specified gist- and comment id.
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="commentId">The id of the comment</param>
         /// <param name="comment">The updated body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        Task<GistComment> Update(int gistId, int commentId, string comment);
+        Task<GistComment> Update(string gistId, int commentId, string comment);
 
         /// <summary>
         /// Deletes the comment with the specified gist- and comment id.
@@ -57,6 +57,6 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task.</returns>
-        Task Delete(int gistId, int commentId);
+        Task Delete(string gistId, int commentId);
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -718,7 +718,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for the comments for the specified gist.
         /// </summary>
         /// <param name="gistId">The id of the gist</param>
-        public static Uri GistComments(int gistId)
+        public static Uri GistComments(string gistId)
         {
             return "gists/{0}/comments".FormatUri(gistId);
         }
@@ -773,7 +773,7 @@ namespace Octokit
         /// </summary>
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
-        public static Uri GistComment(int gistId, int commentId)
+        public static Uri GistComment(string gistId, int commentId)
         {
             return "gists/{0}/comments/{1}".FormatUri(gistId, commentId);
         }


### PR DESCRIPTION
Gists & their comments all have string Ids. Changed the GistCommentClient to take a string instead of an int.

e.g: https://api.github.com/gists/edaab9be9eaa9bf1ee5f/comments