### PR TITLE
add filename for code search

### DIFF
--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -44,6 +44,19 @@ public class SearchClientTests
     }
 
     [Fact]
+    public async Task SearchForFileNameInCode()
+    {
+        var request = new SearchCodeRequest("swag")
+        {
+            FileName = "readme.md"
+        };
+
+        var repos = await _gitHubClient.Search.SearchCode(request);
+
+        Assert.NotEmpty(repos.Items);
+    }
+
+    [Fact]
     public async Task SearchForWordInCode()
     {
         var request = new SearchIssuesRequest("windows");

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1496,6 +1496,21 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void TestingTheFileNameQualifier()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+                var request = new SearchCodeRequest("something");
+                request.FileName = "packages.config";
+
+                client.SearchCode(request);
+
+                connection.Received().Get<SearchCodeResult>(
+                    Arg.Is<Uri>(u => u.ToString() == "search/code"),
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+filename:packages.config"));
+            }
+
+            [Fact]
             public void TestingTheUserQualifier()
             {
                 var connection = Substitute.For<IApiConnection>();

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -107,6 +107,14 @@ namespace Octokit
         public string Extension { get; set; }
 
         /// <summary>
+        /// Matches specific file names
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-code/#search-by-filename
+        /// </remarks>
+        public string FileName { get; set; }
+
+        /// <summary>
         /// Limits searches to a specific user.
         /// </summary>
         /// <remarks>
@@ -159,6 +167,11 @@ namespace Octokit
             if (Extension.IsNotBlank())
             {
                 parameters.Add(String.Format(CultureInfo.InvariantCulture, "extension:{0}", Extension));
+            }
+
+            if (FileName.IsNotBlank())
+            {
+                parameters.Add(String.Format(CultureInfo.InvariantCulture, "filename:{0}", FileName));
             }
 
             if (User.IsNotBlank())


### PR DESCRIPTION
I couldn't find a helpful `FileName` property for code search (see https://help.github.com/articles/searching-code/#search-by-filename) , so I added it!

