### PR TITLE
Add a bunch of XML doc comments

### DIFF
--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -52,7 +52,7 @@ public class DeploymentStatusClientTests : IDisposable
     [IntegrationTest]
     public async Task CanCreateDeploymentStatus()
     {
-        var newStatus = new NewDeploymentStatus { State = DeploymentState.Success };
+        var newStatus = new NewDeploymentStatus(DeploymentState.Success);
 
         var status = await _deploymentsClient.Status.Create(_repositoryOwner, _repository.Name, _deployment.Id, newStatus);
 
@@ -63,7 +63,7 @@ public class DeploymentStatusClientTests : IDisposable
     [IntegrationTest]
     public async Task CanReadDeploymentStatuses()
     {
-        var newStatus = new NewDeploymentStatus { State = DeploymentState.Success };
+        var newStatus = new NewDeploymentStatus(DeploymentState.Success);
         await _deploymentsClient.Status.Create(_repositoryOwner, _repository.Name, _deployment.Id, newStatus);
 
         var statuses = await _deploymentsClient.Status.GetAll(_repositoryOwner, _repository.Name, _deployment.Id);

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -194,7 +194,7 @@ public class PullRequestsClientTests : IDisposable
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
 
-        var merge = new MergePullRequest { Message = "thing the thing" };
+        var merge = new MergePullRequest { CommitMessage = "thing the thing" };
         var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
@@ -221,7 +221,7 @@ public class PullRequestsClientTests : IDisposable
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
 
-        var merge = new MergePullRequest { Message = "thing the thing", Sha = pullRequest.Head.Sha };
+        var merge = new MergePullRequest { CommitMessage = "thing the thing", Sha = pullRequest.Head.Sha };
         var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
@@ -250,7 +250,7 @@ public class PullRequestsClientTests : IDisposable
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _repository.Name, newPullRequest);
 
-        var merge = new MergePullRequest { Message = "thing the thing" };
+        var merge = new MergePullRequest { CommitMessage = "thing the thing" };
         var result = await _fixture.Merge(Helper.UserName, _repository.Name, pullRequest.Number, merge);
 
         var master = await _client.GitDatabase.Reference.Get(Helper.UserName, _repository.Name, "heads/master");

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -72,7 +72,8 @@ public class TeamsClientTests
         {
             var github = Helper.GetBadCredentialsClient();
 
-            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.IsMember(team.Id, Helper.UserName));
+            var e = await Assert.ThrowsAsync<AuthorizationException>(
+                () => github.Organization.Team.GetMembership(team.Id, Helper.UserName));
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -1,11 +1,8 @@
-﻿using NSubstitute;
-using Octokit;
-using Octokit.Tests.Helpers;
-using System;
-using System.Collections.Generic;
-using Xunit;
-using Xunit.Extensions;
+﻿using System;
 using System.Threading.Tasks;
+using NSubstitute;
+using Octokit;
+using Xunit;
 
 public class DeploymentStatusClientTests
 {
@@ -57,7 +54,7 @@ public class DeploymentStatusClientTests
 
     public class TheCreateMethod
     {
-        readonly NewDeploymentStatus newDeploymentStatus = new NewDeploymentStatus();
+        readonly NewDeploymentStatus newDeploymentStatus = new NewDeploymentStatus(DeploymentState.Success);
 
         [Fact]
         public async Task EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -1,11 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
-using Octokit.Tests.Helpers;
-using System;
-using System.Collections.Generic;
 using Xunit;
-using Xunit.Extensions;
 
 public class DeploymentsClientTests
 {
@@ -57,7 +54,7 @@ public class DeploymentsClientTests
 
     public class TheCreateMethod
     {
-        readonly NewDeployment newDeployment = new NewDeployment { Ref = "aRef" };
+        readonly NewDeployment newDeployment = new NewDeployment("aRef");
 
         [Fact]
         public async Task EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -140,7 +139,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void PutsToCorrectUrl()
             {
-                var mergePullRequest = new MergePullRequest { Message = "fake commit message" };
+                var mergePullRequest = new MergePullRequest { CommitMessage = "fake commit message" };
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
@@ -157,9 +156,9 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge(null, "name", 42, new MergePullRequest { Message = "message" }));
+                    client.Merge(null, "name", 42, new MergePullRequest { CommitMessage = "message" }));
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge("owner", null, 42, new MergePullRequest { Message = "message" }));
+                    client.Merge("owner", null, 42, new MergePullRequest { CommitMessage = "message" }));
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }

--- a/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
@@ -7,7 +7,6 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-
 namespace Octokit.Tests.Reactive
 {
     public class ObservableDeploymentStatusClientTests
@@ -62,7 +61,7 @@ namespace Octokit.Tests.Reactive
 
         public class TheCreateMethod
         {
-            IGitHubClient _githubClient = Substitute.For<IGitHubClient>();
+            readonly IGitHubClient _githubClient = Substitute.For<IGitHubClient>();
             ObservableDeploymentStatusClient _client;
 
             public void SetupWithoutNonReactiveClient()
@@ -81,8 +80,8 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 SetupWithNonReactiveClient();
-                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", 1, new NewDeploymentStatus()));
-                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, 1, new NewDeploymentStatus()));
+                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
+                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, 1, new NewDeploymentStatus(DeploymentState.Success)));
                 Assert.Throws<ArgumentNullException>(() => _client.Create("owner", "repo", 1, null));
             }
 
@@ -90,8 +89,8 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonEmptyArguments()
             {
                 SetupWithNonReactiveClient();
-                Assert.Throws<ArgumentException>(() => _client.Create("", "repo", 1, new NewDeploymentStatus()));
-                Assert.Throws<ArgumentException>(() => _client.Create("owner", "", 1, new NewDeploymentStatus()));
+                Assert.Throws<ArgumentException>(() => _client.Create("", "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
+                Assert.Throws<ArgumentException>(() => _client.Create("owner", "", 1, new NewDeploymentStatus(DeploymentState.Success)));
             }
 
             [Fact]
@@ -99,9 +98,9 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithNonReactiveClient();
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.Create(whitespace, "repo", 1, new NewDeploymentStatus()));
+                    async whitespace => await _client.Create(whitespace, "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.Create("owner", whitespace, 1, new NewDeploymentStatus()));
+                    async whitespace => await _client.Create("owner", whitespace, 1, new NewDeploymentStatus(DeploymentState.Success)));
             }
 
             [Fact]
@@ -109,7 +108,7 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                var newStatus = new NewDeploymentStatus();
+                var newStatus = new NewDeploymentStatus(DeploymentState.Success);
                 _client.Create("owner", "repo", 1, newStatus);
                 _githubClient.Repository.Deployment.Status.Received(1)
                     .Create(Arg.Is("owner"),

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -1,12 +1,11 @@
-﻿using NSubstitute;
-using Octokit.Reactive.Clients;
-using Octokit.Tests.Helpers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive.Clients;
+using Octokit.Tests.Helpers;
 using Xunit;
-using System.Linq;
 
 namespace Octokit.Tests.Reactive
 {
@@ -86,8 +85,8 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithNonReactiveClient();
 
-                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", new NewDeployment()));
-                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, new NewDeployment()));
+                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", new NewDeployment("ref")));
+                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, new NewDeployment("ref")));
                 Assert.Throws<ArgumentNullException>(() => _client.Create("owner", "repo", null));
             }
 
@@ -96,8 +95,8 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithNonReactiveClient();
 
-                Assert.Throws<ArgumentException>(() => _client.Create("", "repo", new NewDeployment()));
-                Assert.Throws<ArgumentException>(() => _client.Create("owner", "", new NewDeployment()));
+                Assert.Throws<ArgumentException>(() => _client.Create("", "repo", new NewDeployment("ref")));
+                Assert.Throws<ArgumentException>(() => _client.Create("owner", "", new NewDeployment("ref")));
             }
 
             [Fact]
@@ -106,9 +105,9 @@ namespace Octokit.Tests.Reactive
                 SetupWithNonReactiveClient();
 
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.Create(whitespace, "repo", new NewDeployment()));
+                    async whitespace => await _client.Create(whitespace, "repo", new NewDeployment("ref")));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.Create("owner", whitespace, new NewDeployment()));
+                    async whitespace => await _client.Create("owner", whitespace, new NewDeployment("ref")));
             }
 
             [Fact]
@@ -116,7 +115,7 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                var newDeployment = new NewDeployment();
+                var newDeployment = new NewDeployment("ref");
                 _client.Create("owner", "repo", newDeployment);
                 _githubClient.Repository.Deployment.Received(1).Create(Arg.Is("owner"),
                                                             Arg.Is("repo"),

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -225,7 +225,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void MergesPullRequest()
             {
-                var mergePullRequest = new MergePullRequest { Message = "fake commit message" };
+                var mergePullRequest = new MergePullRequest { CommitMessage = "fake commit message" };
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
@@ -241,9 +241,9 @@ namespace Octokit.Tests.Reactive
                 var client = new PullRequestsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge(null, "name", 42, new MergePullRequest { Message = "message" }));
+                    client.Merge(null, "name", 42, new MergePullRequest { CommitMessage = "message" }));
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge("owner", null, 42, new MergePullRequest { Message = "message" }));
+                    client.Merge("owner", null, 42, new MergePullRequest { CommitMessage = "message" }));
                 await Assert.ThrowsAsync<ArgumentNullException>(() =>
                     client.Merge("owner", "name", 42, null));
             }

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -10,6 +10,10 @@ namespace Octokit
     /// </remarks>
     public class MergingClient : ApiClient, IMergingClient
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergingClient"/> class.
+        /// </summary>
+        /// <param name="apiConnection">The client's connection</param>
         public MergingClient(IApiConnection apiConnection) : base(apiConnection)
         {
         }

--- a/Octokit/Models/Request/BaseSearchRequest.cs
+++ b/Octokit/Models/Request/BaseSearchRequest.cs
@@ -11,6 +11,9 @@ namespace Octokit
     [SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors")]
     public abstract class BaseSearchRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseSearchRequest"/> class.
+        /// </summary>
         protected BaseSearchRequest()
         {
             Page = 1;
@@ -18,6 +21,10 @@ namespace Octokit
             Order = SortDirection.Descending;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseSearchRequest"/> class.
+        /// </summary>
+        /// <param name="term">The term.</param>
         protected BaseSearchRequest(string term) : this()
         {
             Ensure.ArgumentNotNullOrEmptyString(term, "term");
@@ -37,6 +44,12 @@ namespace Octokit
             get;
         }
 
+        /// <summary>
+        /// Gets the sort order as a properly formatted lowercased query string parameter.
+        /// </summary>
+        /// <value>
+        /// The sort order.
+        /// </value>
         private string SortOrder
         {
             get

--- a/Octokit/Models/Request/BodyWrapper.cs
+++ b/Octokit/Models/Request/BodyWrapper.cs
@@ -1,12 +1,25 @@
 ﻿namespace Octokit
 {
+    /// <summary>
+    /// Wraps a string for the body of a request.
+    /// </summary>
     public class BodyWrapper
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BodyWrapper"/> class.
+        /// </summary>
+        /// <param name="body">The body.</param>
         public BodyWrapper(string body)
         {
             Body = body;
         }
 
+        /// <summary>
+        /// Gets the body.
+        /// </summary>
+        /// <value>
+        /// The body.
+        /// </value>
         public string Body { get; private set; } 
     }
 }

--- a/Octokit/Models/Request/CommitRequest.cs
+++ b/Octokit/Models/Request/CommitRequest.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Encapsulates the parameters for a request to retrieve commits.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CommitRequest : RequestParameters
     {

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -8,9 +8,12 @@ namespace Octokit
     /// <summary>
     /// Base class with common properties for all the Repository Content Request APIs.
     /// </summary>
-    /// 
     public abstract class ContentRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContentRequest"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
         protected ContentRequest(string message)
         {
             Ensure.ArgumentNotNullOrEmptyString(message, "message");
@@ -45,6 +48,11 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class DeleteFileRequest : ContentRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteFileRequest"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="sha">The sha.</param>
         public DeleteFileRequest(string message, string sha) : base(message)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");

--- a/Octokit/Models/Request/EditRepositoryHook.cs
+++ b/Octokit/Models/Request/EditRepositoryHook.cs
@@ -6,13 +6,22 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Represents the requested changes to an edit repository hook.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class EditRepositoryHook
     {
-        public EditRepositoryHook()
-            : this(null)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditRepositoryHook"/> class.
+        /// </summary>
+        public EditRepositoryHook() : this(null)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EditRepositoryHook"/> class.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
         public EditRepositoryHook(IDictionary<string, string> config)
         {
             Config = config;
@@ -20,14 +29,32 @@ namespace Octokit
 
         public IDictionary<string, string> Config { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the events.
+        /// </summary>
+        /// <value>
+        /// The events.
+        /// </value>
         public IEnumerable<string> Events { get; set; }
 
         [Parameter(Key = "add_events")]
         public IEnumerable<string> AddEvents { get; set; }
 
+        /// <summary>
+        /// Gets or sets the remove events.
+        /// </summary>
+        /// <value>
+        /// The remove events.
+        /// </value>
         [Parameter(Key = "remove_events")]
         public IEnumerable<string> RemoveEvents { get; set; }
 
+        /// <summary>
+        /// Gets or sets the active.
+        /// </summary>
+        /// <value>
+        /// The active.
+        /// </value>
         public bool? Active { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/GistFileUpdate.cs
+++ b/Octokit/Models/Request/GistFileUpdate.cs
@@ -4,11 +4,29 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used as part of a <see cref="GistUpdate" /> to update the name or contents of an existing gist file
+    /// </summary>
+    /// <remarks>
+    /// API docs: https://developer.github.com/v3/gists/
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistFileUpdate
     {
+        /// <summary>
+        /// Gets or sets the new name of the file.
+        /// </summary>
+        /// <value>
+        /// The new name of the file.
+        /// </value>
         public string NewFileName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
         public string Content { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/GistRequest.cs
+++ b/Octokit/Models/Request/GistRequest.cs
@@ -4,14 +4,33 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to request Gists since a certain date.
+    /// </summary>
+    /// <remarks>
+    /// API docs: https://developer.github.com/v3/gists/
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GistRequest"/> class.
+        /// </summary>
+        /// <param name="since">The date for which only gists updated at or after this time are returned.</param>
         public GistRequest(DateTimeOffset since)
         {
             Since = since;
         }
 
+        /// <summary>
+        /// Gets or sets the date for which only gists updated at or after this time are returned.
+        /// </summary>
+        /// <remarks>
+        /// This is sent as a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ 
+        /// </remarks>
+        /// <value>
+        /// The since.
+        /// </value>
         public DateTimeOffset Since { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/GistUpdate.cs
+++ b/Octokit/Models/Request/GistUpdate.cs
@@ -5,6 +5,14 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update a gist and its contents.
+    /// </summary>
+    /// <remarks>
+    /// Note: All files from the previous version of the gist are carried over by default if not included in the
+    ///  object. Deletes can be performed by including the filename with a null object.
+    /// API docs: https://developer.github.com/v3/gists/
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class GistUpdate
     {
@@ -19,8 +27,8 @@ namespace Octokit
         /// Gets a dictionary of gist files to update.
         /// </summary>
         /// <remarks>
-        /// Note: All files from the previous version of the gist are carried over by default if not included in the hash. 
-        /// Deletes can be performed by including the filename with a `null` hash.
+        /// Note: All files from the previous version of the gist are carried over by default if not included in the
+        /// hash. Deletes can be performed by including the filename with a `null` hash.
         /// </remarks>
         public IDictionary<string, GistFileUpdate> Files { get; private set; }
 

--- a/Octokit/Models/Request/IssueRequest.cs
+++ b/Octokit/Models/Request/IssueRequest.cs
@@ -6,9 +6,15 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to filter a request to list issues.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IssueRequest"/> class.
+        /// </summary>
         public IssueRequest()
         {
             Filter = IssueFilter.Assigned;
@@ -18,13 +24,59 @@ namespace Octokit
             SortDirection = SortDirection.Descending;
         }
 
+        /// <summary>
+        /// Gets or sets the <see cref="IssueFilter" /> which indicates which sorts of issues to return.
+        /// </summary>
+        /// <value>
+        /// The filter.
+        /// </value>
         public IssueFilter Filter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ItemState"/> for the issues to return.
+        /// </summary>
+        /// <value>
+        /// The state.
+        /// </value>
         public ItemState State { get; set; }
+
+        /// <summary>
+        /// Gets the labels to filter by. Add labels to the collection to only request issues with those labels.
+        /// </summary>
+        /// <remarks>Sent as a comma separated list</remarks>
+        /// <value>
+        /// The labels.
+        /// </value>
         public Collection<string> Labels { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IssueSort"/> property to sort the returned issues by.
+        /// Combine this with <see cref="SortDirection"/> to specify sort direction.
+        /// </summary>
+        /// <value>
+        /// The sort property.
+        /// </value>
         [Parameter(Key = "sort")]
         public IssueSort SortProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sort direction.
+        /// </summary>
+        /// <value>
+        /// The sort direction.
+        /// </value>
         [Parameter(Key = "direction")]
         public SortDirection SortDirection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date for which only issues updated at or after this time are returned.
+        /// </summary>
+        /// <remarks>
+        /// This is sent as a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.
+        /// </remarks>
+        /// <value>
+        /// The since.
+        /// </value>
         public DateTimeOffset? Since { get; set; }
 
         internal string DebuggerDisplay
@@ -37,7 +89,7 @@ namespace Octokit
     }
 
     /// <summary>
-    /// 
+    /// The range of filters available for issues.
     /// </summary>
     /// <remarks>http://developer.github.com/v3/issues/#list-issues</remarks>
     public enum IssueFilter
@@ -68,6 +120,9 @@ namespace Octokit
         All
     }
 
+    /// <summary>
+    /// The range of states that an issue can be in.
+    /// </summary>
     public enum ItemState
     {
         /// <summary>
@@ -86,6 +141,9 @@ namespace Octokit
         All
     }
 
+    /// <summary>
+    /// The available properties to sort issues by.
+    /// </summary>
     public enum IssueSort
     {
         /// <summary>
@@ -104,11 +162,20 @@ namespace Octokit
         Comments
     }
 
+    /// <summary>
+    /// The two possible sort directions.
+    /// </summary>
     public enum SortDirection
     {
+        /// <summary>
+        /// Sort ascending
+        /// </summary>
         [Parameter(Value = "asc")]
         Ascending,
 
+        /// <summary>
+        /// Sort descending
+        /// </summary>
         [Parameter(Value = "desc")]
         Descending
     }

--- a/Octokit/Models/Request/IssueUpdate.cs
+++ b/Octokit/Models/Request/IssueUpdate.cs
@@ -6,6 +6,9 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Specifies the values used to update an issue.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueUpdate
     {
@@ -59,6 +62,10 @@ namespace Octokit
             }
         }
 
+        /// <summary>
+        /// Adds the specified label to the issue.
+        /// </summary>
+        /// <param name="name">The name of the label.</param>
         public void AddLabel(string name)
         {
             // lazily create the label array
@@ -70,6 +77,9 @@ namespace Octokit
             Labels.Add(name);
         }
 
+        /// <summary>
+        /// Clears all the labels.
+        /// </summary>
         public void ClearLabels()
         {
             // lazily create the label array

--- a/Octokit/Models/Request/LabelUpdate.cs
+++ b/Octokit/Models/Request/LabelUpdate.cs
@@ -5,11 +5,19 @@ using System.Text.RegularExpressions;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update an existing label.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class LabelUpdate
     {
         private string _color;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LabelUpdate"/> class.
+        /// </summary>
+        /// <param name="name">The name of the label.</param>
+        /// <param name="color">The color of the label.</param>
         public LabelUpdate(string name, string color)
         {
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Models/Request/MarkAsReadRequest.cs
+++ b/Octokit/Models/Request/MarkAsReadRequest.cs
@@ -4,17 +4,30 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to mark a notification as "read" which removes it from the default view on GitHub.com.
+    /// </summary>
+    /// <remarks>
+    /// https://developer.github.com/v3/activity/notifications/#mark-as-read
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class MarkAsReadRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkAsReadRequest"/> class.
+        /// </summary>
         public MarkAsReadRequest()
         {
             LastReadAt = null;
         }
 
         /// <summary>
-        /// Describes the last point that notifications were checked. Anything updated since this time will not be updated.
+        /// Describes the last point that notifications were checked. Anything updated since this time will not be
+        /// updated.
         /// </summary>
+        /// <remarks>
+        /// This is sent as a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ. Default: the current time.
+        /// </remarks>
         public DateTimeOffset? LastReadAt { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/MergePullRequest.cs
+++ b/Octokit/Models/Request/MergePullRequest.cs
@@ -1,20 +1,22 @@
-﻿
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
 {
     /// <summary>
-    /// Used to merge a pull request.
+    /// Used to merge a pull request (Merge Button).
     /// </summary>
+    /// <remarks>
+    /// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class MergePullRequest
     {
         /// <summary>
         /// The message that will be used for the merge commit (optional)
         /// </summary>
-        public string Message { get; set; }
+        public string CommitMessage { get; set; }
 
         /// <summary>
         /// The SHA that pull request head must match to allow merge (optional)
@@ -25,7 +27,7 @@ namespace Octokit
         {
             get
             {
-                return String.Format(CultureInfo.InvariantCulture, "Message: '{0}', Sha: '{1}'", Message, Sha);
+                return String.Format(CultureInfo.InvariantCulture, "Message: '{0}', Sha: '{1}'", CommitMessage, Sha);
             }
         }
     }

--- a/Octokit/Models/Request/MilestoneRequest.cs
+++ b/Octokit/Models/Request/MilestoneRequest.cs
@@ -5,6 +5,9 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to filter requests for lists of milestones 
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class MilestoneRequest : RequestParameters
     {

--- a/Octokit/Models/Request/MilestoneUpdate.cs
+++ b/Octokit/Models/Request/MilestoneUpdate.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update a milestone
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class MilestoneUpdate
     {

--- a/Octokit/Models/Request/NewAuthorization.cs
+++ b/Octokit/Models/Request/NewAuthorization.cs
@@ -12,16 +12,30 @@ namespace Octokit
     public class NewAuthorization
     {
         // TODO: I'd love to not need this
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewAuthorization"/> class.
+        /// </summary>
         public NewAuthorization()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewAuthorization"/> class.
+        /// </summary>
+        /// <param name="note">The note.</param>
+        /// <param name="scopes">The scopes.</param>
         public NewAuthorization(string note, IEnumerable<string> scopes)
         {
             Scopes = scopes;
             Note = note;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewAuthorization"/> class.
+        /// </summary>
+        /// <param name="note">The note.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <param name="fingerprint">The fingerprint.</param>
         public NewAuthorization(string note, IEnumerable<string> scopes, string fingerprint)
         {
             Scopes = scopes;

--- a/Octokit/Models/Request/NewBlob.cs
+++ b/Octokit/Models/Request/NewBlob.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a Blob.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewBlob
     {

--- a/Octokit/Models/Request/NewCommit.cs
+++ b/Octokit/Models/Request/NewCommit.cs
@@ -6,6 +6,12 @@ using System.Linq;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a commit.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/git/commits/#create-a-commit
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewCommit
     {
@@ -14,7 +20,11 @@ namespace Octokit
         /// </summary>
         /// <param name="message">The message to associate with the commit</param>
         /// <param name="tree">The tree associated with the commit</param>
-        /// <param name="parents">An array of parent commits to associate with the commit</param>
+        /// <param name="parents">
+        /// The SHAs of the commits that were the parents of this commit. If empty, the commit will be written as a
+        /// root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of
+        /// more than one should be provided.
+        /// </param>
         public NewCommit(string message, string tree, IEnumerable<string> parents)
         {
             Message = message;
@@ -43,11 +53,48 @@ namespace Octokit
         {
         }
 
-        public string Message { get; set; }
-        public string Tree { get; set; }
-        public IEnumerable<string> Parents { get; set; }
+        /// <summary>
+        /// Gets the commit message.
+        /// </summary>
+        /// <value>
+        /// The message.
+        /// </value>
+        public string Message { get; private set; }
 
+        /// <summary>
+        /// Gets the tree associated with the commit.
+        /// </summary>
+        /// <value>
+        /// The tree.
+        /// </value>
+        public string Tree { get; private set; }
+
+        /// <summary>
+        /// Gets the SHAs of the commits that were the parents of this commit. If empty, the commit will be written as
+        /// a root commit. For a single parent, an array of one SHA should be provided; for a merge commit, an array of
+        /// more than one should be provided.
+        /// </summary>
+        /// <value>
+        /// The parents.
+        /// </value>
+        public IEnumerable<string> Parents { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the author of the commit. If omitted, it will be filled in with the authenticated user’s
+        /// information and the current date.
+        /// </summary>
+        /// <value>
+        /// The author.
+        /// </value>
         public SignatureResponse Author { get; set; }
+
+        /// <summary>
+        /// Gets or sets the person who applied the commit. If omitted, this will be filled in with the
+        /// <see cref="Author"/>.
+        /// </summary>
+        /// <value>
+        /// The committer.
+        /// </value>
         public SignatureResponse Committer { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/NewCommitComment.cs
+++ b/Octokit/Models/Request/NewCommitComment.cs
@@ -10,6 +10,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewCommitComment
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewCommitComment"/> class.
+        /// </summary>
+        /// <param name="body">The body of the comment.</param>
         public NewCommitComment(string body)
         {
             Ensure.ArgumentNotNull(body, "body");

--- a/Octokit/Models/Request/NewCommitStatus.cs
+++ b/Octokit/Models/Request/NewCommitStatus.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new commit status.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewCommitStatus
     {

--- a/Octokit/Models/Request/NewDeployKey.cs
+++ b/Octokit/Models/Request/NewDeployKey.cs
@@ -7,11 +7,26 @@ namespace Octokit
     /// <summary>
     /// Describes a new deployment key to create.
     /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/repos/keys/
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewDeployKey
     {
+        /// <summary>
+        /// Gets or sets a name for the deployment key.
+        /// </summary>
+        /// <value>
+        /// The title.
+        /// </value>
         public string Title { get; set; }
 
+        /// <summary>
+        /// Gets or sets the contents of the deployment key.
+        /// </summary>
+        /// <value>
+        /// The key.
+        /// </value>
         public string Key { get; set; }
 
         /// <summary>

--- a/Octokit/Models/Request/NewDeployKey.cs
+++ b/Octokit/Models/Request/NewDeployKey.cs
@@ -14,6 +14,15 @@ namespace Octokit
 
         public string Key { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the key will only be able to read repository contents. Otherwise, 
+        /// the key will be able to read and write.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [read only]; otherwise, <c>false</c>.
+        /// </value>
+        public bool ReadOnly { get; set; }
+
         internal string DebuggerDisplay
         {
             get { return String.Format(CultureInfo.InvariantCulture, "Key: {0}, Title: {1}", Key, Title); }

--- a/Octokit/Models/Request/NewDeployment.cs
+++ b/Octokit/Models/Request/NewDeployment.cs
@@ -1,26 +1,62 @@
 ﻿
 using System;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
     /// <summary>
-    /// Describes a new deployment status to create.
+    /// Describes a new deployment status to create. Deployments are a request for a specific ref(branch,sha,tag) to
+    /// be deployed.
     /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/repos/deployments/
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewDeployment
     {
         /// <summary>
-        /// The ref to deploy. This can be a branch, tag, or sha.
+        /// Initializes a new instance of the <see cref="NewDeployment"/> class.
         /// </summary>
-        public string Ref { get; set; }
+        /// <param name="ref">The ref to deploy.</param>
+        public NewDeployment(string @ref)
+        {
+            Ref = @ref;
+        }
 
         /// <summary>
-        /// Optional parameter to bypass any ahead/behind checks or commit status checks.
+        /// The ref to deploy. This can be a branch, tag, or sha. (REQUIRED)
         /// </summary>
-        [Obsolete("No longer supported in the API, will be removed in a future release")]
-        public bool? Force { get; set; }
+        public string Ref { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the optional task used to specify a task to execute, e.g. deploy or deploy:migrations. 
+        /// Default: deploy
+        /// </summary>
+        /// <value>
+        /// The task.
+        /// </value>
+        public DeployTask Task { get; set; }
+
+        /// <summary>
+        /// Merges the default branch into the requested deployment branch if true;
+        /// Does nothing if false. (DEFAULT if not specified: True)
+        /// </summary>
+        public bool? AutoMerge { get; set; }
+
+        /// <summary>
+        /// Optional array of status contexts verified against commit status checks. If this property is null then 
+        /// all unique contexts will be verified before a deployment is created. To bypass checking entirely, set this
+        /// to an empty collection. Defaults to all unique contexts (aka null).
+        /// </summary>
+        /// <value>
+        /// The required contexts.
+        /// </value>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
+        public Collection<string> RequiredContexts { get; set; }
 
         /// <summary>
         /// JSON payload with extra information about the deployment.
@@ -28,10 +64,12 @@ namespace Octokit
         public string Payload { get; set; }
 
         /// <summary>
-        /// Merges the default branch into the requested deployment branch if true;
-        /// Does nothing if false.
+        /// Optional name for the target deployment environment (e.g., production, staging, qa). Default: "production"
         /// </summary>
-        public bool? AutoMerge { get; set; }
+        /// <value>
+        /// The environment.
+        /// </value>
+        public string Environment { get; set; }
 
         /// <summary>
         /// A short description of the deployment.
@@ -45,5 +83,22 @@ namespace Octokit
                 return String.Format(CultureInfo.InvariantCulture, "Description: {0}", Description);
             }
         }
+    }
+
+    /// <summary>
+    /// The types of deployments tasks that are availabel.
+    /// </summary>
+    public enum DeployTask
+    {
+        /// <summary>
+        /// Deploy everything (default)
+        /// </summary>
+        Deploy,
+
+        /// <summary>
+        /// Deploy migrations only.
+        /// </summary>
+        [Parameter(Value = "deploy:migrations")]
+        DeployMigrations
     }
 }

--- a/Octokit/Models/Request/NewDeploymentStatus.cs
+++ b/Octokit/Models/Request/NewDeploymentStatus.cs
@@ -11,9 +11,18 @@ namespace Octokit
     public class NewDeploymentStatus
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="NewDeploymentStatus"/> class.
+        /// </summary>
+        /// <param name="deploymentState">State of the deployment (Required).</param>
+        public NewDeploymentStatus(DeploymentState deploymentState)
+        {
+            State = deploymentState;
+        }
+
+        /// <summary>
         /// The state of the status.
         /// </summary>
-        public DeploymentState State { get; set; }
+        public DeploymentState State { get; private set; }
 
         /// <summary>
         /// The target URL to associate with this status. This URL should contain

--- a/Octokit/Models/Request/NewGist.cs
+++ b/Octokit/Models/Request/NewGist.cs
@@ -5,6 +5,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new Gist.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewGist
     {

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -6,11 +6,15 @@ using System.Globalization;
 namespace Octokit
 {
     /// <summary>
-    /// Describes a new issue to create via the <see cref="IIssuesClient.Create(string,string,NewIssue)"/> method.
+    /// Describes a new issue to create via the <see cref="IIssuesClient.Create(string,string,NewIssue)" /> method.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewIssue
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewIssue"/> class.
+        /// </summary>
+        /// <param name="title">The title of the issue.</param>
         public NewIssue(string title)
         {
             Title = title;

--- a/Octokit/Models/Request/NewLabel.cs
+++ b/Octokit/Models/Request/NewLabel.cs
@@ -13,6 +13,11 @@ namespace Octokit
     {
         private string _color;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewLabel"/> class.
+        /// </summary>
+        /// <param name="name">The name of the label.</param>
+        /// <param name="color">The color of the label.</param>
         public NewLabel(string name, string color)
         {
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Models/Request/NewMerge.cs
+++ b/Octokit/Models/Request/NewMerge.cs
@@ -4,6 +4,18 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to merge branches in a repository.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Repo Merging API supports merging branches in a repository. This accomplishes essentially the same thing
+    ///  as merging one branch into another in a local repository and then pushing to GitHub. The benefit is that the
+    ///  merge is done on the server side and a local repository is not needed. This makes it more appropriate for
+    ///  automation and other tools where maintaining local repositories would be cumbersome and inefficient.
+    /// </para>
+    /// <para>API: https://developer.github.com/v3/repos/merging/</para>
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewMerge
     {
@@ -21,8 +33,28 @@ namespace Octokit
             Head = head;
         }
 
+        /// <summary>
+        /// Gets or sets the commit message.
+        /// </summary>
+        /// <value>
+        /// The commit message.
+        /// </value>
         public string CommitMessage { get; set; }
+
+        /// <summary>
+        /// The name of the base branch that the head will be merged into (REQUIRED).
+        /// </summary>
+        /// <value>
+        /// The base.
+        /// </value>
         public string Base { get; private set; }
+
+        /// <summary>
+        /// The head to merge. This can be a branch name or a commit SHA1 (REQUIRED).
+        /// </summary>
+        /// <value>
+        /// The head.
+        /// </value>
         public string Head { get; private set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/NewMilestone.cs
+++ b/Octokit/Models/Request/NewMilestone.cs
@@ -10,6 +10,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewMilestone
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewMilestone"/> class.
+        /// </summary>
+        /// <param name="title">The title.</param>
         public NewMilestone(string title)
         {
             Ensure.ArgumentNotNull(title, "title");

--- a/Octokit/Models/Request/NewPullRequest.cs
+++ b/Octokit/Models/Request/NewPullRequest.cs
@@ -10,6 +10,12 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewPullRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewPullRequest"/> class.
+        /// </summary>
+        /// <param name="title">The title of the pull request.</param>
+        /// <param name="head">The branch (or git ref where your changes are implemented. In other words, the source branch/ref</param>
+        /// <param name="baseRef">The base (or git ref) reference you want your changes pulled into. In other words, the target branch/ref</param>
         public NewPullRequest(string title, string head, string baseRef)
         {
             Ensure.ArgumentNotNullOrEmptyString(title, "title");

--- a/Octokit/Models/Request/NewReference.cs
+++ b/Octokit/Models/Request/NewReference.cs
@@ -5,11 +5,23 @@ using System.Linq;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new Git reference.
+    /// </summary>
+    /// <remarks>API: https://developer.github.com/v3/git/refs/#create-a-reference</remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewReference
     {
         const string _refsPrefix = "refs";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewReference"/> class.
+        /// </summary>
+        /// <param name="reference">
+        /// The name of the fully qualified reference (ie: refs/heads/master). If it doesn’t start with ‘refs’ and
+        ///  have at least two slashes, it will be rejected.
+        /// </param>
+        /// <param name="sha">The SHA1 value to set this reference to</param>
         public NewReference(string reference, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "ref");
@@ -19,7 +31,21 @@ namespace Octokit
             Sha = sha;
         }
 
+        /// <summary>
+        /// The name of the fully qualified reference (ie: refs/heads/master). If it doesn’t start with ‘refs’ and
+        /// have at least two slashes, it will be rejected.
+        /// </summary>
+        /// <value>
+        /// The reference.
+        /// </value>
         public string Ref { get; private set; }
+
+        /// <summary>
+        /// The SHA1 value to set this reference to
+        /// </summary>
+        /// <value>
+        /// The sha.
+        /// </value>
         public string Sha { get; private set; }
 
         static string GetReference(string reference)

--- a/Octokit/Models/Request/NewRelease.cs
+++ b/Octokit/Models/Request/NewRelease.cs
@@ -4,20 +4,74 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new release.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/repos/releases/#create-a-release
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewRelease
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewRelease"/> class.
+        /// </summary>
+        /// <param name="tagName">Name of the tag to create in the repository for this release.</param>
         public NewRelease(string tagName)
         {
             Ensure.ArgumentNotNullOrEmptyString(tagName, "tagName");
             TagName = tagName;
         }
 
+        /// <summary>
+        /// Gets the name of the tag.
+        /// </summary>
+        /// <value>
+        /// The name of the tag.
+        /// </value>
         public string TagName { get; private set; }
+
+        /// <summary>
+        /// Specifies the commitish value that determines where the Git tag is created from. Can be any branch or
+        /// commit SHA. Unused if the Git tag already exists. Default: the repository’s default branch
+        /// (usually master).
+        /// </summary>
+        /// <value>
+        /// The target commitish.
+        /// </value>
         public string TargetCommitish { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the release.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text describing the contents of the tag.
+        /// </summary>
+        /// <value>
+        /// The body.
+        /// </value>
         public string Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="NewRelease"/> is a draft (unpublished).
+        /// Default: false
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if draft; otherwise, <c>false</c>.
+        /// </value>
         public bool Draft { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="NewRelease"/> is prerelease.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if prerelease; otherwise, <c>false</c>.
+        /// </value>
         public bool Prerelease { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// <summary>
         /// Optional. Gets or sets whether to enable issues for the new repository. The default is true.
         /// </summary>
-        public bool? HasIssues { get; set; }
+        public bool HasIssues { get; set; }
 
         /// <summary>
         /// Optional. Gets or sets whether to enable the wiki for the new repository. The default is true.

--- a/Octokit/Models/Request/NewRepositoryFork.cs
+++ b/Octokit/Models/Request/NewRepositoryFork.cs
@@ -4,9 +4,22 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to fork a repository.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/repos/forks/#create-a-fork
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewRepositoryFork
     {
+        /// <summary>
+        /// Gets or sets the organization name to fork into (Optional). If not specified, creates a fork for the
+        /// authenticated user.
+        /// </summary>
+        /// <value>
+        /// The organization.
+        /// </value>
         public string Organization { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/NewRepositoryHook.cs
+++ b/Octokit/Models/Request/NewRepositoryHook.cs
@@ -2,29 +2,102 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Creates a Webhook for the repository.
+    /// </summary>
+    /// <remarks>
+    /// To create a webhook, the following fields are required by the config:
+    /// <list type="bullet">
+    /// <item>
+    ///   <term>url</term>
+    ///   <description>A required string defining the URL to which the payloads will be delivered.</description>
+    /// </item>
+    /// <item>
+    ///   <term>content_type</term>
+    ///   <description>
+    ///     An optional string defining the media type used to serialize the payloads.Supported values include json and
+    ///     form.The default is form.
+    ///   </description>
+    /// </item>
+    /// <item>
+    ///   <term>secret</term>
+    ///   <description>
+    ///     An optional string that’s passed with the HTTP requests as an X-Hub-Signature header. The value of this
+    ///     header is computed as the HMAC hex digest of the body, using the secret as the key.
+    ///   </description>
+    /// </item>
+    /// <item>
+    ///   <term>insecure_ssl:</term>
+    ///   <description>
+    ///     An optional string that determines whether the SSL certificate of the host for url will be verified when 
+    ///     delivering payloads.Supported values include "0" (verification is performed) and "1" (verification is not 
+    ///     performed). The default is "0".
+    ///   </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// API: https://developer.github.com/v3/repos/hooks/#create-a-hook
+    /// </para>
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewRepositoryHook
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewRepositoryHook"/> class.
+        /// </summary>
+        /// <param name="name">
+        /// Use "web" for a webhook or use the name of a valid service. (See 
+        /// <see href="https://api.github.com/hooks">https://api.github.com/hooks</see> for the list of valid service
+        /// names.)
+        /// </param>
+        /// <param name="config">
+        /// Key/value pairs to provide settings for this hook. These settings vary between the services and are
+        /// defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for
+        /// false. Any JSON true/false values will be converted automatically.
+        /// </param>
         public NewRepositoryHook(string name, IReadOnlyDictionary<string, string> config)
         {
             Name = name;
             Config = config;
         }
 
-        [Parameter(Key = "name")]
-        public string Name { get; set; }
+        /// <summary>
+        /// Gets the name of the hook to create. Use "web" for a webhook or use the name of a valid service. (See 
+        /// <see href="https://api.github.com/hooks">https://api.github.com/hooks</see> for the list of valid service
+        /// names.)
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        public string Name { get; private set; }
 
         /// <summary>
-        /// Is a key value structure determined by the web hook being created
+        /// Key/value pairs to provide settings for this hook. These settings vary between the services and are
+        /// defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for
+        /// false. Any JSON true/false values will be converted automatically.
         /// </summary>
+        /// <value>
+        /// The configuration.
+        /// </value>
         public IReadOnlyDictionary<string, string> Config { get; private set; }
 
+        /// <summary>
+        /// Determines what events the hook is triggered for. Default: ["push"]
+        /// </summary>
+        /// <value>
+        /// The events.
+        /// </value>
         public IEnumerable<string> Events { get; set; }
 
+        /// <summary>
+        /// Determines whether the hook is actually triggered on pushes.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if active; otherwise, <c>false</c>.
+        /// </value>
         public bool Active { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/NewSubscription.cs
+++ b/Octokit/Models/Request/NewSubscription.cs
@@ -4,12 +4,24 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to watch a repository (subscribe to repository's notifications). Called by the 
+    /// <see cref="IWatchedClient.WatchRepo"/> method.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewSubscription
     {
         /// <summary>
         /// Determines if notifications should be received from this repository.
         /// </summary>
+        /// <remarks>
+        /// If you would like to watch a repository, set subscribed to true. If you would like to ignore notifications
+        /// made within a repository, set ignored to true. If you would like to stop watching a repository, delete the 
+        /// repository’s subscription completely using the <see cref="IWatchedClient.UnwatchRepo"/> method.
+        /// </remarks>
         public bool Subscribed { get; set; }
 
         /// <summary>

--- a/Octokit/Models/Request/NewTag.cs
+++ b/Octokit/Models/Request/NewTag.cs
@@ -5,15 +5,59 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new tag
+    /// </summary>
+    /// <remarks>
+    /// Note that creating a tag object does not create the reference that makes a tag in Git. If you want to create
+    ///  an annotated tag in Git, you have to do this call to create the tag object, and then create the
+    ///  refs/tags/[tag] reference. If you want to create a lightweight tag, you only have to create the tag reference
+    ///  - this call would be unnecessary.
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewTag
     {
+        /// <summary>
+        /// Gets or sets the tag.
+        /// </summary>
+        /// <value>
+        /// The tag.
+        /// </value>
         public string Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tag message.
+        /// </summary>
+        /// <value>
+        /// The message.
+        /// </value>
         public string Message { get; set; }
+
+        /// <summary>
+        /// The SHA of the git object this is tagging
+        /// </summary>
+        /// <value>
+        /// The object.
+        /// </value>
         public string Object { get; set; }
+
+        /// <summary>
+        /// The type of the object we’re tagging. Normally this is a commit but it can also be a tree or a blob.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "Property name as defined by web api")]
         public TaggedType Type { get; set; }
+
+        /// <summary>
+        /// An object with information about the individual creating the tag.
+        /// </summary>
+        /// <value>
+        /// The tagger.
+        /// </value>
         public SignatureResponse Tagger { get; set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/NewTeam.cs
+++ b/Octokit/Models/Request/NewTeam.cs
@@ -5,9 +5,22 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a team.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In order to create a team, the authenticated user must be a member of :org.
+    /// </para>
+    /// <para>API: https://developer.github.com/v3/orgs/teams/#create-team</para>
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewTeam
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewTeam"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
         public NewTeam(string name)
         {
             Name = name;
@@ -16,9 +29,17 @@ namespace Octokit
         }
 
         /// <summary>
-        /// team name
+        /// The name of the team (required).
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the description of the team
+        /// </summary>
+        /// <value>
+        /// The description.
+        /// </value>
+        public string Description { get; set; }
 
         /// <summary>
         /// permission associated to this team

--- a/Octokit/Models/Request/NewTree.cs
+++ b/Octokit/Models/Request/NewTree.cs
@@ -6,6 +6,13 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a new Tree.
+    /// </summary>
+    /// <remarks>
+    /// The tree creation API will take nested entries as well. If both a tree and a nested path modifying that tree 
+    /// are specified, it will overwrite the contents of that tree with the new path contents and write a new tree out.
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewTree
     {

--- a/Octokit/Models/Request/NewTreeItem.cs
+++ b/Octokit/Models/Request/NewTreeItem.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A tree item that would be included as part of a <see cref="NewTree"/> when creating a tree.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class NewTreeItem
     {
@@ -23,13 +27,22 @@ namespace Octokit
         /// <summary>
         /// The type of tree item this is.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
         public TreeType Type { get; set; }
 
         /// <summary>
         /// The SHA for this Tree item.
         /// </summary>
         public string Sha { get; set; }
+
+        /// <summary>
+        /// Gets or sets the The content you want this file to have. GitHub will write this blob out and use that SHA 
+        /// for this entry. Use either this, or tree.sha.
+        /// </summary>
+        /// <value>
+        /// The content.
+        /// </value>
+        public string Content { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/NotificationsRequest.cs
+++ b/Octokit/Models/Request/NotificationsRequest.cs
@@ -21,19 +21,20 @@ namespace Octokit
         public bool Participating { get; set; }
 
         /// <summary>
-        /// Filters out any notifications updated before the given time. Default: DateTimeOffset.MinValue
+        /// Only show notifications updated after the given time. Defaults to the everything if unspecified.
         /// </summary>
-        public DateTimeOffset Since { get; set; }
+        public DateTimeOffset? Since { get; set; }
 
         /// <summary>
-        /// Construct a <see cref="NotificationsRequest"/> object
+        /// Only show notifications updated before the given time.
         /// </summary>
-        public NotificationsRequest()
-        {
-            All = false;
-            Participating = false;
-            Since = DateTimeOffset.MinValue;
-        }
+        /// <remarks>
+        /// This is sent as a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.
+        /// </remarks>
+        /// <value>
+        /// The before.
+        /// </value>
+        public DateTimeOffset? Before { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/OauthLoginRequest.cs
+++ b/Octokit/Models/Request/OauthLoginRequest.cs
@@ -6,6 +6,9 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to initiate an OAuth2 authentication flow from 3rd party web sites.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class OauthLoginRequest : RequestParameters
     {

--- a/Octokit/Models/Request/OauthTokenRequest.cs
+++ b/Octokit/Models/Request/OauthTokenRequest.cs
@@ -5,6 +5,9 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create an Oauth login request.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class OauthTokenRequest : RequestParameters
     {

--- a/Octokit/Models/Request/OrganizationUpdate.cs
+++ b/Octokit/Models/Request/OrganizationUpdate.cs
@@ -36,6 +36,14 @@ namespace Octokit
         /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the description of the organization.
+        /// </summary>
+        /// <value>
+        /// The description.
+        /// </value>
+        public string Description { get; set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/Permission.cs
+++ b/Octokit/Models/Request/Permission.cs
@@ -1,6 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Octokit
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
+    /// <summary>
+    /// Used to describe a permission level.
+    /// </summary>
+    [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
     public enum Permission
     {
         /// <summary>

--- a/Octokit/Models/Request/PublicRepositoryRequest.cs
+++ b/Octokit/Models/Request/PublicRepositoryRequest.cs
@@ -4,9 +4,16 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used as part of the request to retrieve all public repositories.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PublicRepositoryRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicRepositoryRequest"/> class.
+        /// </summary>
+        /// <param name="since">The integer ID of the last Repository that you’ve seen.</param>
         public PublicRepositoryRequest(int since)
         {
             Ensure.ArgumentNotNull(since, "since");
@@ -14,6 +21,12 @@ namespace Octokit
             Since = since;
         }
 
+        /// <summary>
+        /// Gets or sets the integer ID of the last Repository that you’ve seen.
+        /// </summary>
+        /// <value>
+        /// The since.
+        /// </value>
         public long Since { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/PullRequestRequest.cs
+++ b/Octokit/Models/Request/PullRequestRequest.cs
@@ -5,6 +5,9 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to filter requests for lists of pull requests.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestRequest : RequestParameters
     {

--- a/Octokit/Models/Request/PullRequestReviewCommentCreate.cs
+++ b/Octokit/Models/Request/PullRequestReviewCommentCreate.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a pull request review comment.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewCommentCreate : RequestParameters
     {

--- a/Octokit/Models/Request/PullRequestReviewCommentEdit.cs
+++ b/Octokit/Models/Request/PullRequestReviewCommentEdit.cs
@@ -4,13 +4,16 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to edit a pull request review comment
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewCommentEdit : RequestParameters
     {
         /// <summary>
         /// Creates an edit to a comment
         /// </summary>
-        /// <param name="body">The text of the comment</param>
+        /// <param name="body">The new text of the comment</param>
         public PullRequestReviewCommentEdit(string body)
         {
             Ensure.ArgumentNotNullOrEmptyString(body, "body");
@@ -19,7 +22,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// The text of the comment.
+        /// The new text of the comment.
         /// </summary>
         public string Body { get; private set; }
 

--- a/Octokit/Models/Request/PullRequestReviewCommentReplyCreate.cs
+++ b/Octokit/Models/Request/PullRequestReviewCommentReplyCreate.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to create a reply to a pull request review comment.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewCommentReplyCreate : RequestParameters
     {

--- a/Octokit/Models/Request/PullRequestReviewCommentRequest.cs
+++ b/Octokit/Models/Request/PullRequestReviewCommentRequest.cs
@@ -4,9 +4,15 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to filter pull request review comments.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewCommentRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PullRequestReviewCommentRequest"/> class.
+        /// </summary>
         public PullRequestReviewCommentRequest()
         {
             // Default arguments

--- a/Octokit/Models/Request/PullRequestUpdate.cs
+++ b/Octokit/Models/Request/PullRequestUpdate.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update an existing pull request.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestUpdate
     {

--- a/Octokit/Models/Request/ReferenceUpdate.cs
+++ b/Octokit/Models/Request/ReferenceUpdate.cs
@@ -4,13 +4,28 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Upsed to update a Git reference.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReferenceUpdate
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceUpdate"/> class.
+        /// </summary>
+        /// <param name="sha">The sha.</param>
         public ReferenceUpdate(string sha) : this(sha, false)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceUpdate"/> class.
+        /// </summary>
+        /// <param name="sha">The SHA1 value to set this reference to.</param>
+        /// <param name="force">
+        /// Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this
+        /// out or setting it to false will make sure you’re not overwriting work.
+        /// </param>
         public ReferenceUpdate(string sha, bool force)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
@@ -19,7 +34,21 @@ namespace Octokit
             Force = force;
         }
 
+        /// <summary>
+        /// The SHA1 value to set this reference to.
+        /// </summary>
+        /// <value>
+        /// The sha.
+        /// </value>
         public string Sha { get; private set; }
+
+        /// <summary>
+        /// Indicates whether to force the update or to make sure the update is a fast-forward update. Leaving this
+        /// out or setting it to false will make sure you’re not overwriting work.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if force; otherwise, <c>false</c>.
+        /// </value>
         public bool Force { get; private set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/ReleaseAssetUpdate.cs
+++ b/Octokit/Models/Request/ReleaseAssetUpdate.cs
@@ -4,9 +4,16 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update a release asset.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseAssetUpdate
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseAssetUpdate"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
         public ReleaseAssetUpdate(string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Models/Request/ReleaseAssetUpload.cs
+++ b/Octokit/Models/Request/ReleaseAssetUpload.cs
@@ -5,11 +5,34 @@ using System.IO;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to upload a release asset.
+    /// </summary>
+    /// <remarks>
+    /// This endpoint makes use of a Hypermedia relation to determine which URL to access. This endpoint is provided
+    /// by a URI template in the release’s API response. You need to use an HTTP client which supports SNI to make
+    /// calls to this endpoint. The asset data is expected in its raw binary form, rather than JSON. Everything else
+    ///  about the endpoint is the same as the rest of the API. For example, you’ll still need to pass your
+    ///  authentication to be able to upload an asset.
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseAssetUpload
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseAssetUpload"/> class.
+        /// </summary>
         public ReleaseAssetUpload() { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseAssetUpload"/> class.
+        /// </summary>
+        /// <param name="fileName">Name of the file.</param>
+        /// <param name="contentType">
+        /// The content type of the asset. Example: "application/zip". For a list of acceptable types, refer this list 
+        /// of <see href="https://en.wikipedia.org/wiki/Media_type#List_of_common_media_types">common media types</see>.
+        /// </param>
+        /// <param name="rawData">The raw data.</param>
+        /// <param name="timeout">The timeout.</param>
         public ReleaseAssetUpload(string fileName, string contentType, Stream rawData, TimeSpan? timeout)
         {
             FileName = fileName;
@@ -18,9 +41,36 @@ namespace Octokit
             Timeout = timeout;
         }
 
+        /// <summary>
+        /// Gets or sets the name of the file.
+        /// </summary>
+        /// <value>
+        /// The name of the file.
+        /// </value>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the content.
+        /// </summary>
+        /// <value>
+        /// The type of the content.
+        /// </value>
         public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw data.
+        /// </summary>
+        /// <value>
+        /// The raw data.
+        /// </value>
         public Stream RawData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout.
+        /// </summary>
+        /// <value>
+        /// The timeout.
+        /// </value>
         public TimeSpan? Timeout { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/ReleaseUpdate.cs
+++ b/Octokit/Models/Request/ReleaseUpdate.cs
@@ -4,14 +4,64 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update a release.
+    /// </summary>
+    /// <remarks>
+    /// API: https://developer.github.com/v3/repos/releases/#create-a-release
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ReleaseUpdate
     {
+        /// <summary>
+        /// Gets the name of the tag.
+        /// </summary>
+        /// <value>
+        /// The name of the tag.
+        /// </value>
         public string TagName { get; set; }
+
+        /// <summary>
+        /// Specifies the commitish value that determines where the Git tag is created from. Can be any branch or
+        /// commit SHA. Unused if the Git tag already exists. Default: the repository’s default branch
+        /// (usually master).
+        /// </summary>
+        /// <value>
+        /// The target commitish.
+        /// </value>
         public string TargetCommitish { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the release.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text describing the contents of the tag.
+        /// </summary>
+        /// <value>
+        /// The body.
+        /// </value>
         public string Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="NewRelease"/> is a draft (unpublished).
+        /// Default: false
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if draft; otherwise, <c>false</c>.
+        /// </value>
         public bool? Draft { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="NewRelease"/> is prerelease.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if prerelease; otherwise, <c>false</c>.
+        /// </value>
         public bool? Prerelease { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/RepositoryForksListRequest.cs
+++ b/Octokit/Models/Request/RepositoryForksListRequest.cs
@@ -4,14 +4,26 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to request and filter a list of repository forks.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryForksListRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepositoryForksListRequest"/> class.
+        /// </summary>
         public RepositoryForksListRequest()
         {
             Sort = Sort.Newest; // Default in accordance with the documentation
         }
 
+        /// <summary>
+        /// Gets or sets the sort property.
+        /// </summary>
+        /// <value>
+        /// The sort.
+        /// </value>
         public Sort Sort { get; set; }
 
         internal string DebuggerDisplay
@@ -23,10 +35,24 @@ namespace Octokit
         }
     }
 
+    /// <summary>
+    /// The sort order.
+    /// </summary>
     public enum Sort
     {
+        /// <summary>
+        /// Sort by date and show the newest first.
+        /// </summary>
         Newest,
+
+        /// <summary>
+        /// Sort by date and show the oldest first.
+        /// </summary>
         Oldest,
+
+        /// <summary>
+        /// Sort by the number of stargazers.
+        /// </summary>
         Stargazers
     }
 }

--- a/Octokit/Models/Request/RepositoryIssueRequest.cs
+++ b/Octokit/Models/Request/RepositoryIssueRequest.cs
@@ -2,6 +2,9 @@
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to requent and filter a list of repository issues.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryIssueRequest : IssueRequest
     {

--- a/Octokit/Models/Request/RepositoryRequest.cs
+++ b/Octokit/Models/Request/RepositoryRequest.cs
@@ -1,18 +1,40 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to request and filter a list of repositories.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryRequest : RequestParameters
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+        /// <summary>
+        /// Gets or sets the repository type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
         public RepositoryType Type { get; set; }
 
+        /// <summary>
+        /// Gets or sets the sort property.
+        /// </summary>
+        /// <value>
+        /// The sort.
+        /// </value>
         public RepositorySort Sort { get; set; }
 
+        /// <summary>
+        /// Gets or sets the sort direction.
+        /// </summary>
+        /// <value>
+        /// The direction.
+        /// </value>
         public SortDirection Direction { get; set; }
 
         internal string DebuggerDisplay
@@ -24,21 +46,60 @@ namespace Octokit
         }
     }
 
+    /// <summary>
+    /// The properties that repositories can be filtered by.
+    /// </summary>
     public enum RepositoryType
     {
+        /// <summary>
+        /// Return all repositories.
+        /// </summary>
         All,
+
+        /// <summary>
+        /// Return repositories that the current authenticated user owns.
+        /// </summary>
         Owner,
+
+        /// <summary>
+        /// Returns public repositoires.
+        /// </summary>
         Public,
+
+        /// <summary>
+        /// The privateReturn private repositories.
+        /// </summary>
         Private,
+
+        /// <summary>
+        /// Return repositories for which the current authenticated user is a member of the org or team.
+        /// </summary>
         Member
     }
 
+    /// <summary>
+    /// The properties that repositories can be sorted by.
+    /// </summary>
     public enum RepositorySort
     {
+        /// <summary>
+        /// Sort by the date the repository was created.
+        /// </summary>
         Created,
+
+        /// <summary>
+        /// Sort by the date the repository was last updated.
+        /// </summary>
         Updated,
+
+        /// <summary>
+        /// Sort by the date the repository was last pushed.
+        /// </summary>
         Pushed,
 
+        /// <summary>
+        /// Sort by the repository name.
+        /// </summary>
         [Parameter(Value = "full_name")]
         FullName
     }

--- a/Octokit/Models/Request/RequestParameters.cs
+++ b/Octokit/Models/Request/RequestParameters.cs
@@ -23,6 +23,10 @@ namespace Octokit
         static readonly ConcurrentDictionary<Type, List<PropertyParameter>> _propertiesMap =
             new ConcurrentDictionary<Type, List<PropertyParameter>>();
 #endif
+        /// <summary>
+        /// Converts the derived object into a dictionary that can be used to supply query string parameters.
+        /// </summary>
+        /// <returns></returns>
         public virtual IDictionary<string, string> ToParametersDictionary()
         {
             var map = _propertiesMap.GetOrAdd(GetType(), GetPropertyParametersForType);

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -16,11 +16,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchCodeRequest : BaseSearchRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchCodeRequest"/> class.
+        /// </summary>
+        /// <param name="term">The search term.</param>
         public SearchCodeRequest(string term) : base(term)
         {
             Repos = new RepositoryCollection();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchCodeRequest"/> class.
+        /// </summary>
+        /// <param name="term">The term.</param>
+        /// <param name="owner">The owner.</param>
+        /// <param name="name">The name.</param>
         public SearchCodeRequest(string term, string owner, string name)
             : this(term)
         {

--- a/Octokit/Models/Request/SearchQualifierOperator.cs
+++ b/Octokit/Models/Request/SearchQualifierOperator.cs
@@ -1,10 +1,28 @@
 ﻿namespace Octokit
 {
+    /// <summary>
+    /// Used to qualify a serch term.
+    /// </summary>
     public enum SearchQualifierOperator
     {
-        GreaterThan, // >
-        LessThan, // <
-        LessThanOrEqualTo, // <=
-        GreaterThanOrEqualTo// >=
+        /// <summary>
+        /// Greater than "&gt;"
+        /// </summary>
+        GreaterThan,
+
+        /// <summary>
+        /// Less than "&lt;"
+        /// </summary>
+        LessThan,
+
+        /// <summary>
+        /// Less than or equal to. "&lt;="
+        /// </summary>
+        LessThanOrEqualTo,
+
+        /// <summary>
+        /// Greater than or equal to. "&gt;="
+        /// </summary>
+        GreaterThanOrEqualTo
     }
 }

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -15,10 +15,17 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchRepositoriesRequest : BaseSearchRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchRepositoriesRequest"/> class.
+        /// </summary>
         public SearchRepositoriesRequest()
         {
             Order = SortDirection.Descending;
         }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchRepositoriesRequest"/> class.
+        /// </summary>
+        /// <param name="term">The search term.</param>
         public SearchRepositoriesRequest(string term)
             : base(term)
         {

--- a/Octokit/Models/Request/SearchUsersRequest.cs
+++ b/Octokit/Models/Request/SearchUsersRequest.cs
@@ -14,6 +14,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SearchUsersRequest : BaseSearchRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchUsersRequest"/> class.
+        /// </summary>
+        /// <param name="term">The search term.</param>
         public SearchUsersRequest(string term) : base(term)
         {
         }
@@ -24,6 +28,9 @@ namespace Octokit
         /// </summary>
         public UsersSearchSort? SortField { get; set; }
 
+        /// <summary>
+        /// The sort field as a string.
+        /// </summary>
         public override string Sort
         {
             get { return SortField.ToParameter(); }

--- a/Octokit/Models/Request/SshKeyUpdate.cs
+++ b/Octokit/Models/Request/SshKeyUpdate.cs
@@ -4,6 +4,9 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update an SSH key
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SshKeyUpdate
     {

--- a/Octokit/Models/Request/StarredRequest.cs
+++ b/Octokit/Models/Request/StarredRequest.cs
@@ -5,18 +5,36 @@ using Octokit.Internal;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to retrieve and filter lists of stars.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class StarredRequest : RequestParameters
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StarredRequest"/> class.
+        /// </summary>
         public StarredRequest()
         {
             SortProperty = StarredSort.Created;
             SortDirection = SortDirection.Ascending;
         }
 
+        /// <summary>
+        /// Gets or sets the sort property.
+        /// </summary>
+        /// <value>
+        /// The sort property.
+        /// </value>
         [Parameter(Key = "sort")]
         public StarredSort SortProperty { get; set; }
 
+        /// <summary>
+        /// Gets or sets the sort direction.
+        /// </summary>
+        /// <value>
+        /// The sort direction.
+        /// </value>
         [Parameter(Key = "direction")]
         public SortDirection SortDirection { get; set; }
 
@@ -29,9 +47,19 @@ namespace Octokit
         }
     }
 
+    /// <summary>
+    /// Property to sort stars by.
+    /// </summary>
     public enum StarredSort
     {
+        /// <summary>
+        /// Sort y the date the star was created.
+        /// </summary>
         Created,
+
+        /// <summary>
+        /// Sort by the date the star was last updated.
+        /// </summary>
         Updated
     }
 }

--- a/Octokit/Models/Request/UpdateTeam.cs
+++ b/Octokit/Models/Request/UpdateTeam.cs
@@ -4,14 +4,26 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Used to update a teamm.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class UpdateTeam
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateTeam"/> class.
+        /// </summary>
+        /// <param name="team">The team.</param>
         public UpdateTeam(string team)
         {
             Name = team;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateTeam"/> class.
+        /// </summary>
+        /// <param name="team">The team.</param>
+        /// <param name="permission">The permission.</param>
         public UpdateTeam(string team, Permission permission)
         {
             Name = team;

--- a/Octokit/Models/Response/PullRequestMerge.cs
+++ b/Octokit/Models/Response/PullRequestMerge.cs
@@ -4,9 +4,19 @@ using System.Globalization;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Represents the response from an attempt to merge a pull request.
+    /// </summary>
+    /// <remarks>
+    /// Note the request to merge is represented by <see cref="MergePullRequest"/>
+    /// API: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+    /// </remarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestMerge
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PullRequestMerge"/> class.
+        /// </summary>
         public PullRequestMerge() { }
 
         public PullRequestMerge(string sha, bool merged, string message)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,7 @@
 ### New in 0.17.0 (released TBD)
 
 * Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
+* Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via @haacked
 * Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
 
 **Breaking Changes:**

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,7 @@
 * Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
 * Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via @haacked
 * Improved: Added `Description` property to `NewTeam` to allow specifying a description for a team - via @haacked
+* Improved: Added `Description` property to `OrganizationUpdate` to allow specifying a description for an organization - via @haacked
 * Improved: Added `Before` property to `NotificationsRequest` to find notifications updated before a specific time - via @haacked
 * Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,11 +1,11 @@
 ### New in 0.17.0 (released TBD)
 
-* Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
-* Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via @haacked
-* Improved: Added `Description` property to `NewTeam` to allow specifying a description for a team - via @haacked
-* Improved: Added `Description` property to `OrganizationUpdate` to allow specifying a description for an organization - via @haacked
-* Improved: Added `Before` property to `NotificationsRequest` to find notifications updated before a specific time - via @haacked
-* Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
+* Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via #915 @haacked
+* Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via #915 @haacked
+* Improved: Added `Description` property to `NewTeam` to allow specifying a description for a team - via #915 @haacked
+* Improved: Added `Description` property to `OrganizationUpdate` to allow specifying a description for an organization - via #915 @haacked
+* Improved: Added `Before` property to `NotificationsRequest` to find notifications updated before a specific time - via #915 @haacked
+* Fixed: Bug that prevented sepecifying a commit message for pull request merges - via #915 @haacked
 
 **Breaking Changes:**
  - `NewDeployment` constructor requires a ref as this is required for the API. It no longer has a default constructor.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,7 @@
 * Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
 * Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via @haacked
 * Improved: Added `Description` property to `NewTeam` to allow specifying a description for a team - via @haacked
+* Improved: Added `Before` property to `NotificationsRequest` to find notifications updated before a specific time - via @haacked
 * Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
 
 **Breaking Changes:**

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 * Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
 * Improved: Added `Content` property to `NewTreeItem` to allow specifying content for a tree - via @haacked
+* Improved: Added `Description` property to `NewTeam` to allow specifying a description for a team - via @haacked
 * Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
 
 **Breaking Changes:**

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,13 @@
+### New in 0.17.0 (released TBD)
+
+* Improved: Added ability to create deploy keys that are read only and can only be used to read repository contents and not write to them - via @haacked
+* Fixed: Bug that prevented sepecifying a commit message for pull request merges - via @haacked
+
+**Breaking Changes:**
+ - `NewDeployment` constructor requires a ref as this is required for the API. It no longer has a default constructor.
+ - `NewDeploymentStatus` constructor requires a `DeploymentState` as this is required for the API. It no longer has a default constructor.
+ - The `Name` property of `NewTeam` is now read only. It is specified via the constructor.
+
 ### New in 0.16.0 (released 2015/09/17)
 
 * New: Implemented `GetMetadata` method of `IMiscellaneousClient` to retrieve information from the Meta endpoint -#892 via @haacked


### PR DESCRIPTION
Our build status has a :poop: load of warning about undocumented public properties/methods/etc.

We could turn it off, or given that this is a library, we could actually document everything.

This ends up being a big task, so this PR just documents all the Request models. I also fixed a few bugs I found while doing this.