### PR TITLE
[WIP] implement first-class paging support

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -21,6 +21,7 @@
       <Word>Mergeable</Word>
       <Word>Symlink</Word>
       <Word>Submodule</Word>
+      <Word>Awaiter</Word>
     </Recognized>
   </Words>
   <Acronyms>

--- a/Octokit.Tests.Conventions/SyncObservableClients.cs
+++ b/Octokit.Tests.Conventions/SyncObservableClients.cs
@@ -82,6 +82,7 @@ namespace Octokit.Tests.Conventions
                 case TypeCategory.GenericTask:
                     // single item - Task<TResult> => IObservable<TResult>
                 case TypeCategory.ReadOnlyList:
+                case TypeCategory.LazyReadOnlyList:
                     // list - Task<IReadOnlyList<TResult>> => IObservable<TResult>
                     return typeof(IObservable<>).MakeGenericType(typeInfo.Type);
                 case TypeCategory.Other:

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -39,6 +39,11 @@ namespace Octokit.Tests.Conventions
             {
                 typeInfo.TypeCategory = TypeCategory.ClientInterface;
             }
+            else if (type.IsLazyRequest())
+            {
+                typeInfo.TypeCategory = TypeCategory.LazyReadOnlyList;
+                typeInfo.Type = type.GetGenericArgument();
+            }
             else if(type.IsTask())
             {
                 if(!type.IsGenericType)
@@ -85,6 +90,13 @@ namespace Octokit.Tests.Conventions
             return observableInterface;
         }
 
+        public static bool IsLazyRequest(this Type type)
+        {
+            if (!type.IsGenericType) return false;
+            var genericType = type.GetGenericTypeDefinition();
+            return typeof(ILazyRequest<>).IsAssignableFrom(genericType);
+        }
+
         public static bool IsTask(this Type type)
         {
             return typeof(Task).IsAssignableFrom(type);
@@ -101,7 +113,7 @@ namespace Octokit.Tests.Conventions
         }
     }
 
-    public enum TypeCategory { Other, Task, GenericTask, ReadOnlyList, ClientInterface }
+    public enum TypeCategory { Other, Task, GenericTask, ReadOnlyList, LazyReadOnlyList, ClientInterface }
 
     public struct TypeInfo
     {

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -94,7 +94,7 @@ namespace Octokit.Tests.Conventions
         {
             if (!type.IsGenericType) return false;
             var genericType = type.GetGenericTypeDefinition();
-            return typeof(ILazyRequest<>).IsAssignableFrom(genericType);
+            return typeof(IDeferredRequest<>).IsAssignableFrom(genericType);
         }
 
         public static bool IsTask(this Type type)

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -360,7 +360,39 @@ public class IssuesClientTests : IDisposable
 public class MediaTypeTests
 {
     [IntegrationTest]
-    public async Task CanGetMarkdownContent()
+    public async Task CanGetRawContent()
+    {
+        var client = Helper.GetAuthenticatedClient();
+        var issuesForRepo = await client.Issue.GetForRepository("octokit", "octokit.net")
+            .WithOptions(new ApiOptions
+            {
+                Accepts = "application/vnd.github.v3.raw+json",
+                PageCount = 100
+            });
+
+        var matchingIssue = issuesForRepo.First(x => x.Number == 744);
+
+        Assert.NotNull(matchingIssue.Body);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetTextContent()
+    {
+        var client = Helper.GetAuthenticatedClient();
+        var issuesForRepo = await client.Issue.GetForRepository("octokit", "octokit.net")
+            .WithOptions(new ApiOptions
+            {
+                Accepts = "application/vnd.github.v3.text+json",
+                PageCount = 100
+            });
+
+        var matchingIssue = issuesForRepo.First(x => x.Number == 744);
+
+        Assert.NotNull(matchingIssue.Body);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetHtmlContent()
     {
         var client = Helper.GetAuthenticatedClient();
         var issuesForRepo = await client.Issue.GetForRepository("octokit", "octokit.net")
@@ -374,4 +406,5 @@ public class MediaTypeTests
 
         Assert.NotNull(matchingIssue.Body);
     }
+
 }

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -356,3 +356,22 @@ public class IssuesClientTests : IDisposable
         Helper.DeleteRepo(_repository);
     }
 }
+
+public class MediaTypeTests
+{
+    [IntegrationTest]
+    public async Task CanGetMarkdownContent()
+    {
+        var client = Helper.GetAuthenticatedClient();
+        var issuesForRepo = await client.Issue.GetForRepository("octokit", "octokit.net")
+            .WithOptions(new ApiOptions
+            {
+                Accepts = "application/vnd.github.v3.html+json",
+                PageCount = 100
+            });
+
+        var matchingIssue = issuesForRepo.First(x => x.Number == 744);
+
+        Assert.NotNull(matchingIssue.Body);
+    }
+}

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -553,7 +553,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
 
             var repositories = await github.Repository.GetAllForCurrent()
-                .WithOptions(pageSize: 10, startPage: 0, pageCount: 1);
+                .WithOptions(new ApiOptions { PageSize = 10, PageCount = 1 });
 
             Assert.Equal(10, repositories.Count);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -546,6 +546,17 @@ public class RepositoriesClientTests
             Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
             Assert.True(repository.Fork);
         }
+
+        [IntegrationTest]
+        public async Task CanPageRepositories()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repositories = await github.Repository.GetAllForCurrent()
+                .WithOptions(pageSize: 10, startPage: 0, pageCount: 1);
+
+            Assert.NotEmpty(repositories);
+        }
     }
 
     public class TheGetAllForOrgMethod

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -555,7 +555,7 @@ public class RepositoriesClientTests
             var repositories = await github.Repository.GetAllForCurrent()
                 .WithOptions(pageSize: 10, startPage: 0, pageCount: 1);
 
-            Assert.NotEmpty(repositories);
+            Assert.Equal(10, repositories.Count);
         }
     }
 

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -121,11 +121,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository(null, "name", new RepositoryIssueRequest()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetForRepository("", "name", new RepositoryIssueRequest()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository("owner", null, new RepositoryIssueRequest()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetForRepository("owner", "", new RepositoryIssueRequest()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository(null, "name", new RepositoryIssueRequest()).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetForRepository("", "name", new RepositoryIssueRequest()).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository("owner", null, new RepositoryIssueRequest()).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetForRepository("owner", "", new RepositoryIssueRequest()).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetForRepository("owner", "name", null).ToTask());
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -265,15 +265,8 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
-                var apiInfo = new ApiInfo(
-                    new Dictionary<string, Uri>(),
-                    new string[0],
-                    new string[0],
-                    "etag",
-                    new RateLimit(new Dictionary<string, string>()));
-
                 var response = Substitute.For<IResponse>();
-                response.ApiInfo.Returns(apiInfo);
+                response.ApiInfo.Returns(ApiInfo.Empty);
 
                 var emptySet = Substitute.For<IApiResponse<List<Repository>>>();
                 emptySet.Body.Returns(new List<Repository>());

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -263,15 +263,34 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForCurrentMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsRepositories()
+            public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
+                var apiInfo = new ApiInfo(
+                    new Dictionary<string, Uri>(),
+                    new string[0],
+                    new string[0],
+                    "etag",
+                    new RateLimit(new Dictionary<string, string>()));
+
+                var response = Substitute.For<IResponse>();
+                response.ApiInfo.Returns(apiInfo);
+
+                var emptySet = Substitute.For<IApiResponse<List<Repository>>>();
+                emptySet.Body.Returns(new List<Repository>());
+                emptySet.HttpResponse.Returns(response);
+
                 var connection = Substitute.For<IApiConnection>();
+                connection.Connection.Get<List<Repository>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(emptySet));
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllForCurrent();
+                await client.GetAllForCurrent();
 
-                connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"));
+                connection.Connection.Received()
+                    .Get<List<Repository>>(
+                        Arg.Is<Uri>(u => u.ToString() == "user/repos"),
+                        Args.EmptyDictionary,
+                        null);
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -290,15 +290,27 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForUserMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsRepositories()
+            public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
+                var response = Substitute.For<IResponse>();
+                response.ApiInfo.Returns(ApiInfo.Empty);
+
+                var emptySet = Substitute.For<IApiResponse<List<Repository>>>();
+                emptySet.Body.Returns(new List<Repository>());
+                emptySet.HttpResponse.Returns(response);
+
                 var connection = Substitute.For<IApiConnection>();
+                connection.Connection.Get<List<Repository>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(emptySet));
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllForUser("username");
+                await client.GetAllForUser("username");
 
-                connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "users/username/repos"));
+                connection.Connection.Received()
+                    .Get<List<Repository>>(
+                        Arg.Is<Uri>(u => u.ToString() == "users/username/repos"),
+                        Args.EmptyDictionary,
+                        null);
             }
 
             [Fact]
@@ -306,22 +318,34 @@ namespace Octokit.Tests.Clients
             {
                 var reposEndpoint = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => reposEndpoint.GetAllForUser(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => reposEndpoint.GetAllForUser(null).ToTask());
             }
         }
 
         public class TheGetAllForOrgMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsRepositories()
+            public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
+                var response = Substitute.For<IResponse>();
+                response.ApiInfo.Returns(ApiInfo.Empty);
+
+                var emptySet = Substitute.For<IApiResponse<List<Repository>>>();
+                emptySet.Body.Returns(new List<Repository>());
+                emptySet.HttpResponse.Returns(response);
+
                 var connection = Substitute.For<IApiConnection>();
+                connection.Connection.Get<List<Repository>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(emptySet));
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllForOrg("orgname");
+                await client.GetAllForOrg("orgname");
 
-                connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgname/repos"));
+                connection.Connection.Received()
+                    .Get<List<Repository>>(
+                        Arg.Is<Uri>(u => u.ToString() == "orgs/orgname/repos"),
+                        Args.EmptyDictionary,
+                        null);
             }
 
             [Fact]
@@ -329,7 +353,7 @@ namespace Octokit.Tests.Clients
             {
                 var reposEndpoint = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => reposEndpoint.GetAllForOrg(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => reposEndpoint.GetAllForOrg(null).ToTask());
             }
         }
 

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -126,7 +126,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Issue>> GetForRepository(string owner, string name);
+        IDeferredRequest<Issue> GetForRepository(string owner, string name);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -138,7 +138,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Issue>> GetForRepository(string owner, string name, RepositoryIssueRequest request);
+        IDeferredRequest<Issue> GetForRepository(string owner, string name, RepositoryIssueRequest request);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -107,7 +107,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        ILazyRequest<Repository> GetAllForCurrent();
+        IDeferredRequest<Repository> GetAllForCurrent();
 
         
         /// <summary>
@@ -121,7 +121,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        ILazyRequest<Repository> GetAllForUser(string login);
+        IDeferredRequest<Repository> GetAllForUser(string login);
 
         /// <summary>
         /// Gets all repositories owned by the specified organization.
@@ -134,7 +134,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        ILazyRequest<Repository> GetAllForOrg(string organization);
+        IDeferredRequest<Repository> GetAllForOrg(string organization);
 
         /// <summary>
         /// Gets the preferred README for the specified repository.

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -107,7 +107,8 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        Task<IReadOnlyList<Repository>> GetAllForCurrent();
+        ILazyRequest<Repository> GetAllForCurrent();
+
         
         /// <summary>
         /// Gets all repositories owned by the specified user.

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -121,7 +121,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        Task<IReadOnlyList<Repository>> GetAllForUser(string login);
+        ILazyRequest<Repository> GetAllForUser(string login);
 
         /// <summary>
         /// Gets all repositories owned by the specified organization.
@@ -134,7 +134,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "Makes a network request")]
-        Task<IReadOnlyList<Repository>> GetAllForOrg(string organization);
+        ILazyRequest<Repository> GetAllForOrg(string organization);
 
         /// <summary>
         /// Gets the preferred README for the specified repository.

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Issue>> GetForRepository(string owner, string name)
+        public IDeferredRequest<Issue> GetForRepository(string owner, string name)
         {
             return GetForRepository(owner, name, new RepositoryIssueRequest());
         }
@@ -179,14 +179,14 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Issue>> GetForRepository(string owner, string name,
+        public IDeferredRequest<Issue> GetForRepository(string owner, string name,
             RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
-            return ApiConnection.GetAll<Issue>(ApiUrls.Issues(owner, name), request.ToParametersDictionary());
+            return new DeferredRequest<Issue>(ApiConnection, ApiUrls.Issues(owner, name), request.ToParametersDictionary());
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -184,9 +184,9 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public Task<IReadOnlyList<Repository>> GetAllForCurrent()
+        public ILazyRequest<Repository> GetAllForCurrent()
         {
-            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories());
+            return new LazyRequest<Repository>(ApiConnection, ApiUrls.Repositories());
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -198,11 +198,11 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public Task<IReadOnlyList<Repository>> GetAllForUser(string login)
+        public ILazyRequest<Repository> GetAllForUser(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.Repositories(login));
+            return new LazyRequest<Repository>(ApiConnection, ApiUrls.Repositories(login));
         }
 
         /// <summary>
@@ -214,11 +214,11 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public Task<IReadOnlyList<Repository>> GetAllForOrg(string organization)
+        public ILazyRequest<Repository> GetAllForOrg(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.OrganizationRepositories(organization));
+            return new LazyRequest<Repository>(ApiConnection, ApiUrls.OrganizationRepositories(organization));
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -184,9 +184,9 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public ILazyRequest<Repository> GetAllForCurrent()
+        public IDeferredRequest<Repository> GetAllForCurrent()
         {
-            return new LazyRequest<Repository>(ApiConnection, ApiUrls.Repositories());
+            return new DeferredRequest<Repository>(ApiConnection, ApiUrls.Repositories());
         }
 
         /// <summary>
@@ -198,11 +198,11 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public ILazyRequest<Repository> GetAllForUser(string login)
+        public IDeferredRequest<Repository> GetAllForUser(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return new LazyRequest<Repository>(ApiConnection, ApiUrls.Repositories(login));
+            return new DeferredRequest<Repository>(ApiConnection, ApiUrls.Repositories(login));
         }
 
         /// <summary>
@@ -214,11 +214,11 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
-        public ILazyRequest<Repository> GetAllForOrg(string organization)
+        public IDeferredRequest<Repository> GetAllForOrg(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
 
-            return new LazyRequest<Repository>(ApiConnection, ApiUrls.OrganizationRepositories(organization));
+            return new DeferredRequest<Repository>(ApiConnection, ApiUrls.OrganizationRepositories(organization));
         }
 
         /// <summary>

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -11,6 +11,14 @@ namespace Octokit
     /// </summary>
     public class ApiInfo
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        public static readonly ApiInfo Empty = new ApiInfo(
+            new Dictionary<string, Uri>(),
+            new string[0],
+            new string[0],
+            "",
+            new RateLimit(new Dictionary<string, string>()));
+
         public ApiInfo(IDictionary<string, Uri> links,
             IList<string> oauthScopes,
             IList<string> acceptedOauthScopes,

--- a/Octokit/Http/CustomAwaiter.cs
+++ b/Octokit/Http/CustomAwaiter.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Octokit
+{
+    public static class CustomAwaiter
+    {
+        public static TaskAwaiter<IReadOnlyList<T>> GetAwaiter<T>(this ILazyRequest<T> request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return request.ToTask();
+        }
+    }
+}

--- a/Octokit/Http/CustomAwaiter.cs
+++ b/Octokit/Http/CustomAwaiter.cs
@@ -9,7 +9,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(request, "request");
 
-            return request.ToTask();
+            return request.ToTask().GetAwaiter();
         }
     }
 }

--- a/Octokit/Http/CustomAwaiter.cs
+++ b/Octokit/Http/CustomAwaiter.cs
@@ -5,7 +5,7 @@ namespace Octokit
 {
     public static class CustomAwaiter
     {
-        public static TaskAwaiter<IReadOnlyList<T>> GetAwaiter<T>(this ILazyRequest<T> request)
+        public static TaskAwaiter<IReadOnlyList<T>> GetAwaiter<T>(this IDeferredRequest<T> request)
         {
             Ensure.ArgumentNotNull(request, "request");
 

--- a/Octokit/Http/DeferredRequest.cs
+++ b/Octokit/Http/DeferredRequest.cs
@@ -49,7 +49,7 @@ namespace Octokit
             }
 
             return _pagination.GetAllPages(
-                    async () => await GetPage<T>(_uri, _parameters, null).ConfigureAwait(false), _uri);
+                    async () => await GetPage<T>(_uri, _parameters, _options.Accepts).ConfigureAwait(false), _uri);
         }
 
 

--- a/Octokit/Http/DeferredRequest.cs
+++ b/Octokit/Http/DeferredRequest.cs
@@ -10,7 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit
 {
-    public class LazyRequest<T> : ILazyRequest<T>
+    public class DeferredRequest<T> : IDeferredRequest<T>
     {
         readonly IApiPagination _pagination = new ApiPagination();
         readonly IApiConnection _apiConnection;
@@ -20,17 +20,17 @@ namespace Octokit
 
         ApiOptions _options = new ApiOptions();
 
-        public LazyRequest(IApiConnection apiConnection, Uri uri)
+        public DeferredRequest(IApiConnection apiConnection, Uri uri)
             : this(apiConnection, uri, new Dictionary<string, string>()) { }
 
-        public LazyRequest(IApiConnection apiConnection, Uri uri, IDictionary<string, string> parameters)
+        public DeferredRequest(IApiConnection apiConnection, Uri uri, IDictionary<string, string> parameters)
         {
             _apiConnection = apiConnection;
             _uri = uri;
             _parameters = parameters;
         }
 
-        public ILazyRequest<T> WithOptions(ApiOptions options)
+        public IDeferredRequest<T> WithOptions(ApiOptions options)
         {
             this._options = options;
             return this;

--- a/Octokit/Http/IDeferredRequest.cs
+++ b/Octokit/Http/IDeferredRequest.cs
@@ -11,9 +11,9 @@ namespace Octokit
         public string Accepts { get; set; }
     }
 
-    public interface ILazyRequest<T>
+    public interface IDeferredRequest<T>
     {
-        ILazyRequest<T> WithOptions(ApiOptions options);
+        IDeferredRequest<T> WithOptions(ApiOptions options);
 
         Task<IReadOnlyList<T>> ToTask();
     }

--- a/Octokit/Http/ILazyRequest.cs
+++ b/Octokit/Http/ILazyRequest.cs
@@ -1,15 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Octokit
 {
     public interface ILazyRequest<T>
     {
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed",
+            Justification = "let me make this money")]
         ILazyRequest<T> WithOptions(
             int startPage = 0,
             int pageCount = -1,
             int pageSize = 30,
-            string userAgent = null);
+            string accepts = null);
 
         TaskAwaiter<IReadOnlyList<T>> ToTask();
     }

--- a/Octokit/Http/ILazyRequest.cs
+++ b/Octokit/Http/ILazyRequest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 namespace Octokit
 {
@@ -16,6 +15,6 @@ namespace Octokit
     {
         ILazyRequest<T> WithOptions(ApiOptions options);
 
-        TaskAwaiter<IReadOnlyList<T>> ToTask();
+        Task<IReadOnlyList<T>> ToTask();
     }
 }

--- a/Octokit/Http/ILazyRequest.cs
+++ b/Octokit/Http/ILazyRequest.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Octokit
+{
+    public interface ILazyRequest<T>
+    {
+        ILazyRequest<T> WithOptions(
+            int startPage = 0,
+            int pageCount = -1,
+            int pageSize = 30,
+            string userAgent = null);
+
+        TaskAwaiter<IReadOnlyList<T>> ToTask();
+    }
+}

--- a/Octokit/Http/ILazyRequest.cs
+++ b/Octokit/Http/ILazyRequest.cs
@@ -4,15 +4,17 @@ using System.Runtime.CompilerServices;
 
 namespace Octokit
 {
+    public class ApiOptions
+    {
+        public int? StartPage { get; set; }
+        public int? PageCount { get; set; }
+        public int? PageSize { get; set; }
+        public string Accepts { get; set; }
+    }
+
     public interface ILazyRequest<T>
     {
-        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed",
-            Justification = "let me make this money")]
-        ILazyRequest<T> WithOptions(
-            int startPage = 0,
-            int pageCount = -1,
-            int pageSize = 30,
-            string accepts = null);
+        ILazyRequest<T> WithOptions(ApiOptions options);
 
         TaskAwaiter<IReadOnlyList<T>> ToTask();
     }

--- a/Octokit/Http/LazyRequest.cs
+++ b/Octokit/Http/LazyRequest.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Octokit.Internal;
+using System.Globalization;
+
+namespace Octokit
+{
+    public class LazyRequest<T> : ILazyRequest<T>
+    {
+        readonly IApiPagination _pagination = new ApiPagination();
+        readonly IApiConnection _apiConnection;
+
+        readonly Uri _uri;
+        readonly IDictionary<string, string> _parameters;
+
+        int _pageSize;
+        int _startPage;
+        int _pageCount;
+
+        public LazyRequest(IApiConnection apiConnection, Uri uri)
+            : this(apiConnection, uri, new Dictionary<string, string>()) { }
+
+        public LazyRequest(IApiConnection apiConnection, Uri uri, IDictionary<string, string> parameters)
+        {
+            _apiConnection = apiConnection;
+            _uri = uri;
+            _parameters = parameters;
+        }
+
+        public ILazyRequest<T> WithOptions(
+            int startPage = 0,
+            int pageCount = -1,
+            int pageSize = 30,
+            string userAgent = null)
+        {
+            this._pageSize = pageSize;
+            this._startPage = startPage;
+            this._pageCount = pageCount;
+
+            return this;
+        }
+
+        public TaskAwaiter<IReadOnlyList<T>> ToTask()
+        {
+            _parameters.Add("per_page", _pageSize.ToString(CultureInfo.InvariantCulture));
+
+            if (_startPage > 0)
+            {
+                _parameters.Add("page", _startPage.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return _pagination.GetAllPages(
+                    async () => await GetPage<T>(_uri, _parameters, null).ConfigureAwait(false), _uri)
+                .GetAwaiter();
+        }
+
+
+        async Task<IReadOnlyPagedCollection<TU>> GetPage<TU>(
+            Uri uri,
+            IDictionary<string, string> parameters,
+            string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, "uri");
+
+            var connection = _apiConnection.Connection;
+
+            var response = await connection.Get<List<TU>>(uri, parameters, accepts).ConfigureAwait(false);
+            return new ReadOnlyPagedCollection<TU>(
+                response,
+                nextPageUri =>
+                {
+                    if (nextPageUri.Query.Contains("page=") && _pageCount > -1)
+                    {
+                        var allValues = ToQueryStringDictionary(nextPageUri);
+
+                        string pageValue;
+                        if (allValues.TryGetValue("page", out pageValue))
+                        {
+                            var endPage = _startPage + _pageCount;
+                            if (pageValue.Equals(endPage.ToString(), StringComparison.OrdinalIgnoreCase))
+                            {
+                                return null;
+                            }
+                        }
+                    }
+
+                    return connection.Get<List<TU>>(nextPageUri, parameters, accepts);
+                });
+        }
+
+        static Dictionary<string, string> ToQueryStringDictionary(Uri uri)
+        {
+            var allValues = uri.Query.Split('&')
+                .Select(keyValue =>
+                {
+                    var indexOf = keyValue.IndexOf('=');
+                    if (indexOf > 0)
+                    {
+                        var key = keyValue.Substring(0, indexOf);
+                        var value = keyValue.Substring(indexOf + 1);
+                        return new KeyValuePair<string, string>(key, value);
+                    }
+
+                    //just a plain old value, return it
+                    return new KeyValuePair<string, string>(keyValue, null);
+                })
+                .ToDictionary(x => x.Key, x => x.Value);
+            return allValues;
+        }
+    }
+}

--- a/Octokit/Http/LazyRequest.cs
+++ b/Octokit/Http/LazyRequest.cs
@@ -85,7 +85,7 @@ namespace Octokit
                         string pageValue;
                         if (allValues.TryGetValue("page", out pageValue))
                         {
-                            var endPage = _startPage + _pageCount;
+                            var endPage = _startPage + _pageCount + 1;
                             if (pageValue.Equals(endPage.ToString(), StringComparison.OrdinalIgnoreCase))
                             {
                                 return null;

--- a/Octokit/Http/LazyRequest.cs
+++ b/Octokit/Http/LazyRequest.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Octokit.Internal;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit
 {
@@ -31,15 +32,19 @@ namespace Octokit
             _parameters = parameters;
         }
 
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed",
+            Justification = "let me make this money")]
         public ILazyRequest<T> WithOptions(
-            int startPage = 0,
-            int pageCount = -1,
-            int pageSize = 30,
-            string userAgent = null)
+            int startPage,
+            int pageCount,
+            int pageSize,
+            string accepts = null)
         {
             this._pageSize = pageSize;
             this._startPage = startPage;
             this._pageCount = pageCount;
+
+            // TODO: set custom accepts
 
             return this;
         }

--- a/Octokit/Http/LazyRequest.cs
+++ b/Octokit/Http/LazyRequest.cs
@@ -18,7 +18,8 @@ namespace Octokit
         readonly Uri _uri;
         readonly IDictionary<string, string> _parameters;
 
-        int _pageSize;
+        int defaultPageSize = 30;
+        int _pageSize = 30;
         int _startPage;
         int _pageCount;
 
@@ -51,7 +52,10 @@ namespace Octokit
 
         public TaskAwaiter<IReadOnlyList<T>> ToTask()
         {
-            _parameters.Add("per_page", _pageSize.ToString(CultureInfo.InvariantCulture));
+            if (_pageSize != defaultPageSize)
+            {
+                _parameters.Add("per_page", _pageSize.ToString(CultureInfo.InvariantCulture));
+            }
 
             if (_startPage > 0)
             {

--- a/Octokit/Http/LazyRequest.cs
+++ b/Octokit/Http/LazyRequest.cs
@@ -36,7 +36,7 @@ namespace Octokit
             return this;
         }
 
-        public TaskAwaiter<IReadOnlyList<T>> ToTask()
+        public Task<IReadOnlyList<T>> ToTask()
         {
             if (_options.PageSize.HasValue)
             {
@@ -49,8 +49,7 @@ namespace Octokit
             }
 
             return _pagination.GetAllPages(
-                    async () => await GetPage<T>(_uri, _parameters, null).ConfigureAwait(false), _uri)
-                .GetAwaiter();
+                    async () => await GetPage<T>(_uri, _parameters, null).ConfigureAwait(false), _uri);
         }
 
 

--- a/Octokit/Http/ReadOnlyPagedCollection.cs
+++ b/Octokit/Http/ReadOnlyPagedCollection.cs
@@ -28,7 +28,10 @@ namespace Octokit.Internal
             var nextPageUrl = _info.GetNextPageUrl();
             if (nextPageUrl == null) return null;
 
-            var response = await _nextPageFunc(nextPageUrl).ConfigureAwait(false);
+            var nextPage = _nextPageFunc(nextPageUrl);
+            if (nextPage == null) return null;
+
+            var response = await nextPage.ConfigureAwait(false);
             return new ReadOnlyPagedCollection<T>(response, _nextPageFunc);
         }
     }

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -117,7 +117,32 @@ namespace Octokit.Internal
                     }
                 }
 
-                return base.DeserializeObject(value, type);
+                var deserializeObject = base.DeserializeObject(value, type);
+
+                if (type == typeof(Issue))
+                {
+                    DeserializeIssueBodyResponse(value, deserializeObject);
+                }
+
+                return deserializeObject;
+            }
+
+            static void DeserializeIssueBodyResponse(object value, object deserializeObject)
+            {
+                var dictionary = value as JsonObject;
+                var bodyProperty = typeof(Issue).GetProperty("Body");
+                var setter = bodyProperty.SetMethod;
+
+                object newBodyValue;
+
+                if (dictionary.TryGetValue("body_html", out newBodyValue))
+                {
+                    setter.Invoke(deserializeObject, new[] { newBodyValue });
+                }
+                else if (dictionary.TryGetValue("body_text", out newBodyValue))
+                {
+                    setter.Invoke(deserializeObject, new[] { newBodyValue });
+                }
             }
 
             static string RemoveHyphenAndUnderscore(string stringValue)

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -368,6 +368,9 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -91,6 +91,8 @@
     <Compile Include="Clients\IMilestonesClient.cs" />
     <Compile Include="Helpers\ParameterAttribute.cs" />
     <Compile Include="Helpers\ReflectionExtensions.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\GistRequest.cs" />
     <Compile Include="Models\Request\GistUpdate.cs" />
@@ -368,9 +370,7 @@
     <Compile Include="Http\Response.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -380,9 +380,9 @@
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -380,6 +380,9 @@
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -373,9 +373,9 @@
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -373,6 +373,9 @@
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Response\AccountType.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -143,9 +143,11 @@
     <Compile Include="Http\ApiResponse.cs" />
     <Compile Include="Http\Credentials.cs" />
     <Compile Include="Http\CredentialsExtensions.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
     <Compile Include="Http\HttpVerb.cs" />
     <Compile Include="Http\IApiConnection.cs" />
     <Compile Include="Http\ICredentialStore.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
     <Compile Include="Http\IHttpClient.cs" />
     <Compile Include="Http\InMemoryCredentialStore.cs" />
     <Compile Include="Http\JsonHttpPipeline.cs" />
@@ -366,9 +368,7 @@
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -366,6 +366,9 @@
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -147,9 +147,11 @@
     <Compile Include="Http\ApiResponse.cs" />
     <Compile Include="Http\Credentials.cs" />
     <Compile Include="Http\CredentialsExtensions.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
     <Compile Include="Http\HttpVerb.cs" />
     <Compile Include="Http\IApiConnection.cs" />
     <Compile Include="Http\ICredentialStore.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
     <Compile Include="Http\IHttpClient.cs" />
     <Compile Include="Http\InMemoryCredentialStore.cs" />
     <Compile Include="Http\JsonHttpPipeline.cs" />
@@ -370,9 +372,7 @@
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -370,6 +370,9 @@
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -81,8 +81,8 @@
     <Compile Include="Helpers\PropertyOrField.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Http\CustomAwaiter.cs" />
-    <Compile Include="Http\ILazyRequest.cs" />
-    <Compile Include="Http\LazyRequest.cs" />
+    <Compile Include="Http\IDeferredRequest.cs" />
+    <Compile Include="Http\DeferredRequest.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -80,6 +80,9 @@
     <Compile Include="Helpers\HttpClientExtensions.cs" />
     <Compile Include="Helpers\PropertyOrField.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
+    <Compile Include="Http\CustomAwaiter.cs" />
+    <Compile Include="Http\ILazyRequest.cs" />
+    <Compile Include="Http\LazyRequest.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />


### PR DESCRIPTION
:cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: **WORK IN PROGRESS** :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: 
:cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus: :cactus:  **DO NOT MERGE** :cactus: :cactus: :cactus::cactus: :cactus: :cactus: :cactus: :cactus: :cactus:  

I'd been noodling around with how to tackle paging in Octokit, and here's my first attempt at a solution.

#### The Problem

By default, if there's new data to fetch, the Octokit client will go and fetch it. Thanks to the [pagination](https://developer.github.com/v3/#pagination) APIs, this is rather easy to do. For my use case, that's been Good Enough. But I'm at the point where I'd like to do things like:

 - adjust the number of results per page
 - stop at a certain page number
 - skip certain pages
 - opt-in to preview API behaviour by overriding accepts header

Some endpoints support other sorts of filtering (for example, [issues search](https://developer.github.com/v3/issues/#list-issues-for-a-repository) has a `since` parameter. I'm not worrying about those here - this approach should work for all endpoints that return arrays of results.

This isn't something I've focused on given I spent most of my days working with desktop apps, but I know other platforms would love having this level of control to conserve data.

And we have #259 and #625 as open issues, so why not do try and resolve this?

#### The Approach

You can await any type in C# with the presence of `async`/`await` - and it's pretty easy once you know how to get started. For backwards-compatibility, I didn't want to force you to update your code - if you didn't opt-in to this behaviour, you should get the existing behaviour.

So I started with this ideal API:

```csharp
var repositories = await client.Repository.GetAllForCurrent()
    .WithPageCount(10)
    .SelectPages(10);
 ```

Instead of returning `Task<IReadOnlyList<T>>` here I'm returning `ILazyRequest<T>` - and it's this type that has the extra options necessary. These is how one can tweak the internal state of the request before it executes.

To get the `await` *magic* to work, you need to define a public static method in a static type that takes your type as an extension method and returns a `TaskAwaiter<T>`.

```csharp
public static class CustomAwaiter
{
    public static TaskAwaiter<IReadOnlyList<T>> GetAwaiter<T>(this ILazyRequest<T> request)
    {
        Ensure.ArgumentNotNull(request, "request");

        return request.ToTask();
    }
}
```

This lives under the `Octokit` namespace, so it should Just Work with existing users.

`ToTask()` just defers to the existing behaviour, but this gives me the hook necessary to inject the additional parameters before executing the request.

There's also some enhancements necessary to `IApiPagination` to allow clients to opt-out to paging early. I should be able to extract this dependency from `ApiConnection` by the time this is done, so I'm fine with changing that behaviour around.

This is the API I've settled on:

```csharp
var repositories = await github.Repository.GetAllForCurrent()
    .WithOptions(new ApiOptions { PageSize = 10, PageCount = 1 });
```

#### Limitations

~~I need to think about how to do this with the Observable-based APIs - currently we just cheat and transform the Task-based API, but because we surface an  `IObservable<T>` we'd need to do something similar here. Plus there are extension methods like `Skip` and `Take` available that we should be respecting (and not fetching all the records in the first place). Perhaps this is when the two libraries diverge, implementation-wise :cry:~~ 

**EDIT:** we actually use a different implementation inside the `GetAll`s for the observable clients - `GetAndFlattenAllPages` - so I'm gonna put this question aside for another day.

#### TODO

 - [x] unbreak all the tests
 - [x] resolve muted fx:cop: issues
 - [x] `ILazyRequest` -> `IDeferredRequest`
 - [ ] finish `RepositoriesClient` migration
 - [x] experiment with content responses in Issue Comments
 - ~~[ ] ponder on how to do this with `Octokit.Reactive`~~ :boot: punt to another time