### PR TITLE
Support the correct spelling of event types

### DIFF
--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Diagnostics.CodeAnalysis;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -155,11 +156,13 @@ namespace Octokit
         /// <summary>
         /// The pull request’s branch was deleted.
         /// </summary>
+        [Parameter(Value = "head_ref_deleted")]
         HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
         /// </summary>
+        [Parameter(Value = "head_ref_restored")]
         HeadRefRestored,
     }
 }


### PR DESCRIPTION
Let's use the official spelling of [event types](https://developer.github.com/v3/issues/events/) to avoid blowing up on deserialization of events. 

Fixes https://github.com/octokit/octokit.net/issues/707