### PR TITLE
Access to the last ApiInfo object

### DIFF
--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -1,6 +1,6 @@
 ﻿namespace Octokit.Reactive
 {
-    public interface IObservableGitHubClient
+    public interface IObservableGitHubClient : IApiInfo
     {
         IConnection Connection { get; }
 

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -68,5 +68,11 @@ namespace Octokit.Reactive
         public IObservableNotificationsClient Notification { get; private set; }
         public IObservableGitDatabaseClient GitDatabase { get; private set; }
         public IObservableSearchClient Search { get; private set; }
+
+        /// <summary>
+        /// Gets the latest API Info - this will be null if no API calls have been made
+        /// </summary>
+        /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
+        public ApiInfo LastApiInfo { get { return _gitHubClient.Connection.LastApiInfo; } }
     }
 }

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -73,6 +73,9 @@ namespace Octokit.Reactive
         /// Gets the latest API Info - this will be null if no API calls have been made
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
-        public ApiInfo LastApiInfo { get { return _gitHubClient.Connection.LastApiInfo; } }
+        public ApiInfo GetLastApiInfo()
+        { 
+            return _gitHubClient.Connection.GetLastApiInfo();
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -1,4 +1,5 @@
-﻿using Octokit.Tests.Integration;
+﻿using Octokit;
+using Octokit.Tests.Integration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,22 +12,72 @@ public class GitHubClientTests
     public class TheLastApiInfoProperty
     {
         [IntegrationTest]
-        public async Task CanRetrieveLastApiInfo()
+        public async Task CanRetrieveLastApiInfoWithEtag()
         {
+            // To check for etag, I'm using a new repository
+            // As per suggestion here -> https://github.com/octokit/octokit.net/pull/855#issuecomment-126966532
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            var createdRepository = await github.Repository.Create(new NewRepository(repoName));
+
+            try
+            {
+                var result = github.LastApiInfo;
+
+                Assert.True(result.Links.Count == 0);
+                Assert.True(result.AcceptedOauthScopes.Count > -1);
+                Assert.True(result.OauthScopes.Count > -1);
+                Assert.False(String.IsNullOrEmpty(result.Etag));
+                Assert.True(result.RateLimit.Limit > 0);
+                Assert.True(result.RateLimit.Remaining > -1);
+                Assert.NotNull(result.RateLimit.Reset);
+            }
+            finally
+            {
+                Helper.DeleteRepo(createdRepository);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CanRetrieveLastApiInfoWithLinks()
+        {
+            // To check for links, I'm doing a list of all contributors to the octokit.net project
+            // Adapted from suggestion here -> https://github.com/octokit/octokit.net/pull/855#issuecomment-126966532
             var github = Helper.GetAuthenticatedClient();
 
-            // Doesn't matter which API gets called
-            await github.Miscellaneous.GetRateLimits();
+            await github.Repository.GetAllContributors("octokit", "octokit.net");
 
             var result = github.LastApiInfo;
 
-            //Assert.True(result.Links.Count > 0);
-            //Assert.True(result.AcceptedOauthScopes.Count > 0);
-            //Assert.True(result.OauthScopes.Count > 0);
-            //Assert.False(String.IsNullOrEmpty(result.Etag));
+            Assert.True(result.Links.Count > 0);
+            Assert.True(result.AcceptedOauthScopes.Count > -1);
+            Assert.True(result.OauthScopes.Count > -1);
+            Assert.False(String.IsNullOrEmpty(result.Etag));
             Assert.True(result.RateLimit.Limit > 0);
             Assert.True(result.RateLimit.Remaining > -1);
             Assert.NotNull(result.RateLimit.Reset);
         }
+
+        [PersonalAccessTokenTest]
+        public async Task CanRetrieveLastApiInfoAcceptedOauth()
+        {
+            // To check for OAuth & AcceptedOAuth I'm getting the octokit user
+            // Adapted from suggestion here -> https://github.com/octokit/octokit.net/pull/855#issuecomment-126966532
+            var github = Helper.GetAuthenticatedClient();
+
+            await github.User.Get("octokit");
+
+            var result = github.LastApiInfo;
+
+            Assert.True(result.Links.Count == 0);
+            Assert.True(result.AcceptedOauthScopes.Count > 0);
+            Assert.True(result.OauthScopes.Count > 0);
+            Assert.False(String.IsNullOrEmpty(result.Etag));
+            Assert.True(result.RateLimit.Limit > 0);
+            Assert.True(result.RateLimit.Remaining > -1);
+            Assert.NotNull(result.RateLimit.Reset);
+        }
+
     }
 }

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -1,0 +1,32 @@
+﻿using Octokit.Tests.Integration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+public class GitHubClientTests
+{
+    public class TheLastApiInfoProperty
+    {
+        [IntegrationTest]
+        public async Task CanRetrieveLastApiInfo()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            // Doesn't matter which API gets called
+            await github.Miscellaneous.GetRateLimits();
+
+            var result = github.LastApiInfo;
+
+            //Assert.True(result.Links.Count > 0);
+            //Assert.True(result.AcceptedOauthScopes.Count > 0);
+            //Assert.True(result.OauthScopes.Count > 0);
+            //Assert.False(String.IsNullOrEmpty(result.Etag));
+            Assert.True(result.RateLimit.Limit > 0);
+            Assert.True(result.RateLimit.Remaining > -1);
+            Assert.NotNull(result.RateLimit.Reset);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -23,7 +23,7 @@ public class GitHubClientTests
 
             try
             {
-                var result = github.LastApiInfo;
+                var result = github.GetLastApiInfo();
 
                 Assert.True(result.Links.Count == 0);
                 Assert.True(result.AcceptedOauthScopes.Count > -1);
@@ -48,7 +48,7 @@ public class GitHubClientTests
 
             await github.Repository.GetAllContributors("octokit", "octokit.net");
 
-            var result = github.LastApiInfo;
+            var result = github.GetLastApiInfo();
 
             Assert.True(result.Links.Count > 0);
             Assert.True(result.AcceptedOauthScopes.Count > -1);
@@ -68,7 +68,7 @@ public class GitHubClientTests
 
             await github.User.Get("octokit");
 
-            var result = github.LastApiInfo;
+            var result = github.GetLastApiInfo();
 
             Assert.True(result.Links.Count == 0);
             Assert.True(result.AcceptedOauthScopes.Count > 0);

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Integration
             var githubUsername = Environment.GetEnvironmentVariable("OCTOKIT_GITHUBUSERNAME");
             UserName = githubUsername;
             Organization = Environment.GetEnvironmentVariable("OCTOKIT_GITHUBORGANIZATION");
-            
+
             var githubToken = Environment.GetEnvironmentVariable("OCTOKIT_OAUTHTOKEN");
 
             if (githubToken != null)
@@ -51,6 +51,14 @@ namespace Octokit.Tests.Integration
         public static Credentials Credentials { get { return _credentialsThunk.Value; }}
 
         public static Credentials ApplicationCredentials { get { return _oauthApplicationCredentials.Value; } }
+
+        public static bool IsUsingToken
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OCTOKIT_OAUTHTOKEN"));
+            }
+        }
 
         public static bool IsPaidAccount
         {

--- a/Octokit.Tests.Integration/Helpers/PersonalAccessTokenTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/PersonalAccessTokenTestAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Octokit.Tests.Integration
+{
+    public class PersonalAccessTokenTestDiscoverer : IXunitTestCaseDiscoverer
+    {
+        readonly IMessageSink diagnosticMessageSink;
+
+        public PersonalAccessTokenTestDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            this.diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            return Helper.IsUsingToken
+                ? new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) } 
+                : Enumerable.Empty<IXunitTestCase>();
+        }
+    }
+
+    [XunitTestCaseDiscoverer("Octokit.Tests.Integration.PersonalAccessTokenTestDiscoverer", "Octokit.Tests.Integration")]
+    public class PersonalAccessTokenTestAttribute : FactAttribute
+    {
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -102,6 +102,7 @@
     <Compile Include="fixtures\RepositoriesHooksCollection.cs" />
     <Compile Include="fixtures\RepositoriesHooksFixture.cs" />
     <Compile Include="Helpers\ApplicationTestAttribute.cs" />
+    <Compile Include="Helpers\PersonalAccessTokenTestAttribute.cs" />
     <Compile Include="Helpers\PaidAccountTestAttribute.cs" />
     <Compile Include="Helpers\RepositorySetupHelper.cs" />
     <Compile Include="HttpClientAdapterTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Clients\AuthorizationClientTests.cs" />
     <Compile Include="Clients\BlobClientTests.cs" />
     <Compile Include="Clients\BranchesClientTests.cs" />
+    <Compile Include="Clients\GitHubClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />
     <Compile Include="Clients\CommitsClientTests.cs" />
     <Compile Include="Clients\CommitStatusClientTests.cs" />

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -112,14 +112,14 @@ namespace Octokit.Tests
             public async Task ReturnsNullIfNew()
             {
                 var connection = Substitute.For<IConnection>();
-                connection.LastApiInfo.Returns((ApiInfo)null);
+                connection.GetLastApiInfo().Returns((ApiInfo)null);
                 var client = new GitHubClient(connection);
 
-                var result = client.LastApiInfo;
+                var result = client.GetLastApiInfo();
 
                 Assert.Null(result);
 
-                var temp = connection.Received(1).LastApiInfo;
+                var temp = connection.Received(1).GetLastApiInfo();
             }
 
             [Fact]
@@ -160,14 +160,14 @@ namespace Octokit.Tests
                                 new RateLimit(100, 75, 1372700873)
                             );
                 var connection = Substitute.For<IConnection>();
-                connection.LastApiInfo.Returns(apiInfo);
+                connection.GetLastApiInfo().Returns(apiInfo);
                 var client = new GitHubClient(connection);
 
-                var result = client.LastApiInfo;
+                var result = client.GetLastApiInfo();
 
                 Assert.NotNull(result);
 
-                var temp = connection.Received(1).LastApiInfo;
+                var temp = connection.Received(1).GetLastApiInfo();
             }
         }
 

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using Octokit.Internal;
 using Xunit;
 using Xunit.Extensions;
+using System.Collections.Generic;
 
 namespace Octokit.Tests
 {
@@ -104,5 +105,71 @@ namespace Octokit.Tests
                 Assert.Equal("bar", client.Credentials.Password);
             }
         }
+
+        public class TheLastApiInfoProperty
+        {
+            [Fact]
+            public async Task ReturnsNullIfNew()
+            {
+                var connection = Substitute.For<IConnection>();
+                connection.LastApiInfo.Returns((ApiInfo)null);
+                var client = new GitHubClient(connection);
+
+                var result = client.LastApiInfo;
+
+                Assert.Null(result);
+
+                var temp = connection.Received(1).LastApiInfo;
+            }
+
+            [Fact]
+            public async Task ReturnsObjectIfNotNew()
+            {
+                var apiInfo = new ApiInfo(
+                                new Dictionary<string, Uri>
+                                {
+                                    {
+                                        "next",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=4&per_page=5")
+                                    },
+                                    {
+                                        "last",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=131&per_page=5")
+                                    },
+                                    {
+                                        "first",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=1&per_page=5")
+                                    },
+                                    {
+                                        "prev",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=2&per_page=5")
+                                    }
+                                },
+                                new List<string>
+                                {
+                                    "user",
+                                },
+                                new List<string>
+                                {
+                                    "user", 
+                                    "public_repo",
+                                    "repo",
+                                    "gist"
+                                },
+                                "5634b0b187fd2e91e3126a75006cc4fa",
+                                new RateLimit(100, 75, 1372700873)
+                            );
+                var connection = Substitute.For<IConnection>();
+                connection.LastApiInfo.Returns(apiInfo);
+                var client = new GitHubClient(connection);
+
+                var result = client.LastApiInfo;
+
+                Assert.NotNull(result);
+
+                var temp = connection.Received(1).LastApiInfo;
+            }
+        }
+
     }
 }

--- a/Octokit.Tests/Http/ApiInfoTests.cs
+++ b/Octokit.Tests/Http/ApiInfoTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Http
+{
+    public class ApiInfoTests
+    {
+        public class TheMethods
+        {
+            [Fact]
+            public void CanClone()
+            {
+                var original = new ApiInfo(
+                                new Dictionary<string, Uri>
+                                {
+                                    {
+                                        "next",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=4&per_page=5")
+                                    },
+                                    {
+                                        "last",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=131&per_page=5")
+                                    },
+                                    {
+                                        "first",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=1&per_page=5")
+                                    },
+                                    {
+                                        "prev",
+                                        new Uri("https://api.github.com/repos/rails/rails/issues?page=2&per_page=5")
+                                    }
+                                },
+                                new List<string>
+                                {
+                                    "user",
+                                },
+                                new List<string>
+                                {
+                                    "user", 
+                                    "public_repo",
+                                    "repo",
+                                    "gist"
+                                },
+                                "5634b0b187fd2e91e3126a75006cc4fa",
+                                new RateLimit(100, 75, 1372700873)
+                            );
+
+                var clone = original.Clone();
+
+                // Note the use of Assert.NotSame tests for value types - this should continue to test should the underlying 
+                // model are changed to Object types
+                Assert.NotSame(original, clone);
+
+                Assert.Equal(original.Etag, clone.Etag);
+                Assert.NotSame(original.Etag, clone.Etag);
+
+                Assert.Equal(original.AcceptedOauthScopes.Count, clone.AcceptedOauthScopes.Count);
+                Assert.NotSame(original.AcceptedOauthScopes, clone.AcceptedOauthScopes);
+                for (int i = 0; i < original.AcceptedOauthScopes.Count; i++)
+                {
+                    Assert.Equal(original.AcceptedOauthScopes[i], clone.AcceptedOauthScopes[i]);
+                    Assert.NotSame(original.AcceptedOauthScopes[i], clone.AcceptedOauthScopes[i]);
+                }
+
+                Assert.Equal(original.Links.Count, clone.Links.Count);
+                Assert.NotSame(original.Links, clone.Links);
+                for (int i = 0; i < original.Links.Count; i++)
+                {
+                    Assert.Equal(original.Links.Keys.ToArray()[i], clone.Links.Keys.ToArray()[i]);
+                    Assert.NotSame(original.Links.Keys.ToArray()[i], clone.Links.Keys.ToArray()[i]);
+                    Assert.Equal(original.Links.Values.ToArray()[i].ToString(), clone.Links.Values.ToArray()[i].ToString());
+                    Assert.NotSame(original.Links.Values.ToArray()[i], clone.Links.Values.ToArray()[i]);
+                }
+
+                Assert.Equal(original.OauthScopes.Count, clone.OauthScopes.Count);
+                Assert.NotSame(original.OauthScopes, clone.OauthScopes);
+                for (int i = 0; i < original.OauthScopes.Count; i++)
+                {
+                    Assert.Equal(original.OauthScopes[i], clone.OauthScopes[i]);
+                    Assert.NotSame(original.OauthScopes[i], clone.OauthScopes[i]);
+                }
+
+                Assert.NotSame(original.RateLimit, clone.RateLimit);
+                Assert.Equal(original.RateLimit.Limit, clone.RateLimit.Limit);
+                Assert.NotSame(original.RateLimit.Limit, clone.RateLimit.Limit);
+                Assert.Equal(original.RateLimit.Remaining, clone.RateLimit.Remaining);
+                Assert.NotSame(original.RateLimit.Remaining, clone.RateLimit.Remaining);
+                Assert.Equal(original.RateLimit.ResetAsUtcEpochSeconds, clone.RateLimit.ResetAsUtcEpochSeconds);
+                Assert.NotSame(original.RateLimit.ResetAsUtcEpochSeconds, clone.RateLimit.ResetAsUtcEpochSeconds);
+                Assert.Equal(original.RateLimit.Reset, clone.RateLimit.Reset);
+                Assert.NotSame(original.RateLimit.Reset, clone.RateLimit.Reset);
+            }
+        }
+
+    }
+}

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -630,7 +630,7 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var result = connection.LastApiInfo;
+                var result = connection.GetLastApiInfo();
 
                 Assert.Null(result);
             }
@@ -692,7 +692,7 @@ namespace Octokit.Tests.Http
 
                 connection.Get<PullRequest>(new Uri("https://example.com"), TimeSpan.MaxValue);
 
-                var result = connection.LastApiInfo;
+                var result = connection.GetLastApiInfo();
 
                 // No point checking all of the values as they are tested elsewhere
                 // Just provde that the ApiInfo is populated

--- a/Octokit.Tests/Http/RateLimitTests.cs
+++ b/Octokit.Tests/Http/RateLimitTests.cs
@@ -109,6 +109,30 @@ namespace Octokit.Tests.Http
             {
                 Assert.Throws<ArgumentNullException>(() => new RateLimit(null));
             }
+
+        }
+
+        public class TheMethods
+        {
+            [Fact]
+            public void CanClone()
+            {
+                var original = new RateLimit(100, 42, 1372700873);
+
+                var clone = original.Clone();
+
+                // Note the use of Assert.NotSame tests for value types - this should continue to test should the underlying 
+                // model are changed to Object types
+                Assert.NotSame(original, clone);
+                Assert.Equal(original.Limit, clone.Limit);
+                Assert.NotSame(original.Limit, clone.Limit);
+                Assert.Equal(original.Remaining, clone.Remaining);
+                Assert.NotSame(original.Remaining, clone.Remaining);
+                Assert.Equal(original.ResetAsUtcEpochSeconds, clone.ResetAsUtcEpochSeconds);
+                Assert.NotSame(original.ResetAsUtcEpochSeconds, clone.ResetAsUtcEpochSeconds);
+                Assert.Equal(original.Reset, clone.Reset);
+                Assert.NotSame(original.Reset, clone.Reset);
+            }
         }
     }
 }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Clients\OrganizationsClientTests.cs" />
     <Compile Include="Helpers\Arg.cs" />
     <Compile Include="Helpers\AssertEx.cs" />
+    <Compile Include="Http\ApiInfoTests.cs" />
     <Compile Include="Http\HttpClientAdapterTests.cs" />
     <Compile Include="Http\ApiInfoParserTests.cs">
       <SubType>Code</SubType>

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -104,7 +104,10 @@ namespace Octokit
         /// Gets the latest API Info - this will be null if no API calls have been made
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
-        public ApiInfo LastApiInfo { get { return Connection.LastApiInfo; } }
+        public ApiInfo GetLastApiInfo()
+        {
+            return Connection.GetLastApiInfo();
+        }
 
         /// <summary>
         /// Convenience property for getting and setting credentials.

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -101,6 +101,12 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets the latest API Info - this will be null if no API calls have been made
+        /// </summary>
+        /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
+        public ApiInfo LastApiInfo { get { return Connection.LastApiInfo; } }
+
+        /// <summary>
         /// Convenience property for getting and setting credentials.
         /// </summary>
         /// <remarks>

--- a/Octokit/Helpers/CollectionExtensions.cs
+++ b/Octokit/Helpers/CollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Octokit
 {
@@ -10,6 +12,38 @@ namespace Octokit
 
             TValue value;
             return dictionary.TryGetValue(key, out value) ? value : default(TValue);
+        }
+
+        public static IList<string> Clone(this IReadOnlyList<string> input)
+        {
+            List<string> output = null;
+            if (input == null)
+                return output;
+
+            output = new List<string>();
+
+            foreach (var item in input)
+            {
+                output.Add(new String(item.ToCharArray()));
+            }
+
+            return output;
+        }
+
+        public static IDictionary<string, Uri> Clone(this IReadOnlyDictionary<string, Uri> input)
+        {
+            Dictionary<string, Uri> output = null;
+            if (input == null)
+                return output;
+
+            output = new Dictionary<string, Uri>();
+            
+            foreach (var item in input)
+            {
+                output.Add(new String(item.Key.ToCharArray()), new Uri(item.Value.ToString()));
+            }
+
+            return output;
         }
     }
 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -51,5 +51,25 @@ namespace Octokit
         /// Information about the API rate limit
         /// </summary>
         public RateLimit RateLimit { get; private set; }
+
+        /// <summary>
+        /// Allows you to clone ApiInfo 
+        /// </summary>
+        /// <returns>A clone of <seealso cref="ApiInfo"/></returns>
+        public ApiInfo Clone()
+        {
+            // Seem to have to do this to pass a whole bunch of tests (for example Octokit.Tests.Clients.EventsClientTests.DeserializesCommitCommentEventCorrectly)
+            // I believe this has something to do with the Mocking framework.
+            if (this == null || this.Links == null || this.OauthScopes == null || this.RateLimit == null || this.Etag == null)
+                return null;
+
+            return new ApiInfo(this.Links.Clone(),
+                                this.OauthScopes.Clone(),
+                                this.AcceptedOauthScopes.Clone(),
+                                new String(this.Etag.ToCharArray()),
+                                this.RateLimit.Clone());
+        }
+
+
     }
 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -60,7 +60,7 @@ namespace Octokit
         {
             // Seem to have to do this to pass a whole bunch of tests (for example Octokit.Tests.Clients.EventsClientTests.DeserializesCommitCommentEventCorrectly)
             // I believe this has something to do with the Mocking framework.
-            if (this == null || this.Links == null || this.OauthScopes == null || this.RateLimit == null || this.Etag == null)
+            if (this.Links == null || this.OauthScopes == null || this.RateLimit == null || this.Etag == null)
                 return null;
 
             return new ApiInfo(this.Links.Clone(),

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -136,6 +136,12 @@ namespace Octokit
             _jsonPipeline = new JsonHttpPipeline();
         }
 
+        /// <summary>
+        /// Gets the latest API Info - this will be null if no API calls have been made
+        /// </summary>
+        /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
+        public ApiInfo LastApiInfo { get { return _httpClient.LastApiInfo; } }
+
         public Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts)
         {
             Ensure.ArgumentNotNull(uri, "uri");

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -140,25 +140,15 @@ namespace Octokit
         /// Gets the latest API Info - this will be null if no API calls have been made
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
-        public ApiInfo LastApiInfo
-        { 
-            get
-            {
-                lock (LastApiInfoLocker)
-                {
-                    return _lastApiInfo;
-                }
-            }
-            private set
-            {
-                lock (LastApiInfoLocker)
-                {
-                    _lastApiInfo = value;
-                }
-            }
+        public ApiInfo GetLastApiInfo()
+        {
+            // We've choosen to not wrap the _lastApiInfo in a lock.  Originally the code was returning a reference - so there was a danger of
+            // on thread writing to the object while another was reading.  Now we are cloning the ApiInfo on request - thus removing the need (or overhead)
+            // of putting locks in place.
+            // See https://github.com/octokit/octokit.net/pull/855#discussion_r36774884
+            return _lastApiInfo == null ? null : _lastApiInfo.Clone();
         }
         private ApiInfo _lastApiInfo;
-        private readonly object LastApiInfoLocker = new object();
 
         public Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts)
         {
@@ -550,7 +540,8 @@ namespace Octokit
             var response = await _httpClient.Send(request, cancellationToken).ConfigureAwait(false);
             if (response != null)
             {
-                LastApiInfo = response.ApiInfo;
+                // Use the clone method to avoid keeping hold of the original (just in case it effect the lifetime of the whole response
+                _lastApiInfo = response.ApiInfo.Clone();
             }
             HandleErrors(response);
             return response;

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -29,6 +29,12 @@ namespace Octokit.Internal
         }
 
         /// <summary>
+        /// Gets the latest API Info - this will be null if no API calls have been made
+        /// </summary>
+        /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
+        public ApiInfo LastApiInfo { get; private set; }
+
+        /// <summary>
         /// Sends the specified request and returns a response.
         /// </summary>
         /// <param name="request">A <see cref="IRequest"/> that represents the HTTP request</param>
@@ -45,7 +51,11 @@ namespace Octokit.Internal
                 // Make the request
                 var responseMessage = await _http.SendAsync(requestMessage, HttpCompletionOption.ResponseContentRead, cancellationTokenForRequest)
                                                 .ConfigureAwait(false);
-                return await BuildResponse(responseMessage).ConfigureAwait(false);
+                var response = await BuildResponse(responseMessage).ConfigureAwait(false);
+
+                LastApiInfo = response.ApiInfo;
+
+                return response;
             }
         }
 

--- a/Octokit/Http/IApiInfo.cs
+++ b/Octokit/Http/IApiInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Provides a property for the Last recorded API infomation
+    /// </summary>
+    public interface IApiInfo
+    {
+        /// <summary>
+        /// Gets the latest API Info - this will be null if no API calls have been made
+        /// </summary>
+        /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
+        ApiInfo LastApiInfo { get; }
+    }
+}

--- a/Octokit/Http/IApiInfoProvider.cs
+++ b/Octokit/Http/IApiInfoProvider.cs
@@ -9,6 +9,7 @@
         /// Gets the latest API Info - this will be null if no API calls have been made
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
-        ApiInfo LastApiInfo { get; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        ApiInfo GetLastApiInfo();
     }
 }

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -10,7 +10,7 @@ namespace Octokit
     /// <summary>
     /// A connection for making HTTP requests against URI endpoints.
     /// </summary>
-    public interface IConnection
+    public interface IConnection : IApiInfo
     {
         /// <summary>
         /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing HTML.

--- a/Octokit/Http/IHttpClient.cs
+++ b/Octokit/Http/IHttpClient.cs
@@ -10,7 +10,7 @@ namespace Octokit.Internal
     /// <remarks>
     /// Most folks won't ever need to swap this out. But if you're trying to run this on Windows Phone, you might.
     /// </remarks>
-    public interface IHttpClient : IDisposable
+    public interface IHttpClient : IDisposable, IApiInfo
     {
         /// <summary>
         /// Sends the specified request and returns a response.

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -99,5 +99,19 @@ namespace Octokit
             }
         }
 
+        /// <summary>
+        /// Allows you to clone RateLimit
+        /// </summary>
+        /// <returns>A clone of <seealso cref="RateLimit"/></returns>
+        public RateLimit Clone()
+        {
+            var clone = new RateLimit();
+            clone.Limit = this.Limit;
+            clone.Remaining = this.Remaining;
+            clone.ResetAsUtcEpochSeconds = this.ResetAsUtcEpochSeconds;
+
+            return clone;
+        }
+
     }
 }

--- a/Octokit/Http/RateLimit.cs
+++ b/Octokit/Http/RateLimit.cs
@@ -105,12 +105,12 @@ namespace Octokit
         /// <returns>A clone of <seealso cref="RateLimit"/></returns>
         public RateLimit Clone()
         {
-            var clone = new RateLimit();
-            clone.Limit = this.Limit;
-            clone.Remaining = this.Remaining;
-            clone.ResetAsUtcEpochSeconds = this.ResetAsUtcEpochSeconds;
-
-            return clone;
+            return new RateLimit
+            {
+                Limit = this.Limit,
+                Remaining = this.Remaining,
+                ResetAsUtcEpochSeconds = this.ResetAsUtcEpochSeconds
+            };
         }
 
     }

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -5,7 +5,7 @@ namespace Octokit
     /// <summary>
     /// A Client for the GitHub API v3. You can read more about the api here: http://developer.github.com.
     /// </summary>
-    public interface IGitHubClient
+    public interface IGitHubClient : IApiInfo
     {
         /// <summary>
         /// Provides a client connection to make rest requests to HTTP endpoints.

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -415,6 +415,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -408,6 +408,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Helpers\PropertyOrField.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
+    <Compile Include="Http\IApiInfo.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />


### PR DESCRIPTION
As discussed in issue #504 

Allows the user to get the contents of the last ApiInfo (so last Api call).  Provided as a property of GitHubClient which calls a property of Connection then a property of HttpClientAdapter.

The most obvious use for it is to check the current rate limit without making a separate API call.

Two concerns for me:

* Can't put a test in for the HttpClientAdapter.  The underlying HttpClient is concrete and the send method is not virtual so can be substituted.  Could abstract the HttpClient (interface and wrapper) - this would help to put more testing into for the HttpClientAdapter (currently quite light).
* Must be a better design than having to implement a property through every layer

Thanks