### PR TITLE
Obsolete assert ex.throws

### DIFF
--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -119,7 +119,7 @@ namespace Octokit.Tests.Integration.Clients
             Assert.Equal(created.Token, applicationAuthorization.Token);
 
             await client.Authorization.Delete(created.Id);
-            AssertEx.Throws<NotFoundException>(async () => await client.Authorization.Get(created.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
@@ -145,7 +145,7 @@ namespace Octokit.Tests.Integration.Clients
             Assert.NotEqual(created.Token, applicationAuthorization.Token);
 
             await client.Authorization.Delete(created.Id);
-            AssertEx.Throws<NotFoundException>(async () => await client.Authorization.Get(created.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
@@ -167,8 +167,8 @@ namespace Octokit.Tests.Integration.Clients
             var applicationClient = Helper.GetAuthenticatedApplicationClient();
             await applicationClient.Authorization.RevokeApplicationAuthentication(Helper.ClientId, created.Token);
 
-            AssertEx.Throws<NotFoundException>(async () => await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, created.Token));
-            AssertEx.Throws<NotFoundException>(async () => await client.Authorization.Get(created.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, created.Token));
+            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
@@ -199,13 +199,13 @@ namespace Octokit.Tests.Integration.Clients
             var applicationClient = Helper.GetAuthenticatedApplicationClient();
             await applicationClient.Authorization.RevokeAllApplicationAuthentications(Helper.ClientId);
 
-            AssertEx.Throws<NotFoundException>(async () => 
+            Assert.ThrowsAsync<NotFoundException>(async () => 
                 await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, token1.Token));
-            AssertEx.Throws<NotFoundException>(async () => 
+            Assert.ThrowsAsync<NotFoundException>(async () => 
                 await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, token2.Token));
 
-            AssertEx.Throws<NotFoundException>(async () => await client.Authorization.Get(token1.Id));
-            AssertEx.Throws<NotFoundException>(async () => await client.Authorization.Get(token2.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(token1.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(token2.Id));
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -243,8 +243,8 @@ public class IssuesClientTests : IDisposable
     {
         var owner = _repository.Owner.Login;
 
-        await AssertEx.Throws<ApiValidationException>(
-            async () => await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        await Assert.ThrowsAsync<ApiValidationException>(
+            () => _issuesClient.GetAllForRepository(owner, _repository.Name,
                 new RepositoryIssueRequest { Assignee = "some-random-account" }));
     }
 

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -237,7 +237,7 @@ public class PullRequestsClientTests : IDisposable
         var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
 
         var merge = new MergePullRequest { Sha = fakeSha };
-        var ex = await AssertEx.Throws<ApiException>(async () => await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge));
+        var ex = await Assert.ThrowsAsync<ApiException>(() => _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge));
 
         Assert.True(ex.ApiError.Message.StartsWith("Head branch was modified"));
     }

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -41,7 +41,7 @@ public class ReferencesClientTests : IDisposable
     [IntegrationTest]
     public async Task WhenReferenceDoesNotExistAnExeptionIsThrown()
     {
-        await AssertEx.Throws<NotFoundException>(
+        await Assert.ThrowsAsync<NotFoundException>(
             () => _fixture.Get("octokit", "octokit.net", "heads/foofooblahblah"));
     }
 
@@ -66,7 +66,7 @@ public class ReferencesClientTests : IDisposable
         var repo = "octokit.net";
         var subNamespace = "666";
 
-        var result = await AssertEx.Throws<NotFoundException>(
+        var result = await Assert.ThrowsAsync<NotFoundException>(
             async () => { await _fixture.GetAllForSubNamespace(owner, repo, subNamespace); });
         Assert.Equal(string.Format("{0} was not found.", ApiUrls.Reference(owner, repo, subNamespace)), result.Message);
     }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -258,8 +258,8 @@ public class RepositoriesClientTests
             {
                 var message = string.Format(CultureInfo.InvariantCulture, "There is already a repository named '{0}' for the current account.", repoName);
 
-                var thrown = await AssertEx.Throws<RepositoryExistsException>(
-                    async () => await github.Repository.Create(repository));
+                var thrown = await Assert.ThrowsAsync<RepositoryExistsException>(
+                    () => github.Repository.Create(repository));
 
                 Assert.NotNull(thrown);
                 Assert.Equal(repoName, thrown.RepositoryName);
@@ -358,8 +358,8 @@ public class RepositoriesClientTests
                 var repositoryUrl = string.Format(CultureInfo.InvariantCulture, "https://github.com/{0}/{1}", Helper.Organization, repository.Name);
                 var message = string.Format(CultureInfo.InvariantCulture, "There is already a repository named '{0}' in the organization '{1}'.", repository.Name, Helper.Organization);
 
-                var thrown = await AssertEx.Throws<RepositoryExistsException>(
-                    async () => await github.Repository.Create(Helper.Organization, repository));
+                var thrown = await Assert.ThrowsAsync<RepositoryExistsException>(
+                    () => github.Repository.Create(Helper.Organization, repository));
 
                 Assert.NotNull(thrown);
                 Assert.Equal(repoName, thrown.RepositoryName);

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -17,8 +17,7 @@ public class TeamsClientTests
             var github = Helper.GetAnonymousClient();
             var newTeam = new NewTeam("Test");
 
-            var e = await AssertEx.Throws<AuthorizationException>(async
-                () => await github.Organization.Team.Create(Helper.Organization, newTeam));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.Create(Helper.Organization, newTeam));
 
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
@@ -30,8 +29,7 @@ public class TeamsClientTests
 
             var newTeam = new NewTeam("Test");
 
-            var e = await AssertEx.Throws<AuthorizationException>(async
-                () => await github.Organization.Team.Create(Helper.Organization, newTeam));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.Create(Helper.Organization, newTeam));
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 
@@ -64,8 +62,7 @@ public class TeamsClientTests
         {
             var github = Helper.GetAnonymousClient();
 
-            var e = await AssertEx.Throws<AuthorizationException>(async
-                () => await github.Organization.Team.IsMember(team.Id, Helper.UserName));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.IsMember(team.Id, Helper.UserName));
 
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
@@ -75,8 +72,7 @@ public class TeamsClientTests
         {
             var github = Helper.GetBadCredentialsClient();
 
-            var e = await AssertEx.Throws<AuthorizationException>(async
-                () => await github.Organization.Team.IsMember(team.Id, Helper.UserName));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.IsMember(team.Id, Helper.UserName));
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 

--- a/Octokit.Tests.Integration/Clients/UsersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UsersClientTests.cs
@@ -79,8 +79,7 @@ public class UsersClientTests
                 Bio = "UPDATED BIO"
             };
 
-            var e = await AssertEx.Throws<AuthorizationException>(async 
-                () => await github.User.Update(userUpdate));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.User.Update(userUpdate));
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 
@@ -95,8 +94,7 @@ public class UsersClientTests
                 Bio = "UPDATED BIO"
             };
 
-            var e = await AssertEx.Throws<AuthorizationException>(async 
-                () => await github.User.Update(userUpdate));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.User.Update(userUpdate));
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
     }

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Clients
                 var client = new AssigneesClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee(null, "name", "tweety"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckAssignee(null, "", "tweety"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee(null, "", "tweety"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee("owner", null, "tweety"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.CheckAssignee("", null, "tweety"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee("owner", "name", null));

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -29,10 +29,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new AssigneesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository(null, ""));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("", null));
             }
         }
 
@@ -69,7 +69,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(() => client.CheckAssignee("foo", "bar", "cody"));
+                await Assert.ThrowsAsync<ApiException>(() => client.CheckAssignee("foo", "bar", "cody"));
             }
 
             [Fact]
@@ -77,12 +77,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new AssigneesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckAssignee(null, "name", "tweety"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckAssignee(null, "", "tweety"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckAssignee("owner", null, "tweety"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckAssignee("", null, "tweety"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckAssignee("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckAssignee("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee(null, "name", "tweety"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckAssignee(null, "", "tweety"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee("owner", null, "tweety"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckAssignee("", null, "tweety"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckAssignee("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckAssignee("owner", "name", ""));
             }
         }
 

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, ""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", null));
             }
         }
 
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
                     null, null).Returns(response);
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
                     null, null).Returns(response);

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -126,8 +126,8 @@ namespace Octokit.Tests.Clients
                         new Response(HttpStatusCode.Unauthorized , null, new Dictionary<string, string>(), "application/json")));
                 var authEndpoint = new AuthorizationsClient(client);
 
-                await AssertEx.Throws<TwoFactorChallengeFailedException>(async () =>
-                    await authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data, "authenticationCode"));
+                await Assert.ThrowsAsync<TwoFactorChallengeFailedException>(() =>
+                    authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data, "authenticationCode"));
             }
 
             [Fact]
@@ -208,8 +208,8 @@ namespace Octokit.Tests.Clients
                     Arg.Any<NewAuthorization>(),
                     "wrong-code")
                     .Returns(_ => { throw new TwoFactorChallengeFailedException(); });
-                
-                var exception = await AssertEx.Throws<TwoFactorChallengeFailedException>(() =>
+
+                var exception = await Assert.ThrowsAsync<TwoFactorChallengeFailedException>(() =>
                     client.GetOrCreateApplicationAuthentication(
                         "clientId",
                         "secret",
@@ -261,10 +261,10 @@ namespace Octokit.Tests.Clients
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.CheckApplicationAuthentication(null, "accessToken"));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.CheckApplicationAuthentication("", "accessToken"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.CheckApplicationAuthentication("clientId", null));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.CheckApplicationAuthentication("clientId", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.CheckApplicationAuthentication(null, "accessToken"));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.CheckApplicationAuthentication("", "accessToken"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.CheckApplicationAuthentication("clientId", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.CheckApplicationAuthentication("clientId", ""));
             }
         }
 
@@ -289,10 +289,10 @@ namespace Octokit.Tests.Clients
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.ResetApplicationAuthentication(null, "accessToken"));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.ResetApplicationAuthentication("", "accessToken"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.ResetApplicationAuthentication("clientId", null));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.ResetApplicationAuthentication("clientId", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.ResetApplicationAuthentication(null, "accessToken"));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.ResetApplicationAuthentication("", "accessToken"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.ResetApplicationAuthentication("clientId", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.ResetApplicationAuthentication("clientId", ""));
             }
         }
 
@@ -316,10 +316,10 @@ namespace Octokit.Tests.Clients
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.RevokeApplicationAuthentication(null, "accessToken"));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.RevokeApplicationAuthentication("", "accessToken"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.RevokeApplicationAuthentication("clientId", null));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.RevokeApplicationAuthentication("clientId", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.RevokeApplicationAuthentication(null, "accessToken"));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.RevokeApplicationAuthentication("", "accessToken"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.RevokeApplicationAuthentication("clientId", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.RevokeApplicationAuthentication("clientId", ""));
             }
         }
 
@@ -343,8 +343,8 @@ namespace Octokit.Tests.Clients
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await authEndpoint.RevokeAllApplicationAuthentications(null));
-                await AssertEx.Throws<ArgumentException>(async () => await authEndpoint.RevokeAllApplicationAuthentications(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.RevokeAllApplicationAuthentications(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => authEndpoint.RevokeAllApplicationAuthentications(""));
             }
         }
     }

--- a/Octokit.Tests/Clients/BlobClientTests.cs
+++ b/Octokit.Tests/Clients/BlobClientTests.cs
@@ -30,12 +30,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new BlobsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
             }
         }
 
@@ -59,11 +59,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new BlobsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", new NewBlob()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", new NewBlob()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, new NewBlob()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", new NewBlob()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewBlob()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewBlob()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewBlob()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewBlob()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
             }
         }
 

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -28,18 +28,18 @@ namespace Octokit.Tests.Clients
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetAll("", "name", "sha"));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetAll("owner", "", "sha"));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetAll("owner", "name", ""));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetAll(null, "name", "sha"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetAll("owner", null, "sha"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetAll("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetAll("", "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetAll("owner", "", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetAll("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetAll(null, "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetAll("owner", null, "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetAll("owner", "name", null));
             }
         }
 
@@ -62,18 +62,18 @@ namespace Octokit.Tests.Clients
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetCombined("", "name", "sha"));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetCombined("owner", "", "sha"));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.GetCombined("owner", "name", ""));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetCombined(null, "name", "sha"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetCombined("owner", null, "sha"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.GetCombined("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetCombined("", "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetCombined("owner", "", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.GetCombined("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetCombined(null, "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetCombined("owner", null, "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.GetCombined("owner", "name", null));
             }
         }
 
@@ -97,20 +97,20 @@ namespace Octokit.Tests.Clients
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.Create("", "name", "sha", new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.Create("owner", "", "sha", new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentException>(async () =>
-                    await client.Create("owner", "name", "", new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.Create(null, "name", "sha", new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.Create("owner", null, "sha", new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.Create("owner", "name", null, new NewCommitStatus()));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await client.Create("owner", "name", "sha", null));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("", "name", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("owner", "", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("owner", "name", "", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create(null, "name", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", null, "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", "name", null, new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", "name", "sha", null));
             }
         }
 

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -16,12 +16,12 @@ public class CommitsClientTests
         {
             var client = new CommitsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "reference"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "reference"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "reference"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "reference"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "reference"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "reference"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
         }
 
         [Fact]
@@ -60,11 +60,11 @@ public class CommitsClientTests
             var client = new CommitsClient(Substitute.For<IApiConnection>());
 
             var newCommit = new NewCommit("message", "tree", new[]{"parent1", "parent2"});
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", newCommit));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, newCommit));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", newCommit));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", newCommit));            
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newCommit));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newCommit));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit));            
         }
     }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -16,8 +16,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
-            await AssertEx.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
         }
 
         [Fact]
@@ -25,8 +25,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentException>(() => client.GetAll("", "name"));
-            await AssertEx.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
         }
 
         [Theory]
@@ -39,8 +39,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentException>(() => client.GetAll(whitespace, "name"));
-            await AssertEx.Throws<ArgumentException>(() => client.GetAll("owner", whitespace));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace));
         }
 
         [Fact]
@@ -64,9 +64,9 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(() => client.Create(null, "name", newDeployment));
-            await AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", null, newDeployment));
-            await AssertEx.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newDeployment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
         }
 
         [Fact]
@@ -74,8 +74,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentException>(() => client.Create("", "name", newDeployment));
-            await AssertEx.Throws<ArgumentException>(() => client.Create("owner", "", newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newDeployment));
         }
 
         [Theory]
@@ -88,8 +88,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentException>(() => client.Create(whitespace, "name", newDeployment));
-            await AssertEx.Throws<ArgumentException>(() => client.Create("owner", whitespace, newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, newDeployment));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -47,10 +47,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
             }
         }
 
@@ -73,10 +73,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepositoryNetwork(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepositoryNetwork("", "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepositoryNetwork("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepositoryNetwork("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork(null, "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("", "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("owner", ""));
             }
         }
 
@@ -99,8 +99,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForOrganization(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForOrganization(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization(""));
             }
         }
 
@@ -123,8 +123,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserReceived(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserReceived(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceived(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceived(""));
             }
         }
 
@@ -147,8 +147,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserReceivedPublic(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserReceivedPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceivedPublic(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceivedPublic(""));
             }
         }
 
@@ -171,8 +171,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserPerformed(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserPerformed(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformed(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformed(""));
             }
         }
 
@@ -195,8 +195,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserPerformedPublic(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserPerformedPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformedPublic(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformedPublic(""));
             }
         }
 
@@ -219,10 +219,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForAnOrganization(null, "org"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForAnOrganization("", "org"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForAnOrganization("fake", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForAnOrganization("fake", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization(null, "org"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("", "org"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization("fake", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("fake", ""));
             }
         }
 

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -137,7 +137,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(() => client.IsFollowingForCurrent("alfhenrik"));
+                await Assert.ThrowsAsync<ApiException>(() => client.IsFollowingForCurrent("alfhenrik"));
             }
 
             [Fact]
@@ -146,8 +146,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new FollowersClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsFollowingForCurrent(null));
-                await AssertEx.Throws<ArgumentException>(() => client.IsFollowingForCurrent(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowingForCurrent(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowingForCurrent(""));
             }
         }
 
@@ -184,7 +184,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(() => client.IsFollowing("alfhenrik", "alfhenrik-test"));
+                await Assert.ThrowsAsync<ApiException>(() => client.IsFollowing("alfhenrik", "alfhenrik-test"));
             }
 
             [Fact]
@@ -193,10 +193,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new FollowersClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsFollowing(null,  "alfhenrik-test"));
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsFollowing("alfhenrik", null));
-                await AssertEx.Throws<ArgumentException>(() => client.IsFollowing("", "alfhenrik-text"));
-                await AssertEx.Throws<ArgumentException>(() => client.IsFollowing("alfhenrik", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowing(null, "alfhenrik-test"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowing("alfhenrik", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("", "alfhenrik-text"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("alfhenrik", ""));
             }
 
         }
@@ -233,7 +233,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new FollowersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(() => client.Follow("alfhenrik"));
+                await Assert.ThrowsAsync<ApiException>(() => client.Follow("alfhenrik"));
             }
 
             [Fact]
@@ -242,8 +242,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new FollowersClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Follow(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Follow(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Follow(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Follow(""));
             }
         }
 
@@ -266,8 +266,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new FollowersClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Unfollow(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Unfollow(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unfollow(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Unfollow(""));
             }
         }
     }

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -51,8 +51,8 @@ public class GistCommentsClientTests
         {
             var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("24", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("24", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("24", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("24", ""));
         }
 
         [Fact]
@@ -75,8 +75,8 @@ public class GistCommentsClientTests
         {
             var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("24", 1337, null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update("24", 1337, ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("24", 1337, null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("24", 1337, ""));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -259,7 +259,7 @@ public class GistsClientTests
 
             var client = new GistsClient(apiConnection);
 
-            await AssertEx.Throws<ApiException>(async () => await client.IsStarred("1"));
+            await Assert.ThrowsAsync<ApiException>(() => client.IsStarred("1"));
         }
     }
 

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -29,10 +29,10 @@ public class IssueCommentsClientTests
         {
             var client = new IssueCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
         }
 
     }
@@ -56,10 +56,10 @@ public class IssueCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new IssueCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
         }
     }
 
@@ -82,10 +82,10 @@ public class IssueCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new IssueCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForIssue(null, "name", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForIssue("", "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForIssue("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForIssue("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
         }
     }
 
@@ -109,11 +109,11 @@ public class IssueCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new IssueCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", 1, "title"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", 1, "x"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, 1, "x"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", 1, "x"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, "title"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, "x"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, "x"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, "x"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
         }
     }
 
@@ -137,11 +137,11 @@ public class IssueCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new IssueCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update(null, "name", 42, "title"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update("", "name", 42, "x"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", null, 42, "x"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update("owner", "", 42, "x"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", "name", 42, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 42, "title"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 42, "x"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 42, "x"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 42, "x"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
         }
     }
 
@@ -164,10 +164,10 @@ public class IssueCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new IssueCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "name", 42));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "name", 42));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("owner", null, 42));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("owner", "", 42));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 42));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 42));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 42));
         }
     }
 

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -30,8 +30,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
 
         }

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -26,8 +26,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
         }
 
@@ -49,8 +49,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
         }
 
@@ -73,8 +73,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
 
         }

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -27,9 +27,9 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
             }
         }
 
@@ -51,9 +51,9 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
             }
         }
 
@@ -76,8 +76,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
             }
         }
 
@@ -101,9 +101,9 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.AddToIssue(null, "name", 42, labels));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.AddToIssue("owner", null, 42, labels));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.AddToIssue("owner", "name", 42, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue(null, "name", 42, labels));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", null, 42, labels));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", "name", 42, null));
             }
         }
 
@@ -125,9 +125,9 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.RemoveFromIssue(null, "name", 42, "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.RemoveFromIssue("owner", null, 42, "label"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.RemoveFromIssue("owner", "name", 42, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue(null, "name", 42, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", null, 42, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", "name", 42, null));
             }
         }
 
@@ -151,9 +151,9 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.ReplaceAllForIssue(null, "name", 42, labels));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.ReplaceAllForIssue("owner", null, 42, labels));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.ReplaceAllForIssue("owner", "name", 42, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue(null, "name", 42, labels));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", null, 42, labels));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", "name", 42, null));
             }
         }
 
@@ -175,8 +175,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.RemoveAllFromIssue(null, "name", 42));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.RemoveAllFromIssue("owner", null, 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAllFromIssue(null, "name", 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAllFromIssue("owner", null, 42));
             }
         }
 
@@ -198,8 +198,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForMilestone(null, "name", 42));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForMilestone("owner", null, 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42));
             }
         }
     }

--- a/Octokit.Tests/Clients/MergingClientTests.cs
+++ b/Octokit.Tests/Clients/MergingClientTests.cs
@@ -34,12 +34,12 @@ namespace Octokit.Tests.Clients
                 var client = new MergingClient(Substitute.For<IApiConnection>());
 
                 var newMerge = new NewMerge("baseBranch", "shaToMerge") {CommitMessage = "some mergingMessage"};
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", newMerge));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, newMerge));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", newMerge));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", newMerge));            
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", null));            
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newMerge));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newMerge));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newMerge));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newMerge));            
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", null));            
             }
         }
 

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
             }
         }

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -28,10 +28,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new MilestonesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
             }
         }
 

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -126,7 +126,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(async () => await client.CheckMember("org", "username"));
+                await Assert.ThrowsAsync<ApiException>(() => client.CheckMember("org", "username"));
             }
 
             [Fact]
@@ -134,10 +134,10 @@ namespace Octokit.Tests.Clients
             {
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.CheckMember(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.CheckMember(null, ""));
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.CheckMember("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.CheckMember("", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMember(null, "username"));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMember(null, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMember("org", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMember("", null));
             }
         }
 
@@ -174,7 +174,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(async () => await client.CheckMemberPublic("org", "username"));
+                await Assert.ThrowsAsync<ApiException>(() => client.CheckMemberPublic("org", "username"));
             }
 
             [Fact]
@@ -182,10 +182,10 @@ namespace Octokit.Tests.Clients
             {
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.CheckMemberPublic(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.CheckMemberPublic("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.CheckMemberPublic("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.CheckMemberPublic("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMemberPublic(null, "username"));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMemberPublic("", "username"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMemberPublic("org", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMemberPublic("org", ""));
             }
         }
 
@@ -207,10 +207,10 @@ namespace Octokit.Tests.Clients
             {
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Delete(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Delete("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Delete("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Delete("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Delete(null, "username"));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Delete("", "username"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Delete("org", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Delete("org", ""));
             }
         }
 
@@ -246,7 +246,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new OrganizationMembersClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(async () => await client.Publicize("org", "username"));
+                await Assert.ThrowsAsync<ApiException>(() => client.Publicize("org", "username"));
             }
 
             [Fact]
@@ -254,10 +254,10 @@ namespace Octokit.Tests.Clients
             {
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Publicize(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Publicize("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Publicize("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Publicize("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Publicize(null, "username"));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Publicize("", "username"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Publicize("org", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Publicize("org", ""));
             }
         }
 
@@ -279,10 +279,10 @@ namespace Octokit.Tests.Clients
             {
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Conceal(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Conceal("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await orgMembers.Conceal("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await orgMembers.Conceal("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Conceal(null, "username"));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Conceal("", "username"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.Conceal("org", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.Conceal("org", ""));
             }
         }
     }

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -135,7 +135,7 @@ namespace Octokit.Tests.Clients
                 var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMember(null, "username"));
-                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMember(null, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMember(null, ""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.CheckMember("org", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.CheckMember("", null));
             }

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -229,7 +229,7 @@ public class PullRequestReviewCommentsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "fakeRepoName", 1, comment));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", null, 1, comment));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "", 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "fakeRepoName", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", "fakeRepoName", 1, null));
         }
     }
 
@@ -264,7 +264,7 @@ public class PullRequestReviewCommentsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "fakeRepoName", 1, comment));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("fakeOwner", null, 1, comment));
             await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("fakeOwner", "", 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("fakeOwner", "fakeRepoName", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("fakeOwner", "fakeRepoName", 1, null));
         }
     }
 

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -100,10 +100,10 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null, "name", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("", "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
         }
     }
 
@@ -152,11 +152,11 @@ public class PullRequestReviewCommentsClientTests
 
             var request = new PullRequestReviewCommentRequest();
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name", request));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name", request));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null, request));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", "", request));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
         }
 
         [Fact]
@@ -189,10 +189,10 @@ public class PullRequestReviewCommentsClientTests
         {
             var client = new PullRequestReviewCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetComment(null, "name", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetComment("", "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetComment("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetComment("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment("owner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("owner", "", 1));
         }
     }
 
@@ -225,11 +225,11 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentCreate(body, commitId, path, position);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("fakeOwner", null, 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("fakeOwner", "", 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("fakeOwner", "fakeRepoName", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", null, 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "fakeRepoName", 1, null));
         }
     }
 
@@ -260,11 +260,11 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentReplyCreate(body, inReplyTo);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.CreateReply(null, "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.CreateReply("", "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.CreateReply("fakeOwner", null, 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.CreateReply("fakeOwner", "", 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.CreateReply("fakeOwner", "fakeRepoName", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(null, "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("fakeOwner", null, 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("fakeOwner", "", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("fakeOwner", "fakeRepoName", 1, null));
         }
     }
 
@@ -293,11 +293,11 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentEdit(body);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit(null, "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Edit("", "fakeRepoName", 1, comment));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit("fakeOwner", null, 1, comment));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Edit("fakeOwner", "", 1, comment));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit("fakeOwner", null, 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("fakeOwner", null, 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("fakeOwner", "", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("fakeOwner", null, 1, null));
         }
     }
 
@@ -320,10 +320,10 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "fakeRepoName", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "fakeRepoName", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("fakeOwner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("fakeOwner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "fakeRepoName", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "fakeRepoName", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("fakeOwner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("fakeOwner", "", 1));
         }
     }
 }

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -28,10 +28,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new PullRequestsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(() => client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Get(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Get("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
             }
         }
 
@@ -88,15 +88,15 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(() =>
+                await Assert.ThrowsAsync<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(() =>
+                await Assert.ThrowsAsync<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -122,15 +122,15 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(() =>
+                await Assert.ThrowsAsync<ArgumentException>(() =>
                     client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(() =>
+                await Assert.ThrowsAsync<ArgumentException>(() =>
                     client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Create("owner", "name", null));
             }
         }
@@ -156,11 +156,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge(null, "name", 42, new MergePullRequest("message")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", null, 42, new MergePullRequest("message")));
-                await AssertEx.Throws<ArgumentNullException>(() =>
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }
         }
@@ -187,10 +187,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.Merged(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(() => client.Merged("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Merged(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Merged("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", null, 1));
             }
         }
 
@@ -214,10 +214,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.Commits(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(() => client.Commits("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Commits(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Commits("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", null, 1));
             }
         }
 
@@ -241,10 +241,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.Files(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(() => client.Files("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Files("", "name", 1));
-                await AssertEx.Throws<ArgumentException>(() => client.Files("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Files("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Files("owner", "", 1));
             }
         }
 

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
             }
         }
@@ -189,7 +189,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", null, 1));
             }
         }
@@ -216,7 +216,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", null, 1));
             }
         }

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -24,12 +24,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "heads/develop"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "heads/develop"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "heads/develop"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "heads/develop"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
             }
 
             [Fact]
@@ -51,10 +51,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null, "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("", "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
             }
 
             [Fact]
@@ -76,10 +76,10 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForSubNamespace(null, "name", "heads"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForSubNamespace("owner", null, "heads"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForSubNamespace("", "name", "heads"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForSubNamespace("owner", "", "heads"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
             }
 
             [Fact]
@@ -101,11 +101,11 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", new NewReference("heads/develop", "sha")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, new NewReference("heads/develop", "sha")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", new NewReference("heads/develop", "sha")));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", new NewReference("heads/develop", "sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewReference("heads/develop", "sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewReference("heads/develop", "sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewReference("heads/develop", "sha")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewReference("heads/develop", "sha")));
             }
 
             [Fact]
@@ -128,13 +128,13 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update(null, "name", "heads/develop", new ReferenceUpdate("sha")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", null, "heads/develop", new ReferenceUpdate("sha")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", "name", null, new ReferenceUpdate("sha")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", "name", "heads/develop", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Update("", "name", "heads/develop", new ReferenceUpdate("sha")));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Update("owner", "", "heads/develop", new ReferenceUpdate("sha")));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Update("owner", "name", "", new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", "heads/develop", new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, "heads/develop", new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", null, new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", "heads/develop", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", "heads/develop", new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", "heads/develop", new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "name", "", new ReferenceUpdate("sha")));
             }
 
             [Fact]
@@ -157,12 +157,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReferencesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "name", "heads/develop"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("owner", null, "heads/develop"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "name", "heads/develop"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("owner", "", "heads/develop"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", "heads/develop"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "name", ""));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -29,8 +29,8 @@ namespace Octokit.Tests.Clients
             {
                 var releasesClient = new ReleasesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.GetAll(null, "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll("owner", null));
             }
         }
 
@@ -83,12 +83,9 @@ namespace Octokit.Tests.Clients
                 var data = new NewRelease("fake-tag");
 
                 Assert.Throws<ArgumentNullException>(() => new NewRelease(null));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await releasesClient.Create(null, "name", data));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await releasesClient.Create("owner", null, data));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
-                    await releasesClient.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Create(null, "name", data));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Create("owner", null, data));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Create("owner", "name", null));
             }
         }
 
@@ -199,8 +196,8 @@ namespace Octokit.Tests.Clients
 
                 var release = new Release("https://uploads.github.com/anything");
                 var uploadData = new ReleaseAssetUpload("good", "good/good", Stream.Null, null);
-                await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.UploadAsset(null, uploadData));
-                await AssertEx.Throws<ArgumentNullException>(async () => await releasesClient.UploadAsset(release, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.UploadAsset(null, uploadData));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.UploadAsset(release, null));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -81,7 +81,7 @@ namespace Octokit.Tests.Clients
                 apiConnection.Connection.Returns(connection);
                 var client = new AssigneesClient(apiConnection);
 
-                await AssertEx.Throws<ApiException>(() => client.CheckAssignee("foo", "bar", "cody"));
+                await Assert.ThrowsAsync<ApiException>(() => client.CheckAssignee("foo", "bar", "cody"));
             }
 
             [Fact]
@@ -89,12 +89,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsCollaborator(null, "test", "user1"));
-                await AssertEx.Throws<ArgumentException>(() => client.IsCollaborator("", "test", "user1"));
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsCollaborator("owner", null, "user1"));
-                await AssertEx.Throws<ArgumentException>(() => client.IsCollaborator("owner", "", "user1"));
-                await AssertEx.Throws<ArgumentException>(() => client.IsCollaborator("owner", "test", ""));
-                await AssertEx.Throws<ArgumentNullException>(() => client.IsCollaborator("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator(null, "test", "user1"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("", "test", "user1"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator("owner", null, "user1"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("owner", "", "user1"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("owner", "test", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator("owner", "test", null));
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null));
             }
 
             [Fact]
@@ -73,8 +73,8 @@ namespace Octokit.Tests.Clients
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
-                var exception = await AssertEx.Throws<RepositoryExistsException>(
-                    async () => await client.Create(newRepository));
+                var exception = await Assert.ThrowsAsync<RepositoryExistsException>(
+                    () => client.Create(newRepository));
 
                 Assert.False(exception.OwnerIsOrganization);
                 Assert.Null(exception.Organization);
@@ -100,8 +100,8 @@ namespace Octokit.Tests.Clients
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
-                var exception = await AssertEx.Throws<PrivateRepositoryQuotaExceededException>(
-                    async () => await client.Create(newRepository));
+                var exception = await Assert.ThrowsAsync<PrivateRepositoryQuotaExceededException>(
+                    () => client.Create(newRepository));
 
                 Assert.NotNull(exception);
             }
@@ -114,8 +114,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, new NewRepository("aName")));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("aLogin", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, new NewRepository("aName")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("aLogin", null));
             }
 
             [Fact]
@@ -158,8 +158,8 @@ namespace Octokit.Tests.Clients
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
-                var exception = await AssertEx.Throws<RepositoryExistsException>(
-                    async () => await client.Create("illuminati", newRepository));
+                var exception = await Assert.ThrowsAsync<RepositoryExistsException>(
+                    () => client.Create("illuminati", newRepository));
 
                 Assert.True(exception.OwnerIsOrganization);
                 Assert.Equal("illuminati", exception.Organization);
@@ -183,8 +183,8 @@ namespace Octokit.Tests.Clients
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
-                var exception = await AssertEx.Throws<ApiValidationException>(
-                    async () => await client.Create("illuminati", newRepository));
+                var exception = await Assert.ThrowsAsync<ApiValidationException>(
+                    () => client.Create("illuminati", newRepository));
 
                 Assert.Null(exception as RepositoryExistsException);
             }
@@ -204,8 +204,8 @@ namespace Octokit.Tests.Clients
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
-                var exception = await AssertEx.Throws<RepositoryExistsException>(
-                    async () => await client.Create("illuminati", newRepository));
+                var exception = await Assert.ThrowsAsync<RepositoryExistsException>(
+                    () => client.Create("illuminati", newRepository));
 
                 Assert.Equal("aName", exception.RepositoryName);
                 Assert.Equal(new Uri("https://example.com/illuminati/aName"), exception.ExistingRepositoryWebUrl);
@@ -219,8 +219,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "aRepoName"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("anOwner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "aRepoName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("anOwner", null));
             }
 
             [Fact]
@@ -253,8 +253,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -115,7 +115,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, new NewRepository("aName")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("aLogin", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("aLogin", null));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -29,10 +29,10 @@ public class RepositoryCommentsClientTests
         {
             var client = new RepositoryCommentsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
         }
 
     }
@@ -56,10 +56,10 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
         }
     }
 
@@ -82,12 +82,12 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForCommit(null, "name", "sha"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForCommit("", "name", "sha"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForCommit("owner", null, "sha"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForCommit("owner", "", "sha"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForCommit("owner", "name", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForCommit("owner", "name", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", ""));
         }
     }
 
@@ -112,13 +112,13 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", "sha", new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", "sha", new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, "sha", new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", "sha", new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null, new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "name", "", new NewCommitComment("body")));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", "sha", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", "sha", new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", "sha", new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, "sha", new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", "sha", new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null, new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "name", "", new NewCommitComment("body")));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", "sha", null));
         }
     }
 
@@ -142,11 +142,11 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update(null, "name", 42, "updated comment"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update("", "name", 42, "updated comment"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", null, 42, "updated comment"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Update("owner", "", 42, "updated comment"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", "name", 42, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 42, "updated comment"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 42, "updated comment"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 42, "updated comment"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 42, "updated comment"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
         }
     }
 
@@ -169,10 +169,10 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "name", 42));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "name", 42));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("owner", null, 42));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Delete("owner", "", 42));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 42));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 42));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 42));
         }
     }
 

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -102,10 +102,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var contentsClient = new RepositoryContentsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(async () => await contentsClient.GetArchiveLink(null, "name"));
-                AssertEx.Throws<ArgumentNullException>(async () => await contentsClient.GetArchiveLink("owner", null));
-                AssertEx.Throws<ArgumentException>(async () => await contentsClient.GetArchiveLink("", "name"));
-                AssertEx.Throws<ArgumentException>(async () => await contentsClient.GetArchiveLink("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => contentsClient.GetArchiveLink(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => contentsClient.GetArchiveLink("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => contentsClient.GetArchiveLink("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => contentsClient.GetArchiveLink("owner", ""));
             }
         }
     }

--- a/Octokit.Tests/Clients/SshKeysClientTests.cs
+++ b/Octokit.Tests/Clients/SshKeysClientTests.cs
@@ -85,7 +85,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresArgumentsNotNull()
             {
                 var userEndpoint = new SshKeysClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Update(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => userEndpoint.Update(1, null));
             }
         }
 
@@ -108,7 +108,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresArgumentsNotNull()
             {
                 var userEndpoint = new SshKeysClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Create(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => userEndpoint.Create(null));
             }
         }
 

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -37,14 +37,14 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetContributors(null,"repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors(null,"repositoryName"));
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetContributors("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors("owner", null));
             }
         }
 
@@ -67,14 +67,14 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetCommitActivity(null, "repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetCommitActivity(null, "repositoryName"));
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetCommitActivity("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetCommitActivity("owner", null));
             }
         }
 
@@ -97,14 +97,14 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetCodeFrequency(null, "repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetCodeFrequency(null, "repositoryName"));
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetCodeFrequency("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetCodeFrequency("owner", null));
             }
         }
 
@@ -127,14 +127,14 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetParticipation(null, "repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetParticipation(null, "repositoryName"));
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetParticipation("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetParticipation("owner", null));
             }
         }
 
@@ -157,14 +157,14 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetPunchCard(null, "repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetPunchCard(null, "repositoryName"));
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => statisticsClient.GetPunchCard("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetPunchCard("owner", null));
             }
         }
     }

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -27,12 +27,12 @@ public class TagsClientTests
         {
             var client = new TagsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "reference"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "reference"));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "reference"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "reference"));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "reference"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "reference"));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference"));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
         }
     }
 
@@ -55,11 +55,11 @@ public class TagsClientTests
         {
             var client = new TagsClient(Substitute.For<IApiConnection>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", new NewTag()));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, new NewTag()));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", new NewTag()));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", new NewTag()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewTag()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewTag()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewTag()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewTag()));
         }
     }
 

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -129,7 +129,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                AssertEx.Throws<ArgumentNullException>(() => client.IsMember(1, null));
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.IsMember(1, null));
             }
 
             [Fact]
@@ -138,7 +138,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                AssertEx.Throws<ArgumentException>(() => client.IsMember(1, ""));
+                Assert.ThrowsAsync<ArgumentException>(() => client.IsMember(1, ""));
             }
         }
 
@@ -213,7 +213,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                AssertEx.Throws<ArgumentException>(() => client.AddRepository(1, null, "Repo Name"));
+                Assert.ThrowsAsync<ArgumentException>(() => client.AddRepository(1, null, "Repo Name"));
             }
 
             [Fact]
@@ -222,7 +222,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                AssertEx.Throws<ArgumentException>(() => client.AddRepository(1, "org name", null));
+                Assert.ThrowsAsync<ArgumentException>(() => client.AddRepository(1, "org name", null));
 
             }
         }

--- a/Octokit.Tests/Clients/TreesClientTests.cs
+++ b/Octokit.Tests/Clients/TreesClientTests.cs
@@ -30,12 +30,12 @@ namespace Octokit.Tests
             {
                 var client = new TreesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
             }
         }
 
@@ -58,12 +58,12 @@ namespace Octokit.Tests
             {
                 var client = new TreesClient(Substitute.For<IApiConnection>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive(null, "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("", "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive("owner", null, "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("owner", "", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("owner", "name", ""));
             }
         }
 
@@ -87,10 +87,10 @@ namespace Octokit.Tests
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TreesClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", new NewTree()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", new NewTree()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, new NewTree()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", new NewTree()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewTree()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewTree()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewTree()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewTree()));
             }
 
             [Fact]
@@ -102,8 +102,8 @@ namespace Octokit.Tests
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TreesClient(connection);
 
-                await AssertEx.Throws<ArgumentException>(
-                    async () => await client.Create("fake", "repo", newTree));
+                await Assert.ThrowsAsync<ArgumentException>(
+                    () => client.Create("fake", "repo", newTree));
             }
         }
 

--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullUser()
             {
                 var userEndpoint = new UsersClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Get(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => userEndpoint.Get(null));
             }
         }
 
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullUser()
             {
                 var userEndpoint = new UsersClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Get(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => userEndpoint.Get(null));
             }
         }
 
@@ -88,7 +88,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresArgumentsNotNull()
             {
                 var userEndpoint = new UsersClient(Substitute.For<IApiConnection>());
-                await AssertEx.Throws<ArgumentNullException>(() => userEndpoint.Update(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => userEndpoint.Update(null));
             }
         }
 

--- a/Octokit.Tests/Helpers/AssertEx.cs
+++ b/Octokit.Tests/Helpers/AssertEx.cs
@@ -23,6 +23,7 @@ namespace Octokit.Tests.Helpers
             return attribute;
         }
 
+        [Obsolete("This was written before the support for testing asynchronous tasks was added in xUnit 2.0 (because we pre-dated it). Use Assert.ThrowsAsync")]
         public async static Task<T> Throws<T>(Func<Task> testCode) where T : Exception
         {
             try

--- a/Octokit.Tests/Helpers/AssertEx.cs
+++ b/Octokit.Tests/Helpers/AssertEx.cs
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Helpers
         {
             foreach (var argument in whitespaceArguments)
             {
-                await Throws<ArgumentException>(async () => await action(argument));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await action(argument));
             }
         }
 

--- a/Octokit.Tests/Helpers/AssertEx.cs
+++ b/Octokit.Tests/Helpers/AssertEx.cs
@@ -23,23 +23,6 @@ namespace Octokit.Tests.Helpers
             return attribute;
         }
 
-        [Obsolete("This was written before the support for testing asynchronous tasks was added in xUnit 2.0 (because we pre-dated it). Use Assert.ThrowsAsync")]
-        public async static Task<T> Throws<T>(Func<Task> testCode) where T : Exception
-        {
-            try
-            {
-                await testCode();
-                Assert.Throws<T>(() => { }); // Use xUnit's default behavior.
-            }
-            catch (T exception)
-            {
-                return exception;
-            }
-            // We should never reach this line. It's here because the compiler doesn't know that 
-            // Assert.Throws above will always throw.
-            return null;
-        }
-
         static readonly string[] whitespaceArguments = { " ", "\t", "\n", "\n\r", "  " };
 
         public static async Task ThrowsWhenGivenWhitespaceArgument(Func<string, Task> action)

--- a/Octokit.Tests/Http/ApiConnectionTests.cs
+++ b/Octokit.Tests/Http/ApiConnectionTests.cs
@@ -51,8 +51,8 @@ namespace Octokit.Tests.Http
             {
                 var getUri = new Uri("anything", UriKind.Relative);
                 var client = new ApiConnection(Substitute.For<IConnection>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get<object>(null));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get<object>(getUri, new Dictionary<string, string>(), null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get<object>(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get<object>(getUri, new Dictionary<string, string>(), null));
             }
         }
 
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Http
             public async Task EnsuresArgumentNotNull()
             {
                 var client = new ApiConnection(Substitute.For<IConnection>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetHtml(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetHtml(null));
             }
         }
 
@@ -106,14 +106,14 @@ namespace Octokit.Tests.Http
                 var client = new ApiConnection(Substitute.For<IConnection>());
                 
                 // One argument
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll<object>(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll<object>(null));
                 
                 // Two argument
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await client.GetAll<object>(null, new Dictionary<string, string>()));
 
                 // Three arguments
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await client.GetAll<object>(null, new Dictionary<string, string>(), "accepts"));
             }
         }
@@ -158,9 +158,9 @@ namespace Octokit.Tests.Http
             {
                 var connection = new ApiConnection(Substitute.For<IConnection>());
                 var patchUri = new Uri("", UriKind.Relative);
-                await AssertEx.Throws<ArgumentNullException>(async () => await connection.Patch<object>(null, new object()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await connection.Patch<object>(patchUri, null));
-                await AssertEx.Throws<ArgumentNullException>(async () => await connection.Patch<object>(patchUri, new object(), null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Patch<object>(null, new object()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Patch<object>(patchUri, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Patch<object>(patchUri, new object(), null));
             }
         }
 
@@ -219,15 +219,15 @@ namespace Octokit.Tests.Http
                 var connection = new ApiConnection(Substitute.For<IConnection>());
 
                 // 1 parameter overload
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await connection.Post(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Post(null));
 
                 // 2 parameter overload
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await connection.Post<object>(null, new object()));
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await connection.Post<object>(postUri, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Post<object>(null, new object()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Post<object>(postUri, null));
 
                 // 3 parameters
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await connection.Post<object>(null, new MemoryStream(), "anAccept", "some-content-type"));
-                await Assert.ThrowsAsync<ArgumentNullException>(async () => await connection.Post<object>(postUri, null, "anAccept", "some-content-type"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Post<object>(null, new MemoryStream(), "anAccept", "some-content-type"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Post<object>(postUri, null, "anAccept", "some-content-type"));
             }
         }
 
@@ -272,19 +272,19 @@ namespace Octokit.Tests.Http
                 var connection = new ApiConnection(Substitute.For<IConnection>());
 
                 // 2 parameter overload
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await connection.Put<object>(null, new object()));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await connection.Put<object>(putUri, null));
 
                 // 3 parameters
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await connection.Put<object>(null, new MemoryStream(), "two-factor"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await connection.Put<object>(putUri, null, "two-factor"));
-                await AssertEx.Throws<ArgumentNullException>(async () =>
+                await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await connection.Put<object>(putUri, new MemoryStream(), null));
-                await AssertEx.Throws<ArgumentException>(async () =>
+                await Assert.ThrowsAsync<ArgumentException>(async () =>
                     await connection.Put<object>(putUri, new MemoryStream(), ""));
             }
         }
@@ -309,7 +309,7 @@ namespace Octokit.Tests.Http
             public async Task EnsuresArgumentNotNull()
             {
                 var connection = new ApiConnection(Substitute.For<IConnection>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await connection.Delete(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.Delete(null));
             }
         }
 
@@ -342,7 +342,7 @@ namespace Octokit.Tests.Http
                 connection.GetResponse<object>(queuedOperationUrl, Args.CancellationToken).Returns(Task.FromResult(response));
                 var apiConnection = new ApiConnection(connection);
 
-                await AssertEx.Throws<ApiException>(async () => await apiConnection.GetQueuedOperation<object>(queuedOperationUrl, Args.CancellationToken));
+                await Assert.ThrowsAsync<ApiException>(() => apiConnection.GetQueuedOperation<object>(queuedOperationUrl, Args.CancellationToken));
             }
 
             [Fact]
@@ -413,7 +413,7 @@ namespace Octokit.Tests.Http
             public async Task EnsuresArgumentNotNull()
             {
                 var connection = new ApiConnection(Substitute.For<IConnection>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await connection.GetQueuedOperation<object>(null, CancellationToken.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => connection.GetQueuedOperation<object>(null, CancellationToken.None));
             }
         }
 

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -97,8 +97,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<AuthorizationException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<AuthorizationException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
                 Assert.NotNull(exception);
             }
 
@@ -121,8 +121,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<AuthorizationException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<AuthorizationException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
                 Assert.Equal(HttpStatusCode.Unauthorized, exception.StatusCode);
             }
 
@@ -148,8 +148,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<TwoFactorRequiredException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<TwoFactorRequiredException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal(expectedFactorType, exception.TwoFactorType);
             }
@@ -172,8 +172,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<ApiValidationException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<ApiValidationException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal("Validation Failed", exception.Message);
                 Assert.Equal("key is already in use", exception.ApiError.Errors[0].Message);
@@ -196,8 +196,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<RateLimitExceededException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<RateLimitExceededException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal("API rate limit exceeded. See http://developer.github.com/v3/#rate-limiting for details.",
                     exception.Message);
@@ -220,8 +220,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<LoginAttemptsExceededException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<LoginAttemptsExceededException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal("Maximum number of login attempts exceeded", exception.Message);
                 Assert.Equal("http://developer.github.com/v3", exception.ApiError.DocumentationUrl);
@@ -244,8 +244,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<NotFoundException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<NotFoundException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal("GONE BYE BYE!", exception.Message);
             }
@@ -266,8 +266,8 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await AssertEx.Throws<ForbiddenException>(
-                    async () => await connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+                var exception = await Assert.ThrowsAsync<ForbiddenException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
                 Assert.Equal("YOU SHALL NOT PASS!", exception.Message);
             }

--- a/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -28,12 +29,12 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableBlobClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
             }
         }
 
@@ -57,11 +58,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableBlobClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", new NewBlob()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", new NewBlob()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, new NewBlob()));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", new NewBlob()));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewBlob()).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewBlob()).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewBlob()).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewBlob()).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -27,12 +28,12 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableCommitsClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", ""));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, ""));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "reference"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "reference"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));                
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());                
             }
  
             [Fact]
@@ -55,11 +56,11 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableCommitsClient(Substitute.For<IGitHubClient>());
                 var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", newCommit));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, newCommit));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", newCommit));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", newCommit));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newCommit).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newCommit).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit).ToTask());
             }
  
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -44,10 +45,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
             }
         }
 
@@ -70,10 +71,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepositoryNetwork(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepositoryNetwork("", "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepositoryNetwork("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepositoryNetwork("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("", "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("owner", "").ToTask());
             }
         }
 
@@ -96,8 +97,8 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForOrganization(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForOrganization(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("").ToTask());
             }
         }
 
@@ -120,8 +121,8 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserReceived(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserReceived(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceived(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceived("").ToTask());
             }
         }
 
@@ -144,8 +145,8 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserReceivedPublic(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserReceivedPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceivedPublic(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceivedPublic("").ToTask());
             }
         }
 
@@ -168,8 +169,8 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserPerformed(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserPerformed(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformed(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformed("").ToTask());
             }
         }
 
@@ -192,8 +193,8 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllUserPerformedPublic(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllUserPerformedPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformedPublic(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformedPublic("").ToTask());
             }
         }
 
@@ -216,10 +217,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForAnOrganization(null, "org"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForAnOrganization("", "org"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForAnOrganization("fake", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForAnOrganization("fake", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization(null, "org").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("", "org").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization("fake", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("fake", "").ToTask());
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableFollowersTest.cs
+++ b/Octokit.Tests/Reactive/ObservableFollowersTest.cs
@@ -6,6 +6,7 @@ using Octokit.Tests.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -47,8 +48,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("").ToTask());
             }
         }
 
@@ -86,8 +87,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllFollowing(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllFollowing(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllFollowing(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllFollowing("").ToTask());
             }
         }
 
@@ -110,8 +111,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.IsFollowingForCurrent(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.IsFollowingForCurrent(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowingForCurrent(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowingForCurrent("").ToTask());
             }
         }
 
@@ -134,10 +135,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.IsFollowing(null, "alfhenrik-test"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.IsFollowing("", "alfhenrik-test"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.IsFollowing("alfhenrik", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.IsFollowing("alfhenrik", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowing(null, "alfhenrik-test").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("", "alfhenrik-test").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsFollowing("alfhenrik", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("alfhenrik", "").ToTask());
             }
         }
 
@@ -160,8 +161,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Follow(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Follow(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Follow(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Follow("").ToTask());
             }
         }
 
@@ -184,8 +185,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableFollowersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Unfollow(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Unfollow(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unfollow(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Unfollow("").ToTask());
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
@@ -22,11 +23,11 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableGistsClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllCommits(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllCommits(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("").ToTask());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForks(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForks(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("").ToTask());
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -29,10 +30,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableIssueCommentsClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1).ToTask());
             }
 
         }
@@ -57,10 +58,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
             }
         }
 
@@ -84,10 +85,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForIssue(null, "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForIssue("", "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForIssue("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForIssue("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1).ToTask());
             }
         }
 
@@ -111,11 +112,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", 1, "title"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", 1, "x"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, 1, "x"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", 1, "x"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, "title").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null).ToTask());
             }
         }
 
@@ -139,11 +140,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update(null, "name", 42, "title"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Update("", "name", 42, "x"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", null, 42, "x"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Update("owner", "", 42, "x"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Update("owner", "name", 42, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 42, "title").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 42, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 42, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 42, "x").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 42, null).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -32,7 +32,7 @@ public class ObservableIssuesClientTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1).ToTask());
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -6,6 +6,7 @@ using Octokit.Tests.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -29,10 +30,10 @@ public class ObservableIssuesClientTests
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-            await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get(null, "", 1));
-            await AssertEx.Throws<ArgumentException>(async () => await client.Get("", null, 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
         }
     }
 

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
@@ -30,10 +31,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableMilestonesClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -33,7 +33,7 @@ namespace Octokit.Tests.Reactive
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
             }
         }

--- a/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -6,6 +6,7 @@ using Octokit.Tests.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -32,8 +33,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("").ToTask());
             }
         }
 
@@ -56,8 +57,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllPublic(null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic("").ToTask());
             }
         }
 
@@ -79,10 +80,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckMember(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckMember("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckMember("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckMember("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckMember(null, "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckMember("", "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckMember("org", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckMember("org", "").ToTask());
             }
         }
 
@@ -104,10 +105,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckMemberPublic(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckMemberPublic("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CheckMemberPublic("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckMemberPublic("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckMemberPublic(null, "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckMemberPublic("", "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckMemberPublic("org", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckMemberPublic("org", "").ToTask());
             }
         }
 
@@ -129,10 +130,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("org", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("org", "").ToTask());
             }
         }
 
@@ -154,10 +155,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Publicize(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Publicize("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Publicize("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Publicize("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Publicize(null, "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Publicize("", "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Publicize("org", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Publicize("org", "").ToTask());
             }
         }
 
@@ -179,10 +180,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Conceal(null, "username"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Conceal("", "username"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Conceal("org", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Conceal("org", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Conceal(null, "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Conceal("", "username").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Conceal("org", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Conceal("org", "").ToTask());
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
 using Octokit.Reactive;
+using System.Reactive.Threading.Tasks;
 using Octokit.Tests.Helpers;
 using Xunit;
 
@@ -81,12 +82,12 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null, "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("", "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("owner", "", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAll(null, null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAll("", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "", 1).ToTask());
             }
         }
 
@@ -232,11 +233,11 @@ namespace Octokit.Tests.Reactive
 
                 var request = new PullRequestReviewCommentRequest();
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository(null, "name", request));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("", "name", request));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", null, request));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForRepository("owner", "", request));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetAllForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null).ToTask());
             }
         }
 
@@ -258,12 +259,12 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservablePullRequestReviewCommentsClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetComment(null, "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetComment("", "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetComment("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetComment("owner", "", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetComment(null, null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetComment("", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("owner", "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "", 1).ToTask());
             }
         }
 
@@ -295,11 +296,11 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentCreate(body, commitId, path, position);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create(null, "name", 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("", "name", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", null, 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Create("owner", "", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Create("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null).ToTask());
             }
         }
 
@@ -329,11 +330,11 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentReplyCreate(body, inReplyTo);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CreateReply(null, "name", 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CreateReply("", "name", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CreateReply("owner", null, 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CreateReply("owner", "", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.CreateReply("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(null, "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", null, 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("owner", "", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", "name", 1, null).ToTask());
             }
         }
 
@@ -362,11 +363,11 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentEdit(body);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit(null, "name", 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Edit("", "name", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit("owner", null, 1, comment));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Edit("owner", "", 1, comment));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Edit("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "name", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("owner", "", 1, comment).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", "name", 1, null).ToTask());
             }
         }
 
@@ -389,10 +390,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete(null, "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("", "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Delete("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Delete("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 1).ToTask());
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
@@ -31,10 +32,10 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservablePullRequestsClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
             }
         }
 
@@ -173,16 +174,16 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(async () => await
-                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(async () => await
-                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", "name", null).ToTask());
             }
         }
 
@@ -206,16 +207,16 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(async () => await
-                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentException>(async () => await
-                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
-                    client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() =>
+                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                    client.Create("owner", "name", null).ToTask());
             }
         }
 
@@ -239,11 +240,11 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge(null, "name", 42, new MergePullRequest { Message = "message" }));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", null, 42, new MergePullRequest { Message = "message" }));
-                await AssertEx.Throws<ArgumentNullException>(async () => await
+                await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }
         }
@@ -267,10 +268,10 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Merged(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Merged("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Merged(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Merged("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", null, 1));
             }
         }
 
@@ -306,10 +307,10 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Commits(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Commits("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Commits(null, "", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Commits("", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", null, 1));
             }
         }
 
@@ -345,10 +346,10 @@ namespace Octokit.Tests.Reactive
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Files(null, "name", 1));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Files("owner", null, 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Files("", "name", 1));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Files("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Files("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Files("owner", "", 1));
             }
         }
         public class TheCtor

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -34,7 +34,7 @@ namespace Octokit.Tests.Reactive
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(null, "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
             }
         }
@@ -270,7 +270,7 @@ namespace Octokit.Tests.Reactive
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", null, 1));
             }
         }
@@ -309,7 +309,7 @@ namespace Octokit.Tests.Reactive
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits(null, "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", null, 1));
             }
         }

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -24,7 +24,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazers(null, "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazers("owner", null).ToTask());
             }
 
             [Fact]
@@ -86,7 +86,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckStarred(null, "james").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckStarred("james", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckStarred("james", null).ToTask());
             }
 
             [Fact]
@@ -108,7 +108,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.StarRepo(null, "james").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.StarRepo("james", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.StarRepo("james", null).ToTask());
             }
 
             [Fact]
@@ -130,7 +130,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveStarFromRepo(null, "james").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveStarFromRepo("james", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveStarFromRepo("james", null).ToTask());
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -23,7 +23,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazers(null, "name").ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers("owner", null).ToTask());
             }
 
@@ -62,7 +62,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null).ToTask());
             }
 
             [Fact]
@@ -85,7 +85,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckStarred(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CheckStarred(null, "james").ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.CheckStarred("james", null).ToTask());
             }
 
@@ -107,7 +107,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.StarRepo(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.StarRepo(null, "james").ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.StarRepo("james", null).ToTask());
             }
 
@@ -129,7 +129,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveStarFromRepo(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveStarFromRepo(null, "james").ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveStarFromRepo("james", null).ToTask());
             }
 

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
@@ -22,8 +23,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllStargazers(null, "name"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllStargazers("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers("owner", null).ToTask());
             }
 
             [Fact]
@@ -61,7 +62,7 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetAllForUser(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(null).ToTask());
             }
 
             [Fact]
@@ -84,8 +85,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckStarred(null, "james"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.CheckStarred("james", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckStarred(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CheckStarred("james", null).ToTask());
             }
 
             [Fact]
@@ -106,8 +107,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentException>(async () => await client.StarRepo(null, "james"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.StarRepo("james", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.StarRepo(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.StarRepo("james", null).ToTask());
             }
 
             [Fact]
@@ -128,8 +129,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentException>(async () => await client.RemoveStarFromRepo(null, "james"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.RemoveStarFromRepo("james", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveStarFromRepo(null, "james").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveStarFromRepo("james", null).ToTask());
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -27,14 +28,14 @@ namespace Octokit.Tests.Reactive
             public async Task ThrowsIfGivenNullRepositoryName()
             {   
                 var statisticsClient = new ObservableStatisticsClient(Substitute.For<IGitHubClient>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await statisticsClient.GetContributors("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors("owner", null).ToTask());
             }
 
             [Fact]
             public async Task ThrowsIfGivenNullOwnerName()
             {
                 var statisticsClient = new ObservableStatisticsClient(Substitute.For<IGitHubClient>());
-                await AssertEx.Throws<ArgumentNullException>(async () => await statisticsClient.GetContributors(null, "repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors(null, "repositoryName").ToTask());
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -28,12 +29,12 @@ namespace Octokit.Tests
             {
                 var client = new ObservableTreesClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.Get("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
             }
         }
         
@@ -55,12 +56,12 @@ namespace Octokit.Tests
             {
                 var client = new ObservableTreesClient(Substitute.For<IGitHubClient>());
 
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive(null, "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("", "name", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", null, "123456ABCD"));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "", "123456ABCD"));
-                await AssertEx.Throws<ArgumentNullException>(async () => await client.GetRecursive("owner", "name", null));
-                await AssertEx.Throws<ArgumentException>(async () => await client.GetRecursive("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive(null, "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("", "name", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive("owner", null, "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("owner", "", "123456ABCD").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRecursive("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("owner", "name", "").ToTask());
             }
         }
         


### PR DESCRIPTION
Clean up the tests in order to comply with #782 

- [x] `OctoKit.Tests`
  - [x] `Clients`
  - [x] `Helpers`
  - [x] `Http`
  - [x] `Reactive`
- [x] `Octokit.Tests.Integration`
  - [x] `Clients`