### PR TITLE
Fix for Upload to Github releases stopped working #894

### DIFF
--- a/Octokit.Tests/Helpers/StringExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/StringExtensionsTests.cs
@@ -57,8 +57,8 @@ namespace Octokit.Tests.Helpers
             [InlineData("https://host.com/path?name=other", "https://host.com/path?name=other")]
             [InlineData("https://host.com/path?name=example name.txt", "https://host.com/path{?name}")]
             [InlineData("https://host.com/path", "https://host.com/path{?other}")]
-            [InlineData("https://host.com/path?name=example name.txt,label=labeltext", "https://host.com/path{?name,label}")]
-            [InlineData("https://host.com/path?name=example name.txt,label=labeltext", "https://host.com/path{?name,label,other}")]
+            [InlineData("https://host.com/path?name=example name.txt&label=labeltext", "https://host.com/path{?name,label}")]
+            [InlineData("https://host.com/path?name=example name.txt&label=labeltext", "https://host.com/path{?name,label,other}")]
             public void ExpandsUriTemplates(string expected, string template)
             {
                 Assert.Equal(expected, template.ExpandUriTemplate(new { name = "example name.txt",label="labeltext" }).ToString());

--- a/Octokit.Tests/Helpers/StringExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/StringExtensionsTests.cs
@@ -57,9 +57,11 @@ namespace Octokit.Tests.Helpers
             [InlineData("https://host.com/path?name=other", "https://host.com/path?name=other")]
             [InlineData("https://host.com/path?name=example name.txt", "https://host.com/path{?name}")]
             [InlineData("https://host.com/path", "https://host.com/path{?other}")]
+            [InlineData("https://host.com/path?name=example name.txt,label=labeltext", "https://host.com/path{?name,label}")]
+            [InlineData("https://host.com/path?name=example name.txt,label=labeltext", "https://host.com/path{?name,label,other}")]
             public void ExpandsUriTemplates(string expected, string template)
             {
-                Assert.Equal(expected, template.ExpandUriTemplate(new { name = "example name.txt" }).ToString());
+                Assert.Equal(expected, template.ExpandUriTemplate(new { name = "example name.txt",label="labeltext" }).ToString());
             }
         }
     }

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -58,7 +58,7 @@ namespace Octokit
                     var parameterProperty = values.GetType().GetProperty(parameter);
                     if (parameterProperty != null)
                     {
-                        expansion += string.IsNullOrWhiteSpace(expansion) ? "?" : ",";
+                        expansion += string.IsNullOrWhiteSpace(expansion) ? "?" : "&";
                         expansion += parameter + "=" +
                             Uri.EscapeDataString("" + parameterProperty.GetValue(values, new object[0]));
                     }

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -48,14 +48,20 @@ namespace Octokit
         public static Uri ExpandUriTemplate(this string template, object values)
         {
             var optionalQueryStringMatch = _optionalQueryStringRegex.Match(template);
-            if(optionalQueryStringMatch.Success)
+            if (optionalQueryStringMatch.Success)
             {
-                var expansion = "";
-                var parameterName = optionalQueryStringMatch.Groups[1].Value;
-                var parameterProperty = values.GetType().GetProperty(parameterName);
-                if(parameterProperty != null)
+                var expansion = string.Empty;
+                var parameters = optionalQueryStringMatch.Groups[1].Value.Split(new char[] { ',' });
+
+                foreach (var parameter in parameters)
                 {
-                    expansion = "?" + parameterName + "=" + Uri.EscapeDataString("" + parameterProperty.GetValue(values, new object[0]));
+                    var parameterProperty = values.GetType().GetProperty(parameter);
+                    if (parameterProperty != null)
+                    {
+                        expansion += string.IsNullOrWhiteSpace(expansion) ? "?" : ",";
+                        expansion += parameter + "=" +
+                            Uri.EscapeDataString("" + parameterProperty.GetValue(values, new object[0]));
+                    }
                 }
                 template = _optionalQueryStringRegex.Replace(template, expansion);
             }


### PR DESCRIPTION
Fix for Upload to Github releases stopped working #894. The `ExpandUriTemplate` could handle only one parameter which is the bug.