### PR TITLE
search across multiple repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ tools/xunit.runner.console
 *.ncrunch*
 *.GhostDoc.xml
 
+# FAKE temporary files
+.fake/
+
 # New VS Test Runner creates arbitrary folders with PDBs
 *.pdb
 pingme.txt

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -39,7 +39,8 @@
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\Net45\Octokit.Reactive.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -63,7 +63,8 @@ public class SearchClientTests
     [Fact]
     public async Task SearchForOpenIssues()
     {
-        var request = new SearchIssuesRequest("phone", "caliburn-micro", "caliburn.micro");
+        var request = new SearchIssuesRequest("phone");
+        request.Repos.Add("caliburn-micro/caliburn.micro");
         request.State = ItemState.Open;
 
         var issues = await _gitHubClient.Search.SearchIssues(request);
@@ -72,9 +73,25 @@ public class SearchClientTests
     }
 
     [Fact]
-    public async Task SearchForAllIssues()
+    public async Task SearchForAllIssuesWithouTaskUsingTerm()
     {
-        var request = new SearchIssuesRequest("phone", "caliburn-micro", "caliburn.micro");
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("caliburn-micro/caliburn.micro");
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        var closedIssues = issues.Items.Where(x => x.State == ItemState.Closed);
+        var openedIssues = issues.Items.Where(x => x.State == ItemState.Open);
+
+        Assert.NotEmpty(closedIssues);
+        Assert.NotEmpty(openedIssues);
+    }
+
+    [Fact]
+    public async Task SearchForAllIssuesUsingTerm()
+    {
+        var request = new SearchIssuesRequest("phone");
+        request.Repos.Add("caliburn-micro/caliburn.micro");
 
         var issues = await _gitHubClient.Search.SearchIssues(request);
 

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -45,6 +47,11 @@ public class SearchClientTests
     public async Task SearchForWordInCode()
     {
         var request = new SearchIssuesRequest("windows");
+        request.Repos = new Collection<string> {
+            "aspnet/dnx",
+            "aspnet/dnvm"
+        };
+
         request.SortField = IssueSearchSort.Created;
         request.Order = SortDirection.Descending;
 

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -63,8 +63,7 @@ public class SearchClientTests
     [Fact]
     public async Task SearchForOpenIssues()
     {
-        var request = new SearchIssuesRequest("phone");
-        request.Repo = "caliburn-micro/caliburn.micro";
+        var request = new SearchIssuesRequest("phone", "caliburn-micro", "caliburn.micro");
         request.State = ItemState.Open;
 
         var issues = await _gitHubClient.Search.SearchIssues(request);
@@ -75,8 +74,7 @@ public class SearchClientTests
     [Fact]
     public async Task SearchForAllIssues()
     {
-        var request = new SearchIssuesRequest("phone");
-        request.Repo = "caliburn-micro/caliburn.micro";
+        var request = new SearchIssuesRequest("phone", "caliburn-micro", "caliburn.micro");
 
         var issues = await _gitHubClient.Search.SearchIssues(request);
 

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -36,8 +36,8 @@ public class SearchClientTests
     [Fact]
     public async Task SearchForFunctionInCode()
     {
-        var request = new SearchCodeRequest("addClass");
-        request.Repo = "jquery/jquery";
+        var request = new SearchCodeRequest("addClass", "jquery", "jquery");
+
         var repos = await _gitHubClient.Search.SearchCode(request);
 
         Assert.NotEmpty(repos.Items);

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1168,7 +1168,7 @@ namespace Octokit.Tests.Clients
 
                 var request = new SearchIssuesRequest("windows");
                 request.Repos = new RepositoryCollection {
-                    { "haha-business", "some&name" }
+                    "haha-business"
                 };
 
                 request.SortField = IssueSearchSort.Created;

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using NSubstitute;
 using Xunit;
 using System.Threading.Tasks;
@@ -1150,13 +1151,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchIssuesRequest("something");
-                request.Repo = "octokit.net";
+                request.Repo = "octokit/octokit.net";
 
                 client.SearchIssues(request);
 
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit.net"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit/octokit.net"));
             }
 
             [Fact]
@@ -1165,7 +1166,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchIssuesRequest("something");
-                request.Repo = "octokit.net";
+                request.Repo = "octokit/octokit.net";
                 request.User = "alfhenrik";
                 request.Labels = new[] { "bug" };
 
@@ -1174,7 +1175,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] ==
-                        "something+label:bug+user:alfhenrik+repo:octokit.net"));
+                        "something+label:bug+user:alfhenrik+repo:octokit/octokit.net"));
             }
         }
 
@@ -1487,6 +1488,26 @@ namespace Octokit.Tests.Clients
                     Arg.Is<Dictionary<string, string>>(d =>
                         d["q"] == "something+path:tools/FAKE.core+extension:fs+repo:octokit.net"));
             }
+
+            [Fact]
+            public async Task ErrorOccursWhenSpecifyingInvalidFormatForRepos()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+
+                var request = new SearchIssuesRequest("windows");
+                request.Repos = new Collection<string> {
+                    "haha-business"
+                };
+
+                request.SortField = IssueSearchSort.Created;
+                request.Order = SortDirection.Descending;
+
+                await Assert.ThrowsAsync<ArgumentException>(
+                    async () => await client.SearchIssues(request));
+            }
+
+
         }
     }
 }

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1444,8 +1444,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something");
-                request.Repo = "octokit.net";
+                var request = new SearchCodeRequest("something", "octokit", "octokit.net");
 
                 client.SearchCode(request);
 
@@ -1474,8 +1473,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something");
-                request.Repo = "octokit.net";
+                var request = new SearchCodeRequest("something", "octokit", "octokit.net");
                 request.Path = "tools/FAKE.core";
                 request.Extension = "fs";
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1150,8 +1150,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchIssuesRequest("something");
-                request.Repo = "octokit/octokit.net";
+                var request = new SearchIssuesRequest("something", "octokit", "octokit.net");
 
                 client.SearchIssues(request);
 
@@ -1165,8 +1164,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchIssuesRequest("something");
-                request.Repo = "octokit/octokit.net";
+                var request = new SearchIssuesRequest("something", "octokit", "octokit.net");
                 request.User = "alfhenrik";
                 request.Labels = new[] { "bug" };
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1150,7 +1150,8 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchIssuesRequest("something", "octokit", "octokit.net");
+                var request = new SearchIssuesRequest("something");
+                request.Repos.Add("octokit/octokit.net");
 
                 client.SearchIssues(request);
 
@@ -1182,7 +1183,8 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchIssuesRequest("something", "octokit", "octokit.net");
+                var request = new SearchIssuesRequest("something");
+                request.Repos.Add("octokit/octokit.net");
                 request.User = "alfhenrik";
                 request.Labels = new[] { "bug" };
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1160,6 +1160,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task ErrorOccursWhenSpecifyingInvalidFormatForRepos()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+
+                var request = new SearchIssuesRequest("windows");
+                request.Repos = new Collection<string> {
+                    "haha-business"
+                };
+
+                request.SortField = IssueSearchSort.Created;
+                request.Order = SortDirection.Descending;
+
+                await Assert.ThrowsAsync<RepositoryFormatException>(
+                    async () => await client.SearchIssues(request));
+            }
+
+            [Fact]
             public void TestingTheRepoAndUserAndLabelQualifier()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -1450,7 +1468,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit.net"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit/octokit.net"));
             }
 
             [Fact]
@@ -1482,7 +1500,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
                     Arg.Is<Dictionary<string, string>>(d =>
-                        d["q"] == "something+path:tools/FAKE.core+extension:fs+repo:octokit.net"));
+                        d["q"] == "something+path:tools/FAKE.core+extension:fs+repo:octokit/octokit.net"));
             }
 
             [Fact]
@@ -1491,19 +1509,16 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
 
-                var request = new SearchIssuesRequest("windows");
+                var request = new SearchCodeRequest("windows");
                 request.Repos = new Collection<string> {
                     "haha-business"
                 };
 
-                request.SortField = IssueSearchSort.Created;
                 request.Order = SortDirection.Descending;
 
-                await Assert.ThrowsAsync<ArgumentException>(
-                    async () => await client.SearchIssues(request));
+                await Assert.ThrowsAsync<RepositoryFormatException>(
+                    async () => await client.SearchCode(request));
             }
-
-
         }
     }
 }

--- a/Octokit/Exceptions/RepositoryFormatException.cs
+++ b/Octokit/Exceptions/RepositoryFormatException.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class RepositoryFormatException : Exception
+    {
+        readonly string message;
+
+        public RepositoryFormatException(IEnumerable<string> invalidRepositories)
+        {
+            var parameterList = string.Join(", ", invalidRepositories);
+            message = string.Format(
+                CultureInfo.InvariantCulture,
+                "The list of repositories must be formatted as 'owner/name' - these values don't match this rule: {0}",
+                parameterList);
+
+        }
+
+        public override string Message
+        {
+            get
+            {
+                return message;
+            }
+        }
+
+        #if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of LoginAttemptsExceededException
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected RepositoryFormatException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null) return;
+            message = info.GetString("Message");
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("Message", Message);
+        }
+#endif
+    }
+}

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -102,11 +102,14 @@ namespace Octokit
             yield return new String(letters, wordStartIndex, letters.Length - wordStartIndex);
         }
 
-        static Regex nameWithOwner = new Regex("[a-zA-Z.]{1,}/[a-zA-Z.]{1,}"
+        // the rule:
+        // Username may only contain alphanumeric characters or single hyphens
+        // and cannot begin or end with a hyphen
+        static readonly Regex nameWithOwner = new Regex("[a-z0-9.-]{1,}/[a-z0-9.-]{1,}", 
 #if (!PORTABLE && !NETFX_CORE)
-, RegexOptions.Compiled
+            RegexOptions.Compiled | 
 #endif
-);
+            RegexOptions.IgnoreCase);
 
         internal static bool IsNameWithOwnerFormat(this string input)
         {

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -101,5 +101,16 @@ namespace Octokit
             //We need to have the last word.
             yield return new String(letters, wordStartIndex, letters.Length - wordStartIndex);
         }
+
+        static Regex nameWithOwner = new Regex("[a-zA-Z.]{1,}/[a-zA-Z.]{1,}"
+#if (!PORTABLE && !NETFX_CORE)
+, RegexOptions.Compiled
+#endif
+);
+
+        internal static bool IsNameWithOwnerFormat(this string input)
+        {
+            return nameWithOwner.IsMatch(input);
+        }
     }
 }

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -16,7 +16,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchCodeRequest : BaseSearchRequest
     {
-        public SearchCodeRequest(string term) : base(term) { }
+        public SearchCodeRequest(string term) : base(term)
+        {
+            Repos = new Collection<string>();
+        }
 
         public SearchCodeRequest(string term, string owner, string name)
             : this(term)
@@ -24,7 +27,9 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            this.Repo = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, name);
+            var repo = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, name);
+
+            Repos.Add(repo);
         }
 
         /// <summary>
@@ -117,7 +122,8 @@ namespace Octokit
         /// <remarks>
         /// https://help.github.com/articles/searching-code#users-organizations-and-repositories
         /// </remarks>
-        public string Repo { get; set; }
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+        public Collection<string> Repos { get; set; }
 
         [SuppressMessage("Microsoft.Globalization", "CA1304:SpecifyCultureInfo", MessageId = "System.String.ToLower")]
         public override IReadOnlyList<string> MergedQualifiers()
@@ -162,9 +168,16 @@ namespace Octokit
                 parameters.Add(String.Format(CultureInfo.InvariantCulture, "user:{0}", User));
             }
 
-            if (Repo.IsNotBlank())
+            if (Repos.Any())
             {
-                parameters.Add(String.Format(CultureInfo.InvariantCulture, "repo:{0}", Repo));
+                var invalidFormatRepos = Repos.Where(x => !x.IsNameWithOwnerFormat());
+                if (invalidFormatRepos.Any())
+                {
+                    throw new RepositoryFormatException(invalidFormatRepos);
+                }
+
+                parameters.Add(
+                    string.Join("+", Repos.Select(x => "repo:" + x)));
             }
 
             return new ReadOnlyCollection<string>(parameters);

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -336,6 +336,7 @@ namespace Octokit
         Issue
     }
 
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryCollection : Collection<string>
     {
         public void Add(string owner, string name)
@@ -353,12 +354,20 @@ namespace Octokit
             return Remove(GetRepositoryName(owner, name));
         }
 
-        private static string GetRepositoryName(string owner, string name)
+        static string GetRepositoryName(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, name);
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "Repositories: {0}", Count);
+            }
         }
     }
 }

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 
 namespace Octokit
 {

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -16,11 +16,24 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchIssuesRequest : BaseSearchRequest
     {
+        /// <summary>
+        /// Search without specifying a keyword
+        /// </summary>
+        public SearchIssuesRequest()
+        {
+            Repos = new Collection<string>();
+        }
+
+        /// <summary>
+        /// Search using a specify keyword
+        /// </summary>
+        /// <param name="term">The term to filter on</param>
         public SearchIssuesRequest(string term) : base(term)
         {
             Repos = new Collection<string>();
         }
 
+        [Obsolete("this will be deprecated in a future version")]
         public SearchIssuesRequest(string term, string owner, string name)
             : this(term)
         {

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -267,15 +267,10 @@ namespace Octokit
 
             if (Repos.Any())
             {
-                var invalidFormatRepos = Repos.Where(x => !IsNameWithOwnerFormat(x));
+                var invalidFormatRepos = Repos.Where(x => !x.IsNameWithOwnerFormat());
                 if (invalidFormatRepos.Any())
                 {
-                    var parameterList = string.Join(", ", invalidFormatRepos);
-                    var message = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "The list of repositories must be formatted as 'owner/name' - these values don't match this rule: {0}",
-                        parameterList);
-                    throw new ArgumentException(message);
+                    throw new RepositoryFormatException(invalidFormatRepos);
                 }
 
                 parameters.Add(
@@ -283,19 +278,6 @@ namespace Octokit
             }
 
             return new ReadOnlyCollection<string>(parameters);
-        }
-
-        // what rules do we define here?
-
-        static Regex nameWithOwner = new Regex("[a-zA-Z.]{1,}/[a-zA-Z.]{1,}"
-#if (!PORTABLE && !NETFX_CORE)
-            , RegexOptions.Compiled
-#endif
-        );
-
-        static bool IsNameWithOwnerFormat(string input)
-        {
-            return nameWithOwner.IsMatch(input);
         }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -183,25 +183,6 @@ namespace Octokit
         /// </remarks>
         public string User { get; set; }
 
-        /// <summary>
-        /// Limits searches to a specific repository.
-        /// </summary>
-        /// <remarks>
-        /// https://help.github.com/articles/searching-issues#users-organizations-and-repositories
-        /// </remarks>
-        public string Repo
-        {
-            get
-            {
-                return Repos.FirstOrDefault();
-            }
-            set
-            {
-                Repos.Clear();
-                Repos.Add(value);
-            }
-        }
-
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public Collection<string> Repos { get; set; }
 

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -396,6 +396,7 @@
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Models\Response\TeamMembership.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Models\Request\RepositoryHookTestRequest.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Models\Response\TeamMembership.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -405,6 +405,7 @@
     <Compile Include="Models\Request\RepositoryHookTestRequest.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Models\Response\TeamMembership.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -37,7 +37,8 @@
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\Portable\Octokit.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Models\Response\TeamMembership.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Models\Response\TeamMembership.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -41,7 +41,8 @@
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\NetCore45\Octokit.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Clients\RepositoryContentsClient.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />
     <Compile Include="Exceptions\RepositoryExistsException.cs" />
+    <Compile Include="Exceptions\RepositoryFormatException.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Helpers\ApiErrorExtensions.cs" />
     <Compile Include="Helpers\ApiUrls.Authorizations.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -41,7 +41,8 @@
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\Net45\Octokit.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 "tools\nuget\nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.0.0"
-"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "3.12.2"
+"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "3.37.1"
 "tools\nuget\nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0"
 
 :Build

--- a/build.fsx
+++ b/build.fsx
@@ -65,9 +65,19 @@ Target "FixProjects" (fun _ ->
     |> Fake.MSBuild.ProjectSystem.FixProjectFiles "./Octokit.Reactive/Octokit.Reactive.csproj"
 )
 
+let setParams defaults = {
+    defaults with
+        ToolsVersion = Some("12.0")
+        Targets = ["Build"]
+        Properties =
+            [
+                "Configuration", buildMode
+            ]
+    }
+
 Target "BuildApp" (fun _ ->
-    MSBuild null "Build" ["Configuration", buildMode] ["./Octokit.sln"]
-    |> Log "AppBuild-Output: "
+    build setParams "./Octokit.sln"
+        |> DoNothing
 )
 
 Target "ConventionTests" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -29,7 +29,10 @@ let releaseNotes =
 
 let buildMode = getBuildParamOrDefault "buildMode" "Release"
 
-MSBuildDefaults <- { MSBuildDefaults with Verbosity = Some MSBuildVerbosity.Minimal }
+MSBuildDefaults <- { 
+    MSBuildDefaults with 
+        ToolsVersion = Some "12.0"
+        Verbosity = Some MSBuildVerbosity.Minimal }
 
 Target "Clean" (fun _ ->
     CleanDirs [buildDir; reactiveBuildDir; testResultsDir; packagingRoot; packagingDir; reactivePackagingDir]

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,57 @@
+# Search
+
+You can use Octokit to search for different sorts of data available
+on the GitHub or GitHub Enterprise server:
+
+ - issues
+ - repositories
+ - code
+ - users
+
+I won't go into the full details here as the [developer documentation](https://developer.github.com/)
+covers all the options far better than I could.
+
+## Search Issues
+
+You can search for issues containing a given phrase across many repositories:
+
+```csharp
+// a search 
+var request = new SearchIssuesRequest("linux");
+
+// it is highly recommended to search in specific repositories
+request.Repos = new Collection<string> {
+    "aspnet/dnx",
+    "aspnet/dnvm"
+};
+
+// other parameters available for tweaking the output
+request.SortField = IssueSearchSort.Created;
+request.Order = SortDirection.Descending;
+```
+
+By default, search will return the first page of results and use
+a page size of 100 results.
+
+```csharp
+request.Page = 2;
+request.PerPage = 30;
+```
+
+
+Once you've set the right parameters, execute the request:
+
+```csharp
+// actually perform the search
+var repos = await client.Search.SearchIssues(request);
+
+Console.WriteLine("Query has {0} matches.", repos.TotalCount);
+Console.WriteLine("Response has {0} items.", repos.Items.Count);
+Assert.NotEmpty();
+```
+
+## Search Repositories
+
+## Search Code
+
+## Search Users

--- a/docs/search.md
+++ b/docs/search.md
@@ -8,36 +8,73 @@ on the GitHub or GitHub Enterprise server:
  - code
  - users
 
-I won't go into the full details here as the [developer documentation](https://developer.github.com/)
-covers all the options far better than I could.
-
 ## Search Issues
 
-You can search for issues containing a given phrase across many repositories:
+You can search for issues containing a given phrase across many
+repositories:
 
 ```csharp
-// a search 
-var request = new SearchIssuesRequest("linux");
+// searching without specifying a term
+var request = new SearchIssuesRequest();
 
-// it is highly recommended to search in specific repositories
+// you should focus your search to a specific repo
+request.Repos.Add("aspnet/dnx");
+
+// or use a series of repositories
 request.Repos = new Collection<string> {
     "aspnet/dnx",
     "aspnet/dnvm"
 };
-
-// other parameters available for tweaking the output
-request.SortField = IssueSearchSort.Created;
-request.Order = SortDirection.Descending;
 ```
 
-By default, search will return the first page of results and use
-a page size of 100 results.
+There's many other options available here to tweak
+your search criteria:
 
 ```csharp
-request.Page = 2;
-request.PerPage = 30;
+// if you're searching for a specific term, you can
+// focus your search on specific criteria
+request.In = new[] {
+    IssueInQualifier.Title,
+    IssueInQualifier.Body
+};
+
+// you can restrict your search to issues or pull requests
+request.Type = IssueTypeQualifier.Issue;
+
+// you can filter on when the issue was created or updated
+var aWeekAgo = DateTime.Now.Subtract(TimeSpan.FromDays(7));
+request.Created = new DateRange(aWeekAgo, SearchQualifierOperator.GreaterThan)
+
+// you can search for issues created by, assigned to
+// or mentioning a specific user
+request.Author = "davidfowl";
+request.Assignee = "damianedwards";
+request.Mentions = "shiftkey";
+request.Commenter = "haacked";
+
+// rather than setting all these, you can use this to find
+// all the above for a specific user with this one-liner
+request.Involves = "davidfowl";
+
+// by default this will search on open issues, set this if
+// you want to get all issues
+request.State = ItemState.All;
+// or to just search closed issues
+request.State = ItemState.Closed;
 ```
 
+And there's other options available for how the results are returned:
+
+```csharp
+request.SortField = IssueSearchSort.Created;
+request.Order = SortDirection.Descending;
+
+// 100 results per page as default
+request.PerPage = 30;
+
+// execute this when you want to fetch multiple pages
+request.Page = 2;
+```
 
 Once you've set the right parameters, execute the request:
 
@@ -47,11 +84,43 @@ var repos = await client.Search.SearchIssues(request);
 
 Console.WriteLine("Query has {0} matches.", repos.TotalCount);
 Console.WriteLine("Response has {0} items.", repos.Items.Count);
-Assert.NotEmpty();
 ```
+
+## Search Pull Requests
+
+Another scenario to consider is how to search broadly:
+
+```csharp
+var threeMonthsAgoIsh = DateTime.Now.Subtract(TimeSpan.FromDays(90));
+
+// search for a specific term
+var request = new SearchIssuesRequest("linux")
+{
+    // only search pull requests
+    Type = IssueTypeQualifier.PR,
+
+    // search across open and closed PRs
+    State = ItemState.All,
+
+    // search repositories which contain code
+    // matching a given language
+    Language = Language.CSharp,
+
+    // focus on pull requests updated recently
+    Updated = new DateRange(threeMonthsAgoIsh, SearchQualifierOperator.GreaterThan)
+};
+```
+
+
 
 ## Search Repositories
 
+**TODO**
+
 ## Search Code
 
+**TODO**
+
 ## Search Users
+
+**TODO**

--- a/docs/search.md
+++ b/docs/search.md
@@ -10,11 +10,10 @@ on the GitHub or GitHub Enterprise server:
 
 ## Search Issues
 
-You can search for issues containing a given phrase across many
-repositories:
+A common scenario is to search for issues to triage:
 
 ```csharp
-// searching without specifying a term
+// you can also specify a search term here
 var request = new SearchIssuesRequest();
 
 // you should focus your search to a specific repo
@@ -63,7 +62,7 @@ request.State = ItemState.All;
 request.State = ItemState.Closed;
 ```
 
-And there's other options available for how the results are returned:
+There's other options available to control how the results are returned:
 
 ```csharp
 request.SortField = IssueSearchSort.Created;

--- a/docs/search.md
+++ b/docs/search.md
@@ -71,14 +71,13 @@ request.Order = SortDirection.Descending;
 // 100 results per page as default
 request.PerPage = 30;
 
-// execute this when you want to fetch multiple pages
+// set this when you want to fetch subsequent pages
 request.Page = 2;
 ```
 
 Once you've set the right parameters, execute the request:
 
 ```csharp
-// actually perform the search
 var repos = await client.Search.SearchIssues(request);
 
 Console.WriteLine("Query has {0} matches.", repos.TotalCount);


### PR DESCRIPTION
Fixes #834 

This is a breaking API change to support being able to search across repositories. We currently have an `ctor` overload that accepts an `owner` and `name` for the repository:

```csharp
var request = new SearchIssuesRequest("windows", "aspnet", "dnx");
```

The change here is adding a public property `Repos` which accepts a collection of `owner/name` strings (i've added some validation to ensure these are formatted correctly for the server):

```csharp
var request = new SearchIssuesRequest("windows");
request.Repos = new Collection<string> {
    "aspnet/dnx",
    "aspnet/dnvm"
};
```

This replaces the old `Repo` property, which was constrained to one string:

```csharp
var request = new SearchIssuesRequest("windows");
request.Repo = "aspnet/dnx";
```

Rather than carry around both `Repo` and `Repos` for a period of time (leading to possible confusion), I'm just going to :fire: the property here - I think many people would prefer to just use the `Repos` property anyway...

- [x] confirm regex rules match our repository rules
- [x] make changes in `SearchIssueRequest`
- [x] make changes in `SearchCodeRequest`
- [x] a more-friendly abstraction than just a collection?
- [x] document how to search issues (with some examples)
- [x] document how to search pull requests (with some examples)
- ~~[ ] document an example of searching code~~
- [x] wtf ci?

[Rendered docs](https://github.com/octokit/octokit.net/blob/refine-search-api/docs/search.md)

cc @damianedwards @M-Zuber 