### PR TITLE
RepositoriesClientTests - Wrong Method Names #692

### DIFF
--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -263,7 +263,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForCurrentMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsOrganizations()
+            public void RequestsTheCorrectUrlAndReturnsRepositories()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -278,7 +278,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForUserMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsOrganizations()
+            public void RequestsTheCorrectUrlAndReturnsRepositories()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -301,7 +301,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForOrgMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsOrganizations()
+            public void RequestsTheCorrectUrlAndReturnsRepositories()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);


### PR DESCRIPTION
Rename test methods. 

**From:**
_RequestsTheCorrectUrlAndReturnsOrganizations()_
_RequestsTheCorrectUrlAndReturnsOrganizations()_
_RequestsTheCorrectUrlAndReturnsOrganizations()_

**To:**
_RequestsTheCorrectUrlAndReturnsRepositories()_
_RequestsTheCorrectUrlAndReturnsRepositories()_
_RequestsTheCorrectUrlAndReturnsRepositories()_
