### PR TITLE
deprecate httpclient timeout in favour of cancellation token

### DIFF
--- a/Octokit.Tests.Integration/HttpClientAdapterTests.cs
+++ b/Octokit.Tests.Integration/HttpClientAdapterTests.cs
@@ -32,5 +32,25 @@ public class HttpClientAdapterTests
             Assert.Equal(78, imageBytes[2]);
             Assert.Equal(130, imageBytes.Last());
         }
+
+        [IntegrationTest]
+        public async Task CanCancelARequest()
+        {
+            var httpClient = new HttpClientAdapter();
+            var request = new Request
+            {
+                BaseAddress = new Uri("https://github.global.ssl.fastly.net/", UriKind.Absolute),
+                Endpoint = new Uri("/images/icons/emoji/poop.png?v=5", UriKind.RelativeOrAbsolute),
+                AllowAutoRedirect = true,
+                Method = HttpMethod.Get,
+                Timeout = TimeSpan.FromMilliseconds(10)
+            };
+
+            var response = httpClient.Send(request, CancellationToken.None);
+
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            Assert.True(response.IsCanceled);
+        }
     }
 }

--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -16,11 +16,15 @@ namespace Octokit.Tests.Http
     {
         public class TheBuildRequestMessageMethod
         {
+            readonly Uri _endpoint = new Uri("/ha-ha-business", UriKind.Relative);
+
             [Fact]
             public void AddsHeadersToRequestMessage()
             {
                 var request = new Request
                 {
+                    BaseAddress = GitHubClient.GitHubApiUrl,
+                    Endpoint = _endpoint,
                     Method = HttpMethod.Post,
                     Headers =
                     {
@@ -47,6 +51,8 @@ namespace Octokit.Tests.Http
             {
                 var request = new Request
                 {
+                    BaseAddress = GitHubClient.GitHubApiUrl,
+                    Endpoint = _endpoint,
                     Method = HttpMethod.Post,
                     Body = "{}",
                     ContentType = "text/plain"
@@ -64,6 +70,8 @@ namespace Octokit.Tests.Http
             {
                 var request = new Request
                 {
+                    BaseAddress = GitHubClient.GitHubApiUrl,
+                    Endpoint = _endpoint,
                     Method = HttpMethod.Post,
                     Body = new MemoryStream(),
                     ContentType = "text/plain"
@@ -82,6 +90,8 @@ namespace Octokit.Tests.Http
             {
                 var request = new Request
                 {
+                    BaseAddress = GitHubClient.GitHubApiUrl,
+                    Endpoint = _endpoint,
                     Method = HttpMethod.Post,
                     Body = new FormUrlEncodedContent(new Dictionary<string, string> {{"foo", "bar"}})
                 };

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// the user agent for analytics purposes.
         /// </param>
         public GitHubClient(ProductHeaderValue productInformation)
-            : this(new Connection(productInformation))
+            : this(new Connection(productInformation, GitHubApiUrl))
         {
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -60,10 +60,7 @@ namespace Octokit.Internal
                 cancellationTokenForRequest = unifiedCancellationToken.Token;
             }
 
-            var http = new HttpClient(httpOptions)
-            {
-                BaseAddress = request.BaseAddress
-            };
+            var http = new HttpClient(httpOptions);
 
             using (var requestMessage = BuildRequestMessage(request))
             {
@@ -111,7 +108,8 @@ namespace Octokit.Internal
             HttpRequestMessage requestMessage = null;
             try
             {
-                requestMessage = new HttpRequestMessage(request.Method, request.Endpoint);
+                var fullUri = new Uri(request.BaseAddress, request.Endpoint);
+                requestMessage = new HttpRequestMessage(request.Method, fullUri);
                 foreach (var header in request.Headers)
                 {
                     requestMessage.Headers.Add(header.Key, header.Value);

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -50,6 +50,7 @@ namespace Octokit.Internal
                 httpOptions.Proxy = _webProxy;
             }
 
+            var http = new HttpClient(httpOptions);
             var cancellationTokenForRequest = cancellationToken;
 
             if (request.Timeout != TimeSpan.Zero)
@@ -59,8 +60,6 @@ namespace Octokit.Internal
 
                 cancellationTokenForRequest = unifiedCancellationToken.Token;
             }
-
-            var http = new HttpClient(httpOptions);
 
             using (var requestMessage = BuildRequestMessage(request))
             {

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -83,13 +83,13 @@ namespace Octokit.Internal
                     contentType = GetContentMediaType(responseMessage.Content);
 
                     // We added support for downloading images and zip-files. Let's constrain this appropriately.
-                    if (contentType == null || (!contentType.StartsWith("image/") && !contentType.StartsWith("application/")))
+                    if (contentType != null && (contentType.StartsWith("image/") || contentType.Equals("application/zip", StringComparison.OrdinalIgnoreCase)))
                     {
-                        responseBody = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        responseBody = await responseMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                     }
                     else
                     {
-                        responseBody = await responseMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                        responseBody = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
                     }
                 }
             }


### PR DESCRIPTION
This is the first step down the path I talked about in #781 - a minor internal change to `HttpClientAdapter` to make it's `HttpClient` reusable

 - use a `CancellationToken` based on the specified `IRequest.Timeout` value
 - deprecate the `BaseAddress` and `Timeout` values when constructing the `HttpClient`
 - update impacted tests
