### PR TITLE
Repository name is required when creating a repo

### DIFF
--- a/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
@@ -15,7 +15,7 @@ public class AssigneesClientTests
         _gitHubClient = Helper.GetAuthenticatedClient();
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository { Name = repoName }).Result;
+        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Clients/BlobClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BlobClientTests.cs
@@ -17,7 +17,7 @@ public class BlobClientTests : IDisposable
         _fixture = client.GitDatabase.Blob;
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _repository = client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -15,7 +15,7 @@ public class BranchesClientTests
         {
             _github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = _github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = _github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
@@ -56,7 +56,7 @@ public class CommitStatusClientTests
             _client = Helper.GetAuthenticatedClient();
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
             _owner = _repository.Owner.Login;
         }
 

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -17,7 +17,7 @@ public class CommitsClientTests : IDisposable
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
         _fixture = _client.GitDatabase.Commit;
-        _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -19,9 +19,8 @@ public class DeploymentStatusClientTests : IDisposable
 
         _deploymentsClient = _gitHubClient.Repository.Deployment;
 
-        var newRepository = new NewRepository
+        var newRepository = new NewRepository(Helper.MakeNameWithTimestamp("public-repo"))
         {
-            Name = Helper.MakeNameWithTimestamp("public-repo"),
             AutoInit = true
         };
 

--- a/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
@@ -6,11 +6,11 @@ using Xunit;
 
 public class DeploymentsClientTests : IDisposable
 {
-    IGitHubClient _gitHubClient;
-    IDeploymentsClient _deploymentsClient;
-    Repository _repository;
-    Commit _commit;
-    string _repositoryOwner;
+    readonly IGitHubClient _gitHubClient;
+    readonly IDeploymentsClient _deploymentsClient;
+    readonly Repository _repository;
+    readonly Commit _commit;
+    readonly string _repositoryOwner;
 
     public DeploymentsClientTests()
     {
@@ -18,9 +18,8 @@ public class DeploymentsClientTests : IDisposable
 
         _deploymentsClient = _gitHubClient.Repository.Deployment;
 
-        var newRepository = new NewRepository
+        var newRepository = new NewRepository(Helper.MakeNameWithTimestamp("public-repo"))
         {
-            Name = Helper.MakeNameWithTimestamp("public-repo"),
             AutoInit = true
         };
 

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -19,7 +19,7 @@ public class IssuesClientTests : IDisposable
         _gitHubClient = Helper.GetAuthenticatedClient();
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
         _issuesClient = _gitHubClient.Issue;
-        _repository = _gitHubClient.Repository.Create(new NewRepository { Name = repoName }).Result;
+        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -23,7 +23,7 @@ public class IssuesEventsClientTests : IDisposable
         _issuesClient = _gitHubClient.Issue;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository { Name = repoName }).Result;
+        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
         _repositoryOwner = _repository.Owner.Login;
         _repositoryName = _repository.Name;
     }

--- a/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
@@ -21,7 +21,7 @@ public class IssuesLabelsClientTests : IDisposable
         _issuesClient = _gitHubClient.Issue;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository { Name = repoName }).Result;
+        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
         _repositoryOwner = _repository.Owner.Login;
         _repositoryName = _repository.Name;
     }

--- a/Octokit.Tests.Integration/Clients/MergingClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MergingClientTests.cs
@@ -23,7 +23,7 @@ public class MergingClientTests : IDisposable
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
         _fixture = _client.Repository.Merging;
-        _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -20,7 +20,7 @@ public class MilestonesClientTests : IDisposable
         _milestonesClient = _gitHubClient.Issue.Milestone;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository { Name = repoName }).Result;
+        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
         _repositoryOwner = _repository.Owner.Login;
         _repositoryName = _repository.Name;
     }

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -222,7 +222,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
 
     async Task<Repository> CreateRepository(string repoName)
     {
-        return await _gitHubClient.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+        return await _gitHubClient.Repository.Create(new NewRepository(repoName) { AutoInit = true });
     }
 
     /// <summary>

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -25,7 +25,7 @@ public class PullRequestsClientTests : IDisposable
 
         var repoName = Helper.MakeNameWithTimestamp("source-repo");
 
-        _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -20,7 +20,7 @@ public class ReferencesClientTests : IDisposable
         _fixture = _client.GitDatabase.Reference;
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -22,7 +22,7 @@ public class ReleasesClientTests
             _releaseClient = github.Release;
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
             _repositoryOwner = _repository.Owner.Login;
             _repositoryName = _repository.Name;
         }
@@ -69,7 +69,7 @@ public class ReleasesClientTests
             _releaseClient = github.Release;
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
             _repositoryOwner = _repository.Owner.Login;
             _repositoryName = _repository.Name;
         }
@@ -133,7 +133,7 @@ public class ReleasesClientTests
             _releaseClient = _github.Release;
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = _github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = _github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
             _repositoryOwner = _repository.Owner.Login;
             _repositoryName = _repository.Name;
         }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -17,7 +17,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-            var createdRepository = await github.Repository.Create(new NewRepository { Name = repoName });
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName));
                 
             try
             {
@@ -58,9 +58,8 @@ public class RepositoriesClientTests
 
             try
             {
-                createdRepository = await github.Repository.Create(new NewRepository
+                createdRepository = await github.Repository.Create(new NewRepository(repoName)
                 {
-                    Name = repoName,
                     Private = true
                 });
 
@@ -84,9 +83,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-downloads");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 HasDownloads = false
             });
 
@@ -109,9 +107,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-issues");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 HasIssues = false
             });
 
@@ -134,9 +131,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-wiki");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 HasWiki = false
             });
 
@@ -159,9 +155,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-description");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 Description = "theDescription"
             });
 
@@ -184,9 +179,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-homepage");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 Homepage = "http://aUrl.to/nowhere"
             });
 
@@ -209,9 +203,8 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-autoinit");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 AutoInit = true
             });
 
@@ -234,9 +227,8 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("repo-with-gitignore");
 
-            var createdRepository = await github.Repository.Create(new NewRepository
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
             {
-                Name = repoName,
                 AutoInit = true,
                 GitignoreTemplate = "VisualStudio"
             });
@@ -259,7 +251,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("existing-repo");
-            var repository = new NewRepository { Name = repoName };
+            var repository = new NewRepository(repoName);
             var createdRepository = await github.Repository.Create(repository);
 
             try
@@ -298,7 +290,7 @@ public class RepositoriesClientTests
                 .Select(x =>
                 {
                     var repoName = Helper.MakeNameWithTimestamp("private-repo-" + x);
-                    var repository = new NewRepository { Name = repoName, Private = true };
+                    var repository = new NewRepository(repoName) { Private = true };
                     return github.Repository.Create(repository);
                 });
 
@@ -307,7 +299,7 @@ public class RepositoriesClientTests
             try
             {
                 await Assert.ThrowsAsync<PrivateRepositoryQuotaExceededException>(
-                    () => github.Repository.Create(new NewRepository { Name = "x-private", Private = true }));
+                    () => github.Repository.Create(new NewRepository("x-private") { Private = true }));
             }
             finally
             {
@@ -328,7 +320,7 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("public-org-repo");
 
-            var createdRepository = await github.Repository.Create(Helper.Organization, new NewRepository { Name = repoName });
+            var createdRepository = await github.Repository.Create(Helper.Organization, new NewRepository(repoName));
 
             try
             {
@@ -358,7 +350,7 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("existing-org-repo");
 
-            var repository = new NewRepository { Name = repoName };
+            var repository = new NewRepository(repoName);
             var createdRepository = await github.Repository.Create(Helper.Organization, repository);
 
             try
@@ -394,7 +386,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
             var update = new RepositoryUpdate { Name = updatedName };
 
@@ -408,7 +400,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, Description = "Updated description" };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -421,7 +413,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, Homepage = "http://aUrl.to/nowhere" };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -441,7 +433,7 @@ public class RepositoriesClientTests
             }
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, Private = true };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -454,7 +446,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, HasDownloads = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -467,7 +459,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, HasIssues = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -480,7 +472,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = await github.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var update = new RepositoryUpdate { Name = repoName, HasWiki = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
@@ -502,7 +494,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
 
             var repoName = Helper.MakeNameWithTimestamp("repo-to-delete");
-            await github.Repository.Create(new NewRepository { Name = repoName });
+            await github.Repository.Create(new NewRepository(repoName));
 
             await github.Repository.Delete(Helper.UserName, repoName);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -92,7 +92,7 @@ public class RepositoryCommitsClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("source-repo");
 
-            _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+            _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -90,7 +90,7 @@ namespace Octokit.Tests.Integration.Clients
             {
                 var fixture = client.Repository.Content;
                 var repoName = Helper.MakeNameWithTimestamp("source-repo");
-                repository = await client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+                repository = await client.Repository.Create(new NewRepository(repoName) { AutoInit = true });
 
                 var file = await fixture.CreateFile(
                     repository.Owner.Login,

--- a/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
@@ -19,7 +19,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
         _fixture = client.Repository.DeployKeys;
-        _repository = client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
 
     }

--- a/Octokit.Tests.Integration/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/StatisticsClientTests.cs
@@ -83,7 +83,7 @@ namespace Octokit.Tests.Integration.Clients
         async Task<RepositorySummary> CreateRepository()
         {
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            var repository = await _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true });
+            var repository = await _client.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             return new RepositorySummary
             {
                 Owner = repository.Owner.Login,

--- a/Octokit.Tests.Integration/Clients/TreeClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TreeClientTests.cs
@@ -18,7 +18,7 @@ public class TreeClientTests : IDisposable
         _fixture = _client.GitDatabase.Tree;
 
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _repository = _client.Repository.Create(new NewRepository { Name = repoName, AutoInit = true }).Result;
+        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _owner = _repository.Owner.Login;
     }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssuesClientTests.cs
@@ -18,7 +18,7 @@ public class ObservableIssuesClientTests : IDisposable
 
         _client = new ObservableIssuesClient(github);
         _repoName = Helper.MakeNameWithTimestamp("public-repo");
-        var result = github.Repository.Create(new NewRepository { Name = _repoName }).Result;
+        var result = github.Repository.Create(new NewRepository(_repoName)).Result;
         _createdRepository = result;
     }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableRespositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRespositoryDeployKeysClientTests.cs
@@ -21,7 +21,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
 
         _client = new ObservableRepositoryDeployKeysClient(github);
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        var result = github.Repository.Create(new NewRepository() { Name = repoName, AutoInit = true }).Result;
+        var result = github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
         _repository = result;
         _owner = _repository.Owner.Login;
     }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -31,7 +31,6 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
                 await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create(new NewRepository { Name = null }));
             }
 
             [Fact]
@@ -40,7 +39,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.Create(new NewRepository { Name = "aName" });
+                client.Create(new NewRepository("aName"));
 
                 connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Arg.Any<NewRepository>());
             }
@@ -50,7 +49,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
 
                 client.Create(newRepository);
 
@@ -60,7 +59,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsRepositoryExistsExceptionWhenRepositoryExistsForCurrentUser()
             {
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
                 var response = Substitute.For<IResponse>();
                 response.StatusCode.Returns((HttpStatusCode)422);
                 response.Body.Returns(@"{""message"":""Validation Failed"",""documentation_url"":"
@@ -86,7 +85,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsExceptionWhenPrivateRepositoryQuotaExceeded()
             {
-                var newRepository = new NewRepository { Name = "aName", Private = true };
+                var newRepository = new NewRepository("aName") { Private = true };
                 var response = Substitute.For<IResponse>();
                 response.StatusCode.Returns((HttpStatusCode)422);
                 response.Body.Returns(@"{""message"":""Validation Failed"",""documentation_url"":"
@@ -115,9 +114,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, new NewRepository { Name = "aName" }));
+                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, new NewRepository("aName")));
                 await AssertEx.Throws<ArgumentException>(async () => await client.Create("aLogin", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("aLogin", new NewRepository { Name = null }));
             }
 
             [Fact]
@@ -126,7 +124,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.Create("theLogin", new NewRepository { Name = "aName" });
+                await client.Create("theLogin", new NewRepository("aName"));
 
                 connection.Received().Post<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/theLogin/repos"),
@@ -138,7 +136,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
 
                 await client.Create("aLogin", newRepository);
 
@@ -148,7 +146,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsRepositoryExistsExceptionWhenRepositoryExistsForSpecifiedOrg()
             {
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
                 var response = Substitute.For<IResponse>();
                 response.StatusCode.Returns((HttpStatusCode)422);
                 response.Body.Returns(@"{""message"":""Validation Failed"",""documentation_url"":"
@@ -174,7 +172,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsValidationException()
             {
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
                 var response = Substitute.For<IResponse>();
                 response.StatusCode.Returns((HttpStatusCode)422);
                 response.Body.Returns(@"{""message"":""Validation Failed"",""documentation_url"":"
@@ -194,7 +192,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ThrowsRepositoryExistsExceptionForEnterpriseInstance()
             {
-                var newRepository = new NewRepository { Name = "aName" };
+                var newRepository = new NewRepository("aName");
                 var response = Substitute.For<IResponse>();
                 response.StatusCode.Returns((HttpStatusCode)422);
                 response.Body.Returns(@"{""message"":""Validation Failed"",""documentation_url"":"

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -46,9 +46,7 @@ namespace Octokit
         public Task<Repository> Create(NewRepository newRepository)
         {
             Ensure.ArgumentNotNull(newRepository, "newRepository");
-            if (string.IsNullOrEmpty(newRepository.Name))
-                throw new ArgumentException("The new repository's name must not be null.");
-
+            
             return Create(ApiUrls.Repositories(), null, newRepository);
         }
 

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -59,6 +59,16 @@ namespace Octokit
         public string GitignoreTemplate { get; set; }
 
         /// <summary>
+        /// Optional. Gets or sets the desired Desired LICENSE template to apply. Use the name of the template without
+        /// the extension. For example, “mit” or “mozilla”.
+        /// </summary>
+        /// <remarks>
+        /// The list of license templates are here: https://github.com/github/choosealicense.com/tree/gh-pages/_licenses
+        /// Just omit the ".txt" file extension for the template name.
+        /// </remarks>
+        public string LicenseTemplate { get; set; }
+
+        /// <summary>
         /// Required. Gets or sets the new repository's name.
         /// </summary>
         public string Name { get; private set; }

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -12,6 +12,17 @@ namespace Octokit
     public class NewRepository
     {
         /// <summary>
+        /// Creates an object that describes the repository to create on GitHub.
+        /// </summary>
+        /// <param name="name">The name of the repository. This is the only required parameter.</param>
+        public NewRepository(string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            Name = name;
+        }
+
+        /// <summary>
         /// Optional. Gets or sets whether to create an initial commit with empty README. The default is false.
         /// </summary>
         public bool? AutoInit { get; set; }
@@ -50,7 +61,7 @@ namespace Octokit
         /// <summary>
         /// Required. Gets or sets the new repository's name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; private set; }
 
         /// <summary>
         /// Optional. Gets or sets whether the new repository is private; the default is false.


### PR DESCRIPTION
I was trying to create a repository and I wasn't sure which parameters were required. Following our philosophy of exposing required parameters in the constructor, I change the `NewRepository` object to take in a repository name and to make that property readonly.