### PR TITLE
Added Account.Type support

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -520,6 +520,20 @@ public class RepositoriesClientTests
             Assert.Equal("https://github.com/Haacked/SeeGit.git", repository.CloneUrl);
             Assert.False(repository.Private);
             Assert.False(repository.Fork);
+            Assert.Equal(AccountType.User, repository.Owner.Type);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsOrganizationRepository()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repository = await github.Repository.Get("octokit", "octokit.net");
+
+            Assert.Equal("https://github.com/octokit/octokit.net.git", repository.CloneUrl);
+            Assert.False(repository.Private);
+            Assert.False(repository.Fork);
+            Assert.Equal(AccountType.Organization, repository.Owner.Type);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UsersClientTests.cs
@@ -18,6 +18,18 @@ public class UsersClientTests
             var user = await github.User.Get("tclem");
 
             Assert.Equal("GitHub", user.Company);
+            Assert.Equal(AccountType.User, user.Type);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsSpecifiedOrganization()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var user = await github.User.Get("octokit");
+
+            Assert.Null(user.Company);
+            Assert.Equal(AccountType.Organization, user.Type);
         }
 
         [IntegrationTest]
@@ -50,6 +62,7 @@ public class UsersClientTests
             var user = await github.User.Current();
 
             Assert.Equal(Helper.UserName, user.Login);
+            Assert.Equal(AccountType.User, user.Type);
         }
     }
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchUsersRequest("github");
-                request.AccountType = AccountType.User;
+                request.AccountType = AccountSearchType.User;
                 client.SearchUsers(request);
                 connection.Received().Get<SearchUsersResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/users"),
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchUsersRequest("github");
-                request.AccountType = AccountType.Org;
+                request.AccountType = AccountSearchType.Org;
                 client.SearchUsers(request);
                 connection.Received().Get<SearchUsersResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/users"),

--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 #endif
 using System.Threading.Tasks;
 using NSubstitute;
+using Octokit.Internal;
 using Octokit.Tests.Helpers;
 using Xunit;
 
@@ -88,6 +89,20 @@ namespace Octokit.Tests.Clients
             {
                 var userEndpoint = new UsersClient(Substitute.For<IApiConnection>());
                 await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Update(null));
+            }
+        }
+
+        public class SerializationTests
+        {
+            [Fact]
+            public void WhenNotFoundTypeDefaultsToUnknown()
+            {
+                const string json = @"{""private"":true}";
+
+                var user = new SimpleJsonSerializer().Deserialize<User>(json);
+
+                Assert.Equal(0, user.Id);
+                Assert.Null(user.Type);
             }
         }
     }

--- a/Octokit/Models/Request/SearchUsersRequest.cs
+++ b/Octokit/Models/Request/SearchUsersRequest.cs
@@ -63,7 +63,7 @@ namespace Octokit
         /// With this qualifier you can restrict the search to just personal accounts or just organization accounts.
         /// <remarks>https://help.github.com/articles/searching-users#type</remarks>       
         /// </summary>
-        public AccountType? AccountType { get; set; }
+        public AccountSearchType? AccountType { get; set; }
 
         private IEnumerable<UserInQualifier> _inQualifier;
 
@@ -138,7 +138,7 @@ namespace Octokit
     /// <summary>
     /// Account Type used to filter search result
     /// </summary>
-    public enum AccountType
+    public enum AccountSearchType
     {
         /// <summary>
         ///  User account

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         protected Account() { }
 
-        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url)
+        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, AccountType type, string url)
         {
             AvatarUrl = avatarUrl;
             Bio = bio;
@@ -33,6 +33,7 @@ namespace Octokit
             PrivateGists = privateGists;
             PublicGists = publicGists;
             PublicRepos = publicRepos;
+            Type = type;
             Url = url;
         }
 

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -121,7 +121,7 @@ namespace Octokit
         /// The type of account associated with this entity
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public AccountType Type { get; protected set; }
+        public AccountType? Type { get; protected set; }
 
 
         /// <summary>

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -118,6 +118,13 @@ namespace Octokit
         public string Name { get; protected set; }
 
         /// <summary>
+        /// The type of account associated with this entity
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+        public AccountType Type { get; protected set; }
+
+
+        /// <summary>
         /// Number of private repos owned by the account.
         /// </summary>
         public int OwnedPrivateRepos { get; protected set; }

--- a/Octokit/Models/Response/AccountType.cs
+++ b/Octokit/Models/Response/AccountType.cs
@@ -1,0 +1,15 @@
+﻿namespace Octokit
+{
+    public enum AccountType
+    {
+        /// <summary>
+        ///  User account
+        /// </summary>
+        User,
+
+        /// <summary>
+        /// Organization account
+        /// </summary>
+        Organization
+    }
+}

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -10,7 +10,7 @@ namespace Octokit
         public Organization() { }
 
         public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress)
-            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, url)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.Organization, url)
         {
             BillingAddress = billingAddress;
         }

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -13,7 +13,7 @@ namespace Octokit
         public User() { }
 
         public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, bool siteAdmin)
-            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, url)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
         {
             SiteAdmin = siteAdmin;
         }

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Models\Request\RequestParameters.cs" />
     <Compile Include="Models\Request\StarredRequest.cs" />
     <Compile Include="Models\Request\UpdateTeam.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Response\Author.cs" />
     <Compile Include="Models\Response\Branch.cs" />
     <Compile Include="Models\Response\Commit.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -374,6 +374,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Models\Request\UpdateTeam.cs" />
     <Compile Include="Models\Request\UserUpdate.cs" />
     <Compile Include="Models\Response\Account.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Response\Activity.cs" />
     <Compile Include="Models\Response\ApiError.cs" />
     <Compile Include="Models\Response\ApiErrorDetail.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Models\Request\UpdateTeam.cs" />
     <Compile Include="Models\Request\UserUpdate.cs" />
     <Compile Include="Models\Response\Account.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Response\Activity.cs" />
     <Compile Include="Models\Response\ApiError.cs" />
     <Compile Include="Models\Response\ApiErrorDetail.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Models\Response\GitTag.cs" />
     <Compile Include="Models\Response\SignatureResponse.cs" />
     <Compile Include="Models\Response\TagObject.cs" />
+    <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Response\WeeklyCommitActivity.cs" />
     <Compile Include="Models\Response\Participation.cs" />
     <Compile Include="Models\Response\WeeklyHash.cs" />


### PR DESCRIPTION
Supersedes #712

- [x] renamed existing `AccountType` to `AccountSearchType`
- [x] added nullable `Account.Type` property
- [x] added integration tests for user and repository APIs
- [x] update `ctors` to set new field