### PR TITLE
Added PreviousFileName property to GitHubCommitFile

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -76,6 +76,16 @@ public class RepositoryCommitsClientTests
             var list = await _fixture.GetAll("octokit", "octokit.net", request);
             Assert.NotEmpty(list);
         }
+
+        [IntegrationTest]
+        public async Task CanGetCommitWithRenamedFiles()
+        {
+            var commit = await _fixture.Get("octokit", "octokit.net", "997e955f38eb0c2c36e55b1588455fa857951dbf");
+
+            Assert.True(commit.Files
+                .Where(file => file.Status == "renamed")
+                .All(file => string.IsNullOrEmpty(file.PreviousFileName) == false));
+        }
     }
 
     public class TestsWithNewRepository : IDisposable

--- a/Octokit/Models/Response/GitHubCommitFile.cs
+++ b/Octokit/Models/Response/GitHubCommitFile.cs
@@ -14,7 +14,7 @@ namespace Octokit
         public GitHubCommitFile() { }
 
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly")]
-        public GitHubCommitFile(string filename, int additions, int deletions, int changes, string status, string blobUrl, string contentsUrl, string rawUrl, string sha, string patch)
+        public GitHubCommitFile(string filename, int additions, int deletions, int changes, string status, string blobUrl, string contentsUrl, string rawUrl, string sha, string patch, string previousFileName)
         {
             Filename = filename;
             Additions = additions;
@@ -26,6 +26,7 @@ namespace Octokit
             RawUrl = rawUrl;
             Sha = sha;
             Patch = patch;
+            PreviousFileName = previousFileName;
         }
 
         /// <summary>
@@ -78,6 +79,11 @@ namespace Octokit
         /// The patch associated with the commit
         /// </summary>
         public string Patch { get; protected set; }
+
+        /// <summary>
+        /// The previous filename for a renamed file.
+        /// </summary>
+        public string PreviousFileName { get; protected set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
This PreviousFileName property is returned from the GitHub API when a file was modified. Check https://api.github.com/repos/octokit/octokit.net/commits/997e955f for an example of returning a commit containing file renames. 
Let me know what you think about the change and if there are any modifications I should make related to it.