### PR TITLE
Added User.Type property

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -520,6 +520,20 @@ public class RepositoriesClientTests
             Assert.Equal("https://github.com/Haacked/SeeGit.git", repository.CloneUrl);
             Assert.False(repository.Private);
             Assert.False(repository.Fork);
+            Assert.Equal(UserType.User, repository.Owner.Type);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsOrganizationRepository()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repository = await github.Repository.Get("octokit", "octokit.net");
+
+            Assert.Equal("https://github.com/octokit/octokit.net.git", repository.CloneUrl);
+            Assert.False(repository.Private);
+            Assert.False(repository.Fork);
+            Assert.Equal(UserType.Organization, repository.Owner.Type);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UsersClientTests.cs
@@ -18,7 +18,20 @@ public class UsersClientTests
             var user = await github.User.Get("tclem");
 
             Assert.Equal("GitHub", user.Company);
+            Assert.Equal(UserType.User, user.Type);
         }
+
+        [IntegrationTest]
+        public async Task ReturnsSpecifiedOrganization()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var user = await github.User.Get("octokit");
+
+            Assert.Null(user.Company);
+            Assert.Equal(UserType.Organization, user.Type);
+        }
+
 
         [IntegrationTest]
         public async Task ReturnsSpecifiedUserUsingAwaitableCredentialProvider()
@@ -50,6 +63,7 @@ public class UsersClientTests
             var user = await github.User.Current();
 
             Assert.Equal(Helper.UserName, user.Login);
+            Assert.Equal(UserType.User, user.Type);
         }
     }
 

--- a/Octokit.Tests.Integration/Clients/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UsersClientTests.cs
@@ -32,7 +32,6 @@ public class UsersClientTests
             Assert.Equal(UserType.Organization, user.Type);
         }
 
-
         [IntegrationTest]
         public async Task ReturnsSpecifiedUserUsingAwaitableCredentialProvider()
         {

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -148,6 +148,11 @@ namespace Octokit
         public int TotalPrivateRepos { get; protected set; }
 
         /// <summary>
+        /// The type of account associated with this entity
+        /// </summary>
+        public string Type { get; protected set; }
+
+        /// <summary>
         /// The account's API URL.
         /// </summary>
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -148,11 +148,6 @@ namespace Octokit
         public int TotalPrivateRepos { get; protected set; }
 
         /// <summary>
-        /// The type of account associated with this entity
-        /// </summary>
-        public string Type { get; protected set; }
-
-        /// <summary>
         /// The account's API URL.
         /// </summary>
         public string Url { get; protected set; }

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -23,6 +23,11 @@ namespace Octokit
         /// </summary>
         public bool SiteAdmin { get; protected set; }
 
+        /// <summary>
+        /// The type of account associated with this entity
+        /// </summary>
+        public UserType Type { get; protected set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <summary>
         /// The type of account associated with this entity
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
         public UserType Type { get; protected set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/UserType.cs
+++ b/Octokit/Models/Response/UserType.cs
@@ -1,0 +1,15 @@
+﻿namespace Octokit
+{
+    public enum UserType
+    {
+        /// <summary>
+        ///  User account
+        /// </summary>
+        User,
+
+        /// <summary>
+        /// Organization account
+        /// </summary>
+        Organization
+    }
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -365,6 +365,7 @@
     <Compile Include="Models\Response\SearchResult.cs" />
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -372,6 +372,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -367,6 +367,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Models\Response\GitTag.cs" />
     <Compile Include="Models\Response\SignatureResponse.cs" />
     <Compile Include="Models\Response\TagObject.cs" />
+    <Compile Include="Models\Response\UserType.cs" />
     <Compile Include="Models\Response\WeeklyCommitActivity.cs" />
     <Compile Include="Models\Response\Participation.cs" />
     <Compile Include="Models\Response\WeeklyHash.cs" />


### PR DESCRIPTION
I need to put this in for a couple of upcoming API changes, and I think it was added since the Account/User/Organization APIs were first ported over.

~~We have an `AccountType` enum which we use in the search APIs - I didn't want to couple this to that, but perhaps I need to.~~ done and done

- [ ] rename the properties
- [ ] ensure response isn't set (Nullable?) if value doesn't exist in JSON dictionary