### PR TITLE
Add more info to TwoFactorChallengeFailedException

### DIFF
--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -172,7 +172,7 @@ namespace Octokit
             }
             catch (AuthorizationException e)
             {
-                throw new TwoFactorChallengeFailedException(e);
+                throw new TwoFactorChallengeFailedException(twoFactorAuthenticationCode, e);
             }
         }
 

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -67,6 +67,7 @@ namespace Octokit
 
             StatusCode = response.StatusCode;
             ApiError = GetApiErrorFromExceptionMessage(response);
+            HttpResponse = response;
         }
 
         /// <summary>
@@ -96,6 +97,8 @@ namespace Octokit
             ApiError = apiError;
             StatusCode = statusCode;
         }
+
+        public IResponse HttpResponse { get; private set; }
 
         public override string Message
         {

--- a/Octokit/Exceptions/TwoFactorAuthorizationException.cs
+++ b/Octokit/Exceptions/TwoFactorAuthorizationException.cs
@@ -61,7 +61,7 @@ namespace Octokit
         /// </summary>
         public TwoFactorType TwoFactorType { get; private set; }
 
-        #if !NETFX_CORE
+#if !NETFX_CORE
         /// <summary>
         /// Constructs an instance of TwoFactorRequiredException.
         /// </summary>

--- a/Octokit/Exceptions/TwoFactorAuthorizationException.cs
+++ b/Octokit/Exceptions/TwoFactorAuthorizationException.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Octokit
+{
+#if !NETFX_CORE
+    /// <summary>
+    /// Represents a failed 2FA challenge from the API
+    /// </summary>
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public abstract class TwoFactorAuthorizationException : AuthorizationException
+    {
+        /// <summary>
+        /// Constructs an instance of TwoFactorRequiredException.
+        /// </summary>
+        /// <param name="twoFactorType">Expected 2FA response type</param>
+        /// <param name="innerException">The inner exception</param>
+        protected TwoFactorAuthorizationException(TwoFactorType twoFactorType, Exception innerException)
+            : base(HttpStatusCode.Unauthorized, innerException)
+        {
+            TwoFactorType = twoFactorType;
+        }
+
+        /// <summary>
+        /// Constructs an instance of TwoFactorRequiredException.
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        /// <param name="twoFactorType">Expected 2FA response type</param>
+        protected TwoFactorAuthorizationException(IResponse response, TwoFactorType twoFactorType)
+            : base(response)
+        {
+            Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Unauthorized,
+                "TwoFactorRequiredException status code should be 401");
+
+            TwoFactorType = twoFactorType;
+        }
+
+        /// <summary>
+        /// Constructs an instance of TwoFactorRequiredException.
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        /// <param name="twoFactorType">Expected 2FA response type</param>
+        /// <param name="innerException">The inner exception</param>
+        protected TwoFactorAuthorizationException(IResponse response, TwoFactorType twoFactorType, Exception innerException)
+            : base(response, innerException)
+        {
+            Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Unauthorized,
+                "TwoFactorRequiredException status code should be 401");
+
+            TwoFactorType = twoFactorType;
+        }
+
+        /// <summary>
+        /// Expected 2FA response type
+        /// </summary>
+        public TwoFactorType TwoFactorType { get; private set; }
+
+        #if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of TwoFactorRequiredException.
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected TwoFactorAuthorizationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null) return;
+            TwoFactorType = (TwoFactorType) (info.GetInt32("TwoFactorType"));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("TwoFactorType", TwoFactorType);
+        }
+#endif
+
+    }
+
+    /// <summary>
+    /// Methods for receiving 2FA authentication codes
+    /// </summary>
+    public enum TwoFactorType
+    {
+        /// <summary>
+        /// No method configured
+        /// </summary>
+        None,
+        /// <summary>
+        /// Unknown method
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Receive via SMS
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sms")]
+        Sms,
+        /// <summary>
+        /// Receive via application
+        /// </summary>
+        AuthenticatorApp
+    }
+}

--- a/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
+++ b/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using System.Runtime.Serialization;
 
 namespace Octokit
@@ -13,23 +12,26 @@ namespace Octokit
 #endif
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
         Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
-    public class TwoFactorChallengeFailedException : AuthorizationException
+    public class TwoFactorChallengeFailedException : TwoFactorAuthorizationException
     {
         /// <summary>
         /// Constructs an instance of TwoFactorChallengeFailedException
         /// </summary>
-        public TwoFactorChallengeFailedException() :
-            base(HttpStatusCode.Unauthorized, null)
+        public TwoFactorChallengeFailedException() : base(TwoFactorType.None, null)
         {
         }
 
         /// <summary>
         /// Constructs an instance of TwoFactorChallengeFailedException
         /// </summary>
+        /// <param name="authorizationCode">The authorization code that was incorrect</param>
         /// <param name="innerException">The inner exception</param>
-        public TwoFactorChallengeFailedException(Exception innerException)
-            : base(HttpStatusCode.Unauthorized, innerException)
+        public TwoFactorChallengeFailedException(
+            string authorizationCode,
+            ApiException innerException)
+            : base(ParseTwoFactorType(innerException), innerException)
         {
+            AuthorizationCode = authorizationCode;
         }
 
         public override string Message
@@ -37,9 +39,16 @@ namespace Octokit
             get { return "The two-factor authentication code supplied is not correct"; }
         }
 
+        public string AuthorizationCode { get; private set; }
+
+        static TwoFactorType ParseTwoFactorType(ApiException exception)
+        {
+            return exception == null ? TwoFactorType.None : Connection.ParseTwoFactorType(exception.HttpResponse);
+        }
+
 #if !NETFX_CORE
         /// <summary>
-        /// Constructs an instance of TwoFactorChallengeFailedException
+        /// Constructs an instance of TwoFactorRequiredException.
         /// </summary>
         /// <param name="info">
         /// The <see cref="SerializationInfo"/> that holds the
@@ -52,6 +61,14 @@ namespace Octokit
         protected TwoFactorChallengeFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            if (info == null) return;
+            AuthorizationCode = info.GetString("AuthorizationCode");
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("AuthorizationCode", AuthorizationCode);
         }
 #endif
     }

--- a/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
+++ b/Octokit/Exceptions/TwoFactorChallengeFailedException.cs
@@ -48,7 +48,7 @@ namespace Octokit
 
 #if !NETFX_CORE
         /// <summary>
-        /// Constructs an instance of TwoFactorRequiredException.
+        /// Constructs an instance of TwoFactorChallengeFailedException.
         /// </summary>
         /// <param name="info">
         /// The <see cref="SerializationInfo"/> that holds the

--- a/Octokit/Exceptions/TwoFactorRequiredException.cs
+++ b/Octokit/Exceptions/TwoFactorRequiredException.cs
@@ -14,7 +14,7 @@ namespace Octokit
 #endif
     [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
         Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
-    public class TwoFactorRequiredException : AuthorizationException
+    public class TwoFactorRequiredException : TwoFactorAuthorizationException
     {
         /// <summary>
         /// Constructs an instance of TwoFactorRequiredException.
@@ -27,10 +27,8 @@ namespace Octokit
         /// Constructs an instance of TwoFactorRequiredException.
         /// </summary>
         /// <param name="twoFactorType">Expected 2FA response type</param>
-        public TwoFactorRequiredException(TwoFactorType twoFactorType)
-            : base(HttpStatusCode.Unauthorized, null)
+        public TwoFactorRequiredException(TwoFactorType twoFactorType) : base(twoFactorType, null)
         {
-            TwoFactorType = twoFactorType;
         }
 
         /// <summary>
@@ -38,12 +36,11 @@ namespace Octokit
         /// </summary>
         /// <param name="response">The HTTP payload from the server</param>
         /// <param name="twoFactorType">Expected 2FA response type</param>
-        public TwoFactorRequiredException(IResponse response, TwoFactorType twoFactorType) : base(response)
+        public TwoFactorRequiredException(IResponse response, TwoFactorType twoFactorType)
+            : base(response, twoFactorType)
         {
             Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Unauthorized,
                 "TwoFactorRequiredException status code should be 401");
-
-            TwoFactorType = twoFactorType;
         }
 
         public override string Message
@@ -66,44 +63,7 @@ namespace Octokit
         protected TwoFactorRequiredException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            if (info == null) return;
-            TwoFactorType = (TwoFactorType) (info.GetInt32("TwoFactorType"));
-        }
-
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            info.AddValue("TwoFactorType", TwoFactorType);
         }
 #endif
-
-        /// <summary>
-        /// Expected 2FA response type
-        /// </summary>
-        public TwoFactorType TwoFactorType { get; private set; }
-    }
-
-    /// <summary>
-    /// Methods for receiving 2FA authentication codes
-    /// </summary>
-    public enum TwoFactorType
-    {
-        /// <summary>
-        /// No method configured
-        /// </summary>
-        None,
-        /// <summary>
-        /// Unknown method
-        /// </summary>
-        Unknown,
-        /// <summary>
-        /// Receive via SMS
-        /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Sms")]
-        Sms,
-        /// <summary>
-        /// Receive via application
-        /// </summary>
-        AuthenticatorApp
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -489,9 +489,9 @@ namespace Octokit
                     : new ForbiddenException(response);
         }
 
-        static TwoFactorType ParseTwoFactorType(IResponse restResponse)
+        internal static TwoFactorType ParseTwoFactorType(IResponse restResponse)
         {
-            if (restResponse.Headers == null || !restResponse.Headers.Any()) return TwoFactorType.None;
+            if (restResponse == null || restResponse.Headers == null || !restResponse.Headers.Any()) return TwoFactorType.None;
             var otpHeader = restResponse.Headers.FirstOrDefault(header =>
                 header.Key.Equals("X-GitHub-OTP", StringComparison.OrdinalIgnoreCase));
             if (String.IsNullOrEmpty(otpHeader.Value)) return TwoFactorType.None;

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -383,6 +383,7 @@
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -388,6 +388,7 @@
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -381,6 +381,7 @@
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -385,6 +385,7 @@
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Clients\RepositoryContentsClient.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />
     <Compile Include="Exceptions\RepositoryExistsException.cs" />
+    <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Helpers\ApiErrorExtensions.cs" />
     <Compile Include="Helpers\ApiUrls.Authorizations.cs" />
     <Compile Include="Helpers\ApiUrls.Keys.cs" />


### PR DESCRIPTION
I was running into an issue where i wanted more information from the
TwoFactorChallengeFailedException. It turns out, the exception could
easily provide both the TwoFactorType AND the authentication code
provided. So :boom:!