### PR TITLE
Fixes for the comments URL not surfaced in the issue response

### DIFF
--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -237,6 +237,7 @@ namespace Octokit.Tests.Clients
 
             Assert.Equal(new Uri("https://api.github.com/repos/octokit-net-test/public-repo-20131022050247078/issues/1"), response.Body.Url);
             Assert.Equal(new Uri("https://github.com/octokit-net-test/public-repo-20131022050247078/issues/1"), response.Body.HtmlUrl);
+            Assert.Equal(new Uri("https://api.github.com/repos/octokit-net-test/public-repo-20131022050247078/issues/1/comments"), response.Body.CommentsUrl);
         }
     }
 }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -12,10 +12,11 @@ namespace Octokit
     {
         public Issue() { }
 
-        public Issue(Uri url, Uri htmlUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        public Issue(Uri url, Uri htmlUrl, Uri commentsUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
         {
             Url = url;
             HtmlUrl = htmlUrl;
+            CommentsUrl = commentsUrl;
             Number = number;
             State = state;
             Title = title;
@@ -40,6 +41,11 @@ namespace Octokit
         /// The URL for the HTML view of this issue.
         /// </summary>
         public Uri HtmlUrl { get; protected set; }
+
+        /// <summary>
+        /// The Comments URL of this issue.
+        /// </summary>
+        public Uri CommentsUrl { get; protected set; }
 
         /// <summary>
         /// The issue number.


### PR DESCRIPTION
This fix surfaces the comments URL in the Issue response object. #883