### PR TITLE
fix the TeamClient.AddMembership(..) call

### DIFF
--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -165,7 +165,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Put<Dictionary<string, string>>(
                     Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"),
-                    Arg.Is<string>(u => u == null));
+                    Arg.Is<object>(u => u == ApiConnection.EmptyBody));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -165,7 +165,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Put<Dictionary<string, string>>(
                     Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"),
-                    Arg.Is<object>(u => u == ApiConnection.EmptyBody));
+                    Arg.Is<object>(u => u == RequestBody.Empty));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -153,6 +153,22 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task AllowsEmptyBody()
+            {
+                var connection = Substitute.For<IConnection>();
+
+                var apiConnection = new ApiConnection(connection);
+
+                var client = new TeamsClient(apiConnection);
+
+                await client.AddMembership(1, "user");
+
+                connection.Received().Put<Dictionary<string, string>>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"),
+                    Arg.Is<string>(u => u == null));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullOrEmptyLogin()
             {
                 var connection = Substitute.For<IApiConnection>();

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -369,6 +369,31 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
+            public async Task MakesPutRequestWithNoData()
+            {
+                var body = ApiConnection.EmptyBody;
+                var expectedBody = SimpleJson.SerializeObject(body);
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response();
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body);
+
+                Console.WriteLine(expectedBody);
+
+                httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
+                    req.BaseAddress == _exampleUri &&
+                    (string)req.Body == expectedBody &&
+                    req.Method == HttpMethod.Put &&
+                    req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
             public async Task MakesPutRequestWithDataAndTwoFactor()
             {
                 var body = new object();
@@ -390,6 +415,30 @@ namespace Octokit.Tests.Http
                     req.Method == HttpMethod.Put &&
                     req.Headers["X-GitHub-OTP"] == "two-factor" &&
                     req.ContentType == "application/x-www-form-urlencoded" &&
+                    req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task MakesPutRequestWithNoDataAndTwoFactor()
+            {
+                var body = ApiConnection.EmptyBody ;
+                var expectedBody = SimpleJson.SerializeObject(body);
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response();
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body, "two-factor");
+
+                httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
+                    req.BaseAddress == _exampleUri &&
+                    (string)req.Body == expectedBody &&
+                    req.Method == HttpMethod.Put &&
+                    req.Headers["X-GitHub-OTP"] == "two-factor" &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
             }
         }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -347,7 +347,8 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task MakesPutRequestWithData()
             {
-                string data = SimpleJson.SerializeObject(new object());
+                var body = new object();
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -357,11 +358,11 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), new object());
+                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
-                    (string)req.Body == data &&
+                    (string)req.Body == expectedBody &&
                     req.Method == HttpMethod.Put &&
                     req.ContentType == "application/x-www-form-urlencoded" &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
@@ -370,7 +371,8 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task MakesPutRequestWithDataAndTwoFactor()
             {
-                string data = SimpleJson.SerializeObject(new object());
+                var body = new object();
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -380,11 +382,11 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), new object(), "two-factor");
+                await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body, "two-factor");
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
-                    (string)req.Body == data &&
+                    (string)req.Body == expectedBody &&
                     req.Method == HttpMethod.Put &&
                     req.Headers["X-GitHub-OTP"] == "two-factor" &&
                     req.ContentType == "application/x-www-form-urlencoded" &&

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -371,7 +371,7 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task MakesPutRequestWithNoData()
             {
-                var body = ApiConnection.EmptyBody;
+                var body = RequestBody.Empty;
                 var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
@@ -421,7 +421,7 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task MakesPutRequestWithNoDataAndTwoFactor()
             {
-                var body = ApiConnection.EmptyBody ;
+                var body = RequestBody.Empty;
                 var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -164,7 +164,7 @@ namespace Octokit
 
             try
             {
-                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, Octokit.ApiConnection.EmptyBody);
+                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, RequestBody.Empty);
             }
             catch (NotFoundException)
             {

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -164,7 +164,7 @@ namespace Octokit
 
             try
             {
-                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, null);
+                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, Octokit.ApiConnection.EmptyBody);
             }
             catch (NotFoundException)
             {

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -15,9 +15,6 @@ namespace Octokit
     {
         readonly IApiPagination _pagination;
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2211:NonConstantFieldsShouldNotBeVisible")]
-        public static object EmptyBody = new object();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiConnection"/> class.
         /// </summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -15,6 +15,9 @@ namespace Octokit
     {
         readonly IApiPagination _pagination;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2211:NonConstantFieldsShouldNotBeVisible")]
+        public static object EmptyBody = new object();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiConnection"/> class.
         /// </summary>

--- a/Octokit/Http/RequestBody.cs
+++ b/Octokit/Http/RequestBody.cs
@@ -1,0 +1,12 @@
+namespace Octokit
+{
+    /// <summary>
+    /// Container for the static <see cref="Empty"/> method that represents an
+    /// intentional empty request body to avoid overloading <code>null</code>.
+    /// </summary>
+    public static class RequestBody
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2211:NonConstantFieldsShouldNotBeVisible")]
+        public static object Empty = new object();
+    }
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\RequestBody.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -415,6 +415,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\RequestBody.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -408,6 +408,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\RequestBody.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\RequestBody.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Http\RequestBody.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />
+    <Compile Include="Http\RequestBody.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />


### PR DESCRIPTION
While exploring some organizational automation with `octokit.net` I discovered that the `TeamClient.AddMembership(..)` call passes a `null` value into a parameter of `ApiConnection.Put(..)` that fails on an `Octokit.Ensure.ArgumentNotNull(..)` call.

The GitHub API 3.0 Team docs state that the correct way to call the _Add Team Member_ endpoint is to essentially pass an empty body:

> Note that you’ll need to set Content-Length to zero when calling out to this endpoint. For more information, see “HTTP verbs.”
> -  [Add Team Member](https://developer.github.com/v3/orgs/teams/#add-team-member) API docs

My proposed fix (that I will submit shortly in this PR) is to have `ApiConnection.Put(..)` check for a `null` body and respond by setting the `Content-Length` header to zero as instructed, if that is possible, rather than throwing an `ArgumentNullExceptionValue`.

#### Todo
- [x] vet the design approach;
- [x] configure the underlying `Connection` object to add the `Content-Length` header when the `body` is `null`
- [x] removed the `Content-Length` header as that generated a `System.InvalidOperationException: Misused header name.`
- [x] confirmed worked for my use case, used octokit to add users to a team;