### PR TITLE
Use non-deprecated auth endpoint 

### DIFF
--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -229,14 +229,22 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task GetsOrCreatesAuthenticationWithFingerprintAtCorrectUrl()
             {
-                var data = new NewAuthorization { Fingerprint = "ha-ha-fingerprint"};
+                var data = new NewAuthorization { Fingerprint = "ha-ha-fingerprint" };
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
 
-                authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data);
+                Uri calledUri = null;
+                dynamic calledBody = null;
 
-                client.Received().Put<ApplicationAuthorization>(Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId/ha-ha-fingerprint"),
-                    Args.Object);
+                client.Put<ApplicationAuthorization>(Arg.Do<Uri>(u => calledUri = u), Arg.Do<object>(body => calledBody = body));
+
+                authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data);
+                
+                Assert.NotNull(calledUri);
+                Assert.Equal(calledUri.ToString(), "authorizations/clients/clientId");
+
+                Assert.NotNull(calledBody);
+                Assert.Equal(calledBody.fingerprint, "ha-ha-fingerprint");
             }
         }
 

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -178,13 +178,11 @@ namespace Octokit
                 client_secret = clientSecret,
                 scopes = newAuthorization.Scopes,
                 note = newAuthorization.Note,
-                note_url = newAuthorization.NoteUrl
+                note_url = newAuthorization.NoteUrl,
+                fingerprint = newAuthorization.Fingerprint
             };
 
-            var endpoint = string.IsNullOrWhiteSpace(newAuthorization.Fingerprint)
-                ? ApiUrls.AuthorizationsForClient(clientId)
-                : ApiUrls.AuthorizationsForClient(clientId, newAuthorization.Fingerprint);
-
+            var endpoint = ApiUrls.AuthorizationsForClient(clientId);
             return ApiConnection.Put<ApplicationAuthorization>(endpoint, requestData);
         }
 
@@ -224,14 +222,13 @@ namespace Octokit
                 client_secret = clientSecret,
                 scopes = newAuthorization.Scopes,
                 note = newAuthorization.Note,
-                note_url = newAuthorization.NoteUrl
+                note_url = newAuthorization.NoteUrl,
+                fingerprint = newAuthorization.Fingerprint
             };
 
             try
             {
-                var endpoint = string.IsNullOrWhiteSpace(newAuthorization.Fingerprint)
-                    ? ApiUrls.AuthorizationsForClient(clientId)
-                    : ApiUrls.AuthorizationsForClient(clientId, newAuthorization.Fingerprint);
+                var endpoint = ApiUrls.AuthorizationsForClient(clientId);
 
                 return await ApiConnection.Put<ApplicationAuthorization>(
                     endpoint,

--- a/Octokit/Helpers/ApiUrls.Authorizations.cs
+++ b/Octokit/Helpers/ApiUrls.Authorizations.cs
@@ -34,21 +34,6 @@ namespace Octokit
             return "authorizations/clients/{0}".FormatUri(clientId);
         }
 
-        /// <summary>
-        /// Returns the <see cref="Uri"/> that authorizations for a given client and fingerprint
-        /// </summary>
-        /// <param name="clientId">
-        /// The 20 character OAuth app client key for
-        /// which to create the token.</param>
-        /// <param name="fingerprint">
-        /// A unique string to distinguish an authorization from others created
-        /// for the same client and user.
-        /// </param>
-        public static Uri AuthorizationsForClient(string clientId, string fingerprint)
-        {
-            return "authorizations/clients/{0}/{1}".FormatUri(clientId, fingerprint);
-        }
-
         public static Uri ApplicationAuthorization(string clientId)
         {
             return "applications/{0}/tokens".FormatUri(clientId);


### PR DESCRIPTION
Octokit currently uses an undocumented endpoint for creating app authorizations.

```
PUT /authorizations/clients/:client_id/:fingerprint
```

This makes Octokit send the fingerprint as part of the URL which only works as long as the fingerprint doesn't contain any characters that has special meaning in urls (most notably `/`). Seeing how fingerprints are an opaque string we can't expect them not to contain reserved characters.

This PR switches the endpoint to the [documented one](https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app) which accepts the fingerprint as part of the JSON body where we can use any characters we want.

cc @Haacked @shiftkey 