### PR TITLE
added a tailored CodeFormatter to Octokit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ packaging/
 tools/FAKE.Core
 tools/SourceLink.Fake
 tools/xunit.runner.console
+tools/Octokit.CodeFormatter
 *.ncrunch*
 *.GhostDoc.xml
 

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -29,6 +29,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
         /// <returns></returns>
-        IObservable<Commit> Create(string owner, string name, NewCommit commit);            
+        IObservable<Commit> Create(string owner, string name, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -9,7 +9,7 @@ namespace Octokit.Reactive
         /// Returns a client to manage members of an organization.
         /// </summary>
         IObservableOrganizationMembersClient Member { get; }
-        
+
         /// <summary>
         /// Returns a client to manage teams for an organization.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -106,6 +106,5 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request number</param>
         /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
         IObservable<PullRequestFile> Files(string owner, string name, int number);
-
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <remarks>Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.</remarks>
         /// <returns>An <see cref="IObservable{Unit}"/> for the operation</returns>
         IObservable<Unit> Delete(string owner, string name);
-        
+
         /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
         /// </summary>
@@ -154,7 +154,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>        
         IObservableRepositoryForksClient Forks { get; }
-        
+
         /// <summary>
         /// Client for GitHub's Repository Contents API.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
         /// <returns>A <c>bool</c> representing the success of the operation</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId="Unwatch",
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(string owner, string name);
     }

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -8,7 +8,7 @@ namespace Octokit.Reactive
     public class ObservableAuthorizationsClient : IObservableAuthorizationsClient
     {
         readonly IAuthorizationsClient _client;
-        readonly IConnection _connection; 
+        readonly IConnection _connection;
 
         public ObservableAuthorizationsClient(IGitHubClient client)
         {

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return _client.Get(owner, name, reference).ToObservable();            
+            return _client.Get(owner, name, reference).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistsClient.cs
@@ -5,7 +5,7 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
-    public class ObservableGistsClient : IObservableGistsClient 
+    public class ObservableGistsClient : IObservableGistsClient
     {
         readonly IGistsClient _client;
         readonly IConnection _connection;

--- a/Octokit.Reactive/Clients/ObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMergingClient.cs
@@ -6,7 +6,7 @@ namespace Octokit.Reactive
     public class ObservableMergingClient : IObservableMergingClient
     {
         readonly IMergingClient _client;
-        
+
         public ObservableMergingClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -84,7 +84,6 @@ namespace Octokit.Reactive
         public IObservable<Unit> MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
             return _notificationsClient.MarkAsRead(markAsReadRequest).ToObservable();
-
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         public IObservable<User> GetAll(string org, OrganizationMembersFilter filter)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
-            
+
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter));
         }
 

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
 
             Member = new ObservableOrganizationMembersClient(client);
             Team = new ObservableTeamsClient(client);
-        
+
             _client = client.Organization;
             _connection = client.Connection;
         }

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>A <see cref="PullRequestMerge"/> result</returns>
-        public IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest) 
+        public IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -134,7 +134,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
-        public IObservable<bool> Merged(string owner, string name, int number) 
+        public IObservable<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -16,7 +16,7 @@ namespace Octokit.Reactive
         public ObservableRepositoriesClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
-            
+
             _client = client.Repository;
             _connection = client.Connection;
             CommitStatus = new ObservableCommitStatusClient(client);
@@ -288,7 +288,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-           
+
             var endpoint = ApiUrls.RepositoryContributors(owner, name);
             var parameters = new Dictionary<string, string>();
             if (includeAnonymous)
@@ -330,7 +330,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            
+
             var endpoint = ApiUrls.RepositoryTeams(owner, name);
             return _connection.GetAndFlattenAllPages<Team>(endpoint);
         }

--- a/Octokit.Reactive/Clients/ObservableSshKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableSshKeysClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         public ObservableSshKeysClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
-            
+
             _client = client.SshKey;
             _connection = client.Connection;
         }

--- a/Octokit.Reactive/Clients/ObservableTreesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTreesClient.cs
@@ -3,7 +3,6 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
-
     public class ObservableTreesClient : IObservableTreesClient
     {
         readonly ITreesClient _client;

--- a/Octokit.Reactive/Helpers/ObservableExtensions.cs
+++ b/Octokit.Reactive/Helpers/ObservableExtensions.cs
@@ -40,7 +40,7 @@ namespace Octokit.Reactive.Internal
                 var outGate = new object();
                 var q = new Queue<IObservable<TSource>>();
                 var m = new SerialDisposable();
-                var d = new CompositeDisposable {m};
+                var d = new CompositeDisposable { m };
                 var activeCount = 0;
                 var isAcquired = false;
 

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
         public ApiInfo GetLastApiInfo()
-        { 
+        {
             return _gitHubClient.Connection.GetLastApiInfo();
         }
     }

--- a/Octokit.Tests.Conventions/Exception/InterfaceHasAdditionalMethodsException.cs
+++ b/Octokit.Tests.Conventions/Exception/InterfaceHasAdditionalMethodsException.cs
@@ -8,13 +8,16 @@ namespace Octokit.Tests.Conventions
     public class InterfaceHasAdditionalMethodsException : Exception
     {
         public InterfaceHasAdditionalMethodsException(Type type, IEnumerable<string> methodsMissingOnReactiveClient)
-            : base(CreateMessage(type, methodsMissingOnReactiveClient)) { }
+            : base(CreateMessage(type, methodsMissingOnReactiveClient))
+        { }
 
         public InterfaceHasAdditionalMethodsException(Type type, IEnumerable<string> methodsMissingOnReactiveClient, Exception innerException)
-            : base(CreateMessage(type, methodsMissingOnReactiveClient), innerException) { }
+            : base(CreateMessage(type, methodsMissingOnReactiveClient), innerException)
+        { }
 
         protected InterfaceHasAdditionalMethodsException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateMessage(Type type, IEnumerable<string> methods)
         {

--- a/Octokit.Tests.Conventions/Exception/InterfaceMethodsMismatchException.cs
+++ b/Octokit.Tests.Conventions/Exception/InterfaceMethodsMismatchException.cs
@@ -8,13 +8,16 @@ namespace Octokit.Tests.Conventions
     public class InterfaceMethodsMismatchException : Exception
     {
         public InterfaceMethodsMismatchException(Type observableType, Type clientInterface)
-            : base(CreateMessage(observableType, clientInterface)) { }
+            : base(CreateMessage(observableType, clientInterface))
+        { }
 
-        public InterfaceMethodsMismatchException(Type type,Type clientInterface, Exception innerException)
-            : base(CreateMessage(type, clientInterface), innerException) { }
+        public InterfaceMethodsMismatchException(Type type, Type clientInterface, Exception innerException)
+            : base(CreateMessage(type, clientInterface), innerException)
+        { }
 
         protected InterfaceMethodsMismatchException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string Format(ParameterInfo parameterInfo)
         {

--- a/Octokit.Tests.Conventions/Exception/InterfaceMissingMethodsException.cs
+++ b/Octokit.Tests.Conventions/Exception/InterfaceMissingMethodsException.cs
@@ -8,13 +8,16 @@ namespace Octokit.Tests.Conventions
     public class InterfaceMissingMethodsException : Exception
     {
         public InterfaceMissingMethodsException(Type type, IEnumerable<string> methodsMissingOnReactiveClient)
-            : base(CreateMessage(type, methodsMissingOnReactiveClient)) { }
+            : base(CreateMessage(type, methodsMissingOnReactiveClient))
+        { }
 
         public InterfaceMissingMethodsException(Type type, IEnumerable<string> methodsMissingOnReactiveClient, Exception innerException)
-            : base(CreateMessage(type, methodsMissingOnReactiveClient), innerException) { }
+            : base(CreateMessage(type, methodsMissingOnReactiveClient), innerException)
+        { }
 
         protected InterfaceMissingMethodsException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateMessage(Type type, IEnumerable<string> methods)
         {

--- a/Octokit.Tests.Conventions/Exception/InterfaceNotFoundException.cs
+++ b/Octokit.Tests.Conventions/Exception/InterfaceNotFoundException.cs
@@ -8,18 +8,20 @@ namespace Octokit.Tests.Conventions
         public InterfaceNotFoundException() { }
 
         public InterfaceNotFoundException(string type)
-            : base(CreateMessage(type)) { }
+            : base(CreateMessage(type))
+        { }
 
         public InterfaceNotFoundException(string type, Exception innerException)
-            : base(CreateMessage(type), innerException) { }
+            : base(CreateMessage(type), innerException)
+        { }
 
         protected InterfaceNotFoundException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateMessage(string type)
         {
             return String.Format("Could not find the interface {0}. Add this to the Octokit.Reactive project", type);
         }
-
     }
 }

--- a/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayAttributeValueException.cs
+++ b/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayAttributeValueException.cs
@@ -5,7 +5,8 @@ namespace Octokit.Tests.Conventions
     public class InvalidDebuggerDisplayAttributeValueException : Exception
     {
         public InvalidDebuggerDisplayAttributeValueException(Type modelType, string value)
-            : base (CreateMessage(modelType, value)) { }
+            : base(CreateMessage(modelType, value))
+        { }
 
         static string CreateMessage(Type modelType, string value)
         {

--- a/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayReturnType.cs
+++ b/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayReturnType.cs
@@ -5,7 +5,8 @@ namespace Octokit.Tests.Conventions
     public class InvalidDebuggerDisplayReturnType : Exception
     {
         public InvalidDebuggerDisplayReturnType(Type modelType, Type propertyType)
-            : base (CreateMessage(modelType, propertyType)) { }
+            : base(CreateMessage(modelType, propertyType))
+        { }
 
         static string CreateMessage(Type modelType, Type propertyType)
         {

--- a/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayAttributeException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayAttributeException.cs
@@ -5,6 +5,7 @@ namespace Octokit.Tests.Conventions
     public class MissingDebuggerDisplayAttributeException : Exception
     {
         public MissingDebuggerDisplayAttributeException(Type modelType)
-            : base (string.Format("Model type '{0}' is missing the DebuggerDisplayAttribute.", modelType.FullName)) { }
+            : base(string.Format("Model type '{0}' is missing the DebuggerDisplayAttribute.", modelType.FullName))
+        { }
     }
 }

--- a/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayPropertyException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayPropertyException.cs
@@ -5,6 +5,7 @@ namespace Octokit.Tests.Conventions
     public class MissingDebuggerDisplayPropertyException : Exception
     {
         public MissingDebuggerDisplayPropertyException(Type modelType)
-            : base (string.Format("Model type '{0}' is missing the DebuggerDisplay property.", modelType.FullName)) { }
+            : base(string.Format("Model type '{0}' is missing the DebuggerDisplay property.", modelType.FullName))
+        { }
     }
 }

--- a/Octokit.Tests.Conventions/Exception/MutableModelPropertiesException.cs
+++ b/Octokit.Tests.Conventions/Exception/MutableModelPropertiesException.cs
@@ -8,7 +8,8 @@ namespace Octokit.Tests.Conventions
     public class MutableModelPropertiesException : Exception
     {
         public MutableModelPropertiesException(Type modelType, IEnumerable<PropertyInfo> mutableProperties)
-            : base (CreateMessage(modelType, mutableProperties)) { }
+            : base(CreateMessage(modelType, mutableProperties))
+        { }
 
         static string CreateMessage(Type modelType, IEnumerable<PropertyInfo> mutableProperties)
         {

--- a/Octokit.Tests.Conventions/Exception/PaginationGetAllMethodNameMismatchException.cs
+++ b/Octokit.Tests.Conventions/Exception/PaginationGetAllMethodNameMismatchException.cs
@@ -10,7 +10,8 @@ namespace Octokit.Tests.Conventions
     public class PaginationGetAllMethodNameMismatchException : Exception
     {
         public PaginationGetAllMethodNameMismatchException(Type type, IEnumerable<MethodInfo> methods)
-            : base(CreateMessage(type, methods)) { }
+            : base(CreateMessage(type, methods))
+        { }
 
         static string CreateMessage(Type type, IEnumerable<MethodInfo> methods)
         {

--- a/Octokit.Tests.Conventions/Exception/ParameterCountMismatchException.cs
+++ b/Octokit.Tests.Conventions/Exception/ParameterCountMismatchException.cs
@@ -9,13 +9,16 @@ namespace Octokit.Tests.Conventions
     public class ParameterCountMismatchException : Exception
     {
         public ParameterCountMismatchException(MethodInfo method, IEnumerable<ParameterInfo> expected, IEnumerable<ParameterInfo> actual)
-            : base(CreateMessage(method, expected, actual)) { }
+            : base(CreateMessage(method, expected, actual))
+        { }
 
         public ParameterCountMismatchException(MethodInfo method, IEnumerable<ParameterInfo> expected, IEnumerable<ParameterInfo> actual, Exception innerException)
-            : base(CreateMessage(method, expected, actual), innerException) { }
+            : base(CreateMessage(method, expected, actual), innerException)
+        { }
 
         protected ParameterCountMismatchException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateMethodSignature(IEnumerable<ParameterInfo> parameters)
         {

--- a/Octokit.Tests.Conventions/Exception/ParameterMismatchException.cs
+++ b/Octokit.Tests.Conventions/Exception/ParameterMismatchException.cs
@@ -7,13 +7,16 @@ namespace Octokit.Tests.Conventions
     public class ParameterMismatchException : Exception
     {
         public ParameterMismatchException(MethodInfo method, int position, ParameterInfo expected, ParameterInfo actual)
-            : base(CreateMessage(method, position, expected, actual)) { }
+            : base(CreateMessage(method, position, expected, actual))
+        { }
 
         public ParameterMismatchException(MethodInfo method, int position, ParameterInfo expected, ParameterInfo actual, Exception innerException)
-            : base(CreateMessage(method, position, expected, actual), innerException) { }
+            : base(CreateMessage(method, position, expected, actual), innerException)
+        { }
 
         protected ParameterMismatchException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateParameterSignature(ParameterInfo parameter)
         {

--- a/Octokit.Tests.Conventions/Exception/ReturnValueMismatchException.cs
+++ b/Octokit.Tests.Conventions/Exception/ReturnValueMismatchException.cs
@@ -7,17 +7,20 @@ namespace Octokit.Tests.Conventions
     public class ReturnValueMismatchException : Exception
     {
         public ReturnValueMismatchException(MethodInfo method, Type expected, Type actual)
-            : base(CreateMessage(method, expected, actual)) { }
+            : base(CreateMessage(method, expected, actual))
+        { }
 
         public ReturnValueMismatchException(MethodInfo method, Type expected, Type actual, Exception innerException)
-            : base(CreateMessage(method, expected, actual), innerException) { }
+            : base(CreateMessage(method, expected, actual), innerException)
+        { }
 
         protected ReturnValueMismatchException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 
         static string CreateMessage(MethodInfo method, Type expected, Type actual)
         {
-            return String.Format("Return value for {0}.{1} must be \"{2}\" but is \"{3}\"", method.DeclaringType.Name,  method.Name, expected, actual);
+            return String.Format("Return value for {0}.{1} must be \"{2}\" but is \"{3}\"", method.DeclaringType.Name, method.Name, expected, actual);
         }
     }
 }

--- a/Octokit.Tests.Conventions/SyncObservableClients.cs
+++ b/Octokit.Tests.Conventions/SyncObservableClients.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Conventions
             }
 
             int index = 0;
-            foreach(var mainMethod in mainMethods)
+            foreach (var mainMethod in mainMethods)
             {
                 var observableMethod = observableMethods[index];
                 AssertEx.WithMessage(() => CheckMethod(mainMethod, observableMethod), "Invalid signature for " + observableMethod);
@@ -69,7 +69,7 @@ namespace Octokit.Tests.Conventions
         private static Type GetObservableExpectedType(Type mainType)
         {
             var typeInfo = mainType.GetTypeInfo();
-            switch(typeInfo.TypeCategory)
+            switch (typeInfo.TypeCategory)
             {
                 case TypeCategory.ClientInterface:
                     // client interface - IClient => IObservableClient
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Conventions
                     // void - Task => IObservable<Unit>
                     return typeof(IObservable<Unit>);
                 case TypeCategory.GenericTask:
-                    // single item - Task<TResult> => IObservable<TResult>
+                // single item - Task<TResult> => IObservable<TResult>
                 case TypeCategory.ReadOnlyList:
                     // list - Task<IReadOnlyList<TResult>> => IObservable<TResult>
                     return typeof(IObservable<>).MakeGenericType(typeInfo.Type);
@@ -100,7 +100,7 @@ namespace Octokit.Tests.Conventions
             }
 
             int index = 0;
-            foreach(var mainParameter in mainParameters)
+            foreach (var mainParameter in mainParameters)
             {
                 var observableParameter = observableParameters[index];
                 if (mainParameter.Name != observableParameter.Name)

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -35,20 +35,20 @@ namespace Octokit.Tests.Conventions
         public static TypeInfo GetTypeInfo(this Type type)
         {
             var typeInfo = new TypeInfo { Type = type, TypeCategory = TypeCategory.Other };
-            if(type.IsClientInterface())
+            if (type.IsClientInterface())
             {
                 typeInfo.TypeCategory = TypeCategory.ClientInterface;
             }
-            else if(type.IsTask())
+            else if (type.IsTask())
             {
-                if(!type.IsGenericType)
+                if (!type.IsGenericType)
                 {
                     typeInfo.TypeCategory = TypeCategory.Task;
                 }
                 else
                 {
                     var taskResultType = type.GetGenericArgument();
-                    if(taskResultType.IsList())
+                    if (taskResultType.IsList())
                     {
                         typeInfo.TypeCategory = TypeCategory.ReadOnlyList;
                         typeInfo.Type = taskResultType.GetGenericArgument();
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Conventions
             var observableClient = typeof(IObservableEventsClient);
             var observableClientName = observableClient.Namespace + "." + ObservablePrefix + type.Name.Substring(RealNameIndex);
             var observableInterface = observableClient.Assembly.GetType(observableClientName);
-            if(observableInterface == null)
+            if (observableInterface == null)
             {
                 throw new InterfaceNotFoundException(observableClientName);
             }

--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -199,9 +199,9 @@ namespace Octokit.Tests.Integration.Clients
             var applicationClient = Helper.GetAuthenticatedApplicationClient();
             await applicationClient.Authorization.RevokeAllApplicationAuthentications(Helper.ClientId);
 
-            Assert.ThrowsAsync<NotFoundException>(async () => 
+            Assert.ThrowsAsync<NotFoundException>(async () =>
                 await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, token1.Token));
-            Assert.ThrowsAsync<NotFoundException>(async () => 
+            Assert.ThrowsAsync<NotFoundException>(async () =>
                 await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, token2.Token));
 
             Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(token1.Id));

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -14,7 +14,7 @@ public class CommitsClientTests
     {
         var github = Helper.GetAuthenticatedClient();
         var fixture = github.GitDatabase.Commit;
-        
+
         using (var context = await github.CreateRepositoryContext("public-repo"))
         {
             var owner = context.Repository.Owner.Login;

--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -37,11 +37,11 @@ public class DeploymentStatusClientTests : IDisposable
 
         var treeResult = github.GitDatabase.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree).Result;
         var newCommit = new NewCommit("test-commit", treeResult.Sha);
-        
+
         var commit = github.GitDatabase.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit).Result;
 
         var newDeployment = new NewDeployment(commit.Sha) { AutoMerge = false };
-         _deployment = _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment).Result;
+        _deployment = _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment).Result;
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
@@ -39,7 +39,7 @@ public class DeploymentsClientTests : IDisposable
         var newCommit = new NewCommit("test-commit", treeResult.Sha);
         _commit = github.GitDatabase.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit).Result;
     }
-  
+
     [IntegrationTest]
     public async Task CanCreateDeployment()
     {

--- a/Octokit.Tests.Integration/Clients/EventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/EventsClientTests.cs
@@ -21,11 +21,11 @@ namespace Octokit.Tests.Integration.Clients
 
         public class EventPayloads
         {
-            readonly IEnumerable<Activity> _events; 
+            readonly IEnumerable<Activity> _events;
             public EventPayloads()
             {
                 var github = Helper.GetAuthenticatedClient();
-                _events = github.Activity.Events.GetAllUserPerformed("shiftkey").Result; 
+                _events = github.Activity.Events.GetAllUserPerformed("shiftkey").Result;
             }
 
             [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/FollowersClientTests.cs
@@ -35,7 +35,7 @@ public class FollowersClientTests : IDisposable
         Assert.NotNull(following);
         Assert.NotEmpty(following);
     }
-    
+
     [IntegrationTest]
     public async Task ReturnsUsersFollowingTheUser()
     {

--- a/Octokit.Tests.Integration/Clients/GistsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GistsClientTests.cs
@@ -79,7 +79,7 @@ public class GistsClientTests
         await _fixture.Delete(forkedGist.Id);
     }
 
-    [IntegrationTest(Skip="OH GOD THIS TEST IS INSANE AND I DON'T KNOW WHY I DID THIS")]
+    [IntegrationTest(Skip = "OH GOD THIS TEST IS INSANE AND I DON'T KNOW WHY I DID THIS")]
     public async Task CanListGists()
     {
         // Time is tricky between local and remote, be lenient

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -23,7 +23,7 @@ public class GitHubClientTests
             using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
             {
                 var createdRepository = context.Repository;
-            
+
                 var result = github.GetLastApiInfo();
 
                 Assert.True(result.Links.Count == 0);
@@ -75,6 +75,5 @@ public class GitHubClientTests
             Assert.True(result.RateLimit.Remaining > -1);
             Assert.NotNull(result.RateLimit.Reset);
         }
-
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -86,11 +86,11 @@ public class IssuesClientTests : IDisposable
             new IssueUpdate { State = ItemState.Closed });
 
         var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
-            new RepositoryIssueRequest {SortDirection = SortDirection.Ascending});
+            new RepositoryIssueRequest { SortDirection = SortDirection.Ascending });
 
         Assert.Equal(3, issues.Count);
         Assert.Equal("A test issue1", issues[0].Title);
-        Assert.Equal("A test issue2", issues[1].Title); 
+        Assert.Equal("A test issue2", issues[1].Title);
         Assert.Equal("A test issue3", issues[2].Title);
     }
 
@@ -165,7 +165,7 @@ public class IssuesClientTests : IDisposable
 
         Assert.Equal(2, allIssues.Count);
 
-        var assignedIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, 
+        var assignedIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Assignee = _context.RepositoryOwner });
 
         Assert.Equal(1, assignedIssues.Count);

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -29,7 +29,7 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        
+
         var issueEventInfo = await _issuesEventsClientClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.Empty(issueEventInfo);
 
@@ -37,7 +37,7 @@ public class IssuesEventsClientTests : IDisposable
             .Result;
         Assert.NotNull(closed);
         issueEventInfo = await _issuesEventsClientClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-        
+
         Assert.Equal(1, issueEventInfo.Count);
         Assert.Equal(EventInfoState.Closed, issueEventInfo[0].Event);
     }
@@ -53,7 +53,7 @@ public class IssuesEventsClientTests : IDisposable
         Thread.Sleep(1000);
         var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
         Thread.Sleep(1000);
-        
+
         // close and open issue1
         var closed1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Closed })
             .Result;
@@ -66,7 +66,7 @@ public class IssuesEventsClientTests : IDisposable
         var closed2 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number, new IssueUpdate { State = ItemState.Closed })
             .Result;
         Assert.NotNull(closed2);
-        
+
         var issueEvents = await _issuesEventsClientClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.Equal(3, issueEvents.Count);

--- a/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
@@ -15,7 +15,7 @@ public class IssuesLabelsClientTests : IDisposable
     {
         var github = Helper.GetAuthenticatedClient();
 
-        _issuesLabelsClient= github.Issue.Labels;
+        _issuesLabelsClient = github.Issue.Labels;
         _issuesClient = github.Issue;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 

--- a/Octokit.Tests.Integration/Clients/MergingClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MergingClientTests.cs
@@ -11,9 +11,9 @@ public class MergingClientTests : IDisposable
     private readonly IGitHubClient _github;
     private readonly IMergingClient _fixture;
     private readonly RepositoryContext _context;
-    
+
     const string branchName = "my-branch";
-    
+
     public MergingClientTests()
     {
         _github = new GitHubClient(new ProductHeaderValue("OctokitTests"))

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -37,7 +37,7 @@ public class MilestonesClientTests : IDisposable
     public async Task CanListEmptyMilestones()
     {
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
-        
+
         Assert.Empty(milestones);
     }
 

--- a/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
@@ -100,7 +100,6 @@ public class MiscellaneousClientTests
             Assert.True(result.Rate.Remaining <= result.Rate.Limit);
             Assert.True(result.Resources.Search.ResetAsUtcEpochSeconds > 0);
             Assert.NotNull(result.Resources.Search.Reset);
-
         }
     }
 

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -149,7 +149,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var pullRequest = await CreatePullRequest(_context);
 
         const int position = 1;
-        var commentsToCreate = new [] { "Comment One", "Comment Two", "Comment Three" };
+        var commentsToCreate = new[] { "Comment One", "Comment Two", "Comment Three" };
 
         await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
 
@@ -164,7 +164,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var pullRequest = await CreatePullRequest(_context);
 
         const int position = 1;
-        var commentsToCreate = new [] { "Comment One", "Comment Two", "Comment Three", "Comment Four" };
+        var commentsToCreate = new[] { "Comment One", "Comment Two", "Comment Three", "Comment Four" };
 
         await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
 

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -308,9 +308,9 @@ public class PullRequestsClientTests : IDisposable
     {
         var expectedFiles = new List<PullRequestFile>
         {
-            new PullRequestFile(null, "Octokit.Tests.Integration/Clients/ReferencesClientTests.cs", null, 8, 3, 11, null, null, null, null), 
-            new PullRequestFile(null, "Octokit/Clients/ApiPagination.cs", null, 21, 6, 27, null, null, null, null), 
-            new PullRequestFile(null, "Octokit/Helpers/IApiPagination.cs", null, 1, 1, 2, null, null, null, null), 
+            new PullRequestFile(null, "Octokit.Tests.Integration/Clients/ReferencesClientTests.cs", null, 8, 3, 11, null, null, null, null),
+            new PullRequestFile(null, "Octokit/Clients/ApiPagination.cs", null, 21, 6, 27, null, null, null, null),
+            new PullRequestFile(null, "Octokit/Helpers/IApiPagination.cs", null, 1, 1, 2, null, null, null, null),
             new PullRequestFile(null, "Octokit/Http/ApiConnection.cs", null, 1, 1, 2, null, null, null, null)
         };
 

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -65,7 +65,6 @@ public class ReleasesClientTests
             _releaseClient = _github.Release;
 
             _context = _github.CreateRepositoryContext("public-repo").Result;
-
         }
 
         [IntegrationTest]
@@ -191,7 +190,7 @@ public class ReleasesClientTests
 
             var response = await _github.Connection.Get<object>(new Uri(asset.Url), new Dictionary<string, string>(), "application/octet-stream");
 
-            Assert.Contains("This is a plain text file.", Encoding.ASCII.GetString((byte[]) response.Body));
+            Assert.Contains("This is a plain text file.", Encoding.ASCII.GetString((byte[])response.Body));
         }
         [IntegrationTest]
         public async Task CanDownloadBinaryAsset()
@@ -217,9 +216,9 @@ public class ReleasesClientTests
             var response = await _github.Connection.Get<object>(new Uri(asset.Url), new Dictionary<string, string>(), "application/octet-stream");
 
             var textContent = String.Empty;
-            
-            using (var zipstream = new MemoryStream((byte[]) response.Body))
-            using(var archive = new ZipArchive(zipstream))
+
+            using (var zipstream = new MemoryStream((byte[])response.Body))
+            using (var archive = new ZipArchive(zipstream))
             {
                 var enttry = archive.Entries[0];
                 var data = new byte[enttry.Length];
@@ -227,7 +226,7 @@ public class ReleasesClientTests
                 textContent = Encoding.ASCII.GetString(data);
             }
 
-            Assert.Contains("This is a plain text file.",textContent );
+            Assert.Contains("This is a plain text file.", textContent);
         }
 
 

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Integration.Clients
 
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 
-        [IntegrationTest(Skip="this isn't passing in CI - i hate past me right now")]
+        [IntegrationTest(Skip = "this isn't passing in CI - i hate past me right now")]
         public async Task CanAddAndDeleteEmail()
         {
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -34,7 +34,7 @@ namespace Octokit.Tests.Integration
                 return null;
 
             return new Credentials(applicationClientId, applicationClientSecret);
-        }); 
+        });
 
         static Helper()
         {
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Integration
         public static string UserName { get; private set; }
         public static string Organization { get; private set; }
 
-        public static Credentials Credentials { get { return _credentialsThunk.Value; }}
+        public static Credentials Credentials { get { return _credentialsThunk.Value; } }
 
         public static Credentials ApplicationCredentials { get { return _oauthApplicationCredentials.Value; } }
 

--- a/Octokit.Tests.Integration/Helpers/OrganizationTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/OrganizationTestAttribute.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Integration
     {
         readonly IMessageSink diagnosticMessageSink;
 
-       public OrganizationTestDiscoverer(IMessageSink diagnosticMessageSink)
+        public OrganizationTestDiscoverer(IMessageSink diagnosticMessageSink)
         {
             this.diagnosticMessageSink = diagnosticMessageSink;
         }

--- a/Octokit.Tests.Integration/Helpers/PersonalAccessTokenTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/PersonalAccessTokenTestAttribute.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Integration
         public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
             return Helper.IsUsingToken
-                ? new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) } 
+                ? new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) }
                 : Enumerable.Empty<IXunitTestCase>();
         }
     }

--- a/Octokit.Tests.Integration/Helpers/RepositorySetupHelper.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositorySetupHelper.cs
@@ -60,6 +60,5 @@ namespace Octokit.Tests.Integration.Helpers
             // create branch
             return await client.GitDatabase.Reference.Create(repository.Owner.Login, repository.Name, new NewReference("refs/heads/my-branch", featureBranchCommit.Sha));
         }
-
     }
 }

--- a/Octokit.Tests.Integration/fixtures/RepositoriesHooksCollection.cs
+++ b/Octokit.Tests.Integration/fixtures/RepositoriesHooksCollection.cs
@@ -5,6 +5,6 @@ namespace Octokit.Tests.Integration.fixtures
     [CollectionDefinition(Name)]
     public class RepositoriesHooksCollection : ICollectionFixture<RepositoriesHooksFixture>
     {
-      public const string Name = "Repositories Hooks Collection";
+        public const string Name = "Repositories Hooks Collection";
     }
 }

--- a/Octokit.Tests/Authentication/TokenAuthenticatorTests.cs
+++ b/Octokit.Tests/Authentication/TokenAuthenticatorTests.cs
@@ -36,7 +36,7 @@ namespace Octokit.Tests
             {
                 var authenticator = new TokenAuthenticator();
                 Assert.Throws<ArgumentNullException>(() => authenticator.Authenticate(null, Credentials.Anonymous));
-                Assert.Throws<ArgumentNullException>(() => 
+                Assert.Throws<ArgumentNullException>(() =>
                     authenticator.Authenticate(Substitute.For<IRequest>(), null));
             }
         }

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -123,7 +123,7 @@ namespace Octokit.Tests.Clients
                 client.Put<ApplicationAuthorization>(Args.Uri, Args.Object, Args.String)
                     .ThrowsAsync<ApplicationAuthorization>(
                     new AuthorizationException(
-                        new Response(HttpStatusCode.Unauthorized , null, new Dictionary<string, string>(), "application/json")));
+                        new Response(HttpStatusCode.Unauthorized, null, new Dictionary<string, string>(), "application/json")));
                 var authEndpoint = new AuthorizationsClient(client);
 
                 await Assert.ThrowsAsync<TwoFactorChallengeFailedException>(() =>
@@ -137,7 +137,7 @@ namespace Octokit.Tests.Clients
                 var data = new NewAuthorization { Note = "note" };
                 var client = Substitute.For<IAuthorizationsClient>();
                 client.GetOrCreateApplicationAuthentication("clientId", "secret", Arg.Any<NewAuthorization>())
-                    .Returns(_ => {throw new TwoFactorRequiredException();});
+                    .Returns(_ => { throw new TwoFactorRequiredException(); });
                 client.GetOrCreateApplicationAuthentication("clientId",
                     "secret",
                     Arg.Any<NewAuthorization>(),
@@ -161,7 +161,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RetriesWhenResendRequested()
             {
-                var challengeResults = new Queue<TwoFactorChallengeResult>(new []
+                var challengeResults = new Queue<TwoFactorChallengeResult>(new[]
                 {
                     TwoFactorChallengeResult.RequestResendCode,
                     new TwoFactorChallengeResult("two-factor-code")
@@ -197,7 +197,7 @@ namespace Octokit.Tests.Clients
                 var challengeResults = new Queue<TwoFactorChallengeResult>(new[]
                 {
                     TwoFactorChallengeResult.RequestResendCode,
-                    new TwoFactorChallengeResult("wrong-code") 
+                    new TwoFactorChallengeResult("wrong-code")
                 });
                 var data = new NewAuthorization();
                 var client = Substitute.For<IAuthorizationsClient>();
@@ -239,7 +239,7 @@ namespace Octokit.Tests.Clients
                 client.Put<ApplicationAuthorization>(Arg.Do<Uri>(u => calledUri = u), Arg.Do<object>(body => calledBody = body));
 
                 authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data);
-                
+
                 Assert.NotNull(calledUri);
                 Assert.Equal(calledUri.ToString(), "authorizations/clients/clientId");
 
@@ -261,7 +261,7 @@ namespace Octokit.Tests.Clients
                 client.Received().Get<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/tokens/accessToken"),
                     null);
-           }
+            }
 
             [Fact]
             public async Task EnsuresArgumentsNotNull()

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -85,9 +85,9 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitStatusClient(connection);
 
-                client.Create("owner", "repo", "sha", new NewCommitStatus {  State = CommitState.Success });
+                client.Create("owner", "repo", "sha", new NewCommitStatus { State = CommitState.Success });
 
-                connection.Received().Post<CommitStatus>(Arg.Is<Uri>(u => 
+                connection.Received().Post<CommitStatus>(Arg.Is<Uri>(u =>
                     u.ToString() == "repos/owner/repo/statuses/sha"),
                     Arg.Is<NewCommitStatus>(s => s.State == CommitState.Success));
             }

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -59,12 +59,12 @@ public class CommitsClientTests
         {
             var client = new CommitsClient(Substitute.For<IApiConnection>());
 
-            var newCommit = new NewCommit("message", "tree", new[]{"parent1", "parent2"});
+            var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newCommit));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newCommit));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit));            
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit));
         }
     }
 

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -69,7 +69,7 @@ public class DeploymentStatusClientTests
         public async Task EnsuresNonEmptyArguments()
         {
             var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
-                
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
         }
@@ -83,7 +83,7 @@ public class DeploymentStatusClientTests
         public async Task EnsureNonWhitespaceArguments(string whitespace)
         {
             var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
-                
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "repo", 1, newDeploymentStatus));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, 1, newDeploymentStatus));
         }

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -238,7 +238,7 @@ namespace Octokit.Tests.Clients
             {"WatchEvent", typeof(StarredEventPayload)},
             {"unknown", typeof(ActivityPayload)}
         };
-        
+
         [Fact]
         public async Task DeserializesPayloadToCorrectType()
         {
@@ -252,7 +252,7 @@ namespace Octokit.Tests.Clients
                     },
                     sender = new
                     {
-                       id = 1337 
+                       id = 1337
                     }
                 }}};
 

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -112,7 +112,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
                     null, null).Returns(response);
@@ -129,7 +129,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
                     null, null).Returns(response);
@@ -159,7 +159,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following/alfhenrik-test"),
                     null, null).Returns(response);
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following/alfhenrik-test"),
                     null, null).Returns(response);
@@ -198,7 +198,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("", "alfhenrik-text"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.IsFollowing("alfhenrik", ""));
             }
-
         }
 
         public class TheFollowMethod
@@ -208,7 +207,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
                     Args.Object).Returns(response);
@@ -225,7 +224,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/following/alfhenrik"),
                     new { }).Returns(response);

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -45,8 +45,8 @@ public class GistsClientTests
             DateTimeOffset since = DateTimeOffset.Now;
             client.GetAll(since);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), 
-                Arg.Is<IDictionary<string,string>>(x => x.ContainsKey("since")));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
         }
 
         [Fact]
@@ -54,7 +54,7 @@ public class GistsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new GistsClient(connection);
-            
+
             client.GetAllPublic();
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"));
@@ -65,7 +65,7 @@ public class GistsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new GistsClient(connection);
-            
+
             DateTimeOffset since = DateTimeOffset.Now;
             client.GetAllPublic(since);
 
@@ -173,7 +173,7 @@ public class GistsClientTests
             newGist.Public = true;
 
             newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
-            
+
             client.Create(newGist);
 
             connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Arg.Any<object>());
@@ -233,7 +233,7 @@ public class GistsClientTests
         public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
         {
             var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
             var connection = Substitute.For<IConnection>();
             connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
                 null, null).Returns(response);
@@ -250,7 +250,7 @@ public class GistsClientTests
         public async Task ThrowsExceptionForInvalidStatusCode()
         {
             var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
             var connection = Substitute.For<IConnection>();
             connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
                 null, null).Returns(response);
@@ -273,7 +273,7 @@ public class GistsClientTests
 
             client.Fork("1");
 
-            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"), 
+            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
                                              Arg.Any<object>());
         }
     }
@@ -288,8 +288,8 @@ public class GistsClientTests
 
             var updateGist = new GistUpdate();
             updateGist.Description = "my newly updated gist";
-            var gistFileUpdate = new GistFileUpdate 
-            { 
+            var gistFileUpdate = new GistFileUpdate
+            {
                 NewFileName = "myNewGistTestFile.cs",
                 Content = "new GistsClient(connection).Edit();"
             };

--- a/Octokit.Tests/Clients/GitDatabaseClientTests.cs
+++ b/Octokit.Tests/Clients/GitDatabaseClientTests.cs
@@ -36,5 +36,5 @@ public class GitDatabaseClientTests
             var gitDatabaseClient = new GitDatabaseClient(apiConnection);
             Assert.NotNull(gitDatabaseClient.Reference);
         }
-    }    
+    }
 }

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -34,7 +34,6 @@ public class IssueCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
         }
-
     }
 
     public class TheGetForRepositoryMethod
@@ -183,7 +182,7 @@ public class IssueCommentsClientTests
     [Fact]
     public void CanDeserializeIssueComment()
     {
-        const string issueResponseJson = 
+        const string issueResponseJson =
             "{\"id\": 1," +
             "\"url\": \"https://api.github.com/repos/octocat/Hello-World/issues/comments/1\"," +
             "\"html_url\": \"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1\"," +

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -33,7 +33,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
-
         }
 
         public class TheGetAllForCurrentMethod

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -76,7 +76,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             }
-
         }
     }
 }

--- a/Octokit.Tests/Clients/MergingClientTests.cs
+++ b/Octokit.Tests/Clients/MergingClientTests.cs
@@ -33,13 +33,13 @@ namespace Octokit.Tests.Clients
             {
                 var client = new MergingClient(Substitute.For<IApiConnection>());
 
-                var newMerge = new NewMerge("baseBranch", "shaToMerge") {CommitMessage = "some mergingMessage"};
+                var newMerge = new NewMerge("baseBranch", "shaToMerge") { CommitMessage = "some mergingMessage" };
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newMerge));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newMerge));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newMerge));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newMerge));            
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", null));            
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newMerge));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", null));
             }
         }
 

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -39,7 +39,7 @@ namespace Octokit.Tests.Clients
                 IApiResponse<string> response = new ApiResponse<string>(new Response(), "<strong>Test</strong>");
                 var connection = Substitute.For<IConnection>();
                 var forTest = new NewArbitraryMarkdown("testMarkdown", "gfm", "testContext");
-                connection.Post<string>(Args.Uri,forTest, "text/html", "text/plain")
+                connection.Post<string>(Args.Uri, forTest, "text/html", "text/plain")
                     .Returns(Task.FromResult(response));
                 var client = new MiscellaneousClient(connection);
 

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -101,7 +101,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"),
                     null, null).Returns(response);
@@ -118,7 +118,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members/username"),
                     null, null).Returns(response);
@@ -149,7 +149,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
                     null, null).Returns(response);
@@ -166,7 +166,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
                     null, null).Returns(response);
@@ -221,7 +221,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
                     Args.Object).Returns(response);
@@ -238,7 +238,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"),
                     new { }).Returns(response);
@@ -271,7 +271,7 @@ namespace Octokit.Tests.Clients
 
                 client.Conceal("org", "username");
 
-                connection.Received().Delete(Arg.Is<Uri>(u=>u.ToString() == "orgs/org/public_members/username"));
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members/username"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch"});
+                client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" });
 
                 connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 5
@@ -134,7 +134,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheMergeMethod 
+        public class TheMergeMethod
         {
             [Fact]
             public void PutsToCorrectUrl()
@@ -164,7 +164,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheMergedMethod 
+        public class TheMergedMethod
         {
             [Fact]
             public void RequestsCorrectUrl()
@@ -193,7 +193,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheCommitsMethod 
+        public class TheCommitsMethod
         {
             [Fact]
             public async Task RequestsCorrectUrl()
@@ -202,7 +202,7 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestsClient(connection);
 
                 await client.Commits("fake", "repo", 42);
-				
+
                 connection.Received()
                     .GetAll<PullRequestCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/commits"));
             }

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null,"test"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "test"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "test"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
@@ -56,7 +56,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators/user1"),
                     null, null).Returns(response);
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/foo/bar/assignees/cody"),
                     null, null).Returns(response);
@@ -115,7 +115,7 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add(null, "test","user1"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add(null, "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add("owner", null, "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add("owner", "", "user1"));

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -270,7 +270,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"));
-            } 
+            }
         }
 
 
@@ -331,7 +331,7 @@ namespace Octokit.Tests.Clients
                 connection.Received()
                     .GetAll<Repository>(
                         Arg.Is<Uri>(u => u.ToString() == "user/repos"),
-                        Arg.Is<Dictionary<string,string>>(d => d["type"] == "all"));
+                        Arg.Is<Dictionary<string, string>>(d => d["type"] == "all"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -34,7 +34,6 @@ public class RepositoryCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
         }
-
     }
 
     public class TheGetForRepositoryMethod
@@ -97,7 +96,7 @@ public class RepositoryCommentsClientTests
         public void PostsToCorrectUrl()
         {
             NewCommitComment newComment = new NewCommitComment("body");
-            
+
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
@@ -188,7 +187,7 @@ public class RepositoryCommentsClientTests
     [Fact]
     public void CanDeserializeCommitComment()
     {
-        const string commitCommentResponseJson = 
+        const string commitCommentResponseJson =
             "{\"html_url\": \"https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e#commitcomment-1\"," +
             "\"url\": \"https://api.github.com/repos/octocat/Hello-World/comments/1\"," +
             "\"id\": 1," +
@@ -218,7 +217,7 @@ public class RepositoryCommentsClientTests
         var response = jsonPipeline.DeserializeResponse<CommitComment>(httpResponse);
 
         Assert.NotNull(response.Body);
-        Assert.Equal(commitCommentResponseJson, response.HttpResponse.Body); 
+        Assert.Equal(commitCommentResponseJson, response.HttpResponse.Body);
         Assert.Equal(1, response.Body.Id);
     }
 }

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var hook = new NewRepositoryHook("name", new Dictionary<string, string> { {"config", "" }});
+                var hook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
 
                 client.Hooks.Create("fake", "repo", hook);
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -349,7 +349,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 client.SearchRepo(new SearchRepositoriesRequest("something"));
-                connection.Received().Get<SearchRepositoryResult>(Arg.Is<Uri>(u => u.ToString() == "search/repositories"), 
+                connection.Received().Get<SearchRepositoryResult>(Arg.Is<Uri>(u => u.ToString() == "search/repositories"),
                     Arg.Any<Dictionary<string, string>>());
             }
 
@@ -655,12 +655,12 @@ namespace Octokit.Tests.Clients
                 var client = new SearchClient(connection);
                 var request = new SearchRepositoriesRequest("github");
                 request.SortField = RepoSearchSort.Stars;
-                
+
                 client.SearchRepo(request);
-                
+
                 connection.Received().Get<SearchRepositoryResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/repositories"),
-                    Arg.Is<Dictionary<string, string>>(d => 
+                    Arg.Is<Dictionary<string, string>>(d =>
                         d["q"] == "github" &&
                         d["sort"] == "stars"));
             }

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -64,7 +64,7 @@ namespace Octokit.Tests.Clients
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
                 var connection = Substitute.For<IConnection>();
                 connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"), null, null)
                     .Returns(response);
@@ -87,7 +87,7 @@ namespace Octokit.Tests.Clients
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
                 var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status , null, new Dictionary<string, string>(), "application/json")));
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
 
                 var connection = Substitute.For<IConnection>();
                 connection.Put<object>(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"),

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                     .Returns(Task.FromResult(contributors));
                 var statisticsClient = new StatisticsClient(client);
 
-                var result = await statisticsClient.GetContributors("username","repositoryName");
+                var result = await statisticsClient.GetContributors("username", "repositoryName");
 
                 Assert.Equal(1, result.Count);
             }
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
             public async Task ThrowsIfGivenNullOwner()
             {
                 var statisticsClient = new StatisticsClient(Substitute.For<IApiConnection>());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors(null,"repositoryName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors(null, "repositoryName"));
             }
 
             [Fact]
@@ -105,14 +105,14 @@ namespace Octokit.Tests.Clients
                 });
                 var client = Substitute.For<IApiConnection>();
                 client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
-                    .Returns(Task.FromResult(data)); 
+                    .Returns(Task.FromResult(data));
                 var statisticsClient = new StatisticsClient(client);
 
                 var codeFrequency = await statisticsClient.GetCodeFrequency("username", "repositoryName");
 
                 Assert.Equal(2, codeFrequency.AdditionsAndDeletionsByWeek.Count);
                 Assert.Equal(firstTimestamp.FromUnixTime(), codeFrequency.AdditionsAndDeletionsByWeek[0].Timestamp);
-                Assert.Equal(10, codeFrequency.AdditionsAndDeletionsByWeek[0].Additions); 
+                Assert.Equal(10, codeFrequency.AdditionsAndDeletionsByWeek[0].Additions);
                 Assert.Equal(52, codeFrequency.AdditionsAndDeletionsByWeek[0].Deletions);
                 Assert.Equal(secondTimestamp.FromUnixTime(), codeFrequency.AdditionsAndDeletionsByWeek[1].Timestamp);
                 Assert.Equal(0, codeFrequency.AdditionsAndDeletionsByWeek[1].Additions);

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -42,9 +42,9 @@ public class TagsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new TagsClient(connection);
 
-            client.Create("owner", "repo", new NewTag{Type = TaggedType.Tree});
+            client.Create("owner", "repo", new NewTag { Type = TaggedType.Tree });
 
-            connection.Received().Post<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/tags"), 
+            connection.Received().Post<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/tags"),
                                             Arg.Is<NewTag>(nt => nt.Type == TaggedType.Tree));
         }
 
@@ -98,6 +98,6 @@ public class TagsClientTests
                                         "}";
 
             Assert.Equal(expectedResult, json);
-        } 
+        }
     }
 }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -235,7 +235,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveMembership(1, null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveMembership(1, ""));
             }
-
         }
 
         public class TheGetAllRepositoriesMethod

--- a/Octokit.Tests/Clients/WatchedClientTests.cs
+++ b/Octokit.Tests/Clients/WatchedClientTests.cs
@@ -75,7 +75,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ReturnsFalseOnNotFoundException()
             {
-                 var endpoint = new Uri("repos/fight/club/subscription", UriKind.Relative);
+                var endpoint = new Uri("repos/fight/club/subscription", UriKind.Relative);
 
                 var connection = Substitute.For<IApiConnection>();
                 var response = new Response(HttpStatusCode.NotFound, null, new Dictionary<string, string>(), "application/json");

--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -26,9 +26,9 @@ namespace Octokit.Tests.Exceptions
             public void SetsSpecifiedExceptionMessageAndInnerException()
             {
                 var inner = new InvalidOperationException();
-                
+
                 var exception = new ApiException("Shit broke", inner);
-                
+
                 Assert.Equal("Shit broke", exception.Message);
                 Assert.Same(inner, exception.InnerException);
             }

--- a/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
@@ -18,8 +18,8 @@ namespace Octokit.Tests.Exceptions
                 var response = new Response(
                     (HttpStatusCode)422,
                     @"{""errors"":[{""code"":""custom"",""field"":""key"",""message"":""key is " +
-                    @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}", 
-                    new Dictionary<string, string>(), 
+                    @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}",
+                    new Dictionary<string, string>(),
                     "application/json"
                 );
 
@@ -49,7 +49,7 @@ namespace Octokit.Tests.Exceptions
                     @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}",
                     new Dictionary<string, string>(),
                     "application/json");
-                
+
                 var exception = new ApiValidationException(response);
 
                 using (var stream = new MemoryStream())

--- a/Octokit.Tests/Exceptions/ForbiddenExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ForbiddenExceptionTests.cs
@@ -27,7 +27,7 @@ namespace Octokit.Tests.Exceptions
             [Fact]
             public void HasDefaultMessage()
             {
-                var response = new Response(HttpStatusCode.Forbidden , null, new Dictionary<string, string>(), "application/json");
+                var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
                 var forbiddenException = new ForbiddenException(response);
 
                 Assert.Equal("Request Forbidden", forbiddenException.Message);

--- a/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/RateLimitExceededExceptionTests.cs
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Exceptions
                     {"X-RateLimit-Reset", "XXXX"}
                 };
                 var response = new Response(HttpStatusCode.Forbidden, null, headers, "application/json");
-                
+
                 var exception = new RateLimitExceededException(response);
 
                 Assert.Equal(HttpStatusCode.Forbidden, exception.StatusCode);

--- a/Octokit.Tests/Exceptions/RepositoryExistsExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/RepositoryExistsExceptionTests.cs
@@ -9,7 +9,7 @@ namespace Octokit.Tests.Exceptions
         public void WhenOrganizationIsNullShouldThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new RepositoryExistsException(
-                                                        null,                                        
+                                                        null,
                                                         "some-repo",
                                                         GitHubClient.GitHubDotComUrl,
                                                         new ApiValidationException()));

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -151,7 +151,7 @@ namespace Octokit.Tests
                                 },
                                 new List<string>
                                 {
-                                    "user", 
+                                    "user",
                                     "public_repo",
                                     "repo",
                                     "gist"
@@ -170,6 +170,5 @@ namespace Octokit.Tests
                 var temp = connection.Received(1).GetLastApiInfo();
             }
         }
-
     }
 }

--- a/Octokit.Tests/Helpers/Arg.cs
+++ b/Octokit.Tests/Helpers/Arg.cs
@@ -57,7 +57,7 @@ namespace Octokit.Tests
         {
             get { return Arg.Any<OrganizationUpdate>(); }
         }
-        
+
         public static CancellationToken CancellationToken
         {
             get { return Arg.Any<CancellationToken>(); }

--- a/Octokit.Tests/Helpers/StringExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/StringExtensionsTests.cs
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Helpers
             [InlineData("https://host.com/path?name=example name.txt&label=labeltext", "https://host.com/path{?name,label,other}")]
             public void ExpandsUriTemplates(string expected, string template)
             {
-                Assert.Equal(expected, template.ExpandUriTemplate(new { name = "example name.txt",label="labeltext" }).ToString());
+                Assert.Equal(expected, template.ExpandUriTemplate(new { name = "example name.txt", label = "labeltext" }).ToString());
             }
         }
     }

--- a/Octokit.Tests/Helpers/UnixTimestampExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/UnixTimestampExtensionsTests.cs
@@ -27,7 +27,7 @@ public class UnixTimestampExtensionsTests
         public void ReturnsDateFromUnixEpochCorrectly()
         {
             var epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            
+
             var result = ((long)0).FromUnixTime();
 
             Assert.Equal(epoch, result);
@@ -37,9 +37,9 @@ public class UnixTimestampExtensionsTests
         public void ReturnsDateFromRandomTimeCorrectly()
         {
             var expected = new DateTimeOffset(1975, 1, 23, 1, 1, 2, TimeSpan.Zero);
-            
+
             var result = ((long)159670862).FromUnixTime();
-            
+
             Assert.Equal(expected, result);
         }
     }

--- a/Octokit.Tests/Helpers/UriExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/UriExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Helpers
             {
                 var uri = new Uri("https://api.github.com/repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2");
 
-                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other"} };
+                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" } };
 
                 var actual = uri.ApplyParameters(parameters);
 

--- a/Octokit.Tests/Http/ApiConnectionTests.cs
+++ b/Octokit.Tests/Http/ApiConnectionTests.cs
@@ -103,10 +103,10 @@ namespace Octokit.Tests.Http
             public async Task EnsuresArgumentNotNull()
             {
                 var client = new ApiConnection(Substitute.For<IConnection>());
-                
+
                 // One argument
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll<object>(null));
-                
+
                 // Two argument
                 await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                     await client.GetAll<object>(null, new Dictionary<string, string>()));
@@ -351,7 +351,7 @@ namespace Octokit.Tests.Http
             {
                 var queuedOperationUrl = new Uri("anything", UriKind.Relative);
 
-                var result = new [] { new object() };
+                var result = new[] { new object() };
                 const HttpStatusCode statusCode = HttpStatusCode.NoContent;
                 var httpResponse = new Response(statusCode, null, new Dictionary<string, string>(), "application/json");
                 IApiResponse<IReadOnlyList<object>> response = new ApiResponse<IReadOnlyList<object>>(
@@ -370,7 +370,7 @@ namespace Octokit.Tests.Http
             {
                 var queuedOperationUrl = new Uri("anything", UriKind.Relative);
 
-                var result = new [] { new object() };
+                var result = new[] { new object() };
                 IApiResponse<IReadOnlyList<object>> firstResponse = new ApiResponse<IReadOnlyList<object>>(
                     new Response(HttpStatusCode.Accepted, null, new Dictionary<string, string>(), "application/json"), result);
                 IApiResponse<IReadOnlyList<object>> completedResponse = new ApiResponse<IReadOnlyList<object>>(
@@ -378,7 +378,7 @@ namespace Octokit.Tests.Http
                 var connection = Substitute.For<IConnection>();
                 connection.GetResponse<IReadOnlyList<object>>(queuedOperationUrl, Args.CancellationToken)
                           .Returns(x => Task.FromResult(firstResponse),
-                          x => Task.FromResult(firstResponse), 
+                          x => Task.FromResult(firstResponse),
                           x => Task.FromResult(completedResponse));
 
                 var apiConnection = new ApiConnection(connection);
@@ -392,7 +392,7 @@ namespace Octokit.Tests.Http
             {
                 var queuedOperationUrl = new Uri("anything", UriKind.Relative);
 
-                var result = new [] { new object() };
+                var result = new[] { new object() };
                 IApiResponse<IReadOnlyList<object>> accepted = new ApiResponse<IReadOnlyList<object>>(
                     new Response(HttpStatusCode.Accepted, null, new Dictionary<string, string>(), "application/json"), result);
                 var connection = Substitute.For<IConnection>();

--- a/Octokit.Tests/Http/ApiInfoTests.cs
+++ b/Octokit.Tests/Http/ApiInfoTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Http
                                 },
                                 new List<string>
                                 {
-                                    "user", 
+                                    "user",
                                     "public_repo",
                                     "repo",
                                     "gist"
@@ -95,6 +95,5 @@ namespace Octokit.Tests.Http
                 Assert.NotSame(original.RateLimit.Reset, clone.RateLimit.Reset);
             }
         }
-
     }
 }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -74,7 +74,7 @@ namespace Octokit.Tests.Http
                     { "X-Accepted-OAuth-Scopes", "user" },
                 };
                 IResponse response = new Response(headers);
-                
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
@@ -93,7 +93,7 @@ namespace Octokit.Tests.Http
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response(HttpStatusCode.Unauthorized, null, new Dictionary<string, string>(), "application/json");
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
-                var connection = new Connection(new ProductHeaderValue("OctokitTests"), 
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
@@ -155,7 +155,7 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal(expectedFactorType, exception.TwoFactorType);
             }
-            
+
             [Fact]
             public async Task ThrowsApiValidationExceptionFor422Response()
             {
@@ -564,9 +564,9 @@ namespace Octokit.Tests.Http
             {
                 // 1 arg
                 Assert.Throws<ArgumentNullException>(() => new Connection(null));
-                
+
                 // 2 args
-                Assert.Throws<ArgumentNullException>(() => new Connection(null, new Uri("https://example.com"))); 
+                Assert.Throws<ArgumentNullException>(() => new Connection(null, new Uri("https://example.com")));
                 Assert.Throws<ArgumentNullException>(() => new Connection(new ProductHeaderValue("test"), (Uri)null));
 
                 // 3 args
@@ -634,7 +634,7 @@ namespace Octokit.Tests.Http
 
                 Assert.Null(result);
             }
-            
+
             [Fact]
             public async Task ReturnsObjectIfNotNew()
             {
@@ -664,7 +664,7 @@ namespace Octokit.Tests.Http
                                 },
                                 new List<string>
                                 {
-                                    "user", 
+                                    "user",
                                     "public_repo",
                                     "repo",
                                     "gist"

--- a/Octokit.Tests/Http/HttpClientAdapterTests.cs
+++ b/Octokit.Tests/Http/HttpClientAdapterTests.cs
@@ -33,7 +33,7 @@ namespace Octokit.Tests.Http
                     }
                 };
                 var tester = new HttpClientAdapterTester();
-                
+
                 var requestMessage = tester.BuildRequestMessageTester(request);
 
                 Assert.Equal(2, requestMessage.Headers.Count());
@@ -93,7 +93,7 @@ namespace Octokit.Tests.Http
                     BaseAddress = GitHubClient.GitHubApiUrl,
                     Endpoint = _endpoint,
                     Method = HttpMethod.Post,
-                    Body = new FormUrlEncodedContent(new Dictionary<string, string> {{"foo", "bar"}})
+                    Body = new FormUrlEncodedContent(new Dictionary<string, string> { { "foo", "bar" } })
                 };
                 var tester = new HttpClientAdapterTester();
 
@@ -119,7 +119,8 @@ namespace Octokit.Tests.Http
             [InlineData(HttpStatusCode.NotFound)]
             public async Task BuildsResponseFromResponseMessage(HttpStatusCode httpStatusCode)
             {
-                var responseMessage = new HttpResponseMessage {
+                var responseMessage = new HttpResponseMessage
+                {
                     StatusCode = httpStatusCode,
                     Content = new ByteArrayContent(Encoding.UTF8.GetBytes("{}")),
                     Headers =
@@ -131,7 +132,7 @@ namespace Octokit.Tests.Http
                 var tester = new HttpClientAdapterTester();
 
                 var response = await tester.BuildResponseTester(responseMessage);
-                
+
                 var firstHeader = response.Headers.First();
                 Assert.Equal("peanut", firstHeader.Key);
                 Assert.Equal("butter", firstHeader.Value);
@@ -149,7 +150,7 @@ namespace Octokit.Tests.Http
                 var responseMessage = new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new ByteArrayContent(new byte[] { 0, 1, 1, 0, 1}),
+                    Content = new ByteArrayContent(new byte[] { 0, 1, 1, 0, 1 }),
                 };
                 responseMessage.Content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
                 var tester = new HttpClientAdapterTester();

--- a/Octokit.Tests/Http/JsonHttpPipelineTests.cs
+++ b/Octokit.Tests/Http/JsonHttpPipelineTests.cs
@@ -142,9 +142,9 @@ namespace Octokit.Tests.Http
                 const string data = "{\"name\":\"Haack\"}";
                 var jsonPipeline = new JsonHttpPipeline();
                 var httpResponse = new Response(
-                    HttpStatusCode.OK, 
+                    HttpStatusCode.OK,
                     data,
-                    new Dictionary<string, string>(), 
+                    new Dictionary<string, string>(),
                     "application/json");
 
                 var response = jsonPipeline.DeserializeResponse<List<SomeObject>>(httpResponse);

--- a/Octokit.Tests/Http/RateLimitTests.cs
+++ b/Octokit.Tests/Http/RateLimitTests.cs
@@ -19,7 +19,7 @@ namespace Octokit.Tests.Http
             [Fact]
             public void ParsesRateLimitsFromHeaders()
             {
-                var headers = new Dictionary<string, string> 
+                var headers = new Dictionary<string, string>
                 {
                     { "X-RateLimit-Limit", "100" },
                     { "X-RateLimit-Remaining", "42" },
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Http
             [Fact]
             public void HandlesInvalidHeaderValues()
             {
-                var headers = new Dictionary<string, string> 
+                var headers = new Dictionary<string, string>
                 {
                     { "X-RateLimit-Limit", "1234scoobysnacks1234" },
                     { "X-RateLimit-Remaining", "xanadu" },
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Http
             [Fact]
             public void CanPopulateObjectFromSerializedData()
             {
-                var headers = new Dictionary<string, string> 
+                var headers = new Dictionary<string, string>
                 {
                     { "X-RateLimit-Limit", "100" },
                     { "X-RateLimit-Remaining", "42" },
@@ -92,7 +92,7 @@ namespace Octokit.Tests.Http
                     var formatter = new BinaryFormatter();
                     formatter.Serialize(stream, rateLimit);
                     stream.Position = 0;
-                    var deserialized = (RateLimit) formatter.Deserialize(stream);
+                    var deserialized = (RateLimit)formatter.Deserialize(stream);
 
                     Assert.Equal(100, deserialized.Limit);
                     Assert.Equal(42, deserialized.Remaining);
@@ -109,7 +109,6 @@ namespace Octokit.Tests.Http
             {
                 Assert.Throws<ArgumentNullException>(() => new RateLimit(null));
             }
-
         }
 
         public class TheMethods

--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -104,7 +104,7 @@ namespace Octokit.Tests.Http
         [InlineData(HttpStatusCode.MovedPermanently)]  // 301
         [InlineData(HttpStatusCode.Found)]  // 302
         [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
-         public async Task Status301ShouldRedirectPOSTWithBody(HttpStatusCode statusCode)
+        public async Task Status301ShouldRedirectPOSTWithBody(HttpStatusCode statusCode)
         {
             var redirectResponse = new HttpResponseMessage(statusCode);
             redirectResponse.Headers.Location = new Uri("http://example.org/bar");

--- a/Octokit.Tests/Models/DeploymentTests.cs
+++ b/Octokit.Tests/Models/DeploymentTests.cs
@@ -42,7 +42,7 @@ namespace Octokit.Tests.Models
                 }";
 
             var actual = new SimpleJsonSerializer().Deserialize<Deployment>(json);
-            
+
             Assert.Equal(1, actual.Id);
             Assert.Equal("topic-branch", actual.Sha);
             Assert.Equal("https://api.github.com/repos/octocat/example/deployments/1", actual.Url);

--- a/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
+++ b/Octokit.Tests/Models/ReadOnlyPagedCollectionTests.cs
@@ -16,8 +16,8 @@ namespace Octokit.Tests.Models
             {
                 var nextPageUrl = new Uri("https://example.com/page/2");
                 var nextPageResponse = Task.Factory.StartNew<IApiResponse<List<object>>>(() =>
-                    new ApiResponse<List<object>>(new Response(), new List<object> {new object(), new object()}));
-                var links = new Dictionary<string, Uri> {{"next", nextPageUrl}};
+                    new ApiResponse<List<object>>(new Response(), new List<object> { new object(), new object() }));
+                var links = new Dictionary<string, Uri> { { "next", nextPageUrl } };
                 var scopes = new List<string>();
                 var httpResponse = Substitute.For<IResponse>();
                 httpResponse.ApiInfo.Returns(new ApiInfo(links, scopes, scopes, "etag", new RateLimit(new Dictionary<string, string>())));

--- a/Octokit.Tests/Models/RepositoryUpdateTests.cs
+++ b/Octokit.Tests/Models/RepositoryUpdateTests.cs
@@ -31,9 +31,9 @@ namespace Octokit.Tests.Models
                 HasWiki = true,
                 HasDownloads = true
             };
-            
+
             var json = new SimpleJsonSerializer().Serialize(update);
-            
+
             Assert.Equal(expected, json);
         }
     }

--- a/Octokit.Tests/Models/SearchCodeRequestTests.cs
+++ b/Octokit.Tests/Models/SearchCodeRequestTests.cs
@@ -11,7 +11,7 @@ public class SearchCodeRequestTests
         public void ReturnsAReadOnlyDictionary()
         {
             var request = new SearchCodeRequest("test");
-            
+
             var result = request.MergedQualifiers();
 
             // If I can cast this to a writeable collection, then that defeats the purpose of a read only.

--- a/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
+++ b/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
@@ -11,7 +11,7 @@ public class SearchRepositoryRequestTests
         public void ReturnsAReadOnlyDictionary()
         {
             var request = new SearchCodeRequest("test");
-            
+
             var result = request.MergedQualifiers();
 
             // If I can cast this to a writeable collection, then that defeats the purpose of a read only.

--- a/Octokit.Tests/Reactive/AuthorizationExtensionsTests.cs
+++ b/Octokit.Tests/Reactive/AuthorizationExtensionsTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
                 var result = await client.GetOrCreateApplicationAuthentication(
                     "clientId",
                     "secret",
-                    new NewAuthorization { Note = "Was it this one?"},
+                    new NewAuthorization { Note = "Was it this one?" },
                     _ => Observable.Return(twoFactorChallengeResult));
 
                 Assert.Equal("OAUTHSECRET", result.Token);
@@ -84,7 +84,7 @@ namespace Octokit.Tests.Reactive
                 var challengeResults = new Queue<TwoFactorChallengeResult>(new[]
                 {
                     TwoFactorChallengeResult.RequestResendCode,
-                    new TwoFactorChallengeResult("wrong-code") 
+                    new TwoFactorChallengeResult("wrong-code")
                 });
                 var twoFactorFailedException = new TwoFactorChallengeFailedException();
                 var data = new NewAuthorization();

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -33,9 +33,9 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference").ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());                
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
             }
- 
+
             [Fact]
             public async Task RequestsCorrectUrl()
             {
@@ -62,7 +62,7 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit).ToTask());
             }
- 
+
             [Fact]
             public async Task RequestsCorrectUrl()
             {

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -131,5 +131,5 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => new ObservableDeploymentsClient(null));
             }
         }
-    } 
+    }
 }

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -35,7 +35,6 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1).ToTask());
             }
-
         }
 
         public class TheGetForRepositoryMethod
@@ -50,7 +49,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/comments", UriKind.Relative), null, null);
-                }
+            }
 
             [Fact]
             public async Task EnsuresArgumentsNotNull()

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -45,7 +45,7 @@ namespace Octokit.Tests.Reactive
             {
                 var firstPageUrl = new Uri("repos/fake/repo/milestones", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
-                var firstPageLinks = new Dictionary<string, Uri> {{"next", secondPageUrl}};
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<Milestone>>
                 (
                     CreateResponseWithApiInfo(firstPageLinks),
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Reactive
                     }
                 );
                 var thirdPageUrl = new Uri("https://example.com/page/3");
-                var secondPageLinks = new Dictionary<string, Uri> {{"next", thirdPageUrl}};
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
                 var secondPageResponse = new ApiResponse<List<Milestone>>
                 (
                     CreateResponseWithApiInfo(secondPageLinks),
@@ -98,7 +98,7 @@ namespace Octokit.Tests.Reactive
             {
                 var firstPageUrl = new Uri("repos/fake/repo/milestones", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
-                var firstPageLinks = new Dictionary<string, Uri> {{"next", secondPageUrl}};
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<Milestone>>
                 (
                     CreateResponseWithApiInfo(firstPageLinks),
@@ -110,7 +110,7 @@ namespace Octokit.Tests.Reactive
                     }
                 );
                 var thirdPageUrl = new Uri("https://example.com/page/3");
-                var secondPageLinks = new Dictionary<string, Uri> {{"next", thirdPageUrl}};
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
                 var secondPageResponse = new ApiResponse<List<Milestone>>
                 (
                     CreateResponseWithApiInfo(secondPageLinks),

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -193,7 +193,7 @@ namespace Octokit.Tests.Reactive
                     });
                 var lastPageResponse = new ApiResponse<List<PullRequestReviewComment>>
                 (
-                    new Response(),               
+                    new Response(),
                     new List<PullRequestReviewComment>
                     {
                         new PullRequestReviewComment(7),

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoriesClient(gitHubClient);
                 var observable = client.Get("stark", "ned");
-                
+
                 connection.Received(1).Get<Repository>(Args.Uri, null, null);
 
                 var result = await observable;
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Reactive
             {
                 var firstPageUrl = new Uri("user/repos", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
-                var firstPageLinks = new Dictionary<string, Uri> {{"next", secondPageUrl}};
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<Repository>>(
                     CreateResponseWithApiInfo(firstPageLinks),
                     new List<Repository>
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Reactive
                         new Repository(3)
                     });
                 var thirdPageUrl = new Uri("https://example.com/page/3");
-                var secondPageLinks = new Dictionary<string, Uri> {{"next", thirdPageUrl}};
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
                 var secondPageResponse = new ApiResponse<List<Repository>>
                 (
                     CreateResponseWithApiInfo(secondPageLinks),
@@ -122,7 +122,7 @@ namespace Octokit.Tests.Reactive
                 var thirdPageLinks = new Dictionary<string, Uri> { { "next", fourthPageUrl } };
                 var thirdPageResponse = new ApiResponse<List<Repository>>
                 (
-                    
+
                     CreateResponseWithApiInfo(thirdPageLinks),
                     new List<Repository>
                     {
@@ -174,7 +174,7 @@ namespace Octokit.Tests.Reactive
                         new Repository(365),
                         new Repository(366)
                     });
-                
+
                 var thirdPageUrl = new Uri("https://example.com/page/3");
                 var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
                 IApiResponse<List<Repository>> secondPageResponse = new ApiResponse<List<Repository>>

--- a/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Reactive
 
             [Fact]
             public async Task ThrowsIfGivenNullRepositoryName()
-            {   
+            {
                 var statisticsClient = new ObservableStatisticsClient(Substitute.For<IGitHubClient>());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => statisticsClient.GetContributors("owner", null).ToTask());
             }

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -37,7 +37,7 @@ namespace Octokit.Tests
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
             }
         }
-        
+
         public class TheGetRecursiveMethod
         {
             [Fact]
@@ -64,7 +64,7 @@ namespace Octokit.Tests
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetRecursive("owner", "name", "").ToTask());
             }
         }
-        
+
         public class TheCreateMethod
         {
             [Fact]

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -80,14 +80,14 @@ namespace Octokit.Tests
             }
         }
 
-        
+
         public class TheDeserializeMethod
         {
             [Fact]
             public void DeserializesEventInfosWithUnderscoresInName()
             {
                 const string json = "{\"event\":\"head_ref_deleted\"}";
-                new SimpleJsonSerializer().Deserialize<EventInfo>(json);                
+                new SimpleJsonSerializer().Deserialize<EventInfo>(json);
             }
 
             [Fact]

--- a/Octokit/Authentication/TokenAuthenticator.cs
+++ b/Octokit/Authentication/TokenAuthenticator.cs
@@ -22,12 +22,12 @@ namespace Octokit.Internal
             var token = credentials.GetToken();
             if (credentials.Login != null)
             {
-                throw new InvalidOperationException("The Login is not null for a token authentication request. You " + 
+                throw new InvalidOperationException("The Login is not null for a token authentication request. You " +
                     "probably did something wrong.");
             }
             if (token != null)
             {
-                request.Headers["Authorization"] = string.Format(CultureInfo.InvariantCulture, "Token {0}", token);    
+                request.Headers["Authorization"] = string.Format(CultureInfo.InvariantCulture, "Token {0}", token);
             }
         }
     }

--- a/Octokit/Clients/ApiClient.cs
+++ b/Octokit/Clients/ApiClient.cs
@@ -23,7 +23,7 @@
         /// <value>
         /// The API client's connection
         /// </value>
-        protected IApiConnection ApiConnection {get; private set;}
+        protected IApiConnection ApiConnection { get; private set; }
 
         /// <summary>
         /// Returns the underlying <see cref="IConnection"/> used by the <see cref="IApiConnection"/>. This is useful

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -143,7 +143,7 @@ namespace Octokit
             var endpoint = ApiUrls.Authorizations();
             return ApiConnection.Post<ApplicationAuthorization>(endpoint, requestData, null, null, twoFactorAuthenticationCode);
         }
-        
+
         /// <summary>
         /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -14,7 +14,7 @@ namespace Octokit
         /// Instantiates a new GitHub Git Commits API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public CommitsClient(IApiConnection apiConnection) : 
+        public CommitsClient(IApiConnection apiConnection) :
             base(apiConnection)
         {
         }

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -16,8 +16,8 @@ namespace Octokit
         /// Initializes a new GitHub User Followers API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public FollowersClient(IApiConnection apiConnection) : base(apiConnection) 
-        { 
+        public FollowersClient(IApiConnection apiConnection) : base(apiConnection)
+        {
         }
 
         /// <summary>

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -16,7 +16,7 @@ namespace Octokit
         /// Instantiates a new GitHub Gists API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public GistsClient(IApiConnection apiConnection) : 
+        public GistsClient(IApiConnection apiConnection) :
             base(apiConnection)
         {
             Comment = new GistCommentsClient(apiConnection);
@@ -51,15 +51,16 @@ namespace Octokit
             // Allowing the serializer to handle Dictionary<string,NewGistFile> 
             // will fail to match.
             var filesAsJsonObject = new JsonObject();
-            foreach(var kvp in newGist.Files)
+            foreach (var kvp in newGist.Files)
             {
                 filesAsJsonObject.Add(kvp.Key, new { Content = kvp.Value });
             }
 
-            var gist = new { 
+            var gist = new
+            {
                 Description = newGist.Description,
                 Public = newGist.Public,
-                Files = filesAsJsonObject 
+                Files = filesAsJsonObject
             };
 
             return ApiConnection.Post<Gist>(ApiUrls.Gist(), gist);

--- a/Octokit/Clients/GitDatabaseClient.cs
+++ b/Octokit/Clients/GitDatabaseClient.cs
@@ -12,7 +12,7 @@
         /// Instantiates a new GitHub Git API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public GitDatabaseClient(IApiConnection apiConnection) 
+        public GitDatabaseClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
             Blob = new BlobsClient(apiConnection);

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -26,10 +26,10 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Authorization"/>s.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", 
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "It's an API call, so it's not a property.")]
         Task<IReadOnlyList<Authorization>> GetAll();
-        
+
         /// <summary>
         /// Gets a specific <see cref="Authorization"/> for the authenticated user.
         /// </summary>
@@ -96,7 +96,7 @@ namespace Octokit
             string clientSecret,
             NewAuthorization newAuthorization,
             string twoFactorAuthenticationCode);
-        
+
         /// <summary>
         /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.
@@ -120,7 +120,7 @@ namespace Octokit
             string clientId,
             string clientSecret,
             NewAuthorization newAuthorization);
-        
+
         /// <summary>
         /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.

--- a/Octokit/Clients/IDeploymentsClient.cs
+++ b/Octokit/Clients/IDeploymentsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         Task<IReadOnlyList<Deployment>> GetAll(string owner, string name);
-        
+
         /// <summary>
         /// Creates a new deployment for the specified repository.
         /// Users with push access can create a deployment for a given ref.

--- a/Octokit/Clients/IGistCommentsClient.cs
+++ b/Octokit/Clients/IGistCommentsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task{GistComment}.</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", 
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GistComment> Get(string gistId, int commentId);
 

--- a/Octokit/Clients/IOrganizationMembersClient.cs
+++ b/Octokit/Clients/IOrganizationMembersClient.cs
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
         Task<bool> CheckMember(string org, string user);
-        
+
         /// <summary>
         /// Check is a user is publicly a member of the organization.
         /// </summary>
@@ -111,7 +111,7 @@ namespace Octokit
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
         Task Delete(string org, string user);
-        
+
         /// <summary>
         /// Make the authenticated user's organization membership public.
         /// </summary>
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
         Task<bool> Publicize(string org, string user);
-        
+
         /// <summary>
         /// Make the authenticated user's organization membership private.
         /// </summary>

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
         /// <returns></returns>
         Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
-        
+
         /// <summary>
         /// Deletes a deploy key from a repository.
         /// </summary>

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
         /// <returns>A <c>bool</c> representing the success of the operation</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId="Unwatch",
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(string owner, string name);
     }

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(merge, "merge");
-            
+
             return ApiConnection.Post<Merge>(ApiUrls.CreateMerge(owner, name), merge);
         }
     }

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -145,7 +145,7 @@ namespace Octokit
                 var response = await Connection.Get<object>(ApiUrls.CheckMember(org, user), null, null)
                                                .ConfigureAwait(false);
                 var statusCode = response.HttpResponse.StatusCode;
-                if (statusCode != HttpStatusCode.NotFound 
+                if (statusCode != HttpStatusCode.NotFound
                     && statusCode != HttpStatusCode.NoContent
                     && statusCode != HttpStatusCode.Found)
                 {

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -109,7 +109,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
-        public Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest) 
+        public Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -126,7 +126,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>True if the operation has been merged, false otherwise</returns>
-        public async Task<bool> Merged(string owner, string name, int number) 
+        public async Task<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -15,7 +15,7 @@ namespace Octokit
         /// Instantiates a new GitHub References API client
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public ReferencesClient(IApiConnection apiConnection) : 
+        public ReferencesClient(IApiConnection apiConnection) :
             base(apiConnection)
         {
         }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
         public Task<Repository> Create(NewRepository newRepository)
         {
             Ensure.ArgumentNotNull(newRepository, "newRepository");
-            
+
             return Create(ApiUrls.Repositories(), null, newRepository);
         }
 
@@ -81,7 +81,7 @@ namespace Octokit
             catch (ApiValidationException e)
             {
                 string errorMessage = e.ApiError.FirstErrorMessageSafe();
-                
+
                 if (String.Equals(
                     "name already exists on this account",
                     errorMessage,
@@ -116,7 +116,7 @@ namespace Octokit
                 {
                     throw new PrivateRepositoryQuotaExceededException(e);
                 }
-                
+
                 if (errorMessage != null && errorMessage.EndsWith("is an unknown gitignore template.", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new InvalidGitIgnoreTemplateException(e);

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -84,7 +84,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.RepositoryReadme(owner, name);
             var readmeInfo = await ApiConnection.Get<ReadmeResponse>(endpoint, null).ConfigureAwait(false);
-            
+
             return new Readme(readmeInfo, ApiConnection);
         }
 

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="apiConnection">The API connection.</param>
         public RepositoryDeployKeysClient(IApiConnection apiConnection)
             : base(apiConnection)
-        { 
+        {
         }
 
         /// <summary>

--- a/Octokit/Clients/SearchClient.cs
+++ b/Octokit/Clients/SearchClient.cs
@@ -17,7 +17,6 @@ namespace Octokit
         public SearchClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
-
         }
 
         /// <summary>

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -72,7 +72,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "/repos/{0}/{1}/stats/commit_activity".FormatUri(owner, repositoryName);
-            var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(endpoint,cancellationToken);
+            var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(endpoint, cancellationToken);
             return new CommitActivity(activity);
         }
 
@@ -100,7 +100,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "/repos/{0}/{1}/stats/code_frequency".FormatUri(owner, repositoryName);
-            var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(endpoint,cancellationToken);
+            var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(endpoint, cancellationToken);
             return new CodeFrequency(rawFrequencies);
         }
 
@@ -128,7 +128,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "/repos/{0}/{1}/stats/participation".FormatUri(owner, repositoryName);
-            var result = await ApiConnection.GetQueuedOperation<Participation>(endpoint,cancellationToken);
+            var result = await ApiConnection.GetQueuedOperation<Participation>(endpoint, cancellationToken);
             return result.FirstOrDefault();
         }
 
@@ -140,7 +140,7 @@ namespace Octokit
         /// <returns>Returns commit counts per hour in each day</returns>
         public Task<PunchCard> GetPunchCard(string owner, string repositoryName)
         {
-            return GetPunchCard(owner, repositoryName,CancellationToken.None);
+            return GetPunchCard(owner, repositoryName, CancellationToken.None);
         }
 
         /// <summary>

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -14,7 +14,7 @@ namespace Octokit
         /// Instantiates a new GitHub Git Tags API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>
-        public TagsClient(IApiConnection apiConnection) 
+        public TagsClient(IApiConnection apiConnection)
             : base(apiConnection)
         {
         }

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -12,7 +12,7 @@ namespace Octokit
     /// </remarks>
     public class WatchedClient : ApiClient, IWatchedClient
     {
-         /// <summary>
+        /// <summary>
         /// Instantiates a new GitHub Activity Watching API client.
         /// </summary>
         /// <param name="apiConnection">An API connection</param>

--- a/Octokit/Exceptions/ForbiddenException.cs
+++ b/Octokit/Exceptions/ForbiddenException.cs
@@ -40,7 +40,7 @@ namespace Octokit
         {
             get { return ApiErrorMessageSafe ?? "Request Forbidden"; }
         }
-    
+
 #if !NETFX_CORE
         /// <summary>
         /// Constructs an instance of ForbiddenException

--- a/Octokit/Exceptions/InvalidGitignoreTemplateException.cs
+++ b/Octokit/Exceptions/InvalidGitignoreTemplateException.cs
@@ -21,15 +21,17 @@ namespace Octokit
         /// <summary>
         /// Constructs an instance of ApiValidationException
         /// </summary>
-        public InvalidGitIgnoreTemplateException() 
-            : base() { }
+        public InvalidGitIgnoreTemplateException()
+            : base()
+        { }
 
         /// <summary>
         /// Constructs an instance of ApiValidationException
         /// </summary>
         /// <param name="innerException">The inner validation exception.</param>
         public InvalidGitIgnoreTemplateException(ApiValidationException innerException)
-            : base(innerException) { }
+            : base(innerException)
+        { }
 
         public override string Message
         {
@@ -52,7 +54,8 @@ namespace Octokit
         /// contextual information about the source or destination.
         /// </param>
         protected InvalidGitIgnoreTemplateException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context)
+        { }
 #endif
     }
 }

--- a/Octokit/Exceptions/RepositoryExistsException.cs
+++ b/Octokit/Exceptions/RepositoryExistsException.cs
@@ -42,7 +42,7 @@ namespace Octokit
                         ? baseAddress
                         : GitHubClient.GitHubDotComUrl;
             ExistingRepositoryWebUrl = new Uri(webBaseAddress, new Uri(organization + "/" + name, UriKind.Relative));
-            
+
             _message = string.Format(CultureInfo.InvariantCulture, "There is already a repository named '{0}' in the organization '{1}'.", name, organization);
         }
 
@@ -110,10 +110,10 @@ namespace Octokit
             : base(info, context)
         {
             if (info == null) return;
-            _message = info.GetString("Message"); 
+            _message = info.GetString("Message");
             RepositoryName = info.GetString("RepositoryName");
             Organization = info.GetString("Organization");
-            OwnerIsOrganization = info.GetBoolean("OwnerIsOrganization"); 
+            OwnerIsOrganization = info.GetBoolean("OwnerIsOrganization");
             ExistingRepositoryWebUrl = (Uri)(info.GetValue("ExistingRepositoryWebUrl", typeof(Uri)));
         }
 

--- a/Octokit/Exceptions/RepositoryFormatException.cs
+++ b/Octokit/Exceptions/RepositoryFormatException.cs
@@ -22,7 +22,6 @@ namespace Octokit
                 CultureInfo.InvariantCulture,
                 "The list of repositories must be formatted as 'owner/name' - these values don't match this rule: {0}",
                 parameterList);
-
         }
 
         public override string Message
@@ -33,7 +32,7 @@ namespace Octokit
             }
         }
 
-        #if !NETFX_CORE
+#if !NETFX_CORE
         /// <summary>
         /// Constructs an instance of LoginAttemptsExceededException
         /// </summary>

--- a/Octokit/Exceptions/TwoFactorAuthorizationException.cs
+++ b/Octokit/Exceptions/TwoFactorAuthorizationException.cs
@@ -77,7 +77,7 @@ namespace Octokit
             : base(info, context)
         {
             if (info == null) return;
-            TwoFactorType = (TwoFactorType) (info.GetInt32("TwoFactorType"));
+            TwoFactorType = (TwoFactorType)(info.GetInt32("TwoFactorType"));
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -70,7 +70,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(connection, "connection");
             Ensure.ArgumentNotNull(uri, "uri");
-            
+
             return connection.GetHtml(uri, null);
         }
 

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all public repositories in
         /// response to a GET request.
         /// </summary>
-       /// <param name="since">The integer ID of the last Repository that you’ve seen.</param>
+        /// <param name="since">The integer ID of the last Repository that you’ve seen.</param>
         public static Uri AllPublicRepositories(long since)
         {
             return "/repositories?since={0}".FormatUri(since);
@@ -610,7 +610,7 @@ namespace Octokit
         {
             return "repos/{0}/{1}/hooks/{2}/pings".FormatUri(owner, repositoryName, hookId);
         }
-        
+
         /// <summary>
         /// Returns the <see cref="Uri"/> that lists the commit statuses for the specified reference.
         /// </summary>
@@ -870,7 +870,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// /// <param name="number">The pull request number</param>
-        public static Uri MergePullRequest(string owner, string name, int number) 
+        public static Uri MergePullRequest(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/merge".FormatUri(owner, name, number);
         }
@@ -881,7 +881,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// /// <param name="number">The pull request number</param>
-        public static Uri PullRequestCommits(string owner, string name, int number) 
+        public static Uri PullRequestCommits(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, number);
         }
@@ -1102,7 +1102,7 @@ namespace Octokit
             return blob.FormatUri(owner, name, reference);
         }
 
-         /// <summary>
+        /// <summary>
         /// Returns the <see cref="Uri"/> for the specified tree.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Helpers/CollectionExtensions.cs
+++ b/Octokit/Helpers/CollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace Octokit
                 return output;
 
             output = new Dictionary<string, Uri>();
-            
+
             foreach (var item in input)
             {
                 output.Add(new String(item.Key.ToCharArray()), new Uri(item.Value.ToString()));

--- a/Octokit/Helpers/PropertyOrField.cs
+++ b/Octokit/Helpers/PropertyOrField.cs
@@ -106,7 +106,7 @@ namespace Octokit
 
                 if (Base64Encoded)
                 {
-                    return delegate(object source)
+                    return delegate (object source)
                     {
                         var value = getDelegate(source);
                         var stringValue = value as string;
@@ -136,7 +136,7 @@ namespace Octokit
                 }
                 if (Base64Encoded)
                 {
-                    return delegate(object source, object value)
+                    return delegate (object source, object value)
                     {
                         var stringValue = value as string;
                         if (stringValue == null)
@@ -145,7 +145,6 @@ namespace Octokit
                         }
                         setDelegate(source, stringValue.FromBase64String());
                     };
-
                 }
                 return setDelegate;
             }
@@ -163,7 +162,7 @@ namespace Octokit
                 {
                     return _fieldInfo.FieldType;
                 }
-                throw new InvalidOperationException("Property and Field cannot both be null");   
+                throw new InvalidOperationException("Property and Field cannot both be null");
             }
         }
 

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -111,9 +111,9 @@ namespace Octokit
         // the rule:
         // Username may only contain alphanumeric characters or single hyphens
         // and cannot begin or end with a hyphen
-        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9.-]{1,}", 
+        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9.-]{1,}",
 #if (!PORTABLE && !NETFX_CORE)
-            RegexOptions.Compiled | 
+            RegexOptions.Compiled |
 #endif
             RegexOptions.IgnoreCase);
 

--- a/Octokit/Helpers/UnixTimeStampExtensions.cs
+++ b/Octokit/Helpers/UnixTimeStampExtensions.cs
@@ -6,7 +6,7 @@ namespace Octokit.Helpers
     /// Extensions for converting between different time representations
     /// </summary>
     public static class UnixTimestampExtensions
-    { 
+    {
         static readonly DateTimeOffset epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         /// <summary>

--- a/Octokit/Helpers/UriExtensions.cs
+++ b/Octokit/Helpers/UriExtensions.cs
@@ -23,7 +23,7 @@ namespace Octokit
 
             // to prevent values being persisted across requests
             // use a temporary dictionary which combines new and existing parameters
-            IDictionary<string,string> p = new Dictionary<string, string>(parameters);
+            IDictionary<string, string> p = new Dictionary<string, string>(parameters);
 
             string queryString;
             if (uri.IsAbsoluteUri)

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -446,7 +446,7 @@ namespace Octokit
                     case HttpStatusCode.Accepted:
                         continue;
                     case HttpStatusCode.NoContent:
-                        return new ReadOnlyCollection<T>(new T[] {});
+                        return new ReadOnlyCollection<T>(new T[] { });
                     case HttpStatusCode.OK:
                         return response.Body;
                 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -69,7 +69,5 @@ namespace Octokit
                                 new String(this.Etag.ToCharArray()),
                                 this.RateLimit.Clone());
         }
-
-
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -263,7 +263,6 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             return SendData<T>(uri, HttpMethod.Post, body, accepts, contentType, CancellationToken.None, twoFactorAuthenticationCode);
-
         }
 
         public Task<IApiResponse<T>> Post<T>(Uri uri, object body, string accepts, string contentType, TimeSpan timeout)
@@ -525,7 +524,7 @@ namespace Octokit
             return new ApiResponse<string>(response, response.Body as string);
         }
 
-        async Task<IApiResponse<T>> Run<T>(IRequest request, CancellationToken	cancellationToken)
+        async Task<IApiResponse<T>> Run<T>(IRequest request, CancellationToken cancellationToken)
         {
             _jsonPipeline.SerializeRequest(request);
             var response = await RunRequest(request, cancellationToken).ConfigureAwait(false);

--- a/Octokit/Http/Credentials.cs
+++ b/Octokit/Http/Credentials.cs
@@ -46,7 +46,7 @@ namespace Octokit
 
         public AuthenticationType AuthenticationType
         {
-            get; 
+            get;
             private set;
         }
     }

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -60,7 +60,7 @@ namespace Octokit
         /// <returns><see cref="IReadOnlyList{T}"/> of the The API resources in the list.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
         Task<IReadOnlyList<T>> GetAll<T>(Uri uri);
-        
+
         /// <summary>
         /// Gets all API resources in the list at the specified URI.
         /// </summary>
@@ -109,7 +109,7 @@ namespace Octokit
         /// <param name="accepts">Accept header to use for the API request</param>
         /// <returns>The created API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        Task<T> Post<T>(Uri uri, object data, string accepts); 
+        Task<T> Post<T>(Uri uri, object data, string accepts);
 
         /// <summary>
         /// Creates a new API resource in the list at the specified URI.

--- a/Octokit/Http/ICredentialStore.cs
+++ b/Octokit/Http/ICredentialStore.cs
@@ -12,7 +12,7 @@ namespace Octokit
         /// Retrieve the credentials from the underlying store
         /// </summary>
         /// <returns>A continuation containing credentials</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification="Nope")]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Nope")]
         Task<Credentials> GetCredentials();
     }
 }

--- a/Octokit/Http/IResponse.cs
+++ b/Octokit/Http/IResponse.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// Raw response body. Typically a string, but when requesting images, it will be a byte array.
         /// </summary>
         object Body { get; }
-        
+
         /// <summary>
         /// Information about the API.
         /// </summary>

--- a/Octokit/Http/JsonHttpPipeline.cs
+++ b/Octokit/Http/JsonHttpPipeline.cs
@@ -34,7 +34,7 @@ namespace Octokit.Internal
             {
                 request.Headers["Accept"] = v3ApiVersion;
             }
-            
+
             if (request.Method == HttpMethod.Get || request.Body == null) return;
             if (request.Body is string || request.Body is Stream || request.Body is HttpContent) return;
 

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -18,14 +18,14 @@ namespace Octokit
         : ISerializable
 #endif
     {
-        public RateLimit() {}
+        public RateLimit() { }
 
         public RateLimit(IDictionary<string, string> responseHeaders)
         {
             Ensure.ArgumentNotNull(responseHeaders, "responseHeaders");
 
-            Limit = (int) GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Limit");
-            Remaining = (int) GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Remaining");
+            Limit = (int)GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Limit");
+            Remaining = (int)GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Remaining");
             ResetAsUtcEpochSeconds = GetHeaderValueAsInt32Safe(responseHeaders, "X-RateLimit-Reset");
         }
 
@@ -113,6 +113,5 @@ namespace Octokit
                 ResetAsUtcEpochSeconds = this.ResetAsUtcEpochSeconds
             };
         }
-
     }
 }

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -37,7 +37,7 @@ namespace Octokit.Internal
                 foreach (var property in propertiesAndFields.Where(p => p.SerializeNull))
                 {
                     var key = type.FullName + "-" + property.JsonFieldName;
-                    
+
                     _membersWhichShouldPublishNull.Add(key);
                 }
 

--- a/Octokit/Models/Request/BodyWrapper.cs
+++ b/Octokit/Models/Request/BodyWrapper.cs
@@ -20,6 +20,6 @@
         /// <value>
         /// The body.
         /// </value>
-        public string Body { get; private set; } 
+        public string Body { get; private set; }
     }
 }

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -17,7 +17,7 @@ namespace Octokit
         protected ContentRequest(string message)
         {
             Ensure.ArgumentNotNullOrEmptyString(message, "message");
-            
+
             Message = message;
         }
 

--- a/Octokit/Models/Request/EditRepositoryHook.cs
+++ b/Octokit/Models/Request/EditRepositoryHook.cs
@@ -62,8 +62,8 @@ namespace Octokit
             get
             {
                 return String.Format(CultureInfo.InvariantCulture,
-                    "Repository Hook: Replacing Events: {0}, Adding Events: {1}, Removing Events: {2}", Events == null ? "no" : string.Join(", ", Events), 
-                    AddEvents == null ? "no" : string.Join(", ", AddEvents), 
+                    "Repository Hook: Replacing Events: {0}, Adding Events: {1}, Removing Events: {2}", Events == null ? "no" : string.Join(", ", Events),
+                    AddEvents == null ? "no" : string.Join(", ", AddEvents),
                     RemoveEvents == null ? "no" : string.Join(", ", RemoveEvents));
             }
         }

--- a/Octokit/Models/Request/IssueUpdate.cs
+++ b/Octokit/Models/Request/IssueUpdate.cs
@@ -58,7 +58,7 @@ namespace Octokit
         {
             get
             {
-                return String.Format(CultureInfo.InvariantCulture, "Title: {0}",Title);
+                return String.Format(CultureInfo.InvariantCulture, "Title: {0}", Title);
             }
         }
 

--- a/Octokit/Models/Request/NewArbitraryMarkDown.cs
+++ b/Octokit/Models/Request/NewArbitraryMarkDown.cs
@@ -38,9 +38,9 @@ namespace Octokit
         /// </summary>
         /// <param name="text">The Markdown text to render
         /// </param>
-        
+
         public NewArbitraryMarkdown(string text)
-            :this(text,_markdown,null)
+            : this(text, _markdown, null)
         {
         }
 
@@ -51,7 +51,7 @@ namespace Octokit
         /// <param name="mode">The rendering mode. Can be either markdown by default or gfm</param>
         public NewArbitraryMarkdown(string text, string mode)
             : this(text, mode, null)
-        { 
+        {
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Octokit
         public string Context { get; private set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "gfm")]
-        static string GetMode(string mode)        
+        static string GetMode(string mode)
         {
             if (mode != _markdown && mode != _gfm)
             {

--- a/Octokit/Models/Request/NewCommit.cs
+++ b/Octokit/Models/Request/NewCommit.cs
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="message">The message to associate with the commit</param>
         /// <param name="tree">The tree associated with the commit</param>
         public NewCommit(string message, string tree)
-            : this(message,tree, Enumerable.Empty<string>())
+            : this(message, tree, Enumerable.Empty<string>())
         {
         }
 
@@ -49,7 +49,7 @@ namespace Octokit
         /// <param name="tree">The tree associated with the commit</param>
         /// <param name="parent">The commit to use as a parent</param>
         public NewCommit(string message, string tree, string parent)
-            : this(message, tree, new [] { parent })
+            : this(message, tree, new[] { parent })
         {
         }
 

--- a/Octokit/Models/Request/NewGist.cs
+++ b/Octokit/Models/Request/NewGist.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// Indicates whether the gist is public
         /// </summary>
         public bool Public { get; set; }
-        
+
         /// <summary>
         /// Files that make up this gist using the key as Filename
         /// and value as Content

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// Title of the milestone (required)
         /// </summary>
         public string Title { get; private set; }
-        
+
         /// <summary>
         /// Details about the issue.
         /// </summary>
@@ -61,7 +61,7 @@ namespace Octokit
             get
             {
                 var labels = Labels ?? new Collection<string>();
-                return String.Format(CultureInfo.InvariantCulture, "Title: {0} Labels: {1}", Title, string.Join(",",labels));
+                return String.Format(CultureInfo.InvariantCulture, "Title: {0} Labels: {1}", Title, string.Join(",", labels));
             }
         }
     }

--- a/Octokit/Models/Request/NewMerge.cs
+++ b/Octokit/Models/Request/NewMerge.cs
@@ -28,7 +28,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "baseBranch");
             Ensure.ArgumentNotNullOrEmptyString(head, "head");
-            
+
             Base = @base;
             Head = head;
         }

--- a/Octokit/Models/Request/NewMilestone.cs
+++ b/Octokit/Models/Request/NewMilestone.cs
@@ -17,7 +17,7 @@ namespace Octokit
         public NewMilestone(string title)
         {
             Ensure.ArgumentNotNull(title, "title");
-            
+
             Title = title;
             State = ItemState.Open;
         }

--- a/Octokit/Models/Request/NewPullRequest.cs
+++ b/Octokit/Models/Request/NewPullRequest.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// <summary>
         /// Title of the pull request (required)
         /// </summary>
-       public string Title { get; private set; }
+        public string Title { get; private set; }
 
         /// <summary>
         /// The branch (or git ref) you want your changes pulled into (required).

--- a/Octokit/Models/Request/NewReference.cs
+++ b/Octokit/Models/Request/NewReference.cs
@@ -70,7 +70,7 @@ namespace Octokit
         {
             get
             {
-                return String.Format(CultureInfo.InvariantCulture, "Ref: {0} Sha: {1}", Ref,Sha);
+                return String.Format(CultureInfo.InvariantCulture, "Ref: {0} Sha: {1}", Ref, Sha);
             }
         }
     }

--- a/Octokit/Models/Request/PublicRepositoryRequest.cs
+++ b/Octokit/Models/Request/PublicRepositoryRequest.cs
@@ -17,7 +17,7 @@ namespace Octokit
         public PublicRepositoryRequest(int since)
         {
             Ensure.ArgumentNotNull(since, "since");
-            
+
             Since = since;
         }
 

--- a/Octokit/Models/Request/PullRequestRequest.cs
+++ b/Octokit/Models/Request/PullRequestRequest.cs
@@ -36,13 +36,13 @@ namespace Octokit
         /// <summary>
         /// What property to sort pull requests by.
         /// </summary>
-        [Parameter(Key="sort")]
+        [Parameter(Key = "sort")]
         public PullRequestSort SortProperty { get; set; }
 
         /// <summary>
         /// What direction to sort the pull requests.
         /// </summary>
-        [Parameter(Key="direction")]
+        [Parameter(Key = "direction")]
         public SortDirection SortDirection { get; set; }
 
         internal string DebuggerDisplay
@@ -71,7 +71,7 @@ namespace Octokit
         /// <summary>
         /// Sort by age (filtering by pulls updated in the last month)
         /// </summary>
-        [Parameter(Value= "long-running")]
+        [Parameter(Value = "long-running")]
         LongRunning
     }
 }

--- a/Octokit/Models/Request/ReleaseAssetUpdate.cs
+++ b/Octokit/Models/Request/ReleaseAssetUpdate.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// This field is required.
         /// </summary>
         public string Name { get; private set; }
-        
+
         /// <summary>
         /// An alternate description of the asset.
         /// Used in place of the filename.

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -76,7 +76,7 @@ namespace Octokit
                 {
                     if (value == null) return null;
                     string attributeValue;
-                    
+
                     return enumToAttributeDictionary.TryGetValue(value.ToString(), out attributeValue)
                         ? attributeValue ?? value.ToString().ToLowerInvariant()
                         : value.ToString().ToLowerInvariant();

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -210,13 +210,13 @@ namespace Octokit
 
             if (In != null)
             {
-                parameters.Add(String.Format(CultureInfo.InvariantCulture, "in:{0}", 
+                parameters.Add(String.Format(CultureInfo.InvariantCulture, "in:{0}",
                     String.Join(",", In.Select(i => i.ToParameter()))));
             }
 
             if (Type != null)
             {
-                parameters.Add(String.Format(CultureInfo.InvariantCulture, "type:{0}", 
+                parameters.Add(String.Format(CultureInfo.InvariantCulture, "type:{0}",
                     Type.ToParameter()));
             }
 

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -374,7 +374,7 @@ namespace Octokit
         public static DateRange Between(DateTime from, DateTime to)
         {
             return new DateRange(from, to);
-         }
+        }
 
         public override string ToString()
         {

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// <summary>
         /// URL of the account's avatar.
         /// </summary>
-        public string AvatarUrl { get; protected set; } 
+        public string AvatarUrl { get; protected set; }
 
         /// <summary>
         /// The account's bio.

--- a/Octokit/Models/Response/ActivityPayloads/IssueCommentPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/IssueCommentPayload.cs
@@ -9,6 +9,5 @@ namespace Octokit
         public string Action { get; protected set; }
         public Issue Issue { get; protected set; }
         public IssueComment Comment { get; protected set; }
-
     }
 }

--- a/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/PushEventPayload.cs
@@ -9,6 +9,6 @@ namespace Octokit
         public string Head { get; protected set; }
         public string Ref { get; protected set; }
         public int Size { get; protected set; }
-        public IReadOnlyList<Commit> Commits { get; protected set; } 
+        public IReadOnlyList<Commit> Commits { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/AdditionsAndDeletions.cs
+++ b/Octokit/Models/Response/AdditionsAndDeletions.cs
@@ -58,7 +58,7 @@ namespace Octokit
             get
             {
                 return String.Format(CultureInfo.InvariantCulture,
-                    "{0}: Additions: {1} Deletions: {2}", Timestamp.ToString("d",CultureInfo.InvariantCulture),Additions,Deletions);
+                    "{0}: Additions: {1} Deletions: {2}", Timestamp.ToString("d", CultureInfo.InvariantCulture), Additions, Deletions);
             }
         }
     }

--- a/Octokit/Models/Response/Author.cs
+++ b/Octokit/Models/Response/Author.cs
@@ -68,7 +68,7 @@ namespace Octokit
             get
             {
                 return String.Format(CultureInfo.InvariantCulture,
-                    "Author: Id: {0} Login: {1}",Id, Login);
+                    "Author: Id: {0} Login: {1}", Id, Login);
             }
         }
     }

--- a/Octokit/Models/Response/CommitActivity.cs
+++ b/Octokit/Models/Response/CommitActivity.cs
@@ -29,7 +29,7 @@ namespace Octokit
             get
             {
                 return String.Format(CultureInfo.InvariantCulture,
-                    "Weeks of activity: {0}",Activity.Count());
+                    "Weeks of activity: {0}", Activity.Count());
             }
         }
     }

--- a/Octokit/Models/Response/CommitComment.cs
+++ b/Octokit/Models/Response/CommitComment.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 
 namespace Octokit
 {
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]    
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CommitComment
     {
         public CommitComment() { }

--- a/Octokit/Models/Response/DeployKey.cs
+++ b/Octokit/Models/Response/DeployKey.cs
@@ -17,7 +17,7 @@ namespace Octokit
             Title = title;
         }
 
-        public int Id { get; protected set; } 
+        public int Id { get; protected set; }
         public string Key { get; protected set; }
         public string Url { get; protected set; }
         public string Title { get; protected set; }

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 namespace Octokit
 {
     [SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces",
-        Justification="People can use fully qualified names if they want to use both.")]
+        Justification = "People can use fully qualified names if they want to use both.")]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Deployment
     {

--- a/Octokit/Models/Response/EmailAddress.cs
+++ b/Octokit/Models/Response/EmailAddress.cs
@@ -36,7 +36,7 @@ namespace Octokit
         public bool Primary { get; protected set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode",
-            Justification="Used by DebuggerDisplayAttribute")]
+            Justification = "Used by DebuggerDisplayAttribute")]
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Response/GitIgnoreTemplate.cs
+++ b/Octokit/Models/Response/GitIgnoreTemplate.cs
@@ -30,6 +30,5 @@ namespace Octokit
                 return String.Format(CultureInfo.InvariantCulture, "GitIgnore: {0}", Name);
             }
         }
-
     }
 }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -75,7 +75,7 @@ namespace Octokit
         /// The user that created the issue.
         /// </summary>
         public User User { get; protected set; }
-        
+
         /// <summary>
         /// The set of labels applied to the issue
         /// </summary>
@@ -97,7 +97,7 @@ namespace Octokit
         public int Comments { get; protected set; }
 
         public PullRequest PullRequest { get; protected set; }
-        
+
         /// <summary>
         /// The date the issue was closed if closed.
         /// </summary>

--- a/Octokit/Models/Response/LicenseMetadata.cs
+++ b/Octokit/Models/Response/LicenseMetadata.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// The 
         /// </summary>
         public string Key { get; protected set; }
-        
+
         /// <summary>
         /// Friendly name of the license.
         /// </summary>

--- a/Octokit/Models/Response/Merge.cs
+++ b/Octokit/Models/Response/Merge.cs
@@ -27,7 +27,7 @@ namespace Octokit
         public Author Committer { get; protected set; }
         public Commit Commit { get; protected set; }
         public IReadOnlyList<GitReference> Parents { get; protected set; }
-        public string CommentsUrl { get; protected set; } 
+        public string CommentsUrl { get; protected set; }
         public int CommentCount { get; protected set; }
         public string HtmlUrl { get; protected set; }
     }

--- a/Octokit/Models/Response/MiscellaneousRateLimit.cs
+++ b/Octokit/Models/Response/MiscellaneousRateLimit.cs
@@ -7,7 +7,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class MiscellaneousRateLimit
     {
-        public MiscellaneousRateLimit() {}
+        public MiscellaneousRateLimit() { }
 
         public MiscellaneousRateLimit(ResourceRateLimit resources, RateLimit rate)
         {

--- a/Octokit/Models/Response/PunchCardPoint.cs
+++ b/Octokit/Models/Response/PunchCardPoint.cs
@@ -38,7 +38,7 @@ namespace Octokit
             get
             {
                 return String.Format(CultureInfo.InvariantCulture,
-                    "Day: {0} Hour: {1} Commit Count:{2}", DayOfWeek,HourOfTheDay,CommitCount);
+                    "Day: {0} Hour: {1} Commit Count:{2}", DayOfWeek, HourOfTheDay, CommitCount);
             }
         }
     }

--- a/Octokit/Models/Response/ResourceRateLimit.cs
+++ b/Octokit/Models/Response/ResourceRateLimit.cs
@@ -7,7 +7,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ResourceRateLimit
     {
-        public ResourceRateLimit() {}
+        public ResourceRateLimit() { }
 
         public ResourceRateLimit(RateLimit core, RateLimit search)
         {
@@ -36,5 +36,4 @@ namespace Octokit
             }
         }
     }
-
 }

--- a/Octokit/Models/Response/TagObject.cs
+++ b/Octokit/Models/Response/TagObject.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Type = type;
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", 
+        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
             Justification = "Name defined by web api and required for deserialisation")]
         public TaggedType Type { get; protected set; }
     }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1,5 +1,4 @@
 //-----------------------------------------------------------------------
-// <copyright file="SimpleJson.cs" company="The Outercurve Foundation">
 //    Copyright (c) 2011, The Outercurve Foundation.
 //
 //    Licensed under the MIT License (the "License");
@@ -524,7 +523,7 @@ namespace Octokit
         static SimpleJson()
         {
             EscapeTable = new char[93];
-            EscapeTable['"']  = '"';
+            EscapeTable['"'] = '"';
             EscapeTable['\\'] = '\\';
             EscapeTable['\b'] = 'b';
             EscapeTable['\f'] = 'f';
@@ -558,7 +557,7 @@ namespace Octokit
         /// <returns>
         /// Returns true if successfull otherwise false.
         /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification="Need to support .NET 2")]
+        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Need to support .NET 2")]
         public static bool TryDeserializeObject(string json, out object obj)
         {
             bool success = true;
@@ -623,7 +622,7 @@ namespace Octokit
             StringBuilder sb = new StringBuilder();
             char c;
 
-            for (int i = 0; i < jsonString.Length; )
+            for (int i = 0; i < jsonString.Length;)
             {
                 c = jsonString[i++];
 
@@ -1224,7 +1223,7 @@ namespace Octokit
 
 #endif
     }
-    
+
     [GeneratedCode("simple-json", "1.0.0")]
 #if SIMPLE_JSON_INTERNAL
     internal
@@ -1233,7 +1232,7 @@ namespace Octokit
 #endif
  interface IJsonSerializerStrategy
     {
-        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification="Need to support .NET 2")]
+        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Need to support .NET 2")]
         bool TrySerializeNonPrimitiveObject(object input, out object output);
         object DeserializeObject(object value, Type type);
     }
@@ -1337,12 +1336,12 @@ namespace Octokit
             if (type == null) throw new ArgumentNullException("type");
             string str = value as string;
 
-            if (type == typeof (Guid) && string.IsNullOrEmpty(str))
+            if (type == typeof(Guid) && string.IsNullOrEmpty(str))
                 return default(Guid);
 
             if (value == null)
                 return null;
-            
+
             object obj = null;
 
             if (str != null)
@@ -1357,7 +1356,7 @@ namespace Octokit
                         return new Guid(str);
                     if (type == typeof(Uri))
                     {
-                        bool isValid =  Uri.IsWellFormedUriString(str, UriKind.RelativeOrAbsolute);
+                        bool isValid = Uri.IsWellFormedUriString(str, UriKind.RelativeOrAbsolute);
 
                         Uri result;
                         if (isValid && Uri.TryCreate(str, UriKind.RelativeOrAbsolute, out result))
@@ -1365,8 +1364,8 @@ namespace Octokit
 
                         return null;
                     }
-                  
-                    if (type == typeof(string))  
+
+                    if (type == typeof(string))
                         return str;
 
                     return Convert.ChangeType(str, type, CultureInfo.InvariantCulture);
@@ -1386,7 +1385,7 @@ namespace Octokit
             }
             else if (value is bool)
                 return value;
-            
+
             bool valueIsLong = value is long;
             bool valueIsDouble = value is double;
             if ((valueIsLong && type == typeof(long)) || (valueIsDouble && type == typeof(double)))
@@ -1490,7 +1489,7 @@ namespace Octokit
             return Convert.ToDouble(p, CultureInfo.InvariantCulture);
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification="Need to support .NET 2")]
+        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Need to support .NET 2")]
         protected virtual bool TrySerializeKnownTypes(object input, out object output)
         {
             bool returnValue = true;
@@ -1515,7 +1514,7 @@ namespace Octokit
             }
             return returnValue;
         }
-        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification="Need to support .NET 2")]
+        [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "Need to support .NET 2")]
         protected virtual bool TrySerializeUnknownTypes(object input, out object output)
         {
             if (input == null) throw new ArgumentNullException("input");
@@ -1617,7 +1616,7 @@ namespace Octokit
     namespace Reflection
     {
         // This class is meant to be copied into other libraries. So we want to exclude it from Code Analysis rules
- 	    // that might be in place in the target project.
+        // that might be in place in the target project.
         [GeneratedCode("reflection-utils", "1.0.0")]
 #if SIMPLE_JSON_REFLECTION_UTILS_PUBLIC
         public
@@ -1670,7 +1669,7 @@ namespace Octokit
                 foreach (Type implementedInterface in interfaces)
                 {
                     if (IsTypeGeneric(implementedInterface) &&
-                        implementedInterface.GetGenericTypeDefinition() == typeof (IList<>))
+                        implementedInterface.GetGenericTypeDefinition() == typeof(IList<>))
                     {
                         return GetGenericTypeArguments(implementedInterface)[0];
                     }
@@ -1680,7 +1679,6 @@ namespace Octokit
 
             public static Attribute GetAttribute(Type objectType, Type attributeType)
             {
-
 #if SIMPLE_JSON_TYPEINFO
                 if (objectType == null || attributeType == null || !objectType.GetTypeInfo().IsDefined(attributeType))
                     return null;
@@ -1857,7 +1855,7 @@ namespace Octokit
 
             public static ConstructorDelegate GetConstructorByReflection(ConstructorInfo constructorInfo)
             {
-                return delegate(object[] args) { return constructorInfo.Invoke(args); };
+                return delegate (object[] args) { return constructorInfo.Invoke(args); };
             }
 
             public static ConstructorDelegate GetConstructorByReflection(Type type, params Type[] argsType)
@@ -1884,7 +1882,7 @@ namespace Octokit
                 NewExpression newExp = Expression.New(constructorInfo, argsExp);
                 Expression<Func<object[], object>> lambda = Expression.Lambda<Func<object[], object>>(newExp, param);
                 Func<object[], object> compiledLambda = lambda.Compile();
-                return delegate(object[] args) { return compiledLambda(args); };
+                return delegate (object[] args) { return compiledLambda(args); };
             }
 
             public static ConstructorDelegate GetConstructorByExpression(Type type, params Type[] argsType)
@@ -1916,12 +1914,12 @@ namespace Octokit
             public static GetDelegate GetGetMethodByReflection(PropertyInfo propertyInfo)
             {
                 MethodInfo methodInfo = GetGetterMethodInfo(propertyInfo);
-                return delegate(object source) { return methodInfo.Invoke(source, EmptyObjects); };
+                return delegate (object source) { return methodInfo.Invoke(source, EmptyObjects); };
             }
 
             public static GetDelegate GetGetMethodByReflection(FieldInfo fieldInfo)
             {
-                return delegate(object source) { return fieldInfo.GetValue(source); };
+                return delegate (object source) { return fieldInfo.GetValue(source); };
             }
 
 #if !SIMPLE_JSON_NO_LINQ_EXPRESSION
@@ -1932,7 +1930,7 @@ namespace Octokit
                 ParameterExpression instance = Expression.Parameter(typeof(object), "instance");
                 UnaryExpression instanceCast = (!IsValueType(propertyInfo.DeclaringType)) ? Expression.TypeAs(instance, propertyInfo.DeclaringType) : Expression.Convert(instance, propertyInfo.DeclaringType);
                 Func<object, object> compiled = Expression.Lambda<Func<object, object>>(Expression.TypeAs(Expression.Call(instanceCast, getMethodInfo), typeof(object)), instance).Compile();
-                return delegate(object source) { return compiled(source); };
+                return delegate (object source) { return compiled(source); };
             }
 
             public static GetDelegate GetGetMethodByExpression(FieldInfo fieldInfo)
@@ -1940,7 +1938,7 @@ namespace Octokit
                 ParameterExpression instance = Expression.Parameter(typeof(object), "instance");
                 MemberExpression member = Expression.Field(Expression.Convert(instance, fieldInfo.DeclaringType), fieldInfo);
                 GetDelegate compiled = Expression.Lambda<GetDelegate>(Expression.Convert(member, typeof(object)), instance).Compile();
-                return delegate(object source) { return compiled(source); };
+                return delegate (object source) { return compiled(source); };
             }
 
 #endif
@@ -1966,12 +1964,12 @@ namespace Octokit
             public static SetDelegate GetSetMethodByReflection(PropertyInfo propertyInfo)
             {
                 MethodInfo methodInfo = GetSetterMethodInfo(propertyInfo);
-                return delegate(object source, object value) { methodInfo.Invoke(source, new object[] { value }); };
+                return delegate (object source, object value) { methodInfo.Invoke(source, new object[] { value }); };
             }
 
             public static SetDelegate GetSetMethodByReflection(FieldInfo fieldInfo)
             {
-                return delegate(object source, object value) { fieldInfo.SetValue(source, value); };
+                return delegate (object source, object value) { fieldInfo.SetValue(source, value); };
             }
 
 #if !SIMPLE_JSON_NO_LINQ_EXPRESSION
@@ -1984,7 +1982,7 @@ namespace Octokit
                 UnaryExpression instanceCast = (!IsValueType(propertyInfo.DeclaringType)) ? Expression.TypeAs(instance, propertyInfo.DeclaringType) : Expression.Convert(instance, propertyInfo.DeclaringType);
                 UnaryExpression valueCast = (!IsValueType(propertyInfo.PropertyType)) ? Expression.TypeAs(value, propertyInfo.PropertyType) : Expression.Convert(value, propertyInfo.PropertyType);
                 Action<object, object> compiled = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setMethodInfo, valueCast), new ParameterExpression[] { instance, value }).Compile();
-                return delegate(object source, object val) { compiled(source, val); };
+                return delegate (object source, object val) { compiled(source, val); };
             }
 
             public static SetDelegate GetSetMethodByExpression(FieldInfo fieldInfo)
@@ -1993,7 +1991,7 @@ namespace Octokit
                 ParameterExpression value = Expression.Parameter(typeof(object), "value");
                 Action<object, object> compiled = Expression.Lambda<Action<object, object>>(
                     Assign(Expression.Field(Expression.Convert(instance, fieldInfo.DeclaringType), fieldInfo), Expression.Convert(value, fieldInfo.FieldType)), instance, value).Compile();
-                return delegate(object source, object val) { compiled(source, val); };
+                return delegate (object source, object val) { compiled(source, val); };
             }
 
             public static BinaryExpression Assign(Expression left, Expression right)
@@ -2143,7 +2141,6 @@ namespace Octokit
                     return _dictionary.GetEnumerator();
                 }
             }
-
         }
     }
 }

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -6,8 +6,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersionAttribute("0.17.0")]
 [assembly: AssemblyFileVersionAttribute("0.17.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System {
-    internal static class AssemblyVersionInformation {
+namespace System
+{
+    internal static class AssemblyVersionInformation
+    {
         internal const string Version = "0.17.0";
     }
 }

--- a/build.cmd
+++ b/build.cmd
@@ -3,6 +3,7 @@
 "tools\nuget\nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.0.0"
 "tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.4.2"
 "tools\nuget\nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0"
+"tools\nuget\nuget.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre
 
 :Build
 cls

--- a/build.fsx
+++ b/build.fsx
@@ -71,7 +71,7 @@ Target "FormatCode" (fun _ ->
         let project = pf + "/" + pf + ".csproj"
         ExecProcess (fun info ->
         info.FileName <- codeFormatter
-        info.Arguments <- project + " /nocopyright") (TimeSpan.FromMinutes 1.0)
+        info.Arguments <- project + " /nocopyright /nounicode") (TimeSpan.FromMinutes 1.0)
             |> ignore
     )
 )

--- a/build.fsx
+++ b/build.fsx
@@ -59,6 +59,23 @@ Target "CheckProjects" (fun _ ->
     |> Fake.MSBuild.ProjectSystem.CompareProjectsTo "./Octokit.Reactive/Octokit.Reactive.csproj"
 )
 
+let codeFormatter = @"tools\Octokit.CodeFormatter\tools\CodeFormatter.exe"
+
+Target "FormatCode" (fun _ ->
+    [   "Octokit"
+        "Octokit.Reactive"
+        "Octokit.Tests"
+        "Octokit.Tests.Conventions"
+        "Octokit.Tests.Integration"]
+    |> Seq.iter (fun pf ->
+        let project = pf + "/" + pf + ".csproj"
+        ExecProcess (fun info ->
+        info.FileName <- codeFormatter
+        info.Arguments <- project + " /nocopyright") (TimeSpan.FromMinutes 1.0)
+            |> ignore
+    )
+)
+
 Target "FixProjects" (fun _ ->
     !! "./Octokit/Octokit*.csproj"
     |> Fake.MSBuild.ProjectSystem.FixProjectFiles "./Octokit/Octokit.csproj"


### PR DESCRIPTION
This is wired up in the build script so you can run it at your leisure:

`.\build FormatCode`

The source code for the tool: https://github.com/shiftkey/codeformatter/pull/1

I disabled a couple of rules from the upstream codeformatter repo which go against our coding style:

 - new line above first `using` statement
 - specify the visibility of a field/member explicitly
 - private fields naming style

The net result is that things are actually pretty good, and we get some cleanup of whitespace for free.

- [x] is the unicode (c) correct inside `AssemblyInfo.cs`?
-  ~~[x] update `AssemblyInfo.cs` contents~~ :boot:ed
- [x] braces for empty constructors - what rule is this?
-  ~~[ ] remove copyright rename rule~~ :boot:ed
- [x] wait for #799 to land and then rebase this 
- [x] docs docs docs
- [x] hold for VS2015 support
- [x] run over codebase once #808 is merged