### PR TITLE
[Blocked] Missing application authorization methods

### DIFF
--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -1,4 +1,6 @@
-﻿#if NET_45
+﻿using System;
+using System.Net.NetworkInformation;
+#if NET_45
 using System.Collections.Generic;
 #endif
 using System.Threading.Tasks;
@@ -191,6 +193,26 @@ namespace Octokit
             Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             return ApiConnection.Post<Authorization>(ApiUrls.Authorizations(), newAuthorization);
+        }
+
+        public Task<Authorization> CheckApplicationAuthentication(string clientId, string clientSecret, int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Authorization> ResetApplicationAuthentication(string clientId, string clientSecret, int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RevokeApplicationAuthentication(string clientId, string clientSecret, int id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RevokeAllApplicationAuthentications(string clientId, string clientSecret)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR will implement the following issues as they are all related to the same area of OAuth application authorizations:
- [ ] https://github.com/octokit/octokit.net/issues/682 - Check an authorization
 - [ ] Implementation
 - [ ] Unit tests
 - [ ] Integration tests
- [ ] https://github.com/octokit/octokit.net/issues/654 - Revoke an authorization for an application
 - [ ] Implementation
 - [ ] Unit tests
 - [ ] Integration tests
- [ ] https://github.com/octokit/octokit.net/issues/653 - Revoke all authorizations for an application 
 - [ ] Implementation
 - [ ] Unit tests
 - [ ] Integration tests
- [ ] https://github.com/octokit/octokit.net/issues/652 - Reset an authorization
 - [ ] Implementation
 - [ ] Unit tests
 - [ ] Integration tests