### PR TITLE
Replace qed with AppVeyor in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Octokit - GitHub API Client Library for .NET ![Build Status](https://ci.appveyor.com/api/projects/status/github/octokit/octokit.net?branch=master)
+# Octokit - GitHub API Client Library for .NET [![Build Status](https://ci.appveyor.com/api/projects/status/github/octokit/octokit.net?branch=master)](https://ci.appveyor.com/project/Haacked15676/octokit-net)
 
 Octokit is a client library targeting .NET 4.5 and above that provides an easy
 way to interact with the [GitHub API](http://developer.github.com/v3/).
@@ -54,7 +54,7 @@ for more details.
 
 ## Build Server
 
-The builds and tests for Octokit.net are run on [qed](https://github.com/half-ogre/qed/). This enables us to build and test incoming pull requests: http://half-ogre-qed.cloudapp.net/octokit/octokit.net
+The builds and tests for Octokit.net are run on [AppVeyor](http://www.appveyor.com). This enables us to build and test incoming pull requests: https://ci.appveyor.com/project/Haacked15676/octokit-net
 
 ## Problems?
 


### PR DESCRIPTION
AFAIK qed isn't used in this repo anymore.
I also added a link to the AppVeyor account to the build badge which is much more useful than getting the image.