### PR TITLE
adding missing organization teams APIs

### DIFF
--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -85,7 +85,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         IObservable<TeamMembership> AddMembership(int id, string login);
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         IObservable<TeamMembership> GetMembership(int id, string login);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -72,19 +72,6 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
-        [Obsolete("Use AddMembership(id, login) to track pending requests")]
-        IObservable<bool> AddMember(int id, string login);
-
-        /// <summary>
-        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="id">The team identifier.</param>
-        /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         IObservable<TeamMembership> AddMembership(int id, string login);
 
@@ -97,8 +84,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        IObservable<bool> RemoveMember(int id, string login);
-
+        IObservable<bool> RemoveMembership(int id, string login);
 
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -110,16 +110,6 @@ namespace Octokit.Reactive
         IObservable<bool> RemoveRepository(int id, string organization, string repoName);
 
         /// <summary>
-        /// Returns all <see cref="Repository"/>(ies) associated with the given team. 
-        /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-team-repos">API documentation</a> for more information.
-        /// </remarks>
-        /// <returns>A list of the team's <see cref="Repository"/>(ies).</returns>
-        IObservable<Repository> GetRepositories(int id);
-
-        /// <summary>
         /// Adds a <see cref="Repository"/> to a <see cref="Team"/>.
         /// </summary>
         /// <param name="id">The team identifier.</param>

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -32,6 +32,14 @@ namespace Octokit.Reactive
         IObservable<Team> GetAll(string org);
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<Team> GetAllForCurrent();
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -86,6 +86,7 @@ namespace Octokit.Reactive
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
         IObservable<bool> RemoveMember(int id, string login);
 
+
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
@@ -93,7 +94,17 @@ namespace Octokit.Reactive
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
         /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use GetMembership(id, login) to detect pending memberships")]
         IObservable<bool> IsMember(int id, string login);
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        IObservable<TeamMembership> GetMembership(int id, string login);
 
         /// <summary>
         /// Returns all team's repositories.

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -73,7 +73,20 @@ namespace Octokit.Reactive
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use AddMembership(id, login) to track pending requests")]
         IObservable<bool> AddMember(int id, string login);
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
+        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        IObservable<TeamMembership> AddMembership(int id, string login);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -105,9 +105,25 @@ namespace Octokit.Reactive
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use AddMembership(int, login) to get pending invitations")]
         public IObservable<bool> AddMember(int id, string login)
         {
             return _client.AddMember(id, login).ToObservable();
+        }
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
+        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        public IObservable<TeamMembership> AddMembership(int id, string login)
+        {
+            return _client.AddMembership(id, login).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -104,22 +104,6 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
-        [Obsolete("Use AddMembership(int, login) to get pending invitations")]
-        public IObservable<bool> AddMember(int id, string login)
-        {
-            return _client.AddMember(id, login).ToObservable();
-        }
-
-        /// <summary>
-        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="id">The team identifier.</param>
-        /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public IObservable<TeamMembership> AddMembership(int id, string login)
         {
@@ -135,9 +119,9 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        public IObservable<bool> RemoveMember(int id, string login)
+        public IObservable<bool> RemoveMembership(int id, string login)
         {
-            return _client.RemoveMember(id, login).ToObservable();
+            return _client.RemoveMembership(id, login).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -120,7 +120,7 @@ namespace Octokit.Reactive
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public IObservable<TeamMembership> AddMembership(int id, string login)
         {
             return _client.AddMembership(id, login).ToObservable();
@@ -159,7 +159,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public IObservable<TeamMembership> GetMembership(int id, string login)
         {
             return _client.GetMembership(id, login).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -131,9 +131,22 @@ namespace Octokit.Reactive
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
         /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use GetMembership(id, login) to detect pending memberships")]
         public IObservable<bool> IsMember(int id, string login)
         {
             return _client.IsMember(id, login).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        public IObservable<TeamMembership> GetMembership(int id, string login)
+        {
+            return _client.GetMembership(id, login).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -52,6 +52,16 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        public IObservable<Team> GetAllForCurrent()
+        {
+            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.UserTeams());
+        }
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -147,19 +147,6 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Returns all <see cref="Repository"/>(ies) associated with the given team. 
-        /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-team-repos">API documentation</a> for more information.
-        /// </remarks>
-        /// <returns>A list of the team's <see cref="Repository"/>(ies).</returns>
-        public IObservable<Repository> GetRepositories(int id)
-        {
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.TeamRepositories(id));
-        }
-
-        /// <summary>
         /// Adds a <see cref="Repository"/> to a <see cref="Team"/>.
         /// </summary>
         /// <param name="id">The team identifier.</param>

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -67,7 +67,7 @@ public class TeamsClientTests
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 
-        [OrganizationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for the resolution to this failing test")]
+        [OrganizationTest]
         public async Task FailsWhenAuthenticatedWithBadCredentials()
         {
             var github = Helper.GetBadCredentialsClient();

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -57,16 +57,6 @@ public class TeamsClientTests
             team = github.Organization.Team.GetAll(Helper.Organization).Result.First();
         }
 
-        [OrganizationTest(Skip="actually returning the membership information! Maybe because it's a public organization?")]
-        public async Task FailsWhenNotAuthenticated()
-        {
-            var github = Helper.GetAnonymousClient();
-
-            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.GetMembership(team.Id, Helper.UserName));
-
-            Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
-        }
-
         [OrganizationTest]
         public async Task FailsWhenAuthenticatedWithBadCredentials()
         {

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 
@@ -43,6 +42,17 @@ public class TeamsClientTests
             var team = await github.Organization.Team.Create(Helper.Organization, newTeam);
 
             Assert.Equal(newTeam.Name, team.Name);
+        }
+    }
+
+    public class TheGetAllForCurrentMethod
+    {
+        [IntegrationTest]
+        public async Task GetsIsMemberWhenAuthenticated()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var teams = await github.Organization.Team.GetAllForCurrent();
+            Assert.NotEmpty(teams);
         }
     }
 

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -46,11 +46,11 @@ public class TeamsClientTests
         }
     }
 
-    public class TheIsMemberMethod
+    public class TheGetMembershipMethod
     {
         readonly Team team;
 
-        public TheIsMemberMethod()
+        public TheGetMembershipMethod()
         {
             var github = Helper.GetAuthenticatedClient();
 
@@ -62,7 +62,7 @@ public class TeamsClientTests
         {
             var github = Helper.GetAnonymousClient();
 
-            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.IsMember(team.Id, Helper.UserName));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.GetMembership(team.Id, Helper.UserName));
 
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
@@ -81,9 +81,9 @@ public class TeamsClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var isMember = await github.Organization.Team.IsMember(team.Id, Helper.UserName);
+            var membership = await github.Organization.Team.GetMembership(team.Id, Helper.UserName);
 
-            Assert.True(isMember);
+            Assert.Equal(TeamMembership.Active, membership);
         }
 
         [OrganizationTest]
@@ -91,9 +91,9 @@ public class TeamsClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var isMember = await github.Organization.Team.IsMember(team.Id, "foo");
+            var membership = await github.Organization.Team.GetMembership(team.Id, "foo");
 
-            Assert.False(isMember);
+            Assert.Equal(TeamMembership.NotFound, membership);
         }
     }
 

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -145,7 +145,7 @@ namespace Octokit.Tests.Clients
 
                 client.AddMember(1, "user");
 
-                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
+                connection.Connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
             }
 
             [Fact]
@@ -189,7 +189,7 @@ namespace Octokit.Tests.Clients
                 var client = new TeamsClient(connection);
                 client.RemoveMember(1, "user");
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
+                connection.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
             }
 
             [Fact]
@@ -230,7 +230,7 @@ namespace Octokit.Tests.Clients
                 var client = new TeamsClient(connection);
                 client.RemoveRepository(1, "org", "repo");
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
+                connection.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
             }
         }
 
@@ -259,7 +259,7 @@ namespace Octokit.Tests.Clients
                 var client = new TeamsClient(connection);
                 client.AddRepository(1, "org", "repo");
 
-                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
+                connection.Connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -135,7 +135,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheAddMemberMethod
+        public class TheAddMembershipMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -159,6 +159,20 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetAllForCurrentMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                client.GetAllForCurrent();
+
+                connection.Received().GetAll<Team>(Arg.Is<Uri>(u => u.ToString() == "user/teams"));
+            }
+        }
+
         public class TheGetMembershipMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -159,7 +159,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheIsMemberMethod
+        public class TheGetMembershipMethod
         {
             [Fact]
             public void EnsuresNonNullLogin()
@@ -167,7 +167,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.IsMember(1, null));
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetMembership(1, null));
             }
 
             [Fact]
@@ -176,11 +176,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.IsMember(1, ""));
+                Assert.ThrowsAsync<ArgumentException>(() => client.GetMembership(1, ""));
             }
         }
 
-        public class TheRemoveMemberMethod
+        public class TheRRemoveMembershipMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -143,7 +143,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                client.AddMember(1, "user");
+                client.AddMembership(1, "user");
 
                 connection.Connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
             }
@@ -154,8 +154,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddMember(1, null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.AddMember(1, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddMembership(1, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddMembership(1, ""));
             }
         }
 
@@ -187,7 +187,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
-                client.RemoveMember(1, "user");
+                client.RemoveMembership(1, "user");
 
                 connection.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
             }
@@ -198,8 +198,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveMember(1, null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveMember(1, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveMembership(1, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveMembership(1, ""));
             }
 
         }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -204,7 +204,7 @@ namespace Octokit.Tests.Clients
 
         }
 
-        public class TheGetRepositoriesMethod
+        public class TheGetAllRepositoriesMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -215,7 +215,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"));
 
-                client.GetRepositories(1);
+                client.GetAllRepositories(1);
 
                 connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"));
             }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Tests.Helpers;
@@ -138,14 +139,17 @@ namespace Octokit.Tests.Clients
         public class TheAddMembershipMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
+
                 var client = new TeamsClient(connection);
 
-                client.AddMembership(1, "user");
+                await client.AddMembership(1, "user");
 
-                connection.Connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
+                connection.Received().Put<Dictionary<string, string>>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"),
+                    Args.Object);
             }
 
             [Fact]

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -35,6 +35,13 @@ namespace Octokit
         Task<IReadOnlyList<Team>> GetAll(string org);
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        Task<IReadOnlyList<Team>> GetAllForCurrent();
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -98,6 +98,17 @@ namespace Octokit
         [Obsolete("Use GetMembership(id, login) as this will report on pending requests")]
         Task<bool> IsMember(int id, string login);
 
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        Task<TeamMembership> GetMembership(int id, string login);
+
+
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -87,7 +87,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         Task<TeamMembership> AddMembership(int id, string login);
 
         /// <summary>
@@ -111,16 +111,14 @@ namespace Octokit
         [Obsolete("Use GetMembership(id, login) as this will report on pending requests")]
         Task<bool> IsMember(int id, string login);
 
-
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         Task<TeamMembership> GetMembership(int id, string login);
-
 
         /// <summary>
         /// Returns all team's repositories.

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -75,7 +75,20 @@ namespace Octokit
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use AddMembership(id, login) to track pending requests")]
         Task<bool> AddMember(int id, string login);
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
+        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        Task<TeamMembership> AddMembership(int id, string login);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -39,6 +39,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Team>> GetAllForCurrent();
 
         /// <summary>

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -118,16 +118,6 @@ namespace Octokit
         Task<bool> RemoveRepository(int id, string organization, string repoName);
 
         /// <summary>
-        /// Returns all <see cref="Repository"/>(ies) associated with the given team. 
-        /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-team-repos">API documentation</a> for more information.
-        /// </remarks>
-        /// <returns>A list of the team's <see cref="Repository"/>(ies).</returns>
-        Task<IReadOnlyList<Repository>> GetRepositories(int id);
-
-        /// <summary>
         /// Gets whether or not the given repository is managed by the given team.
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -74,19 +74,6 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
-        [Obsolete("Use AddMembership(id, login) to track pending requests")]
-        Task<bool> AddMember(int id, string login);
-
-        /// <summary>
-        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="id">The team identifier.</param>
-        /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         Task<TeamMembership> AddMembership(int id, string login);
 
@@ -99,7 +86,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        Task<bool> RemoveMember(int id, string login);
+        Task<bool> RemoveMembership(int id, string login);
 
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -1,4 +1,5 @@
-﻿#if NET_45
+﻿using System;
+#if NET_45
 using System.Collections.Generic;
 #endif
 using System.Threading.Tasks;
@@ -94,6 +95,7 @@ namespace Octokit
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
         /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use GetMembership(id, login) as this will report on pending requests")]
         Task<bool> IsMember(int id, string login);
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Collections.Generic;
 #endif
 using System.Threading.Tasks;
-using Octokit.Models.Response;
 
 namespace Octokit
 {
@@ -69,14 +68,12 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
         /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <param name="login">The username to query</param>
-        /// <remarks>
-        /// https://developer.github.com/v3/orgs/teams/#list-team-members
-        /// </remarks>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
         public async Task<TeamMembership> GetMembership(int id, string login)
         {
             var endpoint = ApiUrls.TeamMember(id, login);

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -142,35 +142,6 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
-        [Obsolete("Use AddTeamMember(id, login) to track pending requests")]
-        public async Task<bool> AddMember(int id, string login)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(login, "login");
-
-            var endpoint = ApiUrls.TeamMember(id, login);
-
-            try
-            {
-                var httpStatusCode = await ApiConnection.Connection.Put(endpoint);
-
-                return httpStatusCode == HttpStatusCode.NoContent;
-            }
-            catch (NotFoundException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="id">The team identifier.</param>
-        /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public async Task<TeamMembership> AddMembership(int id, string login)
         {
@@ -203,7 +174,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
-        public async Task<bool> RemoveMember(int id, string login)
+        public async Task<bool> RemoveMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -171,6 +171,11 @@ namespace Octokit
                 return TeamMembership.NotFound;
             }
 
+            if (response == null || !response.ContainsKey("state"))
+            {
+                return TeamMembership.NotFound;
+            }
+
             return response["state"] == "active"
                 ? TeamMembership.Active
                 : TeamMembership.Pending;

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -73,7 +73,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public async Task<TeamMembership> GetMembership(int id, string login)
         {
             var endpoint = ApiUrls.TeamMember(id, login);
@@ -171,7 +171,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public async Task<TeamMembership> AddMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -1,8 +1,10 @@
-﻿#if NET_45
+﻿
+using System;
+#if NET_45
 using System.Collections.Generic;
 #endif
 using System.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
+using Octokit.Models.Response;
 
 namespace Octokit
 {
@@ -66,6 +68,23 @@ namespace Octokit
 
             return ApiConnection.GetAll<User>(endpoint);
         }
+
+        /// <summary>
+        /// Returns all members of the given team. 
+        /// </summary>
+        /// <param name="id">The team identifier</param>
+        /// <param name="login">The username to query</param>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        public Task<TeamMembership> GetMembership(int id, string login)
+        {
+            var endpoint = ApiUrls.TeamMember(id, login);
+
+            return ApiConnection.Get<TeamMembership>(endpoint);
+        }
+
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
@@ -168,6 +187,7 @@ namespace Octokit
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
         /// <returns><see langword="true"/> if the user is a member of the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use GetMembership(id, login) as this will report on pending requests")]
         public async Task<bool> IsMember(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -143,6 +143,7 @@ namespace Octokit
         /// <param name="login">The user to add to the team.</param>
         /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
         /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        [Obsolete("Use AddTeamMember(id, login) to track pending requests")]
         public async Task<bool> AddMember(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
@@ -153,12 +154,44 @@ namespace Octokit
             {
                 var httpStatusCode = await ApiConnection.Connection.Put(endpoint);
 
-                return httpStatusCode == System.Net.HttpStatusCode.NoContent;
+                return httpStatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
+        /// <returns><see langword="true"/> if the user was added to the team; <see langword="false"/> otherwise.</returns>
+        public async Task<TeamMembership> AddMembership(int id, string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
+            var endpoint = ApiUrls.TeamMember(id, login);
+
+            Dictionary<string, string> response;
+
+            try
+            {
+                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, null);
+            }
+            catch (NotFoundException)
+            {
+                return TeamMembership.NotFound;
+            }
+
+            return response["state"] == "active"
+                ? TeamMembership.Active
+                : TeamMembership.Pending;
         }
 
         /// <summary>
@@ -180,7 +213,7 @@ namespace Octokit
             {
                 var httpStatusCode = await ApiConnection.Connection.Delete(endpoint);
 
-                return httpStatusCode == System.Net.HttpStatusCode.NoContent;
+                return httpStatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {
@@ -205,7 +238,7 @@ namespace Octokit
             try
             {
                 var response = await ApiConnection.Connection.GetResponse<string>(endpoint);
-                return response.HttpResponse.StatusCode == System.Net.HttpStatusCode.NoContent;
+                return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {
@@ -255,7 +288,7 @@ namespace Octokit
             try
             {
                 var httpStatusCode = await ApiConnection.Connection.Put(endpoint);
-                return httpStatusCode == System.Net.HttpStatusCode.NoContent;
+                return httpStatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {
@@ -279,7 +312,7 @@ namespace Octokit
             {
                 var httpStatusCode = await ApiConnection.Connection.Delete(endpoint);
 
-                return httpStatusCode == System.Net.HttpStatusCode.NoContent;
+                return httpStatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {
@@ -307,7 +340,7 @@ namespace Octokit
             try
             {
                 var response = await ApiConnection.Connection.GetResponse<string>(endpoint);
-                return response.HttpResponse.StatusCode == System.Net.HttpStatusCode.NoContent;
+                return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
             {

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -93,7 +93,6 @@ namespace Octokit
                 : TeamMembership.Pending;
         }
 
-
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
         /// </summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -53,6 +53,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        public Task<IReadOnlyList<Team>> GetAllForCurrent()
+        {
+            var endpoint = ApiUrls.UserTeams();
+            return ApiConnection.GetAll<Team>(endpoint);
+        }
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -78,14 +78,18 @@ namespace Octokit
         {
             var endpoint = ApiUrls.TeamMember(id, login);
 
-            var response = await ApiConnection.Connection.Get<Dictionary<string, string>>(endpoint, null, null);
+            Dictionary<string, string> response;
 
-            if (response.HttpResponse.StatusCode == HttpStatusCode.NotFound)
+            try
+            {
+                response = await ApiConnection.Get<Dictionary<string, string>>(endpoint);
+            }
+            catch (NotFoundException)
             {
                 return TeamMembership.NotFound;
             }
 
-            return response.Body["state"] == "active"
+            return response["state"] == "active"
                 ? TeamMembership.Active
                 : TeamMembership.Pending;
         }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1149,6 +1149,16 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> to discover teams 
+        /// for the current user
+        /// </summary>
+        /// <returns></returns>
+        public static Uri UserTeams()
+        {
+            return "user/teams".FormatUri();
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for teams
         /// use for getting, updating, or deleting a <see cref="Team"/>.
         /// </summary>

--- a/Octokit/Models/Response/TeamMembership.cs
+++ b/Octokit/Models/Response/TeamMembership.cs
@@ -1,0 +1,9 @@
+﻿namespace Octokit.Models.Response
+{
+    public enum TeamMembership
+    {
+        NotFound = 0,
+        Pending = 1,
+        Active = 2
+    }
+}

--- a/Octokit/Models/Response/TeamMembership.cs
+++ b/Octokit/Models/Response/TeamMembership.cs
@@ -1,4 +1,4 @@
-﻿namespace Octokit.Models.Response
+﻿namespace Octokit
 {
     public enum TeamMembership
     {

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -393,6 +393,7 @@
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Models\Request\RepositoryHooksPingRequest.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Models\Request\RepositoryHookTestRequest.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Models\Request\RepositoryHooksPingRequest.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Models\Request\RepositoryHookTestRequest.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Models\Response\SearchResult.cs" />
     <Compile Include="Models\Response\SearchUsersResult.cs" />
     <Compile Include="Models\Response\Subscription.cs" />
+    <Compile Include="Models\Response\TeamMembership.cs" />
     <Compile Include="Models\Response\ThreadSubscription.cs" />
     <Compile Include="Models\Response\TreeItem.cs" />
     <Compile Include="Models\Response\TreeResponse.cs" />


### PR DESCRIPTION
Thanks to @phantomtypist for starting this off.

 - [x] compare implemented APIs to what is in #331
 - [x] ~~http://developer.github.com/v3/orgs/teams/#get-team-member~~ to be deprecated, use https://developer.github.com/v3/orgs/teams/#get-team-membership
 - [x] ~~http://developer.github.com/v3/orgs/teams/#add-team-member~~ to be deprecated, use https://developer.github.com/v3/orgs/teams/#add-team-membership
 - [x] ~~http://developer.github.com/v3/orgs/teams/#remove-team-member~~ to be deprecated, use https://developer.github.com/v3/orgs/teams/#remove-team-membership
 - [x] http://developer.github.com/v3/orgs/teams/#list-user-teams
 - [x] ensure no breaking changes in existing API
 - [x] lol fxcop
