### PR TITLE
Support the correct spelling of event types, take two.

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -80,8 +80,16 @@ namespace Octokit.Tests
             }
         }
 
+        
         public class TheDeserializeMethod
         {
+            [Fact]
+            public void DeserializesEventInfosWithUnderscoresInName()
+            {
+                const string json = "{\"event\":\"head_ref_deleted\"}";
+                new SimpleJsonSerializer().Deserialize<EventInfo>(json);                
+            }
+
             [Fact]
             public void UnderstandsRubyCasing()
             {

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -87,10 +87,11 @@ namespace Octokit.Internal
                 var stringValue = value as string;
                 if (stringValue != null)
                 {
+                    stringValue = stringValue.Replace("-", "");
                     if (ReflectionUtils.GetTypeInfo(type).IsEnum)
                     {
                         // remove '-' from values coming in to be able to enum utf-8
-                        stringValue = stringValue.Replace("-", "");
+                        stringValue = RemoveHyphenAndUnderscore(stringValue);
                         return Enum.Parse(type, stringValue, ignoreCase: true);
                     }
 
@@ -99,6 +100,7 @@ namespace Octokit.Internal
                         var underlyingType = Nullable.GetUnderlyingType(type);
                         if (ReflectionUtils.GetTypeInfo(underlyingType).IsEnum)
                         {
+                            stringValue = RemoveHyphenAndUnderscore(stringValue);
                             return Enum.Parse(underlyingType, stringValue, ignoreCase: true);
                         }
                     }
@@ -116,6 +118,15 @@ namespace Octokit.Internal
                 }
 
                 return base.DeserializeObject(value, type);
+            }
+
+            static string RemoveHyphenAndUnderscore(string stringValue)
+            {
+                // remove '-' from values coming in to be able to enum utf-8
+                stringValue = stringValue.Replace("-", "");
+                // remove '-' from values coming in to be able to enum EventInfoState names with underscores in them. Like "head_ref_deleted" 
+                stringValue = stringValue.Replace("_", "");
+                return stringValue;
             }
 
             internal override IDictionary<string, KeyValuePair<Type, ReflectionUtils.SetDelegate>> SetterValueFactory(Type type)

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -156,13 +156,11 @@ namespace Octokit
         /// <summary>
         /// The pull request’s branch was deleted.
         /// </summary>
-        [Parameter(Value = "head_ref_deleted")]
         HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
         /// </summary>
-        [Parameter(Value = "head_ref_restored")]
         HeadRefRestored,
     }
 }


### PR DESCRIPTION
[Pull request #711](https://github.com/octokit/octokit.net/pull/711) was created under the assumption that the Parameter attribute worked on both serialization and deserialization of json. Unfortunately that turned out not to be the case. It's only supported under serialization. 

Let's try again! :)