### PR TITLE
Add docs link into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Octokit is a client library targeting .NET 4.5 and above that provides an easy
 way to interact with the [GitHub API](http://developer.github.com/v3/).
 
+## Documentation
+
+Please see https://github.com/octokit/octokit.net/blob/master/docs/index.md for more detailed documentation.
+
 ## Usage examples
 
 Get public info on a specific user.


### PR DESCRIPTION
The readme doesn't mention the docs folder, and it should.

I wasn't sure exactly where to put the link so if anyone thinks it should be bumped down a bit (perhaps in the "Getting Started" section?) let me know and i'll move it.