### PR TITLE
Pagination Support

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -19,6 +19,19 @@ namespace Octokit.Reactive
         IObservable<Release> GetAll(string owner, string name);
 
         /// <summary>
+        /// Gets all <see cref="Release"/>s for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="Release"/>s for the specified repository.</returns>
+        IObservable<Release> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -37,6 +37,26 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all <see cref="Release"/>s for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="Release"/>s for the specified repository.</returns>
+        public IObservable<Release> GetAll(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Release>(ApiUrls.Releases(owner, name), options);
+        }
+
+        /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Helpers/ConnectionExtensions.cs
+++ b/Octokit.Reactive/Helpers/ConnectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 
@@ -10,6 +12,26 @@ namespace Octokit.Reactive.Internal
         public static IObservable<T> GetAndFlattenAllPages<T>(this IConnection connection, Uri url)
         {
             return GetPages(url, null, (pageUrl, pageParams) => connection.Get<List<T>>(pageUrl, null, null).ToObservable());
+        }
+
+        public static IObservable<T> GetAndFlattenAllPages<T>(this IConnection connection, Uri url, ApiOptions options)
+        {
+            return GetPagesWithOptions(url, options, (pageUrl, o) =>
+            {
+                var parameters = new Dictionary<string, string>();
+
+                if (options.PageSize.HasValue)
+                {
+                    parameters.Add("per_page", options.PageSize.Value.ToString(CultureInfo.InvariantCulture));
+                }
+
+                if (options.StartPage.HasValue)
+                {
+                    parameters.Add("page", options.StartPage.Value.ToString(CultureInfo.InvariantCulture));
+                }
+
+                return connection.Get<List<T>>(pageUrl, parameters, null).ToObservable();
+            });
         }
 
         public static IObservable<T> GetAndFlattenAllPages<T>(this IConnection connection, Uri url, IDictionary<string, string> parameters)
@@ -34,6 +56,61 @@ namespace Octokit.Reactive.Internal
             })
             .Where(resp => resp != null)
             .SelectMany(resp => resp.Body);
+        }
+
+        static IObservable<T> GetPagesWithOptions<T>(Uri uri, ApiOptions options,
+            Func<Uri, ApiOptions, IObservable<IApiResponse<List<T>>>> getPageFunc)
+        {
+            return getPageFunc(uri, options).Expand(resp =>
+            {
+                var nextPageUri = resp.HttpResponse.ApiInfo.GetNextPageUrl();
+
+                if (nextPageUri == null)
+                {
+                    return Observable.Empty<IApiResponse<List<T>>>();
+                }
+
+                if (nextPageUri.Query.Contains("page=") && options.PageCount.HasValue)
+                {
+                    var allValues = ToQueryStringDictionary(nextPageUri);
+
+                    string pageValue;
+                    if (allValues.TryGetValue("page", out pageValue))
+                    {
+                        var startPage = options.StartPage ?? 1;
+                        var pageCount = options.PageCount.Value;
+
+                        var endPage = startPage + pageCount;
+                        if (pageValue.Equals(endPage.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+                        {
+                            return Observable.Empty<IApiResponse<List<T>>>();
+                        }
+                    }
+                }
+
+                return Observable.Defer(() => getPageFunc(nextPageUri, null));
+            })
+            .Where(resp => resp != null)
+            .SelectMany(resp => resp.Body);
+        }
+
+        static Dictionary<string, string> ToQueryStringDictionary(Uri uri)
+        {
+            return uri.Query.Split('&')
+                .Select(keyValue =>
+                {
+                    var indexOf = keyValue.IndexOf('=');
+                    if (indexOf > 0)
+                    {
+                        var key = keyValue.Substring(0, indexOf);
+                        var value = keyValue.Substring(indexOf + 1);
+                        return new KeyValuePair<string, string>(key, value);
+                    }
+
+                    //just a plain old value, return it
+                    return new KeyValuePair<string, string>(keyValue, null);
+                })
+                .ToDictionary(x => x.Key, x => x.Value);
         }
     }
 }

--- a/Octokit.Reactive/Octokit.Reactive-Mono.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Mono.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\Octokit\Helpers\Ensure.cs">
       <Link>Helpers\Ensure.cs</Link>
     </Compile>
+    <Compile Include="..\Octokit\Helpers\Pagination.cs">
+      <Link>Helpers\Pagination.cs</Link>
+    </Compile>
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>

--- a/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\Octokit\Helpers\Ensure.cs">
       <Link>Helpers\Ensure.cs</Link>
     </Compile>
+    <Compile Include="..\Octokit\Helpers\Pagination.cs">
+      <Link>Helpers\Pagination.cs</Link>
+    </Compile>
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>

--- a/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
@@ -56,6 +56,9 @@
     <Compile Include="..\Octokit\Helpers\Ensure.cs">
       <Link>Helpers\Ensure.cs</Link>
     </Compile>
+    <Compile Include="..\Octokit\Helpers\Pagination.cs">
+      <Link>Helpers\Pagination.cs</Link>
+    </Compile>
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -72,6 +72,9 @@
     <Compile Include="..\Octokit\Helpers\Ensure.cs">
       <Link>Helpers\Ensure.cs</Link>
     </Compile>
+    <Compile Include="..\Octokit\Helpers\Pagination.cs">
+      <Link>Helpers\Pagination.cs</Link>
+    </Compile>
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>

--- a/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
+++ b/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
@@ -21,10 +21,10 @@ namespace Octokit.Tests.Conventions
 
         static string FormatMethod(MethodInfo m)
         {
-            var parametersFormatteds = m.GetParameters()
+            var formattedParameters = m.GetParameters()
                 .Select(p => string.Format("{0} {1}", p.ParameterType.Name, p.Name));
 
-            var parameterList = string.Join(", ", parametersFormatteds);
+            var parameterList = string.Join(", ", formattedParameters);
 
             return string.Format(" - {0}({1})", m.Name, parameterList);
         }

--- a/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
+++ b/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Octokit.Tests.Conventions
+{
+    public class ApiOptionsMissingException : Exception
+    {
+        public ApiOptionsMissingException(Type type, IEnumerable<MethodInfo> methods)
+            : base(CreateMessage(type, methods)) { }
+
+        static string CreateMessage(Type type, IEnumerable<MethodInfo> methods)
+        {
+            var methodsFormatted = String.Join("\r\n", methods.Select(FormatMethod));
+            return "Methods found on type {0} require an overload which accepts an parameter of type ApiOptions:\r\n{1}"
+                      .FormatWithNewLine(
+                          type.Name,
+                          methodsFormatted);
+        }
+
+        static string FormatMethod(MethodInfo m)
+        {
+            var parametersFormatteds = m.GetParameters()
+                .Select(p => string.Format("{0} {1}", p.ParameterType.Name, p.Name));
+
+            var parameterList = string.Join(", ", parametersFormatteds);
+
+            return string.Format(" - {0}({1})", m.Name, parameterList);
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -95,27 +95,6 @@ namespace Octokit.Tests.Conventions
             }
         }
 
-        //TODO: This should (probably) be moved to the PaginationTests class that is being introduced in PR #760
-        [Theory]
-        [MemberData("GetClientInterfaces")]
-        public void CheckPaginationGetAllMethodNames(Type clientInterface)
-        {
-            var methodsOrdered = clientInterface.GetMethodsOrdered();
-
-            var methodsThatCanPaginate = methodsOrdered
-                .Where(x => x.ReturnType.GetTypeInfo().TypeCategory == TypeCategory.ReadOnlyList)
-                .Where(x => x.Name.StartsWith("Get"));
-
-            var invalidMethods = methodsThatCanPaginate
-                .Where(x => !x.Name.StartsWith("GetAll"))
-                .ToList();
-
-            if (invalidMethods.Any())
-            {
-                throw new PaginationGetAllMethodNameMismatchException(clientInterface, invalidMethods);
-            }
-        }
-
         public static IEnumerable<object[]> GetClientInterfaces()
         {
             return typeof(IEventsClient)

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
     <Compile Include="Exception\MutableModelPropertiesException.cs" />
     <Compile Include="Exception\PaginationGetAllMethodNameMismatchException.cs" />
+    <Compile Include="Exception\ApiOptionsMissingException.cs" />
     <Compile Include="ModelTests.cs" />
     <Compile Include="Exception\InterfaceHasAdditionalMethodsException.cs" />
     <Compile Include="Exception\InterfaceMethodsMismatchException.cs" />
@@ -76,6 +77,7 @@
     <Compile Include="Exception\ParameterCountMismatchException.cs" />
     <Compile Include="Exception\ParameterMismatchException.cs" />
     <Compile Include="Exception\ReturnValueMismatchException.cs" />
+    <Compile Include="PaginationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="SyncObservableClients.cs" />

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Octokit.Tests.Conventions
+{
+    public class PaginationTests
+    {
+        [Theory(Skip = "Disable this to run it and find all the places where things break")]
+        [MemberData("GetClientInterfaces")]
+        public void CheckObservableClients(Type clientInterface)
+        {
+            var methodsOrdered = clientInterface.GetMethodsOrdered();
+
+            var methodsWhichCanPaginate = methodsOrdered
+                .Where(x => x.Name.StartsWith("GetAll"));
+
+            var invalidMethods = methodsWhichCanPaginate
+                .Where(method => MethodHasAppropriateOverload(method, methodsOrdered) == null)
+                .ToList();
+
+            if (invalidMethods.Any())
+            {
+                throw new ApiOptionsMissingException(clientInterface, invalidMethods);
+            }
+        }
+
+        static MethodInfo MethodHasAppropriateOverload(MethodInfo method, MethodInfo[] methodsOrdered)
+        {
+            var parameters = method.GetParametersOrdered();
+            var name = method.Name;
+            return methodsOrdered
+                .Where(x => x.Name == name)
+                .FirstOrDefault(x => MethodHasOverloadForApiOptions(x, parameters));
+        }
+
+        static bool MethodHasOverloadForApiOptions(MethodInfo methodInfo, ParameterInfo[] expected)
+        {
+            var actual = methodInfo.GetParameters();
+
+            if (actual.Length != expected.Length + 1)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < expected.Length; i++)
+            {
+                var a = actual.ElementAt(i);
+                var e = expected.ElementAt(i);
+
+                if (a.Name != e.Name)
+                {
+                    return false;
+                }
+
+                if (a.ParameterType != e.ParameterType)
+                {
+                    return false;
+                }
+            }
+
+            var lastParameter = actual.Last();
+
+            return lastParameter.Name == "options"
+                   && lastParameter.ParameterType == typeof(ApiOptions);
+        }
+
+        public static IEnumerable<object[]> GetClientInterfaces()
+        {
+            return typeof(IEventsClient).Assembly.ExportedTypes.Where(TypeExtensions.IsClientInterface).Select(type => new[] { type });
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -8,7 +8,7 @@ namespace Octokit.Tests.Conventions
 {
     public class PaginationTests
     {
-        [Theory(Skip = "Disable this to run it and find all the places where things break")]
+        [Theory(Skip = "Enable this to run it and find all the places where things break")]
         [MemberData("GetClientInterfaces")]
         public void CheckObservableClients(Type clientInterface)
         {

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -75,6 +75,83 @@ public class ReleasesClientTests
         }
     }
 
+    public class TheGetAllMethod
+    {
+        readonly IReleasesClient _releaseClient;
+        const string owner = "octokit";
+        const string name = "octokit.net";
+
+        public TheGetAllMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            _releaseClient = github.Repository.Release;
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsReleases()
+        {
+            var releases = await _releaseClient.GetAll(owner, name);
+
+            Assert.NotEmpty(releases);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfReleasesWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var releases = await _releaseClient.GetAll(owner, name, options);
+
+            Assert.Equal(5, releases.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfReleasesWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var releases = await _releaseClient.GetAll(owner, name, options);
+
+            Assert.Equal(5, releases.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var firstPage = await _releaseClient.GetAll(owner, name, startOptions);
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondPage = await _releaseClient.GetAll(owner, name, skipStartOptions);
+
+            Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+            Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+            Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
+            Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+        }
+    }
+
     public class TheEditMethod : IDisposable
     {
         private readonly IGitHubClient _github;

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
+    <Compile Include="Reactive\ObservableReleaseClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />
     <Compile Include="Clients\ReleasesClientTests.cs" />
     <Compile Include="Clients\RepositoriesClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableReleaseClientTests
+    {
+        public class TheGetAllMethod
+        {
+            readonly ObservableReleasesClient _releaseClient;
+            const string owner = "octokit";
+            const string name = "octokit.net";
+
+            public TheGetAllMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _releaseClient = new ObservableReleasesClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsReleases()
+            {
+                var releases = await _releaseClient.GetAll(owner, name).ToList();
+
+                Assert.NotEmpty(releases);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfReleasesWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var releases = await _releaseClient.GetAll(owner, name, options).ToList();
+
+                Assert.Equal(5, releases.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfReleasesWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var releases = await _releaseClient.GetAll(owner, name, options).ToList();
+
+                Assert.Equal(5, releases.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstPage = await _releaseClient.GetAll(owner, name, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await _releaseClient.GetAll(owner, name, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+                Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
+                Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().GetAll<Authorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations"),
-                    null);
+                    Arg.Is<IDictionary<string,string>>(d => d == null));
             }
         }
 

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().GetAll<Authorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations"),
-                    Arg.Is<IDictionary<string,string>>(d => d == null));
+                    Args.ApiOptions);
             }
         }
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().GetAll<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
                     null,
-                    AcceptHeaders.StableVersion,
+                    "application/vnd.github.v3",
                     Args.ApiOptions);
             }
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -2,14 +2,13 @@
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class ReleasesClientTests
     {
-        public class TheGetReleasesMethod
+        public class TheGetAllMethod
         {
             [Fact]
             public void RequestsCorrectUrl()
@@ -21,7 +20,8 @@ namespace Octokit.Tests.Clients
 
                 client.Received().GetAll<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
                     null,
-                    "application/vnd.github.v3");
+                    AcceptHeaders.StableVersion,
+                    Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Helpers/Arg.cs
+++ b/Octokit.Tests/Helpers/Arg.cs
@@ -67,5 +67,10 @@ namespace Octokit.Tests
         {
             get { return Arg.Any<NewDeployKey>(); }
         }
+
+        public static ApiOptions ApiOptions
+        {
+            get { return Arg.Any<ApiOptions>(); }
+        }
     }
 }

--- a/Octokit.Tests/Http/ApiConnectionTests.cs
+++ b/Octokit.Tests/Http/ApiConnectionTests.cs
@@ -90,13 +90,13 @@ namespace Octokit.Tests.Http
                     new Response(),
                     new List<object> { new object(), new object() });
                 var connection = Substitute.For<IConnection>();
-                connection.Get<List<object>>(Args.Uri, null, null).Returns(Task.FromResult(response));
+                connection.Get<List<object>>(Args.Uri, Args.EmptyDictionary, null).Returns(Task.FromResult(response));
                 var apiConnection = new ApiConnection(connection);
 
                 var data = await apiConnection.GetAll<object>(getAllUri);
 
                 Assert.Equal(2, data.Count);
-                connection.Received().Get<List<object>>(getAllUri, null, null);
+                connection.Received().Get<List<object>>(getAllUri, Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
+++ b/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Models
 
                 connection.Get<List<object>>(nextPageUrl, null, null).Returns(nextPageResponse);
 
-                var pageCount = 0;
+                var pageCount = 1;
 
                 var pagedCollection = new ReadOnlyPagedCollection<object>(
                     response,
@@ -95,7 +95,7 @@ namespace Octokit.Tests.Models
                 var second = await pagedCollection.GetNextPage();
 
                 Assert.NotNull(first);
-                Assert.NotNull(second);
+                Assert.Null(second);
             }
         }
     }

--- a/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
+++ b/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
@@ -33,6 +33,70 @@ namespace Octokit.Tests.Models
                 Assert.NotNull(nextPage);
                 Assert.Equal(2, nextPage.Count);
             }
+
+            [Fact]
+            public async Task WhenNoInformationSetReturnsNull()
+            {
+                var nextPageUrl = new Uri("https://example.com/page/2");
+                var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
+                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+
+                var links = new Dictionary<string, Uri>();
+                var scopes = new List<string>();
+                var httpResponse = Substitute.For<IResponse>();
+                httpResponse.ApiInfo.Returns(new ApiInfo(links, scopes, scopes, "etag", new RateLimit(new Dictionary<string, string>())));
+
+                var response = new ApiResponse<List<object>>(httpResponse, new List<object>());
+                var connection = Substitute.For<IConnection>();
+
+                connection.Get<List<object>>(nextPageUrl, null, null).Returns(nextPageResponse);
+
+                var pagedCollection = new ReadOnlyPagedCollection<object>(
+                    response,
+                    nextPageUri => connection.Get<List<object>>(nextPageUrl, null, null));
+
+                var nextPage = await pagedCollection.GetNextPage();
+
+                Assert.Null(nextPage);
+            }
+
+            [Fact]
+            public async Task WhenInlineFuncKillsPaginationReturnNull()
+            {
+                var nextPageUrl = new Uri("https://example.com/page/2");
+                var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
+                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+
+                var links = new Dictionary<string, Uri> { { "next", nextPageUrl } };
+                var scopes = new List<string>();
+                var httpResponse = Substitute.For<IResponse>();
+                httpResponse.ApiInfo.Returns(new ApiInfo(links, scopes, scopes, "etag", new RateLimit(new Dictionary<string, string>())));
+
+                var response = new ApiResponse<List<object>>(httpResponse, new List<object>());
+                var connection = Substitute.For<IConnection>();
+
+                connection.Get<List<object>>(nextPageUrl, null, null).Returns(nextPageResponse);
+
+                var pageCount = 0;
+
+                var pagedCollection = new ReadOnlyPagedCollection<object>(
+                    response,
+                    nextPageUri =>
+                    {
+                        if (pageCount > 1)
+                        {
+                            return null;
+                        }
+                        pageCount++;
+                        return connection.Get<List<object>>(nextPageUrl, null, null);
+                    });
+
+                var first = await pagedCollection.GetNextPage();
+                var second = await pagedCollection.GetNextPage();
+
+                Assert.NotNull(first);
+                Assert.NotNull(second);
+            }
         }
     }
 }

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
         /// <returns>A list of <see cref="Authorization"/>s.</returns>
         public Task<IReadOnlyList<Authorization>> GetAll()
         {
-            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), null);
+            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), (IDictionary<string,string>)null);
         }
 
         /// <summary>

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
         /// <returns>A list of <see cref="Authorization"/>s.</returns>
         public Task<IReadOnlyList<Authorization>> GetAll()
         {
-            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), (IDictionary<string,string>)null);
+            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -27,6 +27,19 @@ namespace Octokit
         Task<IReadOnlyList<Release>> GetAll(string owner, string name);
 
         /// <summary>
+        /// Gets all <see cref="Release"/>s for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="Release"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<Release>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -36,8 +36,28 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "repository");
 
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Release"/>s for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-releases-for-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="Release"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<Release>> GetAll(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "repository");
+            Ensure.ArgumentNotNull(options, "options");
+
             var endpoint = ApiUrls.Releases(owner, name);
-            return ApiConnection.GetAll<Release>(endpoint, null, AcceptHeaders.StableVersion);
+            return ApiConnection.GetAll<Release>(endpoint, null, AcceptHeaders.StableVersion, options);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -26,7 +26,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(connection, "connection");
             Ensure.ArgumentNotNull(uri, "uri");
 
-            return connection.GetAll<T>(uri, null);
+            return connection.GetAll<T>(uri, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit/Helpers/Pagination.cs
+++ b/Octokit/Helpers/Pagination.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Octokit
+{
+    internal static class Pagination
+    {
+        internal static IDictionary<string, string> Setup(IDictionary<string, string> parameters, ApiOptions options)
+        {
+            parameters = parameters ?? new Dictionary<string, string>();
+
+            if (options.PageSize.HasValue)
+            {
+                parameters.Add("per_page", options.PageSize.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (options.StartPage.HasValue)
+            {
+                parameters.Add("page", options.StartPage.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            return parameters;
+        }
+
+        internal static bool ShouldContinue(
+            Uri uri,
+            ApiOptions options)
+        {
+            if (uri == null)
+            {
+                return false;
+            }
+
+            if (uri.Query.Contains("page=") && options.PageCount.HasValue)
+            {
+                var allValues = ToQueryStringDictionary(uri);
+
+                string pageValue;
+                if (allValues.TryGetValue("page", out pageValue))
+                {
+                    var startPage = options.StartPage ?? 1;
+                    var pageCount = options.PageCount.Value;
+
+                    var endPage = startPage + pageCount;
+                    if (pageValue.Equals(endPage.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        static Dictionary<string, string> ToQueryStringDictionary(Uri uri)
+        {
+            return uri.Query.Split('&')
+                .Select(keyValue =>
+                {
+                    var indexOf = keyValue.IndexOf('=');
+                    if (indexOf > 0)
+                    {
+                        var key = keyValue.Substring(0, indexOf);
+                        var value = keyValue.Substring(indexOf + 1);
+                        return new KeyValuePair<string, string>(key, value);
+                    }
+
+                    //just a plain old value, return it
+                    return new KeyValuePair<string, string>(keyValue, null);
+                })
+                .ToDictionary(x => x.Key, x => x.Value);
+        }
+    }
+}

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -182,17 +182,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(uri, "uri");
             Ensure.ArgumentNotNull(options, "options");
 
-            parameters = parameters ?? new Dictionary<string, string>();
-
-            if (options.PageSize.HasValue)
-            {
-                parameters.Add("per_page", options.PageSize.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (options.StartPage.HasValue)
-            {
-                parameters.Add("page", options.StartPage.Value.ToString(CultureInfo.InvariantCulture));
-            }
+            parameters = Pagination.Setup(parameters, options);
 
             return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts, options)
                                                                  .ConfigureAwait(false), uri);
@@ -549,45 +539,14 @@ namespace Octokit
                 response,
                 nextPageUri =>
                 {
-                    if (nextPageUri.Query.Contains("page=") && options.PageCount.HasValue)
-                    {
-                        var allValues = ToQueryStringDictionary(nextPageUri);
+                    var shouldContinue = Pagination.ShouldContinue(
+                        nextPageUri,
+                        options);
 
-                        string pageValue;
-                        if (allValues.TryGetValue("page", out pageValue))
-                        {
-                            var startPage = options.StartPage ?? 1;
-                            var pageCount = options.PageCount.Value;
-
-                            var endPage = startPage + pageCount;
-                            if (pageValue.Equals(endPage.ToString(), StringComparison.OrdinalIgnoreCase))
-                            {
-                                return null;
-                            }
-                        }
-                    }
-
-                    return connection.Get<List<TU>>(nextPageUri, parameters, accepts);
+                    return shouldContinue
+                        ? connection.Get<List<TU>>(nextPageUri, parameters, accepts)
+                        : null;
                 });
-        }
-
-        static Dictionary<string, string> ToQueryStringDictionary(Uri uri)
-        {
-            return uri.Query.Split('&')
-                .Select(keyValue =>
-                {
-                    var indexOf = keyValue.IndexOf('=');
-                    if (indexOf > 0)
-                    {
-                        var key = keyValue.Substring(0, indexOf);
-                        var value = keyValue.Substring(indexOf + 1);
-                        return new KeyValuePair<string, string>(key, value);
-                    }
-
-                    //just a plain old value, return it
-                    return new KeyValuePair<string, string>(keyValue, null);
-                })
-                .ToDictionary(x => x.Key, x => x.Value);
         }
     }
 }

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -76,6 +76,16 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">Type of the API resource in the list.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, ApiOptions options);
+
+        /// <summary>
+        /// Gets all API resources in the list at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource in the list.</typeparam>
+        /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
@@ -87,10 +97,33 @@ namespace Octokit
         /// <typeparam name="T">Type of the API resource in the list.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, ApiOptions options);
+
+        /// <summary>
+        /// Gets all API resources in the list at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource in the list.</typeparam>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
         Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts);
+
+        /// <summary>
+        /// Gets all API resources in the list at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource in the list.</typeparam>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <param name="accepts">Accept header to use for the API request</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.

--- a/Octokit/Http/ReadOnlyPagedCollection.cs
+++ b/Octokit/Http/ReadOnlyPagedCollection.cs
@@ -28,7 +28,14 @@ namespace Octokit.Internal
             var nextPageUrl = _info.GetNextPageUrl();
             if (nextPageUrl == null) return null;
 
-            var response = await _nextPageFunc(nextPageUrl).ConfigureAwait(false);
+            var maybeTask = _nextPageFunc(nextPageUrl);
+
+            if (maybeTask == null)
+            {
+                return null;
+            }
+
+            var response = await maybeTask.ConfigureAwait(false);
             return new ReadOnlyPagedCollection<T>(response, _nextPageFunc);
         }
     }

--- a/Octokit/Models/Request/ApiOptions.cs
+++ b/Octokit/Models/Request/ApiOptions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class ApiOptions
+    {
+        public static ApiOptions None
+        {
+            get { return new ApiOptions(); }
+        }
+
+        /// <summary>
+        /// Specify the start page for pagination actions
+        /// </summary>
+        /// <remarks>
+        /// Page numbering is 1-based on the server
+        /// </remarks>
+        public int? StartPage { get; set; }
+
+        /// <summary>
+        /// Specify the number of pages to return
+        /// </summary>
+        public int? PageCount { get; set; }
+
+        /// <summary>
+        /// Specify the number of results to return for each page
+        /// </summary>
+        /// <remarks>
+        /// Results returned may be less than this total if you reach the final page of results
+        /// </remarks>
+        public int? PageSize { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                var values = new List<string>();
+
+                if (StartPage.HasValue)
+                {
+                    values.Add("StartPage: " + StartPage.Value);
+                }
+
+                if (PageCount.HasValue)
+                {
+                    values.Add("PageCount: " + PageCount.Value);
+                }
+
+                if (PageSize.HasValue)
+                {
+                    values.Add("PageSize: " + PageSize.Value);
+                }
+
+                return String.Join(", ", values);
+            }
+        }
+    }
+
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -447,6 +447,7 @@
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -448,6 +448,7 @@
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -456,6 +456,7 @@
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -452,6 +452,7 @@
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -451,6 +451,7 @@
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -445,6 +445,7 @@
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -444,6 +444,7 @@
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -451,6 +451,7 @@
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -452,6 +452,7 @@
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
     <Compile Include="Models\Response\Enterprise\SearchIndexingResponse.cs" />
     <Compile Include="Models\Request\ApiOptions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Http\RequestBody.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />
+    <Compile Include="Models\Request\ApiOptions.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Helpers\ApiUrls.Keys.cs" />
     <Compile Include="Helpers\ConcurrentCache.cs" />
     <Compile Include="Helpers\HttpClientExtensions.cs" />
+    <Compile Include="Helpers\Pagination.cs" />
     <Compile Include="Helpers\PropertyOrField.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Helpers\WebHookConfigComparer.cs" />

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,25 @@
+# Extensibility
+
+Octokit.net has been designed to be easy to get started, but there are options
+available to tweak the default behaviour once you know the basics.
+
+## Pagination
+
+The GitHub API supports paging results whenever collections are returned.
+
+By default, Octokit.net will fetch the entire set of data. Any method prefixed with
+`GetAll*` now has an overload which accepts an `ApiOptions` parameter.
+
+```csharp
+var options = new ApiOptions();
+var repositories = await client.Repository.GetAllForCurrent(options);
+```
+
+`ApiOptions` has a number of properties:
+
+ - `PageCount` - return a set number of pages
+ - `PageSize` - change the number of results to return per page
+ - `StartPage` - start results from a given page
+
+These parameters can be used in any sort of group. If you don't specify a
+`PageSize` the default page size is 30.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ pages:
 - Advanced:
   - 'API Options': 'extensibility.md'
   - 'Debugging from Source': 'debugging-source.md'
-  - 'HttpClient': 'http-client.md'
+  - 'OAuth Flow': 'oauth-flow.md'
   - 'HttpClient': 'http-client.md'
 
 - Contributing:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,8 +29,9 @@ pages:
   - 'Exploring Pull Requests' : 'demos/exploring-pull-requests.md'
 
 - Advanced:
+  - 'API Options': 'extensibility.md'
   - 'Debugging from Source': 'debugging-source.md'
-  - 'OAuth Flow': 'oauth-flow.md'
+  - 'HttpClient': 'http-client.md'
   - 'HttpClient': 'http-client.md'
 
 - Contributing:


### PR DESCRIPTION
The goal here is to have overloads flowing through Octokit which let the consumer specify the pagination options available.

The current properties supported are:

 - `PerPage` - number of results to return for each page
 - `StartPage` - skip pages by specify this value
 - `PageCount` - number of pages to return

Previous attempts at this PR have meant updating everything, but for now I've just updated `IReleasesClient` as it has one usage. I've added some integration tests which caught an issue with the internals that I need to look at (the `HACK:` commit).

 - [x] rewrite one method to support an `ApiOptions` overload
 - [x] port over existing behaviour for internals of pagination
 - [x] write convention test to ensure all `GetAll*` methods have an overload
 - [x] port a usage over and add integration tests
 - [x] add some new unit tests around this behaviour
 - [x] extract duplicated behaviour for pagination into a separate function
 - [x] clean up implementation so there's less null hacks

### Ship List

 - [x] finish all the xml-docs stuff
 - [x] documentation on how pagination works
 - [x] integration tests all pass
 - [x] @haacked is happy
 - [x] someone else is happy
 - [ ] script to generate issues for API migration steps
