### PR TITLE
Clarify why convention tests are failing

### DIFF
--- a/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayAttributeValueException.cs
+++ b/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayAttributeValueException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class InvalidDebuggerDisplayAttributeValueException : Exception
+    {
+        public InvalidDebuggerDisplayAttributeValueException(Type modelType, string value)
+            : base (CreateMessage(modelType, value)) { }
+
+        static string CreateMessage(Type modelType, string value)
+        {
+            return string.Format(
+                "Model type '{0}' has invalid DebuggerDisplayAttribute value '{1}'. Expected '{{DebuggerDisplay, nq}}'",
+                modelType.FullName,
+                value);
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayReturnType.cs
+++ b/Octokit.Tests.Conventions/Exception/InvalidDebuggerDisplayReturnType.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class InvalidDebuggerDisplayReturnType : Exception
+    {
+        public InvalidDebuggerDisplayReturnType(Type modelType, Type propertyType)
+            : base (CreateMessage(modelType, propertyType)) { }
+
+        static string CreateMessage(Type modelType, Type propertyType)
+        {
+            return string.Format(
+                "Model type '{0}' has invalid DebuggerDisplay return type '{1}'. Expected 'string'.",
+                modelType.FullName,
+                propertyType.Name);
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayAttributeException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayAttributeException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MissingDebuggerDisplayAttributeException : Exception
+    {
+        public MissingDebuggerDisplayAttributeException(Type modelType)
+            : base (string.Format("Model type '{0}' is missing the DebuggerDisplayAttribute.", modelType.FullName)) { }
+    }
+}

--- a/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayPropertyException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingDebuggerDisplayPropertyException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MissingDebuggerDisplayPropertyException : Exception
+    {
+        public MissingDebuggerDisplayPropertyException(Type modelType)
+            : base (string.Format("Model type '{0}' is missing the DebuggerDisplay property.", modelType.FullName)) { }
+    }
+}

--- a/Octokit.Tests.Conventions/Exception/MutableModelPropertiesException.cs
+++ b/Octokit.Tests.Conventions/Exception/MutableModelPropertiesException.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MutableModelPropertiesException : Exception
+    {
+        public MutableModelPropertiesException(Type modelType, IEnumerable<PropertyInfo> mutableProperties)
+            : base (CreateMessage(modelType, mutableProperties)) { }
+
+        static string CreateMessage(Type modelType, IEnumerable<PropertyInfo> mutableProperties)
+        {
+            return string.Format("Model type '{0}' contains the following mutable properties: {1}{2}",
+                modelType.FullName,
+                Environment.NewLine,
+                string.Join(Environment.NewLine, mutableProperties.Select(x => x.Name)));
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -58,6 +58,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exception\InvalidDebuggerDisplayAttributeValueException.cs" />
+    <Compile Include="Exception\InvalidDebuggerDisplayReturnType.cs" />
+    <Compile Include="Exception\MissingDebuggerDisplayAttributeException.cs" />
+    <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
+    <Compile Include="Exception\MutableModelPropertiesException.cs" />
     <Compile Include="Exception\PaginationGetAllMethodNameMismatchException.cs" />
     <Compile Include="ModelTests.cs" />
     <Compile Include="Exception\InterfaceHasAdditionalMethodsException.cs" />

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -99,6 +99,20 @@ namespace Octokit.Tests.Conventions
         {
             return type.GetGenericArguments()[0];
         }
+
+        public static bool IsReadOnlyCollection(this Type type)
+        {
+            var isReadOnlyList = type.HasGenericTypeDefinition(typeof(IReadOnlyList<>));
+
+            var isReadOnlyDictionary = type.HasGenericTypeDefinition(typeof(IReadOnlyDictionary<,>));
+
+            return isReadOnlyList || isReadOnlyDictionary;
+        }
+
+        private static bool HasGenericTypeDefinition(this Type type, Type genericTypeDefinition)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == genericTypeDefinition;
+        }
     }
 
     public enum TypeCategory { Other, Task, GenericTask, ReadOnlyList, ClientInterface }

--- a/Octokit.Tests/Helpers/AssertEx.cs
+++ b/Octokit.Tests/Helpers/AssertEx.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,15 +11,6 @@ namespace Octokit.Tests.Helpers
         {
             // TODO: we should just :fire: this to the ground
             assert();
-        }
-
-        public static TAttribute HasAttribute<TAttribute>(MemberInfo memberInfo, bool inherit = false) where TAttribute : Attribute
-        {
-            var attribute = memberInfo.GetCustomAttribute<TAttribute>(inherit);
-
-            Assert.NotNull(attribute);
-
-            return attribute;
         }
 
         static readonly string[] whitespaceArguments = { " ", "\t", "\n", "\n\r", "  " };
@@ -38,15 +28,6 @@ namespace Octokit.Tests.Helpers
             var collection = instance as ICollection<T>;
             // The collection == null case is for .NET 4.0
             Assert.True(instance is IReadOnlyList<T> && (collection == null || collection.IsReadOnly));
-        }
-
-        public static void IsReadOnlyCollection(Type type)
-        {
-            var isReadOnlyList = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>);
-
-            var isReadOnlyDictionary = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>);
-
-            Assert.True(isReadOnlyList || isReadOnlyDictionary);
         }
     }
 }


### PR DESCRIPTION
Related to #907

The failing test yields:

>    Expected: True
      Actual:   False

Now it will include the offending members, which IMO is much more helpful:

> Model type 'Octokit.RepositoryContent' contains the following mutable properties: 
      EncodedContent