### PR TITLE
bring back GetAllPublic repositories

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -51,6 +51,18 @@ namespace Octokit.Reactive
         IObservable<Repository> GetAllPublic();
 
         /// <summary>
+        /// Retrieves every public <see cref="Repository"/> since the last repository seen.
+        /// </summary>
+        /// <remarks>
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="request">Search parameters of the last repository seen</param>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
+            Justification = "Makes a network request")]
+        IObservable<Repository> GetAllPublic(PublicRepositoryRequest request);
+
+        /// <summary>
         /// Retrieves every <see cref="Repository"/> that belongs to the current user.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -103,6 +103,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Retrieves every public <see cref="Repository"/> since the last repository seen.
+        /// </summary>
+        /// <remarks>
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="request">Search parameters of the last repository seen</param>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        public IObservable<Repository> GetAllPublic(PublicRepositoryRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.AllPublicRepositories(), request.ToParametersDictionary());
+        }
+
+        /// <summary>
         /// Retrieves every <see cref="Repository"/> that belongs to the current user.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -114,7 +114,9 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(request, "request");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.AllPublicRepositories(), request.ToParametersDictionary());
+            var url = ApiUrls.AllPublicRepositories(request.Since);
+
+            return _connection.GetAndFlattenAllPages<Repository>(url);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -553,20 +553,20 @@ public class RepositoriesClientTests
             Assert.True(repositories.Count > 80);
         }
 
-        //[IntegrationTest]
-        //public async Task ReturnsAllPublicRepositoriesSinceLastSeen()
-        //{
-        //    var github = Helper.GetAuthenticatedClient();
+        [IntegrationTest]
+        public async Task ReturnsAllPublicRepositoriesSinceLastSeen()
+        {
+            var github = Helper.GetAuthenticatedClient();
 
-        //    var request = new PublicRepositoryRequest(32732250);
-        //    var repositories = await github.Repository.GetAllPublic(request);
+            var request = new PublicRepositoryRequest(32732250);
+            var repositories = await github.Repository.GetAllPublic(request);
 
-        //    Assert.NotNull(repositories);
-        //    Assert.True(repositories.Any());
-        //    Assert.Equal(32732252, repositories[0].Id);
-        //    Assert.False(repositories[0].Private);
-        //    Assert.Equal("zad19", repositories[0].Name);
-        //}
+            Assert.NotNull(repositories);
+            Assert.True(repositories.Any());
+            Assert.Equal(32732252, repositories[0].Id);
+            Assert.False(repositories[0].Private);
+            Assert.Equal("zad19", repositories[0].Name);
+        }
     }
 
     public class TheGetAllForOrgMethod

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -553,7 +553,7 @@ public class RepositoriesClientTests
             Assert.True(repositories.Count > 80);
         }
 
-        [IntegrationTest]
+        [IntegrationTest(Skip = "Takes too long to run.")]
         public async Task ReturnsAllPublicRepositoriesSinceLastSeen()
         {
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
@@ -28,5 +28,22 @@ namespace Octokit.Tests.Integration
                 Assert.False(repository2.Fork);
             }
         }
+
+        public class TheGetAllPublicSinceMethod
+        {
+            [IntegrationTest(Skip = "This will take a very long time to return, so will skip it for now.")]
+            public async Task ReturnsAllPublicReposSinceLastSeen()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var client = new ObservableRepositoriesClient(github);
+                var request = new PublicRepositoryRequest(32732250);
+                var repositories = await client.GetAllPublic(request).ToArray();
+                Assert.NotEmpty(repositories);
+                Assert.Equal(32732252, repositories[0].Id);
+                Assert.False(repositories[0].Private);
+                Assert.Equal("zad19", repositories[0].Name);
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -273,6 +273,37 @@ namespace Octokit.Tests.Clients
             } 
         }
 
+
+        public class TheGetAllPublicSinceMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                client.GetAllPublic(new PublicRepositoryRequest(364));
+
+                connection.Received()
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"),
+                        Arg.Any<Dictionary<string, string>>());
+            }
+
+            [Fact]
+            public void SendsTheCorrectParameter()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                client.GetAllPublic(new PublicRepositoryRequest(364));
+
+                connection.Received()
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"),
+                        Arg.Is<Dictionary<string, string>>(d => d.Count == 1
+                            && d["since"] == "364"));
+            }
+        }
+
         public class TheGetAllForCurrentMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -285,8 +285,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"),
-                        Arg.Any<Dictionary<string, string>>());
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories?since=364"));
             }
 
             [Fact]
@@ -298,9 +297,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"),
-                        Arg.Is<Dictionary<string, string>>(d => d.Count == 1
-                            && d["since"] == "364"));
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories?since=364"));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -158,6 +158,65 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheGetAllPublicRepositoriesSinceMethod
+        {
+            [Fact]
+            public async Task ReturnsEveryPageOfRepositories()
+            {
+                var firstPageUrl = new Uri("/repositories", UriKind.Relative);
+                var secondPageUrl = new Uri("https://example.com/page/2");
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
+                IApiResponse<List<Repository>> firstPageResponse = new ApiResponse<List<Repository>>(
+                    CreateResponseWithApiInfo(firstPageLinks),
+                    new List<Repository>
+                    {
+                        new Repository(364),
+                        new Repository(365),
+                        new Repository(366)
+                    });
+                
+                var thirdPageUrl = new Uri("https://example.com/page/3");
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
+                IApiResponse<List<Repository>> secondPageResponse = new ApiResponse<List<Repository>>
+                (
+                    CreateResponseWithApiInfo(secondPageLinks),
+                    new List<Repository>
+                    {
+                        new Repository(367),
+                        new Repository(368),
+                        new Repository(369)
+                    });
+
+                IApiResponse<List<Repository>> lastPageResponse = new ApiResponse<List<Repository>>(
+                    new Response(),
+                    new List<Repository>
+                    {
+                        new Repository(370)
+                    });
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl,
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 1
+                        && d["since"] == "364"), null)
+                    .Returns(Task.FromResult(firstPageResponse));
+                gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, null, null)
+                    .Returns(Task.FromResult(secondPageResponse));
+                gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, null, null)
+                    .Returns(Task.FromResult(lastPageResponse));
+
+                var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
+
+                var results = await repositoriesClient.GetAllPublic(new PublicRepositoryRequest(364)).ToArray();
+
+                Assert.Equal(7, results.Length);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, 
+                    Arg.Is<Dictionary<string, string>>(d=>d.Count == 1
+                    && d["since"] == "364"), null);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, null, null);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, null, null);
+            }
+        }
+
         public class TheGetAllBranchesMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -163,7 +163,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task ReturnsEveryPageOfRepositories()
             {
-                var firstPageUrl = new Uri("/repositories", UriKind.Relative);
+                var firstPageUrl = new Uri("/repositories?since=364", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 IApiResponse<List<Repository>> firstPageResponse = new ApiResponse<List<Repository>>(
@@ -195,9 +195,7 @@ namespace Octokit.Tests.Reactive
                     });
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl,
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 1
-                        && d["since"] == "364"), null)
+                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, null, null)
                     .Returns(Task.FromResult(firstPageResponse));
                 gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, null, null)
                     .Returns(Task.FromResult(secondPageResponse));
@@ -209,9 +207,7 @@ namespace Octokit.Tests.Reactive
                 var results = await repositoriesClient.GetAllPublic(new PublicRepositoryRequest(364)).ToArray();
 
                 Assert.Equal(7, results.Length);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, 
-                    Arg.Is<Dictionary<string, string>>(d=>d.Count == 1
-                    && d["since"] == "364"), null);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, null, null);
                 gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, null, null);
                 gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, null, null);
             }

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -109,6 +109,20 @@ namespace Octokit
             Justification = "Makes a network request")]
         Task<IReadOnlyList<Repository>> GetAllPublic();
 
+
+        /// <summary>
+        /// Gets all public repositories since the integer ID of the last Repository that you've seen.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#list-all-public-repositories">API documentation</a> for more information.
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="request">Search parameters of the last repository seen</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        Task<IReadOnlyList<Repository>> GetAllPublic(PublicRepositoryRequest request);
+
         /// <summary>
         /// Gets all repositories owned by the current user.
         /// </summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -203,7 +203,9 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(request, "request");
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.AllPublicRepositories(), request.ToParametersDictionary());
+            var url = ApiUrls.AllPublicRepositories(request.Since);
+
+            return ApiConnection.GetAll<Repository>(url);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -189,6 +189,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all public repositories since the integer ID of the last Repository that you've seen.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#list-all-public-repositories">API documentation</a> for more information.
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="request">Search parameters of the last repository seen</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        public Task<IReadOnlyList<Repository>> GetAllPublic(PublicRepositoryRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return ApiConnection.GetAll<Repository>(ApiUrls.AllPublicRepositories(), request.ToParametersDictionary());
+        }
+
+        /// <summary>
         /// Gets all repositories owned by the current user.
         /// </summary>
         /// <remarks>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -19,15 +19,23 @@ namespace Octokit
         static readonly Uri _oauthAuthorize = new Uri("login/oauth/authorize", UriKind.Relative);
         static readonly Uri _oauthAccesToken = new Uri("login/oauth/access_token", UriKind.Relative);
 
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all public repositories in
+        /// response to a GET request.
+        /// </summary>
+        public static Uri AllPublicRepositories()
+        {
+            return "/repositories".FormatUri();
+        }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all public repositories in
         /// response to a GET request.
         /// </summary>
-        /// <returns></returns>
-        public static Uri AllPublicRepositories()
+       /// <param name="since">The integer ID of the last Repository that you’ve seen.</param>
+        public static Uri AllPublicRepositories(long since)
         {
-            return "/repositories".FormatUri();
+            return "/repositories?since={0}".FormatUri(since);
         }
 
         /// <summary>


### PR DESCRIPTION
As part of shipping 0.10 I disabled `GetAllPublic` because I couldn't get to the bottom of why it was infinite-looping. With a bit of sleep, however, I found a workaround.

As part of generating the complete URL for the request, Octokit will take values in it's request collection and overwrite whatever's in the URL. This is fine for the first request, but it was also kicking in for subsequent requests - and getting stuck.

I'm taking away this nice thing for just this endpoint, and providing just the URL it needs to start things off.

The test is still taking too long, so I've disabled it anyway until I can get a chance to finish off #760.

cc @alfhenrik 