### PR TITLE
[WIP] Add new org api parameters

### DIFF
--- a/Octokit/Models/Request/RepositoryRequest.cs
+++ b/Octokit/Models/Request/RepositoryRequest.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// The type.
         /// </value>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public RepositoryType Type { get; set; }
+        public RepositoryType? Type { get; set; }
 
         /// <summary>
         /// Gets or sets the sort property.
@@ -36,6 +36,10 @@ namespace Octokit
         /// The direction.
         /// </value>
         public SortDirection Direction { get; set; }
+
+        public RepositoryAffiliation? Affiliation { get; set; }
+
+        public RepositoryVisibility? Visibility { get; set; }
 
         internal string DebuggerDisplay
         {
@@ -102,5 +106,20 @@ namespace Octokit
         /// </summary>
         [Parameter(Value = "full_name")]
         FullName
+    }
+
+    [Flags]
+    public enum RepositoryAffiliation
+    {
+        Owner = 1,
+        Collaborator = 2,
+        Organization_Member = 4
+    }
+
+    public enum RepositoryVisibility
+    {
+        All,
+        Public,
+        Private
     }
 }

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -91,7 +91,7 @@ namespace Octokit
                             var name = att.Key;
                             var val = att.Value ?? name;
                             var ret = Enum.Parse(type, name) as Enum;
-                            if (obj.HasFlag(ret))
+                            if (obj != null && obj.HasFlag(ret))
                                 values.Add(val.ToLowerInvariant());
                         }
                         return string.Join(",", values);

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -49,6 +49,9 @@ namespace Octokit
             Justification = "GitHub API depends on lower case strings")]
         static Func<PropertyInfo, object, string> GetValueFunc(Type propertyType)
         {
+            if (propertyType.IsNullable())
+                propertyType = Nullable.GetUnderlyingType(propertyType);
+
             if (typeof(IEnumerable<string>).IsAssignableFrom(propertyType))
             {
                 return (prop, value) =>
@@ -76,10 +79,30 @@ namespace Octokit
                 {
                     if (value == null) return null;
                     string attributeValue;
+                    var type = prop.PropertyType;
+                    if (type.IsNullable())
+                        type = Nullable.GetUnderlyingType(type);
 
-                    return enumToAttributeDictionary.TryGetValue(value.ToString(), out attributeValue)
-                        ? attributeValue ?? value.ToString().ToLowerInvariant()
-                        : value.ToString().ToLowerInvariant();
+                    if (type.IsDefined(typeof(FlagsAttribute)))
+                    {
+                        var obj = Enum.ToObject(type, value) as Enum;
+                        var values = new List<string>();
+                        foreach(var att in enumToAttributeDictionary)
+                        {
+                            var name = att.Key;
+                            var val = att.Value ?? name;
+                            var ret = Enum.Parse(type, name) as Enum;
+                            if (obj.HasFlag(ret))
+                                values.Add(val.ToLowerInvariant());
+                        }
+                        return string.Join(",", values);
+                    }
+                    else
+                    {
+                        return enumToAttributeDictionary.TryGetValue(value.ToString(), out attributeValue)
+                            ? attributeValue ?? value.ToString().ToLowerInvariant()
+                            : value.ToString().ToLowerInvariant();
+                    }
                 };
             }
 

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -78,7 +78,6 @@ namespace Octokit
                 return (prop, value) =>
                 {
                     if (value == null) return null;
-                    string attributeValue;
                     var type = prop.PropertyType;
                     if (type.IsNullable())
                         type = Nullable.GetUnderlyingType(type);
@@ -99,6 +98,7 @@ namespace Octokit
                     }
                     else
                     {
+                        string attributeValue;
                         return enumToAttributeDictionary.TryGetValue(value.ToString(), out attributeValue)
                             ? attributeValue ?? value.ToString().ToLowerInvariant()
                             : value.ToString().ToLowerInvariant();

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -83,7 +83,7 @@ namespace Octokit
                     if (type.IsNullable())
                         type = Nullable.GetUnderlyingType(type);
 
-                    if (type.IsDefined(typeof(FlagsAttribute)))
+                    if (type.GetTypeInfo().IsDefined(typeof(FlagsAttribute)))
                     {
                         var obj = Enum.ToObject(type, value) as Enum;
                         var values = new List<string>();

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -85,15 +85,15 @@ namespace Octokit
                     if (type.GetTypeInfo().IsDefined(typeof(FlagsAttribute)))
                     {
                         var obj = Enum.ToObject(type, value) as Enum;
-                        var values = new List<string>();
-                        foreach(var att in enumToAttributeDictionary)
-                        {
-                            var name = att.Key;
-                            var val = att.Value ?? name;
-                            var ret = Enum.Parse(type, name) as Enum;
-                            if (obj != null && obj.HasFlag(ret))
-                                values.Add(val.ToLowerInvariant());
-                        }
+                        var values =
+                        (
+                            from att in enumToAttributeDictionary
+                            let name = att.Key
+                            let val = att.Value ?? name
+                            let ret = Enum.Parse(type, name) as Enum
+                            where obj != null && obj.HasFlag(ret)
+                            select val.ToLowerInvariant()
+                        ).ToList();
                         return string.Join(",", values);
                     }
                     else


### PR DESCRIPTION
`Type` and `Affiliation/Visibility` are exclusive, if one is set the other
can't be, so the enum properties have to be nullable. The default
behaviour when no parameters are passed is whatever the new default
behaviour is on the server for the new api (currently, it is
`Visibility` = `All` and `Affiliation` = `Owner | Collaborator`).

- [ ] Add unit tests
- [ ] Update integration tests
- [ ] Test it

Replaces PR #780