### PR TITLE
Disposable repositories

### DIFF
--- a/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
@@ -2,12 +2,13 @@
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 public class AssigneesClientTests
 {
     readonly IGitHubClient _gitHubClient;
-    readonly Repository _repository;
+    readonly RepositoryContext _context;
     readonly string _owner;
 
     public AssigneesClientTests()
@@ -15,20 +16,20 @@ public class AssigneesClientTests
         _gitHubClient = Helper.GetAuthenticatedClient();
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
-        _owner = _repository.Owner.Login;
+        _context = _gitHubClient.CreateRepositoryContext(new NewRepository(repoName)).Result;
+        _owner = _context.Repository.Owner.Login;
     }
 
     [IntegrationTest]
     public async Task CanCheckAssignees()
     {
         var isAssigned = await
-            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _repository.Name, "FakeHaacked");
+            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _context.Repository.Name, "FakeHaacked");
         Assert.False(isAssigned);
-        
+
         // Repository owner is always an assignee
         isAssigned = await
-            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _repository.Name, _owner);
+            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _context.Repository.Name, _owner);
         Assert.True(isAssigned);
     }
 
@@ -36,12 +37,7 @@ public class AssigneesClientTests
     public async Task CanListAssignees()
     {
         // Repository owner is always an assignee
-        var assignees = await _gitHubClient.Issue.Assignee.GetAllForRepository(_owner, _repository.Name);
+        var assignees = await _gitHubClient.Issue.Assignee.GetAllForRepository(_owner, _context.Repository.Name);
         Assert.True(assignees.Any(u => u.Login == Helper.UserName));
-    }
-
-    public void Dispose()
-    {
-        Helper.DeleteRepo(_repository);
     }
 }

--- a/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
@@ -7,29 +7,27 @@ using Xunit;
 
 public class AssigneesClientTests
 {
-    readonly IGitHubClient _gitHubClient;
+    readonly IGitHubClient _github;
     readonly RepositoryContext _context;
-    readonly string _owner;
 
     public AssigneesClientTests()
     {
-        _gitHubClient = Helper.GetAuthenticatedClient();
+        _github = Helper.GetAuthenticatedClient();
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _context = _gitHubClient.CreateRepositoryContext(new NewRepository(repoName)).Result;
-        _owner = _context.Repository.Owner.Login;
+        _context = _github.CreateRepositoryContext(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]
     public async Task CanCheckAssignees()
     {
         var isAssigned = await
-            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _context.Repository.Name, "FakeHaacked");
+            _github.Issue.Assignee.CheckAssignee(_context.RepositoryOwner, _context.RepositoryName, "FakeHaacked");
         Assert.False(isAssigned);
 
         // Repository owner is always an assignee
         isAssigned = await
-            _gitHubClient.Issue.Assignee.CheckAssignee(_owner, _context.Repository.Name, _owner);
+            _github.Issue.Assignee.CheckAssignee(_context.RepositoryOwner, _context.RepositoryName, _context.RepositoryOwner);
         Assert.True(isAssigned);
     }
 
@@ -37,7 +35,7 @@ public class AssigneesClientTests
     public async Task CanListAssignees()
     {
         // Repository owner is always an assignee
-        var assignees = await _gitHubClient.Issue.Assignee.GetAllForRepository(_owner, _context.Repository.Name);
+        var assignees = await _github.Issue.Assignee.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
         Assert.True(assignees.Any(u => u.Login == Helper.UserName));
     }
 }

--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -10,14 +10,14 @@ namespace Octokit.Tests.Integration.Clients
         [ApplicationTest]
         public async Task CanCreateAndGetAuthorizationWithoutFingerPrint()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
                 note,
                 new[] { "user" });
 
             // the first call will create the authorization
-            var created = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var created = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -27,14 +27,14 @@ namespace Octokit.Tests.Integration.Clients
             Assert.False(String.IsNullOrWhiteSpace(created.HashedToken));
 
             // we can then query it through the regular API
-            var get = await client.Authorization.Get(created.Id);
+            var get = await github.Authorization.Get(created.Id);
 
             Assert.Equal(created.Id, get.Id);
             Assert.Equal(created.Note, get.Note);
 
             // but the second time we call this API we get
             // a different set of data
-            var getExisting = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var getExisting = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -47,13 +47,13 @@ namespace Octokit.Tests.Integration.Clients
             Assert.False(String.IsNullOrWhiteSpace(getExisting.TokenLastEight));
             Assert.False(String.IsNullOrWhiteSpace(getExisting.HashedToken));
 
-            await client.Authorization.Delete(created.Id);
+            await github.Authorization.Delete(created.Id);
         }
 
         [ApplicationTest]
         public async Task CanCreateAndGetAuthorizationByFingerprint()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
             var fingerprint = Helper.MakeNameWithTimestamp("authorization-testing");
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Integration.Clients
                 new[] { "user" },
                 fingerprint);
 
-            var created = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var created = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -70,14 +70,14 @@ namespace Octokit.Tests.Integration.Clients
             Assert.False(String.IsNullOrWhiteSpace(created.Token));
 
             // we can then query it through the regular API
-            var get = await client.Authorization.Get(created.Id);
+            var get = await github.Authorization.Get(created.Id);
 
             Assert.Equal(created.Id, get.Id);
             Assert.Equal(created.Note, get.Note);
 
             // but the second time we call this API we get
             // a different set of data
-            var getExisting = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var getExisting = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -93,13 +93,13 @@ namespace Octokit.Tests.Integration.Clients
             Assert.False(String.IsNullOrWhiteSpace(getExisting.TokenLastEight));
             Assert.False(String.IsNullOrWhiteSpace(getExisting.HashedToken));
 
-            await client.Authorization.Delete(created.Id);
+            await github.Authorization.Delete(created.Id);
         }
 
         [ApplicationTest]
         public async Task CanCheckApplicationAuthentication()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
             var fingerprint = Helper.MakeNameWithTimestamp("authorization-testing");
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
@@ -107,7 +107,7 @@ namespace Octokit.Tests.Integration.Clients
                 new[] { "user" },
                 fingerprint);
 
-            var created = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var created = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -118,14 +118,14 @@ namespace Octokit.Tests.Integration.Clients
             Assert.NotNull(applicationAuthorization);
             Assert.Equal(created.Token, applicationAuthorization.Token);
 
-            await client.Authorization.Delete(created.Id);
-            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
+            await github.Authorization.Delete(created.Id);
+            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
         public async Task CanResetApplicationAuthentication()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
             var fingerprint = Helper.MakeNameWithTimestamp("authorization-testing");
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
@@ -133,7 +133,7 @@ namespace Octokit.Tests.Integration.Clients
                 new[] { "user" },
                 fingerprint);
 
-            var created = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var created = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -144,14 +144,14 @@ namespace Octokit.Tests.Integration.Clients
             Assert.NotNull(applicationAuthorization);
             Assert.NotEqual(created.Token, applicationAuthorization.Token);
 
-            await client.Authorization.Delete(created.Id);
-            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
+            await github.Authorization.Delete(created.Id);
+            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
         public async Task CanRevokeApplicationAuthentication()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
             var fingerprint = Helper.MakeNameWithTimestamp("authorization-testing");
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
@@ -159,7 +159,7 @@ namespace Octokit.Tests.Integration.Clients
                 new[] { "user" },
                 fingerprint);
 
-            var created = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var created = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 newAuthorization);
@@ -168,17 +168,17 @@ namespace Octokit.Tests.Integration.Clients
             await applicationClient.Authorization.RevokeApplicationAuthentication(Helper.ClientId, created.Token);
 
             Assert.ThrowsAsync<NotFoundException>(() => applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, created.Token));
-            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(created.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
         [ApplicationTest]
         public async Task CanRevokeAllApplicationAuthentications()
         {
-            var client = Helper.GetAuthenticatedClient();
+            var github = Helper.GetAuthenticatedClient();
 
             var fingerprint = Helper.MakeNameWithTimestamp("authorization-testing");
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
-            var token1 = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var token1 = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 new NewAuthorization(
@@ -188,7 +188,7 @@ namespace Octokit.Tests.Integration.Clients
 
             fingerprint = Helper.MakeNameWithTimestamp("authorization-testing-2");
             note = Helper.MakeNameWithTimestamp("Testing authentication 2");
-            var token2 = await client.Authorization.GetOrCreateApplicationAuthentication(
+            var token2 = await github.Authorization.GetOrCreateApplicationAuthentication(
                 Helper.ClientId,
                 Helper.ClientSecret,
                 new NewAuthorization(
@@ -204,8 +204,8 @@ namespace Octokit.Tests.Integration.Clients
             Assert.ThrowsAsync<NotFoundException>(async () => 
                 await applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, token2.Token));
 
-            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(token1.Id));
-            Assert.ThrowsAsync<NotFoundException>(() => client.Authorization.Get(token2.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(token1.Id));
+            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(token2.Id));
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/BlobClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BlobClientTests.cs
@@ -4,11 +4,12 @@ using Octokit;
 using Octokit.Tests.Integration;
 using System.Threading.Tasks;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class BlobClientTests : IDisposable
 {
     readonly IBlobsClient _fixture;
-    readonly Repository _repository;
+    readonly RepositoryContext _context;
     readonly string _owner;
 
     public BlobClientTests()
@@ -16,9 +17,8 @@ public class BlobClientTests : IDisposable
         var client = Helper.GetAuthenticatedClient();
         _fixture = client.GitDatabase.Blob;
 
-        var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _repository = client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-        _owner = _repository.Owner.Login;
+        _context = client.CreateRepositoryContext("public-repo").Result;
+        _owner = _context.Repository.Owner.Login;
     }
 
     [IntegrationTest]
@@ -30,7 +30,7 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var result = await _fixture.Create(_owner, _repository.Name, blob);
+        var result = await _fixture.Create(_owner, _context.Repository.Name, blob);
 
         Assert.False(String.IsNullOrWhiteSpace(result.Sha));
     }
@@ -47,7 +47,7 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Base64
         };
 
-        var result = await _fixture.Create(_owner, _repository.Name, blob);
+        var result = await _fixture.Create(_owner, _context.Repository.Name, blob);
 
         Assert.False(String.IsNullOrWhiteSpace(result.Sha));
     }
@@ -61,8 +61,8 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var result = await _fixture.Create(_owner, _repository.Name, newBlob);
-        var blob = await _fixture.Get(_owner, _repository.Name, result.Sha);
+        var result = await _fixture.Create(_owner, _context.Repository.Name, newBlob);
+        var blob = await _fixture.Get(_owner, _context.Repository.Name, result.Sha);
 
         Assert.Equal(result.Sha, blob.Sha);
         Assert.Equal(EncodingType.Base64, blob.Encoding);
@@ -84,8 +84,8 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Base64
         };
 
-        var result = await _fixture.Create(_owner, _repository.Name, newBlob);
-        var blob = await _fixture.Get(_owner, _repository.Name, result.Sha);
+        var result = await _fixture.Create(_owner, _context.Repository.Name, newBlob);
+        var blob = await _fixture.Get(_owner, _context.Repository.Name, result.Sha);
 
         Assert.Equal(result.Sha, blob.Sha);
         Assert.Equal(EncodingType.Base64, blob.Encoding);
@@ -98,6 +98,6 @@ public class BlobClientTests : IDisposable
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/BlobClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BlobClientTests.cs
@@ -8,17 +8,15 @@ using Octokit.Tests.Integration.Helpers;
 
 public class BlobClientTests : IDisposable
 {
-    readonly IBlobsClient _fixture;
-    readonly RepositoryContext _context;
-    readonly string _owner;
+    private readonly IBlobsClient _fixture;
+    private readonly RepositoryContext _context;
 
     public BlobClientTests()
     {
-        var client = Helper.GetAuthenticatedClient();
-        _fixture = client.GitDatabase.Blob;
+        var github = Helper.GetAuthenticatedClient();
+        _fixture = github.GitDatabase.Blob;
 
-        _context = client.CreateRepositoryContext("public-repo").Result;
-        _owner = _context.Repository.Owner.Login;
+        _context = github.CreateRepositoryContext("public-repo").Result;
     }
 
     [IntegrationTest]
@@ -30,7 +28,7 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var result = await _fixture.Create(_owner, _context.Repository.Name, blob);
+        var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
 
         Assert.False(String.IsNullOrWhiteSpace(result.Sha));
     }
@@ -47,7 +45,7 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Base64
         };
 
-        var result = await _fixture.Create(_owner, _context.Repository.Name, blob);
+        var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
 
         Assert.False(String.IsNullOrWhiteSpace(result.Sha));
     }
@@ -61,8 +59,8 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var result = await _fixture.Create(_owner, _context.Repository.Name, newBlob);
-        var blob = await _fixture.Get(_owner, _context.Repository.Name, result.Sha);
+        var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, newBlob);
+        var blob = await _fixture.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
 
         Assert.Equal(result.Sha, blob.Sha);
         Assert.Equal(EncodingType.Base64, blob.Encoding);
@@ -84,8 +82,8 @@ public class BlobClientTests : IDisposable
             Encoding = EncodingType.Base64
         };
 
-        var result = await _fixture.Create(_owner, _context.Repository.Name, newBlob);
-        var blob = await _fixture.Get(_owner, _context.Repository.Name, result.Sha);
+        var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, newBlob);
+        var blob = await _fixture.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
 
         Assert.Equal(result.Sha, blob.Sha);
         Assert.Equal(EncodingType.Base64, blob.Encoding);

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -2,34 +2,27 @@
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 public class BranchesClientTests
 {
-    public class TheGetBranchesMethod : IDisposable
+    public class TheGetBranchesMethod
     {
-        readonly Repository _repository;
-        readonly IGitHubClient _github;
-
-        public TheGetBranchesMethod()
-        {
-            _github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = _github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-        }
+        public TheGetBranchesMethod() { }
 
         [IntegrationTest]
         public async Task ReturnsBranches()
         {
-            var branches = await _github.Repository.GetAllBranches(_repository.Owner.Login, _repository.Name);
-            
-            Assert.NotEmpty(branches);
-            Assert.Equal(branches[0].Name, "master");
-        }
+            var github = Helper.GetAuthenticatedClient();
 
-        public void Dispose()
-        {
-            Helper.DeleteRepo(_repository);
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var branches = await github.Repository.GetAllBranches(context.Repository.Owner.Login, context.Repository.Name);
+
+                Assert.NotEmpty(branches);
+                Assert.Equal(branches[0].Name, "master");
+            }
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -1,58 +1,49 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Octokit;
+using Octokit.Tests.Integration.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 
-public class CommitsClientTests : IDisposable
+public class CommitsClientTests
 {
-    readonly IGitHubClient _client;
-    readonly Repository _repository;
-    readonly ICommitsClient _fixture;
-    readonly string _owner;
-
-    public CommitsClientTests()
-    {
-        _client = Helper.GetAuthenticatedClient();
-
-        var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _fixture = _client.GitDatabase.Commit;
-        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-        _owner = _repository.Owner.Login;
-    }
+    public CommitsClientTests() { }
 
     [IntegrationTest]
     public async Task CanCreateAndRetrieveCommit()
     {
-        var blob = new NewBlob
+        var client = Helper.GetAuthenticatedClient();
+        var fixture = client.GitDatabase.Commit;
+        
+        using (var context = await client.CreateRepositoryContext("public-repo"))
         {
-            Content = "Hello World!",
-            Encoding = EncodingType.Utf8
-        };
-        var blobResult = await _client.GitDatabase.Blob.Create(_owner, _repository.Name, blob);
+            var owner = context.Repository.Owner.Login;
 
-        var newTree = new NewTree();
-        newTree.Tree.Add(new NewTreeItem
-        {
-            Type = TreeType.Blob,
-            Mode = FileMode.File,
-            Path = "README.md",
-            Sha = blobResult.Sha
-        });
+            var blob = new NewBlob
+            {
+                Content = "Hello World!",
+                Encoding = EncodingType.Utf8
+            };
+            var blobResult = await client.GitDatabase.Blob.Create(owner, context.Repository.Name, blob);
 
-        var treeResult = await _client.GitDatabase.Tree.Create(_owner, _repository.Name, newTree);
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
 
-        var newCommit = new NewCommit("test-commit", treeResult.Sha);
+            var treeResult = await client.GitDatabase.Tree.Create(owner, context.Repository.Name, newTree);
 
-        var commit = await _fixture.Create(_owner, _repository.Name, newCommit);
-        Assert.NotNull(commit);
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
 
-        var retrieved = await _fixture.Get(_owner, _repository.Name, commit.Sha);
-        Assert.NotNull(retrieved);
-    }
+            var commit = await fixture.Create(owner, context.Repository.Name, newCommit);
+            Assert.NotNull(commit);
 
-    public void Dispose()
-    {
-        Helper.DeleteRepo(_repository);
+            var retrieved = await fixture.Get(owner, context.Repository.Name, commit.Sha);
+            Assert.NotNull(retrieved);
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -12,10 +12,10 @@ public class CommitsClientTests
     [IntegrationTest]
     public async Task CanCreateAndRetrieveCommit()
     {
-        var client = Helper.GetAuthenticatedClient();
-        var fixture = client.GitDatabase.Commit;
+        var github = Helper.GetAuthenticatedClient();
+        var fixture = github.GitDatabase.Commit;
         
-        using (var context = await client.CreateRepositoryContext("public-repo"))
+        using (var context = await github.CreateRepositoryContext("public-repo"))
         {
             var owner = context.Repository.Owner.Login;
 
@@ -24,7 +24,7 @@ public class CommitsClientTests
                 Content = "Hello World!",
                 Encoding = EncodingType.Utf8
             };
-            var blobResult = await client.GitDatabase.Blob.Create(owner, context.Repository.Name, blob);
+            var blobResult = await github.GitDatabase.Blob.Create(owner, context.Repository.Name, blob);
 
             var newTree = new NewTree();
             newTree.Tree.Add(new NewTreeItem
@@ -35,7 +35,7 @@ public class CommitsClientTests
                 Sha = blobResult.Sha
             });
 
-            var treeResult = await client.GitDatabase.Tree.Create(owner, context.Repository.Name, newTree);
+            var treeResult = await github.GitDatabase.Tree.Create(owner, context.Repository.Name, newTree);
 
             var newCommit = new NewCommit("test-commit", treeResult.Sha);
 

--- a/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
@@ -10,7 +10,6 @@ public class DeploymentsClientTests : IDisposable
     private readonly IDeploymentsClient _deploymentsClient;
     private readonly RepositoryContext _context;
     private readonly Commit _commit;
-    private readonly string _repositoryOwner;
 
     public DeploymentsClientTests()
     {
@@ -18,7 +17,6 @@ public class DeploymentsClientTests : IDisposable
 
         _deploymentsClient = github.Repository.Deployment;
         _context = github.CreateRepositoryContext("public-repo").Result;
-        _repositoryOwner = _context.Repository.Owner.Login;
 
         var blob = new NewBlob
         {
@@ -26,7 +24,7 @@ public class DeploymentsClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var blobResult = github.GitDatabase.Blob.Create(_repositoryOwner, _context.Repository.Name, blob).Result;
+        var blobResult = github.GitDatabase.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob).Result;
 
         var newTree = new NewTree();
         newTree.Tree.Add(new NewTreeItem
@@ -37,9 +35,9 @@ public class DeploymentsClientTests : IDisposable
             Sha = blobResult.Sha
         });
 
-        var treeResult = github.GitDatabase.Tree.Create(_repositoryOwner, _context.Repository.Name, newTree).Result;
+        var treeResult = github.GitDatabase.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree).Result;
         var newCommit = new NewCommit("test-commit", treeResult.Sha);
-        _commit = github.GitDatabase.Commit.Create(_repositoryOwner, _context.Repository.Name, newCommit).Result;
+        _commit = github.GitDatabase.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit).Result;
     }
   
     [IntegrationTest]
@@ -47,7 +45,7 @@ public class DeploymentsClientTests : IDisposable
     {
         var newDeployment = new NewDeployment { Ref = _commit.Sha, AutoMerge = false };
 
-        var deployment = await _deploymentsClient.Create(_repositoryOwner, _context.Repository.Name, newDeployment);
+        var deployment = await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
 
         Assert.NotNull(deployment);
     }
@@ -56,9 +54,9 @@ public class DeploymentsClientTests : IDisposable
     public async Task CanGetDeployments()
     {
         var newDeployment = new NewDeployment { Ref = _commit.Sha, AutoMerge = false };
-        await _deploymentsClient.Create(_repositoryOwner, _context.Repository.Name, newDeployment);
+        await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
 
-        var deployments = await _deploymentsClient.GetAll(_repositoryOwner, _context.Repository.Name);
+        var deployments = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.NotEmpty(deployments);
     }

--- a/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
@@ -3,28 +3,22 @@ using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class DeploymentsClientTests : IDisposable
 {
-    readonly IGitHubClient _gitHubClient;
-    readonly IDeploymentsClient _deploymentsClient;
-    readonly Repository _repository;
-    readonly Commit _commit;
-    readonly string _repositoryOwner;
+    private readonly IDeploymentsClient _deploymentsClient;
+    private readonly RepositoryContext _context;
+    private readonly Commit _commit;
+    private readonly string _repositoryOwner;
 
     public DeploymentsClientTests()
     {
-        _gitHubClient = Helper.GetAuthenticatedClient();
+        var github = Helper.GetAuthenticatedClient();
 
-        _deploymentsClient = _gitHubClient.Repository.Deployment;
-
-        var newRepository = new NewRepository(Helper.MakeNameWithTimestamp("public-repo"))
-        {
-            AutoInit = true
-        };
-
-        _repository = _gitHubClient.Repository.Create(newRepository).Result;
-        _repositoryOwner = _repository.Owner.Login;
+        _deploymentsClient = github.Repository.Deployment;
+        _context = github.CreateRepositoryContext("public-repo").Result;
+        _repositoryOwner = _context.Repository.Owner.Login;
 
         var blob = new NewBlob
         {
@@ -32,7 +26,7 @@ public class DeploymentsClientTests : IDisposable
             Encoding = EncodingType.Utf8
         };
 
-        var blobResult = _gitHubClient.GitDatabase.Blob.Create(_repositoryOwner, _repository.Name, blob).Result;
+        var blobResult = github.GitDatabase.Blob.Create(_repositoryOwner, _context.Repository.Name, blob).Result;
 
         var newTree = new NewTree();
         newTree.Tree.Add(new NewTreeItem
@@ -43,9 +37,9 @@ public class DeploymentsClientTests : IDisposable
             Sha = blobResult.Sha
         });
 
-        var treeResult = _gitHubClient.GitDatabase.Tree.Create(_repositoryOwner, _repository.Name, newTree).Result;
+        var treeResult = github.GitDatabase.Tree.Create(_repositoryOwner, _context.Repository.Name, newTree).Result;
         var newCommit = new NewCommit("test-commit", treeResult.Sha);
-        _commit = _gitHubClient.GitDatabase.Commit.Create(_repositoryOwner, _repository.Name, newCommit).Result;
+        _commit = github.GitDatabase.Commit.Create(_repositoryOwner, _context.Repository.Name, newCommit).Result;
     }
   
     [IntegrationTest]
@@ -53,7 +47,7 @@ public class DeploymentsClientTests : IDisposable
     {
         var newDeployment = new NewDeployment { Ref = _commit.Sha, AutoMerge = false };
 
-        var deployment = await _deploymentsClient.Create(_repositoryOwner, _repository.Name, newDeployment);
+        var deployment = await _deploymentsClient.Create(_repositoryOwner, _context.Repository.Name, newDeployment);
 
         Assert.NotNull(deployment);
     }
@@ -62,15 +56,15 @@ public class DeploymentsClientTests : IDisposable
     public async Task CanGetDeployments()
     {
         var newDeployment = new NewDeployment { Ref = _commit.Sha, AutoMerge = false };
-        await _deploymentsClient.Create(_repositoryOwner, _repository.Name, newDeployment);
-        
-        var deployments = await _deploymentsClient.GetAll(_repositoryOwner, _repository.Name);
+        await _deploymentsClient.Create(_repositoryOwner, _context.Repository.Name, newDeployment);
+
+        var deployments = await _deploymentsClient.GetAll(_repositoryOwner, _context.Repository.Name);
 
         Assert.NotEmpty(deployments);
     }
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/GistsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GistsClientTests.cs
@@ -13,9 +13,9 @@ public class GistsClientTests
 
     public GistsClientTests()
     {
-        var client = Helper.GetAuthenticatedClient();
+        var github = Helper.GetAuthenticatedClient();
 
-        _fixture = client.Gist;
+        _fixture = github.Gist;
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using Octokit;
 using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,10 +20,10 @@ public class GitHubClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName));
-
-            try
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
             {
+                var createdRepository = context.Repository;
+            
                 var result = github.GetLastApiInfo();
 
                 Assert.True(result.Links.Count == 0);
@@ -32,10 +33,6 @@ public class GitHubClientTests
                 Assert.True(result.RateLimit.Limit > 0);
                 Assert.True(result.RateLimit.Remaining > -1);
                 Assert.NotNull(result.RateLimit.Reset);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -25,22 +25,20 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanCreateRetrieveAndCloseIssue()
     {
-        string owner = _context.Repository.Owner.Login;
-
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         try
         {
             Assert.NotNull(issue);
 
-            var retrieved = await _issuesClient.Get(owner, _context.Repository.Name, issue.Number);
-            var all = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name);
+            var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+            var all = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
             Assert.NotNull(retrieved);
             Assert.True(all.Any(i => i.Number == retrieved.Number));
         }
         finally
         {
-            var closed = _issuesClient.Update(owner, _context.Repository.Name, issue.Number,
+            var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number,
             new IssueUpdate { State = ItemState.Closed })
             .Result;
             Assert.NotNull(closed);
@@ -50,21 +48,20 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListOpenIssuesWithDefaultSort()
     {
-        string owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
-        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var closed = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name);
+        var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.Equal(3, issues.Count);
         Assert.Equal("A test issue3", issues[0].Title);
@@ -75,22 +72,20 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListIssuesWithAscendingSort()
     {
-        string owner = _context.Repository.Owner.Login;
-
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
-        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var closed = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest {SortDirection = SortDirection.Ascending});
 
         Assert.Equal(3, issues.Count);
@@ -102,17 +97,15 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListClosedIssues()
     {
-        string owner = _context.Repository.Owner.Login;
-
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A closed issue") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
-        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
-        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        var closed = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { State = ItemState.Closed });
 
         Assert.Equal(1, issues.Count);
@@ -122,14 +115,13 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListMilestoneIssues()
     {
-        string owner = _context.Repository.Owner.Login;
-        var milestone = await _issuesClient.Milestone.Create(owner, _context.Repository.Name, new NewMilestone("milestone"));
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, new NewMilestone("milestone"));
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A milestone issue") { Body = "A new unassigned issue", Milestone = milestone.Number };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Milestone = milestone.Number.ToString(CultureInfo.InvariantCulture) });
 
         Assert.Equal(1, issues.Count);
@@ -139,19 +131,18 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest(Skip = "This is paging for a long long time")]
     public async Task CanRetrieveAllIssues()
     {
-        string owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        var issue1 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        var issue2 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
-        var issue3 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
-        var issue4 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _context.Repository.Name, issue4.Number,
+        var issue1 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        var issue3 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue4.Number,
         new IssueUpdate { State = ItemState.Closed });
 
-        var retrieved = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var retrieved = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { State = ItemState.All });
 
         Assert.True(retrieved.Count >= 4);
@@ -164,24 +155,23 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByAssigned()
     {
-        var owner = _context.Repository.Owner.Login;
-        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = owner };
+        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = _context.RepositoryOwner };
         var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var assignedIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name, 
-            new RepositoryIssueRequest { Assignee = owner });
+        var assignedIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, 
+            new RepositoryIssueRequest { Assignee = _context.RepositoryOwner });
 
         Assert.Equal(1, assignedIssues.Count);
         Assert.Equal("An assigned issue", assignedIssues[0].Title);
 
-        var unassignedIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var unassignedIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Assignee = "none" });
 
         Assert.Equal(1, unassignedIssues.Count);
@@ -191,23 +181,22 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByCreator()
     {
-        var owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("An issue") { Body = "words words words" };
         var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var issuesCreatedByOwner = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
-            new RepositoryIssueRequest { Creator = owner });
+        var issuesCreatedByOwner = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
+            new RepositoryIssueRequest { Creator = _context.RepositoryOwner });
 
         Assert.Equal(2, issuesCreatedByOwner.Count);
 
-        var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Creator = "shiftkey" });
 
         Assert.Equal(0, issuesCreatedByExternalUser.Count);
@@ -216,23 +205,22 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByMentioned()
     {
-        var owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("An issue") { Body = "words words words hello there @shiftkey" };
         var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var mentionsWithShiftkey = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var mentionsWithShiftkey = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Mentioned = "shiftkey" });
 
         Assert.Equal(1, mentionsWithShiftkey.Count);
 
-        var mentionsWithHaacked = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+        var mentionsWithHaacked = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { Mentioned = "haacked" });
 
         Assert.Equal(0, mentionsWithHaacked.Count);
@@ -241,34 +229,30 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task FilteringByInvalidAccountThrowsError()
     {
-        var owner = _context.Repository.Owner.Login;
-
         await Assert.ThrowsAsync<ApiValidationException>(
-            () => _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
+            () => _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
                 new RepositoryIssueRequest { Assignee = "some-random-account" }));
     }
 
     [IntegrationTest]
     public async Task CanAssignAndUnassignMilestone()
     {
-        var owner = _context.Repository.Owner.Login;
-
         var newMilestone = new NewMilestone("a milestone");
-        var milestone = await _issuesClient.Milestone.Create(owner, _context.Repository.Name, newMilestone);
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
 
         var newIssue1 = new NewIssue("A test issue1")
         {
             Body = "A new unassigned issue",
             Milestone = milestone.Number
         };
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
 
         Assert.NotNull(issue.Milestone);
 
         var issueUpdate = issue.ToUpdate();
         issueUpdate.Milestone = null;
 
-        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
 
         Assert.Null(updatedIssue.Milestone);
     }
@@ -276,9 +260,7 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task DoesNotChangeLabelsByDefault()
     {
-        var owner = _context.Repository.Owner.Login;
-
-        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
 
         var newIssue = new NewIssue("A test issue1")
         {
@@ -286,11 +268,11 @@ public class IssuesClientTests : IDisposable
         };
         newIssue.Labels.Add("something");
 
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
         var issueUpdate = issue.ToUpdate();
 
-        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
 
         Assert.Equal(1, updatedIssue.Labels.Count);
     }
@@ -298,11 +280,9 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanUpdateLabelForAnIssue()
     {
-        var owner = _context.Repository.Owner.Login;
-
         // create some labels
-        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
-        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("another thing", "0000FF"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("another thing", "0000FF"));
 
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
@@ -311,13 +291,13 @@ public class IssuesClientTests : IDisposable
         };
         newIssue.Labels.Add("something");
 
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
         // update the issue
         var issueUpdate = issue.ToUpdate();
         issueUpdate.AddLabel("another thing");
 
-        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
 
         Assert.Equal("another thing", updatedIssue.Labels[0].Name);
     }
@@ -325,11 +305,9 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanClearLabelsForAnIssue()
     {
-        var owner = _context.Repository.Owner.Login;
-
         // create some labels
-        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
-        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("another thing", "0000FF"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("another thing", "0000FF"));
 
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
@@ -339,14 +317,14 @@ public class IssuesClientTests : IDisposable
         newIssue.Labels.Add("something");
         newIssue.Labels.Add("another thing");
 
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         Assert.Equal(2, issue.Labels.Count);
 
         // update the issue
         var issueUpdate = issue.ToUpdate();
         issueUpdate.ClearLabels();
 
-        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
 
         Assert.Empty(updatedIssue.Labels);
     }
@@ -355,19 +333,18 @@ public class IssuesClientTests : IDisposable
     public async Task CanAccessUrls()
     {
         var expctedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
-        var owner = _context.Repository.Owner.Login;
 
         var newIssue = new NewIssue("A test issue")
         {
             Body = "A new unassigned issue",
         };
 
-        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
         Assert.NotNull(issue.CommentsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, owner, _context.Repository.Name, issue.Number, "comments")), issue.CommentsUrl);
+        Assert.Equal(new Uri(string.Format(expctedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "comments")), issue.CommentsUrl);
         Assert.NotNull(issue.EventsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, owner, _context.Repository.Name, issue.Number, "events")), issue.EventsUrl);
+        Assert.Equal(new Uri(string.Format(expctedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "events")), issue.EventsUrl);
     }
 
     public void Dispose()

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -7,40 +7,40 @@ using Octokit;
 using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class IssuesClientTests : IDisposable
 {
-    readonly IGitHubClient _gitHubClient;
-    readonly Repository _repository;
-    readonly IIssuesClient _issuesClient;
+    private readonly RepositoryContext _context;
+    private readonly IIssuesClient _issuesClient;
 
     public IssuesClientTests()
     {
-        _gitHubClient = Helper.GetAuthenticatedClient();
+        var github = Helper.GetAuthenticatedClient();
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
-        _issuesClient = _gitHubClient.Issue;
-        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
+        _issuesClient = github.Issue;
+        _context = github.CreateRepositoryContext(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]
     public async Task CanCreateRetrieveAndCloseIssue()
     {
-        string owner = _repository.Owner.Login;
+        string owner = _context.Repository.Owner.Login;
 
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
         try
         {
             Assert.NotNull(issue);
 
-            var retrieved = await _issuesClient.Get(owner, _repository.Name, issue.Number);
-            var all = await _issuesClient.GetAllForRepository(owner, _repository.Name);
+            var retrieved = await _issuesClient.Get(owner, _context.Repository.Name, issue.Number);
+            var all = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name);
             Assert.NotNull(retrieved);
             Assert.True(all.Any(i => i.Number == retrieved.Number));
         }
         finally
         {
-            var closed = _issuesClient.Update(owner, _repository.Name, issue.Number,
+            var closed = _issuesClient.Update(owner, _context.Repository.Name, issue.Number,
             new IssueUpdate { State = ItemState.Closed })
             .Result;
             Assert.NotNull(closed);
@@ -50,21 +50,21 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListOpenIssuesWithDefaultSort()
     {
-        string owner = _repository.Owner.Login;
+        string owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        Thread.Sleep(1000); 
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
-        Thread.Sleep(1000); 
-        await _issuesClient.Create(owner, _repository.Name, newIssue3);
-        var closed = await _issuesClient.Create(owner, _repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _repository.Name, closed.Number,
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        Thread.Sleep(1000);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        Thread.Sleep(1000);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
+        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
+        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _repository.Name);
+        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name);
 
         Assert.Equal(3, issues.Count);
         Assert.Equal("A test issue3", issues[0].Title);
@@ -75,22 +75,22 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListIssuesWithAscendingSort()
     {
-        string owner = _repository.Owner.Login;
+        string owner = _context.Repository.Owner.Login;
 
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
         Thread.Sleep(1000);
-        await _issuesClient.Create(owner, _repository.Name, newIssue3);
-        var closed = await _issuesClient.Create(owner, _repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _repository.Name, closed.Number,
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
+        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
+        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest {SortDirection = SortDirection.Ascending});
 
         Assert.Equal(3, issues.Count);
@@ -102,17 +102,17 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListClosedIssues()
     {
-        string owner = _repository.Owner.Login;
+        string owner = _context.Repository.Owner.Login;
 
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A closed issue") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
-        var closed = await _issuesClient.Create(owner, _repository.Name, newIssue2);
-        await _issuesClient.Update(owner, _repository.Name, closed.Number,
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        var closed = await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        await _issuesClient.Update(owner, _context.Repository.Name, closed.Number,
             new IssueUpdate { State = ItemState.Closed });
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { State = ItemState.Closed });
 
         Assert.Equal(1, issues.Count);
@@ -122,14 +122,14 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListMilestoneIssues()
     {
-        string owner = _repository.Owner.Login;
-        var milestone = await _issuesClient.Milestone.Create(owner, _repository.Name, new NewMilestone("milestone"));
+        string owner = _context.Repository.Owner.Login;
+        var milestone = await _issuesClient.Milestone.Create(owner, _context.Repository.Name, new NewMilestone("milestone"));
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A milestone issue") { Body = "A new unassigned issue", Milestone = milestone.Number };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
 
-        var issues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var issues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Milestone = milestone.Number.ToString(CultureInfo.InvariantCulture) });
 
         Assert.Equal(1, issues.Count);
@@ -139,19 +139,19 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest(Skip = "This is paging for a long long time")]
     public async Task CanRetrieveAllIssues()
     {
-        string owner = _repository.Owner.Login;
+        string owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
         var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
         var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
-        var issue1 = await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        var issue2 = await _issuesClient.Create(owner, _repository.Name, newIssue2);
-        var issue3 = await _issuesClient.Create(owner, _repository.Name, newIssue3);
-        var issue4 = await _issuesClient.Create(owner, _repository.Name, newIssue4);
-        await _issuesClient.Update(owner, _repository.Name, issue4.Number,
+        var issue1 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        var issue2 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
+        var issue3 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue3);
+        var issue4 = await _issuesClient.Create(owner, _context.Repository.Name, newIssue4);
+        await _issuesClient.Update(owner, _context.Repository.Name, issue4.Number,
         new IssueUpdate { State = ItemState.Closed });
 
-        var retrieved = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var retrieved = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { State = ItemState.All });
 
         Assert.True(retrieved.Count >= 4);
@@ -164,24 +164,24 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByAssigned()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = owner };
         var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var assignedIssues = await _issuesClient.GetAllForRepository(owner, _repository.Name, 
+        var assignedIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name, 
             new RepositoryIssueRequest { Assignee = owner });
 
         Assert.Equal(1, assignedIssues.Count);
         Assert.Equal("An assigned issue", assignedIssues[0].Title);
 
-        var unassignedIssues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var unassignedIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Assignee = "none" });
 
         Assert.Equal(1, unassignedIssues.Count);
@@ -191,23 +191,23 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByCreator()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("An issue") { Body = "words words words" };
         var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var issuesCreatedByOwner = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var issuesCreatedByOwner = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Creator = owner });
 
         Assert.Equal(2, issuesCreatedByOwner.Count);
 
-        var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Creator = "shiftkey" });
 
         Assert.Equal(0, issuesCreatedByExternalUser.Count);
@@ -216,23 +216,23 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanFilterByMentioned()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
         var newIssue1 = new NewIssue("An issue") { Body = "words words words hello there @shiftkey" };
         var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
-        await _issuesClient.Create(owner, _repository.Name, newIssue1);
-        await _issuesClient.Create(owner, _repository.Name, newIssue2);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
+        await _issuesClient.Create(owner, _context.Repository.Name, newIssue2);
 
-        var allIssues = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var allIssues = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest());
 
         Assert.Equal(2, allIssues.Count);
 
-        var mentionsWithShiftkey = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var mentionsWithShiftkey = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Mentioned = "shiftkey" });
 
         Assert.Equal(1, mentionsWithShiftkey.Count);
 
-        var mentionsWithHaacked = await _issuesClient.GetAllForRepository(owner, _repository.Name,
+        var mentionsWithHaacked = await _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
             new RepositoryIssueRequest { Mentioned = "haacked" });
 
         Assert.Equal(0, mentionsWithHaacked.Count);
@@ -241,34 +241,34 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task FilteringByInvalidAccountThrowsError()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
         await Assert.ThrowsAsync<ApiValidationException>(
-            () => _issuesClient.GetAllForRepository(owner, _repository.Name,
+            () => _issuesClient.GetAllForRepository(owner, _context.Repository.Name,
                 new RepositoryIssueRequest { Assignee = "some-random-account" }));
     }
 
     [IntegrationTest]
     public async Task CanAssignAndUnassignMilestone()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
         var newMilestone = new NewMilestone("a milestone");
-        var milestone = await _issuesClient.Milestone.Create(owner, _repository.Name, newMilestone);
+        var milestone = await _issuesClient.Milestone.Create(owner, _context.Repository.Name, newMilestone);
 
         var newIssue1 = new NewIssue("A test issue1")
         {
             Body = "A new unassigned issue",
             Milestone = milestone.Number
         };
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue1);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue1);
 
         Assert.NotNull(issue.Milestone);
 
         var issueUpdate = issue.ToUpdate();
         issueUpdate.Milestone = null;
 
-        var updatedIssue = await _issuesClient.Update(owner, _repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
 
         Assert.Null(updatedIssue.Milestone);
     }
@@ -276,9 +276,9 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task DoesNotChangeLabelsByDefault()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
-        await _issuesClient.Labels.Create(owner, _repository.Name, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
 
         var newIssue = new NewIssue("A test issue1")
         {
@@ -286,11 +286,11 @@ public class IssuesClientTests : IDisposable
         };
         newIssue.Labels.Add("something");
 
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
 
         var issueUpdate = issue.ToUpdate();
 
-        var updatedIssue = await _issuesClient.Update(owner, _repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
 
         Assert.Equal(1, updatedIssue.Labels.Count);
     }
@@ -298,11 +298,11 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanUpdateLabelForAnIssue()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
         // create some labels
-        await _issuesClient.Labels.Create(owner, _repository.Name, new NewLabel("something", "FF0000"));
-        await _issuesClient.Labels.Create(owner, _repository.Name, new NewLabel("another thing", "0000FF"));
+        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("another thing", "0000FF"));
 
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
@@ -311,13 +311,13 @@ public class IssuesClientTests : IDisposable
         };
         newIssue.Labels.Add("something");
 
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
 
         // update the issue
         var issueUpdate = issue.ToUpdate();
         issueUpdate.AddLabel("another thing");
 
-        var updatedIssue = await _issuesClient.Update(owner, _repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
 
         Assert.Equal("another thing", updatedIssue.Labels[0].Name);
     }
@@ -325,11 +325,11 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanClearLabelsForAnIssue()
     {
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
         // create some labels
-        await _issuesClient.Labels.Create(owner, _repository.Name, new NewLabel("something", "FF0000"));
-        await _issuesClient.Labels.Create(owner, _repository.Name, new NewLabel("another thing", "0000FF"));
+        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(owner, _context.Repository.Name, new NewLabel("another thing", "0000FF"));
 
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
@@ -339,14 +339,14 @@ public class IssuesClientTests : IDisposable
         newIssue.Labels.Add("something");
         newIssue.Labels.Add("another thing");
 
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
         Assert.Equal(2, issue.Labels.Count);
 
         // update the issue
         var issueUpdate = issue.ToUpdate();
         issueUpdate.ClearLabels();
 
-        var updatedIssue = await _issuesClient.Update(owner, _repository.Name, issue.Number, issueUpdate);
+        var updatedIssue = await _issuesClient.Update(owner, _context.Repository.Name, issue.Number, issueUpdate);
 
         Assert.Empty(updatedIssue.Labels);
     }
@@ -355,23 +355,23 @@ public class IssuesClientTests : IDisposable
     public async Task CanAccessUrls()
     {
         var expctedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
-        var owner = _repository.Owner.Login;
+        var owner = _context.Repository.Owner.Login;
 
         var newIssue = new NewIssue("A test issue")
         {
             Body = "A new unassigned issue",
         };
 
-        var issue = await _issuesClient.Create(owner, _repository.Name, newIssue);
+        var issue = await _issuesClient.Create(owner, _context.Repository.Name, newIssue);
 
         Assert.NotNull(issue.CommentsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, owner, _repository.Name, issue.Number, "comments")), issue.CommentsUrl);
+        Assert.Equal(new Uri(string.Format(expctedUri, owner, _context.Repository.Name, issue.Number, "comments")), issue.CommentsUrl);
         Assert.NotNull(issue.EventsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, owner, _repository.Name, issue.Number, "events")), issue.EventsUrl);
+        Assert.Equal(new Uri(string.Format(expctedUri, owner, _context.Repository.Name, issue.Number, "events")), issue.EventsUrl);
     }
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
@@ -3,27 +3,23 @@ using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class IssuesLabelsClientTests : IDisposable
 {
-    readonly IGitHubClient _gitHubClient;
-    readonly IIssuesLabelsClient _issuesLabelsClient;
-    readonly IIssuesClient _issuesClient;
-    readonly Repository _repository;
-    readonly string _repositoryOwner;
-    readonly string _repositoryName;
+    private readonly IIssuesLabelsClient _issuesLabelsClient;
+    private readonly IIssuesClient _issuesClient;
+    private readonly RepositoryContext _context;
 
     public IssuesLabelsClientTests()
     {
-        _gitHubClient = Helper.GetAuthenticatedClient();
+        var github = Helper.GetAuthenticatedClient();
 
-        _issuesLabelsClient= _gitHubClient.Issue.Labels;
-        _issuesClient = _gitHubClient.Issue;
+        _issuesLabelsClient= github.Issue.Labels;
+        _issuesClient = github.Issue;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
-        _repositoryOwner = _repository.Owner.Login;
-        _repositoryName = _repository.Name;
+        _context = github.CreateRepositoryContext(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]
@@ -32,17 +28,17 @@ public class IssuesLabelsClientTests : IDisposable
         var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
         var newLabel = new NewLabel("test label", "FFFFFF");
 
-        var label = await _issuesLabelsClient.Create(_repositoryOwner, _repository.Name, newLabel);
-        var issue = await _issuesClient.Create(_repositoryOwner, _repositoryName, newIssue);
+        var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
-        var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_repositoryOwner, _repositoryName, issue.Number);
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.Empty(issueLabelsInfo);
 
         var issueUpdate = new IssueUpdate();
         issueUpdate.AddLabel(label.Name);
-        var updated = await _issuesClient.Update(_repositoryOwner, _repository.Name, issue.Number, issueUpdate);
+        var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
         Assert.NotNull(updated);
-        issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_repositoryOwner, _repositoryName, issue.Number);
+        issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         Assert.Equal(1, issueLabelsInfo.Count);
         Assert.Equal(newLabel.Color, issueLabelsInfo[0].Color);
@@ -54,12 +50,12 @@ public class IssuesLabelsClientTests : IDisposable
         var newLabel1 = new NewLabel("test label 1", "FFFFFF");
         var newLabel2 = new NewLabel("test label 2", "FFFFFF");
 
-        var originalIssueLabels = await _issuesLabelsClient.GetAllForRepository(_repositoryOwner, _repositoryName);
+        var originalIssueLabels = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
-        await _issuesLabelsClient.Create(_repositoryOwner, _repository.Name, newLabel1);
-        await _issuesLabelsClient.Create(_repositoryOwner, _repository.Name, newLabel2);
+        await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel1);
+        await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel2);
 
-        var issueLabels = await _issuesLabelsClient.GetAllForRepository(_repositoryOwner, _repositoryName);
+        var issueLabels = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.Equal(originalIssueLabels.Count + 2, issueLabels.Count);
     }
@@ -68,10 +64,10 @@ public class IssuesLabelsClientTests : IDisposable
     public async Task CanRetrieveIssueLabelByName()
     {
         var newLabel = new NewLabel("test label 1b", "FFFFFF");
-        var label = await _issuesLabelsClient.Create(_repositoryOwner, _repository.Name, newLabel);
+        var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
         Assert.NotNull(label);
 
-        var issueLabelLookupByName = await _issuesLabelsClient.Get(_repositoryOwner, _repositoryName, label.Name);
+        var issueLabelLookupByName = await _issuesLabelsClient.Get(_context.RepositoryOwner, _context.RepositoryName, label.Name);
 
         Assert.Equal(label.Name, issueLabelLookupByName.Name);
         Assert.Equal(label.Color, issueLabelLookupByName.Color);
@@ -79,6 +75,6 @@ public class IssuesLabelsClientTests : IDisposable
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -4,34 +4,31 @@ using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class MilestonesClientTests : IDisposable
 {
-    readonly IGitHubClient _gitHubClient;
-    readonly IMilestonesClient _milestonesClient;
-    readonly Repository _repository;
-    readonly string _repositoryOwner;
-    readonly string _repositoryName;
+    private readonly IGitHubClient _github;
+    private readonly IMilestonesClient _milestonesClient;
+    private readonly RepositoryContext _context;
 
     public MilestonesClientTests()
     {
-        _gitHubClient = Helper.GetAuthenticatedClient();
+        _github = Helper.GetAuthenticatedClient();
 
-        _milestonesClient = _gitHubClient.Issue.Milestone;
+        _milestonesClient = _github.Issue.Milestone;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-        _repository = _gitHubClient.Repository.Create(new NewRepository(repoName)).Result;
-        _repositoryOwner = _repository.Owner.Login;
-        _repositoryName = _repository.Name;
+        _context = _github.CreateRepositoryContext(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]
     public async Task CanRetrieveOneMilestone()
     {
         var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
-        var created = await _milestonesClient.Create(_repositoryOwner, _repositoryName, newMilestone);
+        var created = await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
 
-        var result = await _milestonesClient.Get(_repositoryOwner, _repositoryName, created.Number);
+        var result = await _milestonesClient.Get(_context.RepositoryOwner, _context.RepositoryName, created.Number);
 
         Assert.Equal("a milestone", result.Title);
     }
@@ -39,7 +36,7 @@ public class MilestonesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanListEmptyMilestones()
     {
-        var milestones = await _milestonesClient.GetAllForRepository(_repositoryOwner, _repositoryName);
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
         
         Assert.Empty(milestones);
     }
@@ -50,11 +47,11 @@ public class MilestonesClientTests : IDisposable
         var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
         var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
         var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone1);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone2);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
 
-        var milestones = await _milestonesClient.GetAllForRepository(_repositoryOwner, _repositoryName);
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
         Assert.Equal(2, milestones.Count);
         Assert.Equal("milestone 1", milestones[0].Title);
         Assert.Equal("milestone 2", milestones[1].Title);
@@ -66,11 +63,11 @@ public class MilestonesClientTests : IDisposable
         var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
         var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
         var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone1);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone2);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
 
-        var milestones = await _milestonesClient.GetAllForRepository(_repositoryOwner, _repositoryName,
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new MilestoneRequest { SortDirection = SortDirection.Descending });
         Assert.Equal(2, milestones.Count);
         Assert.Equal("milestone 2", milestones[0].Title);
@@ -83,11 +80,11 @@ public class MilestonesClientTests : IDisposable
         var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
         var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
         var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone1);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone2);
-        await _milestonesClient.Create(_repositoryOwner, _repositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
 
-        var milestones = await _milestonesClient.GetAllForRepository(_repositoryOwner, _repositoryName,
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new MilestoneRequest { State = ItemState.Closed });
 
         Assert.Equal(1, milestones.Count);
@@ -97,17 +94,15 @@ public class MilestonesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanRetrieveClosedIssues()
     {
-        string owner = _repository.Owner.Login;
-
         var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
-        var issue1 = await _gitHubClient.Issue.Create(owner, _repository.Name, newIssue);
-        var issue2 = await _gitHubClient.Issue.Create(owner, _repository.Name, newIssue);
-        await _gitHubClient.Issue.Update(owner, _repository.Name, issue1.Number,
+        var issue1 = await _github.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+        var issue2 = await _github.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+        await _github.Issue.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number,
         new IssueUpdate { State = ItemState.Closed });
-        await _gitHubClient.Issue.Update(owner, _repository.Name, issue2.Number,
+        await _github.Issue.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number,
         new IssueUpdate { State = ItemState.Closed });
 
-        var retrieved = await _gitHubClient.Issue.GetAllForRepository(owner, _repository.Name,
+        var retrieved = await _github.Issue.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new RepositoryIssueRequest { State = ItemState.Closed });
 
         Assert.True(retrieved.Count >= 2);
@@ -117,6 +112,6 @@ public class MilestonesClientTests : IDisposable
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -6,27 +6,26 @@ using Octokit;
 using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
+using Octokit.Tests.Integration.Helpers;
 
 public class PullRequestsClientTests : IDisposable
 {
-    readonly IGitHubClient _client;
-    readonly IPullRequestsClient _fixture;
-    readonly Repository _repository;
-    readonly IRepositoryCommentsClient _repositoryCommentsClient;
+    private readonly IGitHubClient _github;
+    private readonly IPullRequestsClient _fixture;
+    private readonly RepositoryContext _context;
+    private readonly IRepositoryCommentsClient _repositoryCommentsClient;
 
     const string branchName = "my-branch";
     const string otherBranchName = "my-other-branch";
 
     public PullRequestsClientTests()
     {
-        _client = Helper.GetAuthenticatedClient();
+        _github = Helper.GetAuthenticatedClient();
 
-        _fixture = _client.Repository.PullRequest;
-        _repositoryCommentsClient = _client.Repository.RepositoryComments;
+        _fixture = _github.Repository.PullRequest;
+        _repositoryCommentsClient = _github.Repository.RepositoryComments;
 
-        var repoName = Helper.MakeNameWithTimestamp("source-repo");
-
-        _repository = _client.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
+        _context = _github.CreateRepositoryContext("source-repo").Result;
     }
 
     [IntegrationTest]
@@ -35,7 +34,7 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var result = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         Assert.Equal("a pull request", result.Title);
         Assert.False(result.Merged);
@@ -47,9 +46,9 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var result = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name);
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -61,10 +60,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var result = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var openPullRequests = new PullRequestRequest { State = ItemState.Open };
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, openPullRequests);
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -76,10 +75,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var openPullRequests = new PullRequestRequest { State = ItemState.Closed };
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, openPullRequests);
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests);
 
         Assert.Empty(pullRequests);
     }
@@ -90,10 +89,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body" };
-        var result = await _fixture.Update(Helper.UserName, _repository.Name, pullRequest.Number, updatePullRequest);
+        var result = await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
 
         Assert.Equal(updatePullRequest.Title, result.Title);
         Assert.Equal(updatePullRequest.Body, result.Body);
@@ -105,10 +104,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var updatePullRequest = new PullRequestUpdate { State = ItemState.Closed };
-        var result = await _fixture.Update(Helper.UserName, _repository.Name, pullRequest.Number, updatePullRequest);
+        var result = await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
 
         Assert.Equal(ItemState.Closed, result.State);
         Assert.Equal(pullRequest.Title, result.Title);
@@ -121,13 +120,13 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var updatePullRequest = new PullRequestUpdate { State = ItemState.Closed };
-        await _fixture.Update(Helper.UserName, _repository.Name, pullRequest.Number, updatePullRequest);
+        await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
 
         var closedPullRequests = new PullRequestRequest { State = ItemState.Closed };
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, closedPullRequests);
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, closedPullRequests);
 
         Assert.Equal(1, pullRequests.Count);
     }
@@ -138,20 +137,20 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var newPullRequest2 = new NewPullRequest("another pull request", otherBranchName, "master");
-        var anotherPullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest2);
+        var anotherPullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
 
         var updatePullRequest = new PullRequestUpdate { Body = "This is the body" };
-        await _fixture.Update(Helper.UserName, _repository.Name, pullRequest.Number, updatePullRequest);
+        await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
 
         var sortPullRequestsByUpdated = new PullRequestRequest { SortProperty = PullRequestSort.Updated, SortDirection = SortDirection.Ascending };
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, sortPullRequestsByUpdated);
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, sortPullRequestsByUpdated);
         Assert.Equal(anotherPullRequest.Title, pullRequests[0].Title);
 
         var sortPullRequestsByLongRunning = new PullRequestRequest { SortProperty = PullRequestSort.LongRunning };
-        var pullRequestsByLongRunning = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, sortPullRequestsByLongRunning);
+        var pullRequestsByLongRunning = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, sortPullRequestsByLongRunning);
         Assert.Equal(pullRequest.Title, pullRequestsByLongRunning[0].Title);
     }
 
@@ -161,15 +160,15 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var newPullRequest2 = new NewPullRequest("another pull request", otherBranchName, "master");
-        var anotherPullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest2);
+        var anotherPullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
 
-        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, new PullRequestRequest { SortDirection = SortDirection.Ascending });
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, new PullRequestRequest { SortDirection = SortDirection.Ascending });
         Assert.Equal(pullRequest.Title, pullRequests[0].Title);
 
-        var pullRequestsDescending = await _fixture.GetAllForRepository(Helper.UserName, _repository.Name, new PullRequestRequest());
+        var pullRequestsDescending = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, new PullRequestRequest());
         Assert.Equal(anotherPullRequest.Title, pullRequestsDescending[0].Title);
     }
 
@@ -179,9 +178,9 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
-        var result = await _fixture.Merged(Helper.UserName, _repository.Name, pullRequest.Number);
+        var result = await _fixture.Merged(Helper.UserName, _context.RepositoryName, pullRequest.Number);
 
         Assert.False(result);
     }
@@ -192,10 +191,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var merge = new MergePullRequest { Message = "thing the thing" };
-        var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
     }
@@ -206,10 +205,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var merge = new MergePullRequest();
-        var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
     }
@@ -219,10 +218,10 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var merge = new MergePullRequest { Message = "thing the thing", Sha = pullRequest.Head.Sha };
-        var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
     }
@@ -234,10 +233,10 @@ public class PullRequestsClientTests : IDisposable
         var fakeSha = new string('f', 40);
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var merge = new MergePullRequest { Sha = fakeSha };
-        var ex = await Assert.ThrowsAsync<ApiException>(() => _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge));
+        var ex = await Assert.ThrowsAsync<ApiException>(() => _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge));
 
         Assert.True(ex.ApiError.Message.StartsWith("Head branch was modified"));
     }
@@ -248,12 +247,12 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var merge = new MergePullRequest { Message = "thing the thing" };
-        var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
 
-        var master = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/master");
+        var master = await _github.GitDatabase.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/master");
 
         Assert.Equal(result.Sha, master.Object.Sha);
     }
@@ -264,9 +263,9 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
-        var result = await _fixture.Commits(Helper.UserName, _repository.Name, pullRequest.Number);
+        var result = await _fixture.Commits(Helper.UserName, _context.RepositoryName, pullRequest.Number);
 
         Assert.Equal(1, result.Count);
         Assert.Equal("this is the commit to merge into the pull request", result[0].Commit.Message);
@@ -278,24 +277,24 @@ public class PullRequestsClientTests : IDisposable
         await CreateTheWorld();
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
-        var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         // create new commit for branch
 
         const string commitMessage = "Another commit in branch";
 
-        var branch = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/" + branchName);
+        var branch = await _github.GitDatabase.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/" + branchName);
 
         var newTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World!" } });
         var newCommit = await CreateCommit(commitMessage, newTree.Sha, branch.Object.Sha);
-        await _client.GitDatabase.Reference.Update(Helper.UserName, _repository.Name, "heads/" + branchName, new ReferenceUpdate(newCommit.Sha));
+        await _github.GitDatabase.Reference.Update(Helper.UserName, _context.RepositoryName, "heads/" + branchName, new ReferenceUpdate(newCommit.Sha));
 
-        await _repositoryCommentsClient.Create(Helper.UserName, _repository.Name, newCommit.Sha, new NewCommitComment("I am a nice comment") { Path = "README.md", Position = 1 });
+        await _repositoryCommentsClient.Create(Helper.UserName, _context.RepositoryName, newCommit.Sha, new NewCommitComment("I am a nice comment") { Path = "README.md", Position = 1 });
 
         // don't try this at home
         await Task.Delay(TimeSpan.FromSeconds(5));
 
-        var result = await _fixture.Commits(Helper.UserName, _repository.Name, pullRequest.Number);
+        var result = await _fixture.Commits(Helper.UserName, _context.RepositoryName, pullRequest.Number);
 
         Assert.Equal(2, result.Count);
         Assert.Equal("this is the commit to merge into the pull request", result[0].Commit.Message);
@@ -330,26 +329,26 @@ public class PullRequestsClientTests : IDisposable
 
     async Task CreateTheWorld()
     {
-        var master = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/master");
+        var master = await _github.GitDatabase.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/master");
 
         // create new commit for master branch
         var newMasterTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World!" } });
         var newMaster = await CreateCommit("baseline for pull request", newMasterTree.Sha, master.Object.Sha);
 
         // update master
-        await _client.GitDatabase.Reference.Update(Helper.UserName, _repository.Name, "heads/master", new ReferenceUpdate(newMaster.Sha));
+        await _github.GitDatabase.Reference.Update(Helper.UserName, _context.RepositoryName, "heads/master", new ReferenceUpdate(newMaster.Sha));
 
         // create new commit for feature branch
         var featureBranchTree = await CreateTree(new Dictionary<string, string> { { "README.md", "I am overwriting this blob with something new" } });
         var featureBranchCommit = await CreateCommit("this is the commit to merge into the pull request", featureBranchTree.Sha, newMaster.Sha);
 
         // create branch
-        await _client.GitDatabase.Reference.Create(Helper.UserName, _repository.Name, new NewReference("refs/heads/my-branch", featureBranchCommit.Sha));
+        await _github.GitDatabase.Reference.Create(Helper.UserName, _context.RepositoryName, new NewReference("refs/heads/my-branch", featureBranchCommit.Sha));
 
         var otherFeatureBranchTree = await CreateTree(new Dictionary<string, string> { { "README.md", "I am overwriting this blob with something else" } });
         var otherFeatureBranchCommit = await CreateCommit("this is the other commit to merge into the other pull request", otherFeatureBranchTree.Sha, newMaster.Sha);
 
-        await _client.GitDatabase.Reference.Create(Helper.UserName, _repository.Name, new NewReference("refs/heads/my-other-branch", otherFeatureBranchCommit.Sha));
+        await _github.GitDatabase.Reference.Create(Helper.UserName, _context.RepositoryName, new NewReference("refs/heads/my-other-branch", otherFeatureBranchCommit.Sha));
     }
 
     async Task<TreeResponse> CreateTree(IEnumerable<KeyValuePair<string, string>> treeContents)
@@ -363,7 +362,7 @@ public class PullRequestsClientTests : IDisposable
                 Content = c.Value,
                 Encoding = EncodingType.Utf8
             };
-            var baselineBlobResult = await _client.GitDatabase.Blob.Create(Helper.UserName, _repository.Name, baselineBlob);
+            var baselineBlobResult = await _github.GitDatabase.Blob.Create(Helper.UserName, _context.RepositoryName, baselineBlob);
 
             collection.Add(new NewTreeItem
             {
@@ -380,17 +379,17 @@ public class PullRequestsClientTests : IDisposable
             newTree.Tree.Add(item);
         }
 
-        return await _client.GitDatabase.Tree.Create(Helper.UserName, _repository.Name, newTree);
+        return await _github.GitDatabase.Tree.Create(Helper.UserName, _context.RepositoryName, newTree);
     }
 
     async Task<Commit> CreateCommit(string message, string sha, string parent)
     {
         var newCommit = new NewCommit(message, sha, parent);
-        return await _client.GitDatabase.Commit.Create(Helper.UserName, _repository.Name, newCommit);
+        return await _github.GitDatabase.Commit.Create(Helper.UserName, _context.RepositoryName, newCommit);
     }
 
     public void Dispose()
     {
-        Helper.DeleteRepo(_repository);
+        _context.Dispose();
     }
 }

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -11,20 +11,15 @@ public class ReleasesClientTests
 {
     public class TheGetReleasesMethod : IDisposable
     {
-        readonly IReleasesClient _releaseClient;
-        readonly Repository _repository;
-        readonly string _repositoryOwner;
-        readonly string _repositoryName;
+        private readonly IReleasesClient _releaseClient;
+        private readonly RepositoryContext _context;
 
         public TheGetReleasesMethod()
         {
             var github = Helper.GetAuthenticatedClient();
             _releaseClient = github.Release;
 
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-            _repositoryOwner = _repository.Owner.Login;
-            _repositoryName = _repository.Name;
+            _context = github.CreateRepositoryContext("public-repo").Result;
         }
 
         [IntegrationTest]
@@ -41,9 +36,9 @@ public class ReleasesClientTests
         {
             // create a release without a publish date
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
-            var releases = await _releaseClient.GetAll(_repositoryOwner, _repositoryName);
+            var releases = await _releaseClient.GetAll(_context.RepositoryOwner, _context.RepositoryName);
 
             Assert.True(releases.Count == 1);
             Assert.False(releases.First().PublishedAt.HasValue);
@@ -51,40 +46,36 @@ public class ReleasesClientTests
 
         public void Dispose()
         {
-            Helper.DeleteRepo(_repository);
+            _context.Dispose();
         }
     }
 
     public class TheEditMethod : IDisposable
     {
-        readonly IReleasesClient _releaseClient;
-        readonly Repository _repository;
-        readonly string _repositoryOwner;
-        readonly string _repositoryName;
-        readonly IGitHubClient github;
+        private readonly IGitHubClient _github;
+        private readonly RepositoryContext _context;
+        private readonly IReleasesClient _releaseClient;
 
         public TheEditMethod()
         {
-            github = Helper.GetAuthenticatedClient();
-            _releaseClient = github.Release;
+            _github = Helper.GetAuthenticatedClient();
+            _releaseClient = _github.Release;
 
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-            _repositoryOwner = _repository.Owner.Login;
-            _repositoryName = _repository.Name;
+            _context = _github.CreateRepositoryContext("public-repo").Result;
+
         }
 
         [IntegrationTest]
         public async Task CanChangeBodyOfRelease()
         {
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            var release = await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            var release = await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
             var editRelease = release.ToUpdate();
             editRelease.Body = "**This is an updated release";
             editRelease.Draft = false;
 
-            var updatedRelease = await _releaseClient.Edit(_repositoryOwner, _repositoryName, release.Id, editRelease);
+            var updatedRelease = await _releaseClient.Edit(_context.RepositoryOwner, _context.RepositoryName, release.Id, editRelease);
 
             Assert.Equal(release.Id, updatedRelease.Id);
             Assert.False(updatedRelease.Draft);
@@ -96,17 +87,17 @@ public class ReleasesClientTests
         public async Task CanChangeCommitIshOfRelease()
         {
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            var release = await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            var release = await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
             Assert.Equal("master", release.TargetCommitish);
 
-            var newHead = await github.CreateTheWorld(_repository);
+            var newHead = await _github.CreateTheWorld(_context.Repository);
 
             var editRelease = release.ToUpdate();
             editRelease.Draft = false;
             editRelease.TargetCommitish = newHead.Object.Sha;
 
-            var updatedRelease = await _releaseClient.Edit(_repositoryOwner, _repositoryName, release.Id, editRelease);
+            var updatedRelease = await _releaseClient.Edit(_context.RepositoryOwner, _context.RepositoryName, release.Id, editRelease);
 
             Assert.Equal(release.Id, updatedRelease.Id);
             Assert.False(updatedRelease.Draft);
@@ -115,34 +106,29 @@ public class ReleasesClientTests
 
         public void Dispose()
         {
-            Helper.DeleteRepo(_repository);
+            _context.Dispose();
         }
     }
 
     public class TheUploadAssetMethod : IDisposable
     {
-        readonly IReleasesClient _releaseClient;
-        readonly Repository _repository;
-        readonly string _repositoryOwner;
-        readonly string _repositoryName;
         readonly IGitHubClient _github;
+        readonly RepositoryContext _context;
+        readonly IReleasesClient _releaseClient;
 
         public TheUploadAssetMethod()
         {
             _github = Helper.GetAuthenticatedClient();
             _releaseClient = _github.Release;
 
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            _repository = _github.Repository.Create(new NewRepository(repoName) { AutoInit = true }).Result;
-            _repositoryOwner = _repository.Owner.Login;
-            _repositoryName = _repository.Name;
+            _context = _github.CreateRepositoryContext("public-repo").Result;
         }
 
         [IntegrationTest]
         public async Task CanUploadAndRetrieveAnAsset()
         {
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            var release = await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            var release = await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
@@ -152,7 +138,7 @@ public class ReleasesClientTests
 
             Assert.True(result.Id > 0);
 
-            var assets = await _releaseClient.GetAllAssets(_repositoryOwner, _repositoryName, release.Id);
+            var assets = await _releaseClient.GetAllAssets(_context.RepositoryOwner, _context.RepositoryName, release.Id);
 
             Assert.Equal(1, assets.Count);
             var asset = assets[0];
@@ -165,19 +151,19 @@ public class ReleasesClientTests
         public async Task CanEditAnAssetLabel()
         {
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            var release = await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            var release = await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
             var newAsset = new ReleaseAssetUpload("hello-world.txt", "text/plain", stream, null);
 
             var result = await _releaseClient.UploadAsset(release, newAsset);
-            var asset = await _releaseClient.GetAsset(_repositoryOwner, _repositoryName, result.Id);
+            var asset = await _releaseClient.GetAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id);
 
             var updateAsset = asset.ToUpdate();
             updateAsset.Label = "some other thing";
 
-            var updatedAsset = await _releaseClient.EditAsset(_repositoryOwner, _repositoryName, result.Id, updateAsset);
+            var updatedAsset = await _releaseClient.EditAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id, updateAsset);
 
             Assert.Equal("some other thing", updatedAsset.Label);
         }
@@ -186,7 +172,7 @@ public class ReleasesClientTests
         public async Task CanDownloadAnAsset()
         {
             var releaseWithNoUpdate = new NewRelease("0.1") { Draft = true };
-            var release = await _releaseClient.Create(_repositoryOwner, _repositoryName, releaseWithNoUpdate);
+            var release = await _releaseClient.Create(_context.RepositoryOwner, _context.RepositoryName, releaseWithNoUpdate);
 
             var stream = Helper.LoadFixture("hello-world.txt");
 
@@ -196,7 +182,7 @@ public class ReleasesClientTests
 
             Assert.True(result.Id > 0);
 
-            var asset = await _releaseClient.GetAsset(_repositoryOwner, _repositoryName, result.Id);
+            var asset = await _releaseClient.GetAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id);
 
             Assert.Equal(result.Id, asset.Id);
 
@@ -207,7 +193,7 @@ public class ReleasesClientTests
 
         public void Dispose()
         {
-            Helper.DeleteRepo(_repository);
+            _context.Dispose();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 public class RepositoriesClientTests
@@ -16,10 +17,10 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName));
-                
-            try
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
             {
+                var createdRepository = context.Repository;
+
                 var cloneUrl = string.Format("https://github.com/{0}/{1}.git", Helper.UserName, repoName);
                 Assert.Equal(repoName, createdRepository.Name);
                 Assert.False(createdRepository.Private);
@@ -33,10 +34,6 @@ public class RepositoriesClientTests
                 Assert.True(repository.HasWiki);
                 Assert.Null(repository.Homepage);
                 Assert.NotNull(repository.DefaultBranch);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -53,25 +50,13 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("private-repo");
 
-            Repository createdRepository = null;
-
-            try
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { Private = true }))
             {
-                createdRepository = await github.Repository.Create(new NewRepository(repoName)
-                {
-                    Private = true
-                });
+                var createdRepository = context.Repository;
 
                 Assert.True(createdRepository.Private);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.True(repository.Private);
-            }
-            finally
-            {
-                if (createdRepository != null)
-                {
-                    Helper.DeleteRepo(createdRepository);
-                }
             }
         }
 
@@ -82,20 +67,15 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-downloads");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
-            {
-                HasDownloads = false
-            });
+            var newRepository = new NewRepository(repoName) { HasDownloads = false };
 
-            try
+            using (var context = await github.CreateRepositoryContext(newRepository))
             {
+                var createdRepository = context.Repository;
+
                 Assert.False(createdRepository.HasDownloads);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.False(repository.HasDownloads);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -106,20 +86,13 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-issues");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { HasIssues = false }))
             {
-                HasIssues = false
-            });
+                var createdRepository = context.Repository;
 
-            try
-            {
                 Assert.False(createdRepository.HasIssues);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.False(repository.HasIssues);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -130,20 +103,13 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-without-wiki");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { HasWiki = false }))
             {
-                HasWiki = false
-            });
+                var createdRepository = context.Repository;
 
-            try
-            {
                 Assert.False(createdRepository.HasWiki);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.False(repository.HasWiki);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -154,20 +120,13 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-description");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { Description = "theDescription" }))
             {
-                Description = "theDescription"
-            });
+                var createdRepository = context.Repository;
 
-            try
-            {
                 Assert.Equal("theDescription", createdRepository.Description);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.Equal("theDescription", repository.Description);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -178,20 +137,13 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-homepage");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { Homepage = "http://aUrl.to/nowhere" }))
             {
-                Homepage = "http://aUrl.to/nowhere"
-            });
+                var createdRepository = context.Repository;
 
-            try
-            {
                 Assert.Equal("http://aUrl.to/nowhere", createdRepository.Homepage);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.Equal("http://aUrl.to/nowhere", repository.Homepage);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -202,21 +154,14 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("repo-with-autoinit");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
             {
-                AutoInit = true
-            });
+                var createdRepository = context.Repository;
 
-            try
-            {
                 // TODO: Once the contents API has been added, check the actual files in the created repo
                 Assert.Equal(repoName, createdRepository.Name);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.Equal(repoName, repository.Name);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -226,22 +171,20 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("repo-with-gitignore");
 
-            var createdRepository = await github.Repository.Create(new NewRepository(repoName)
+            var newRepository = new NewRepository(repoName)
             {
                 AutoInit = true,
                 GitignoreTemplate = "VisualStudio"
-            });
+            };
 
-            try
+            using (var context = await github.CreateRepositoryContext(newRepository))
             {
+                var createdRepository = context.Repository;
+
                 // TODO: Once the contents API has been added, check the actual files in the created repo
                 Assert.Equal(repoName, createdRepository.Name);
                 var repository = await github.Repository.Get(Helper.UserName, repoName);
                 Assert.Equal(repoName, repository.Name);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -251,10 +194,11 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("existing-repo");
             var repository = new NewRepository(repoName);
-            var createdRepository = await github.Repository.Create(repository);
 
-            try
+            using (var context = await github.CreateRepositoryContext(repository))
             {
+                var createdRepository = context.Repository;
+
                 var message = string.Format(CultureInfo.InvariantCulture, "There is already a repository named '{0}' for the current account.", repoName);
 
                 var thrown = await Assert.ThrowsAsync<RepositoryExistsException>(
@@ -264,10 +208,6 @@ public class RepositoriesClientTests
                 Assert.Equal(repoName, thrown.RepositoryName);
                 Assert.Equal(message, thrown.Message);
                 Assert.False(thrown.OwnerIsOrganization);
-            }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
             }
         }
 
@@ -284,7 +224,7 @@ public class RepositoriesClientTests
                 throw new Exception("Test cannot complete, account is on free plan");
             }
 
-            var createRepoTasks = 
+            var createRepoTasks =
                 Enumerable.Range(0, (int)freePrivateSlots)
                 .Select(x =>
                 {
@@ -319,10 +259,10 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("public-org-repo");
 
-            var createdRepository = await github.Repository.Create(Helper.Organization, new NewRepository(repoName));
-
-            try
+            using (var context = await github.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
             {
+                var createdRepository = context.Repository;
+
                 var cloneUrl = string.Format("https://github.com/{0}/{1}.git", Helper.Organization, repoName);
                 Assert.Equal(repoName, createdRepository.Name);
                 Assert.False(createdRepository.Private);
@@ -336,10 +276,6 @@ public class RepositoriesClientTests
                 Assert.True(repository.HasWiki);
                 Assert.Null(repository.Homepage);
             }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
-            }
         }
 
         [OrganizationTest]
@@ -350,10 +286,11 @@ public class RepositoriesClientTests
             var repoName = Helper.MakeNameWithTimestamp("existing-org-repo");
 
             var repository = new NewRepository(repoName);
-            var createdRepository = await github.Repository.Create(Helper.Organization, repository);
 
-            try
+            using (var context = await github.CreateRepositoryContext(Helper.Organization, repository))
             {
+                var createdRepository = context.Repository;
+
                 var repositoryUrl = string.Format(CultureInfo.InvariantCulture, "https://github.com/{0}/{1}", Helper.Organization, repository.Name);
                 var message = string.Format(CultureInfo.InvariantCulture, "There is already a repository named '{0}' in the organization '{1}'.", repository.Name, Helper.Organization);
 
@@ -367,13 +304,9 @@ public class RepositoriesClientTests
                 Assert.Equal(Helper.Organization, thrown.Organization);
                 Assert.Equal(repositoryUrl, thrown.ExistingRepositoryWebUrl.ToString());
             }
-            finally
-            {
-                Helper.DeleteRepo(createdRepository);
-            }
         }
 
-        // TODO: Add a test for the team_id param once an overload that takes an oranization is added
+        // TODO: Add a test for the team_id param once an overload that takes an organization is added
     }
 
     public class TheEditMethod : IDisposable

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -74,7 +74,7 @@ namespace Octokit.Tests.Integration.Clients
             var fixture = client.Repository.Content;
             var repoName = Helper.MakeNameWithTimestamp("source-repo");
 
-            using(var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
             {
                 var repository = context.Repository;
 

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
@@ -70,13 +71,12 @@ namespace Octokit.Tests.Integration.Clients
         public async Task CrudTest()
         {
             var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
 
-            Repository repository = null;
-            try
+            using(var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
             {
-                var fixture = client.Repository.Content;
-                var repoName = Helper.MakeNameWithTimestamp("source-repo");
-                repository = await client.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+                var repository = context.Repository;
 
                 var file = await fixture.CreateFile(
                     repository.Owner.Login,
@@ -108,10 +108,6 @@ namespace Octokit.Tests.Integration.Clients
 
                 await Assert.ThrowsAsync<NotFoundException>(
                     async () => await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
-            }
-            finally
-            {
-                Helper.DeleteRepo(repository);
             }
         }
 

--- a/Octokit.Tests.Integration/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/StatisticsClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using Octokit.Tests.Integration.Helpers;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -6,99 +7,106 @@ namespace Octokit.Tests.Integration.Clients
 {
     public class StatisticsClientTests
     {
-        readonly IGitHubClient _client;
-        readonly ICommitsClient _fixture;
+        private readonly IGitHubClient _client;
+        private readonly ICommitsClient _fixture;
 
         public StatisticsClientTests()
         {
             _client = Helper.GetAuthenticatedClient();
-
             _fixture = _client.GitDatabase.Commit;
         }
 
         [IntegrationTest]
         public async Task CanCreateAndRetrieveContributors()
         {
-            var repository = await CreateRepository();
-            await CommitToRepository(repository);
-            var contributors = await _client.Repository.Statistics.GetContributors(repository.Owner, repository.Name);
+            using (var context = await _client.CreateRepositoryContext("public-repo"))
+            {
+                var repository = new RepositorySummary(context);
+                await CommitToRepository(repository);
+                var contributors = await _client.Repository.Statistics.GetContributors(repository.Owner, repository.Name);
 
-            Assert.NotNull(contributors);
-            Assert.Equal(1, contributors.Count);
+                Assert.NotNull(contributors);
+                Assert.Equal(1, contributors.Count);
 
-            var soleContributor = contributors.First();
-            Assert.NotNull(soleContributor.Author);
-            Assert.True(soleContributor.Author.Login == repository.Owner);
+                var soleContributor = contributors.First();
+                Assert.NotNull(soleContributor.Author);
+                Assert.True(soleContributor.Author.Login == repository.Owner);
 
-            Assert.Equal(1, soleContributor.Weeks.Count);
-            Assert.Equal(1, soleContributor.Total);
+                Assert.Equal(1, soleContributor.Weeks.Count);
+                Assert.Equal(1, soleContributor.Total);
+            }
         }
 
         [IntegrationTest]
         public async Task CanCreateAndRetrieveEmptyContributors()
         {
-            var repository = await CreateRepository(autoInit: false);
-            var contributors = await _client.Repository.Statistics.GetContributors(repository.Owner, repository.Name);
+            var newRepository = new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = false };
+            using (var context = await _client.CreateRepositoryContext(newRepository))
+            {
+                var repository = new RepositorySummary(context);
+                var contributors = await _client.Repository.Statistics.GetContributors(repository.Owner, repository.Name);
 
-            Assert.NotNull(contributors);
-            Assert.Empty(contributors);
+                Assert.NotNull(contributors);
+                Assert.Empty(contributors);
+            }
         }
 
         [IntegrationTest]
         public async Task CanGetCommitActivityForTheLastYear()
         {
-            var repository = await CreateRepository();
-            await CommitToRepository(repository);
-            var commitActivities = await _client.Repository.Statistics.GetCommitActivity(repository.Owner, repository.Name);
-            Assert.NotNull(commitActivities);
-            Assert.Equal(52, commitActivities.Activity.Count);
+            using (var context = await _client.CreateRepositoryContext("public-repo"))
+            {
+                var repository = new RepositorySummary(context);
+                await CommitToRepository(repository);
+                var commitActivities = await _client.Repository.Statistics.GetCommitActivity(repository.Owner, repository.Name);
+                Assert.NotNull(commitActivities);
+                Assert.Equal(52, commitActivities.Activity.Count);
 
-            var thisWeek = commitActivities.Activity.Last();
-            Assert.Equal(1, thisWeek.Total);
-            Assert.NotNull(thisWeek.Days);
+                var thisWeek = commitActivities.Activity.Last();
+                Assert.Equal(1, thisWeek.Total);
+                Assert.NotNull(thisWeek.Days);
+            }
         }
 
         [IntegrationTest]
         public async Task CanGetAdditionsAndDeletionsPerWeek()
         {
-            var repository = await CreateRepository();
-            await CommitToRepository(repository);
-            var commitActivities = await _client.Repository.Statistics.GetCodeFrequency(repository.Owner, repository.Name);
-            Assert.NotNull(commitActivities);
-            Assert.True(commitActivities.AdditionsAndDeletionsByWeek.Any());
+            using (var context = await _client.CreateRepositoryContext("public-repo"))
+            {
+                var repository = new RepositorySummary(context);
+                await CommitToRepository(repository);
+                var commitActivities = await _client.Repository.Statistics.GetCodeFrequency(repository.Owner, repository.Name);
+                Assert.NotNull(commitActivities);
+                Assert.True(commitActivities.AdditionsAndDeletionsByWeek.Any());
+            }
         }
 
         [IntegrationTest]
         public async Task CanGetParticipationStatistics()
         {
-            var repository = await CreateRepository();
-            await CommitToRepository(repository);
-            var weeklyCommitCounts = await _client.Repository.Statistics.GetParticipation(repository.Owner, repository.Name);
-            Assert.Equal(52, weeklyCommitCounts.All.Count);
+            using (var context = await _client.CreateRepositoryContext("public-repo"))
+            {
+                var repository = new RepositorySummary(context);
+                await CommitToRepository(repository);
+                var weeklyCommitCounts = await _client.Repository.Statistics.GetParticipation(repository.Owner, repository.Name);
+                Assert.Equal(52, weeklyCommitCounts.All.Count);
+            }
         }
 
         [IntegrationTest]
         public async Task CanGetPunchCardForRepository()
         {
-            var repository = await CreateRepository();
-            await CommitToRepository(repository);
-            var punchCard = await _client.Repository.Statistics.GetPunchCard(repository.Owner, repository.Name);
-            Assert.NotNull(punchCard);
-            Assert.NotNull(punchCard.PunchPoints);
-        }
-
-        async Task<RepositorySummary> CreateRepository(bool autoInit = true)
-        {
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            var repository = await _client.Repository.Create(new NewRepository(repoName) { AutoInit = autoInit });
-            return new RepositorySummary
+            using (var context = await _client.CreateRepositoryContext("public-repo"))
             {
-                Owner = repository.Owner.Login,
-                Name = repoName
-            };
+                var repository = new RepositorySummary(context);
+                await CommitToRepository(repository);
+                var punchCard = await _client.Repository.Statistics.GetPunchCard(repository.Owner, repository.Name);
+                Assert.NotNull(punchCard);
+                Assert.NotNull(punchCard.PunchPoints);
+            }
         }
 
-        async Task<Commit> CommitToRepository(RepositorySummary repositorySummary)
+        private async Task<Commit> CommitToRepository(RepositorySummary repositorySummary)
         {
             var owner = repositorySummary.Owner;
             var repository = repositorySummary.Name;
@@ -126,11 +134,17 @@ namespace Octokit.Tests.Integration.Clients
             return commit;
         }
 
-        class RepositorySummary
+        private class RepositorySummary
         {
-            public string Name { get; set; }
+            public RepositorySummary(RepositoryContext context)
+            {
+                Name = context.Repository.Name;
+                Owner = context.Repository.Owner.Login;
+            }
 
-            public string Owner { get; set; }
+            public string Name { get; private set; }
+
+            public string Owner { get; private set; }
         }
     }
 }

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Tests.Integration.Helpers
+{
+    internal static class GithubClientExtensions
+    {
+        internal async static Task<RepositoryContext> CreateRepositoryContext(this IGitHubClient client, string repositoryName)
+        {
+            var repoName = Helper.MakeNameWithTimestamp(repositoryName);
+            var repo = await client.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+
+            return new RepositoryContext(repo);
+        }
+
+        internal async static Task<RepositoryContext> CreateRepositoryContext(this IGitHubClient client, string organizationLogin, NewRepository newRepository)
+        {
+            var repo = await client.Repository.Create(organizationLogin, newRepository);
+
+            return new RepositoryContext(repo);
+        }
+
+        internal async static Task<RepositoryContext> CreateRepositoryContext(this IGitHubClient client, NewRepository newRepository)
+        {
+            var repo = await client.Repository.Create(newRepository);
+
+            return new RepositoryContext(repo);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
@@ -11,7 +11,12 @@ namespace Octokit.Tests.Integration.Helpers
         internal RepositoryContext(Repository repo)
         {
             Repository = repo;
+            RepositoryOwner = repo.Owner.Login;
+            RepositoryName = repo.Name;
         }
+
+        internal string RepositoryOwner { get; private set; }
+        internal string RepositoryName { get; private set; }
 
         internal Repository Repository { get; private set; }
 

--- a/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Tests.Integration.Helpers
+{
+    internal sealed class RepositoryContext : IDisposable
+    {
+        internal RepositoryContext(Repository repo)
+        {
+            Repository = repo;
+        }
+
+        internal Repository Repository { get; private set; }
+
+        public void Dispose()
+        {
+            Helper.DeleteRepo(Repository);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -102,8 +102,10 @@
     <Compile Include="fixtures\RepositoriesHooksCollection.cs" />
     <Compile Include="fixtures\RepositoriesHooksFixture.cs" />
     <Compile Include="Helpers\ApplicationTestAttribute.cs" />
+    <Compile Include="Helpers\GithubClientExtensions.cs" />
     <Compile Include="Helpers\PersonalAccessTokenTestAttribute.cs" />
     <Compile Include="Helpers\PaidAccountTestAttribute.cs" />
+    <Compile Include="Helpers\RepositoryContext.cs" />
     <Compile Include="Helpers\RepositorySetupHelper.cs" />
     <Compile Include="HttpClientAdapterTests.cs" />
     <Compile Include="Clients\TeamsClientTests.cs" />


### PR DESCRIPTION
This solves Issue #655 

I created the structure and refactored the `RepositoriesClientTests` as a way to test what the new syntax looks like. It looks good, but having to write  `var createdRepository = context.Repository;` every  time is kinda boring, I wonder if this can be simplified somehow.

If this looks good I'll refactor the other test classes to use the new syntax as well

____
Those use the same repository for multiple tests, so they won't have the nice `using` syntax. I'll change them for consistency, though

 - [x] AssigneesClientTests.cs
 - [x] BlobClientTests.cs
 - [x] CommitsClientTests.cs
 - [x] CommitStatusClientTests.cs
 - [x] DeploymentsClientTests.cs
 - [x] DeploymentStatusClientTests.cs
 - [x] IssuesClientTests.cs
 - [x] IssuesEventsClientTests.cs
 - [x] IssuesLabelsClientTests.cs
 - [x] MergingClientTests.cs
 - [x] MilestonesClientTests.cs
 - [x] PullRequestReviewCommentsClientTests.cs
 - [x] PullRequestsClientTests.cs
 - [x] ReferencesClientTests.cs
 - [x] ReleasesClientTests.cs
 - [x] RepositoryCommitsClientTests.cs
 - [x] RepositoryDeployKeysClientTests.cs
 - [x] TreeClientTests.cs
 - [x] ObservableIssuesClientTests.cs

`RepositoryHooksClientTests`, however, uses the `RepositoriesHooksFixture` class, I wonder if this shoud be replaced to use the new context approach or not