### PR TITLE
Add helper class for creating web hooks

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
@@ -72,13 +72,15 @@ namespace Octokit.Tests.Integration.Clients
                     { "username", "username" },
                     { "password", "password" }
                 };
-                var parameters = new NewRepositoryWebHook("windowsazure", config, url, contentType, secret, false)
+                var parameters = new NewRepositoryWebHook("windowsazure", config, url)
                 {
                     Events = new[] { "push" },
-                    Active = false
+                    Active = false,
+                    ContentType = contentType,
+                    Secret = secret
                 };
 
-                var hook = await github.Repository.Hooks.Create(Helper.Credentials.Login, repository.Name, parameters);
+                var hook = await github.Repository.Hooks.Create(Helper.Credentials.Login, repository.Name, parameters.ToRequest());
 
                 var baseHookUrl = CreateExpectedBaseHookUrl(repository.Url, hook.Id);
                 var webHookConfig = CreateExpectedConfigDictionary(config, url, contentType, secret);
@@ -102,7 +104,7 @@ namespace Octokit.Tests.Integration.Clients
                     { "url", url },
                     { "content_type", contentType.ToString().ToLowerInvariant() },
                     { "secret", secret },
-                    { "insecure_ssl", "0" }
+                    { "insecure_ssl", "False" }
                 }).ToDictionary(k => k.Key, v => v.Value);
             } 
 

--- a/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
+++ b/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Octokit.Tests.Models
+{
+    public class NewRepositoryWebHookTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void UsesDefaultValuesForDefaultConfig()
+            {
+                var create = new NewRepositoryWebHook("windowsazure", new Dictionary<string, string>(), "http://test.com/example");
+
+                Assert.Equal(create.Config.Count, 4);
+
+                Assert.True(create.Config.ContainsKey("url"));
+                Assert.True(create.Config.ContainsKey("content_type"));
+                Assert.True(create.Config.ContainsKey("secret"));
+                Assert.True(create.Config.ContainsKey("insecure_ssl"));
+
+                Assert.Equal(create.Config["url"], "http://test.com/example");
+                Assert.Equal(create.Config["content_type"], WebHookContentType.Form.ToParameter());
+                Assert.Equal(create.Config["secret"], "");
+                Assert.Equal(create.Config["insecure_ssl"], "0");
+
+                Assert.Equal(create.Url, "http://test.com/example");
+                Assert.Equal(create.ContentType, WebHookContentType.Form);
+                Assert.Empty(create.Secret);
+                Assert.False(create.InsecureSsl);
+            }
+
+            [Fact]
+            public void CombinesUserSpecifiedContentTypeWithConfig()
+            {
+                var config = new Dictionary<string, string>
+                {
+                    {"hostname", "http://hostname.url"},
+                    {"username", "username"},
+                    {"password", "password"}
+                };
+
+                var create = new NewRepositoryWebHook("windowsazure", config, "http://test.com/example", WebHookContentType.Json, string.Empty, true);
+
+                Assert.Equal(create.Config.Count, 7);
+
+                Assert.True(create.Config.ContainsKey("url"));
+                Assert.True(create.Config.ContainsKey("content_type"));
+                Assert.True(create.Config.ContainsKey("secret"));
+                Assert.True(create.Config.ContainsKey("insecure_ssl"));
+
+                Assert.Equal(create.Config["url"], "http://test.com/example");
+                Assert.Equal(create.Config["content_type"], WebHookContentType.Json.ToParameter());
+                Assert.Equal(create.Config["secret"], "");
+                Assert.Equal(create.Config["insecure_ssl"], "1");
+
+                Assert.True(create.Config.ContainsKey("hostname"));
+                Assert.Equal(create.Config["hostname"], config["hostname"]);
+                Assert.True(create.Config.ContainsKey("username"));
+                Assert.Equal(create.Config["username"], config["username"]);
+                Assert.True(create.Config.ContainsKey("password"));
+                Assert.Equal(create.Config["password"], config["password"]);
+
+                Assert.Equal(create.Url, "http://test.com/example");
+                Assert.Equal(create.ContentType, WebHookContentType.Json);
+                Assert.Empty(create.Secret);
+                Assert.True(create.InsecureSsl);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
+++ b/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
@@ -7,6 +7,9 @@ namespace Octokit.Tests.Models
     {
         public class TheCtor
         {
+            string ExpectedRepositoryWebHookConfigExceptionMessage =
+                "Duplicate webhook config values found - these values: Url should not be passed in as part of the config values. Use the properties on the NewRepositoryWebHook class instead.";
+
             [Fact]
             public void UsesDefaultValuesForDefaultConfig()
             {
@@ -72,6 +75,33 @@ namespace Octokit.Tests.Models
                 Assert.Equal(request.Config["username"], config["username"]);
                 Assert.True(request.Config.ContainsKey("password"));
                 Assert.Equal(request.Config["password"], config["password"]);
+            }
+
+            [Fact]
+            public void ShouldThrowRepositoryWebHookConfigExceptionWhenDuplicateKeysExists()
+            {
+                var config = new Dictionary<string, string>
+                {
+                    {"url", "http://example.com/test"},
+                    {"hostname", "http://hostname.url"},
+                    {"username", "username"},
+                    {"password", "password"}
+                };
+
+                var create = new NewRepositoryWebHook("windowsazure", config, "http://test.com/example")
+                {
+                    ContentType = WebHookContentType.Json,
+                    Secret = string.Empty,
+                    InsecureSsl = true
+                };
+
+                Assert.Equal(create.Url, "http://test.com/example");
+                Assert.Equal(create.ContentType, WebHookContentType.Json);
+                Assert.Empty(create.Secret);
+                Assert.True(create.InsecureSsl);
+
+                var ex = Assert.Throws<RepositoryWebHookConfigException>(() => create.ToRequest());
+                Assert.Equal(ExpectedRepositoryWebHookConfigExceptionMessage, ex.Message);
             }
         }
     }

--- a/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
+++ b/Octokit.Tests/Models/NewRepositoryWebHookTests.cs
@@ -11,23 +11,23 @@ namespace Octokit.Tests.Models
             public void UsesDefaultValuesForDefaultConfig()
             {
                 var create = new NewRepositoryWebHook("windowsazure", new Dictionary<string, string>(), "http://test.com/example");
-
-                Assert.Equal(create.Config.Count, 4);
-
-                Assert.True(create.Config.ContainsKey("url"));
-                Assert.True(create.Config.ContainsKey("content_type"));
-                Assert.True(create.Config.ContainsKey("secret"));
-                Assert.True(create.Config.ContainsKey("insecure_ssl"));
-
-                Assert.Equal(create.Config["url"], "http://test.com/example");
-                Assert.Equal(create.Config["content_type"], WebHookContentType.Form.ToParameter());
-                Assert.Equal(create.Config["secret"], "");
-                Assert.Equal(create.Config["insecure_ssl"], "0");
-
                 Assert.Equal(create.Url, "http://test.com/example");
                 Assert.Equal(create.ContentType, WebHookContentType.Form);
                 Assert.Empty(create.Secret);
                 Assert.False(create.InsecureSsl);
+
+                var request = create.ToRequest();
+                Assert.Equal(request.Config.Count, 4);
+
+                Assert.True(request.Config.ContainsKey("url"));
+                Assert.True(request.Config.ContainsKey("content_type"));
+                Assert.True(request.Config.ContainsKey("secret"));
+                Assert.True(request.Config.ContainsKey("insecure_ssl"));
+
+                Assert.Equal(request.Config["url"], "http://test.com/example");
+                Assert.Equal(request.Config["content_type"], WebHookContentType.Form.ToParameter());
+                Assert.Equal(request.Config["secret"], "");
+                Assert.Equal(request.Config["insecure_ssl"], "False");
             }
 
             [Fact]
@@ -40,31 +40,38 @@ namespace Octokit.Tests.Models
                     {"password", "password"}
                 };
 
-                var create = new NewRepositoryWebHook("windowsazure", config, "http://test.com/example", WebHookContentType.Json, string.Empty, true);
-
-                Assert.Equal(create.Config.Count, 7);
-
-                Assert.True(create.Config.ContainsKey("url"));
-                Assert.True(create.Config.ContainsKey("content_type"));
-                Assert.True(create.Config.ContainsKey("secret"));
-                Assert.True(create.Config.ContainsKey("insecure_ssl"));
-
-                Assert.Equal(create.Config["url"], "http://test.com/example");
-                Assert.Equal(create.Config["content_type"], WebHookContentType.Json.ToParameter());
-                Assert.Equal(create.Config["secret"], "");
-                Assert.Equal(create.Config["insecure_ssl"], "1");
-
-                Assert.True(create.Config.ContainsKey("hostname"));
-                Assert.Equal(create.Config["hostname"], config["hostname"]);
-                Assert.True(create.Config.ContainsKey("username"));
-                Assert.Equal(create.Config["username"], config["username"]);
-                Assert.True(create.Config.ContainsKey("password"));
-                Assert.Equal(create.Config["password"], config["password"]);
+                var create = new NewRepositoryWebHook("windowsazure", config, "http://test.com/example")
+                {
+                    ContentType = WebHookContentType.Json,
+                    Secret = string.Empty,
+                    InsecureSsl = true
+                };
 
                 Assert.Equal(create.Url, "http://test.com/example");
                 Assert.Equal(create.ContentType, WebHookContentType.Json);
                 Assert.Empty(create.Secret);
                 Assert.True(create.InsecureSsl);
+
+                var request = create.ToRequest();
+
+                Assert.Equal(request.Config.Count, 7);
+
+                Assert.True(request.Config.ContainsKey("url"));
+                Assert.True(request.Config.ContainsKey("content_type"));
+                Assert.True(request.Config.ContainsKey("secret"));
+                Assert.True(request.Config.ContainsKey("insecure_ssl"));
+
+                Assert.Equal(request.Config["url"], "http://test.com/example");
+                Assert.Equal(request.Config["content_type"], WebHookContentType.Json.ToParameter());
+                Assert.Equal(request.Config["secret"], "");
+                Assert.Equal(request.Config["insecure_ssl"], true.ToString());
+
+                Assert.True(request.Config.ContainsKey("hostname"));
+                Assert.Equal(request.Config["hostname"], config["hostname"]);
+                Assert.True(request.Config.ContainsKey("username"));
+                Assert.Equal(request.Config["username"], config["username"]);
+                Assert.True(request.Config.ContainsKey("password"));
+                Assert.Equal(request.Config["password"], config["password"]);
             }
         }
     }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Models\MilestoneRequestTests.cs" />
     <Compile Include="Models\IssueRequestTests.cs" />
     <Compile Include="Models\ModelExtensionsTests.cs" />
+    <Compile Include="Models\NewRepositoryWebHookTests.cs" />
     <Compile Include="Models\PullRequestRequestTests.cs" />
     <Compile Include="Models\PunchCardTests.cs" />
     <Compile Include="Models\ReadOnlyPagedCollectionTests.cs" />

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -54,7 +54,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
             Ensure.ArgumentNotNull(hook, "hook");
 
-            return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), hook);
+            return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), hook.ToRequest());
         }
 
         /// <summary>

--- a/Octokit/Exceptions/RepositoryWebHookConfigException.cs
+++ b/Octokit/Exceptions/RepositoryWebHookConfigException.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class RepositoryWebHookConfigException : Exception
+    {
+        readonly string message;
+
+        public RepositoryWebHookConfigException(IEnumerable<string> invalidConfig)
+        {
+            var parameterList = string.Join(", ", invalidConfig.Select(ic => ic.FromRubyCase()));
+            message = string.Format(CultureInfo.InvariantCulture,
+                "Duplicate webhook config values found - these values: {0} should not be passed in as part of the config values. Use the properties on the NewRepositoryWebHook class instead.",
+                parameterList);
+        }
+
+        public override string Message
+        {
+            get { return message; }
+        }
+
+#if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of RepositoryWebHookConfigException
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected RepositoryWebHookConfigException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null) return;
+            message = info.GetString("Message");
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("Message", Message);
+        }
+#endif
+    }
+}

--- a/Octokit/Helpers/StringExtensions.cs
+++ b/Octokit/Helpers/StringExtensions.cs
@@ -84,6 +84,17 @@ namespace Octokit
             return string.Join("_", propertyName.SplitUpperCase()).ToLowerInvariant();
         }
 
+        public static string FromRubyCase(this string propertyName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(propertyName, "s");
+            return string.Join("", propertyName.Split('_')).ToCapitalizedInvariant();
+        }
+
+        public static string ToCapitalizedInvariant(this string value)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(value, "s");
+            return string.Concat(value[0].ToString().ToUpperInvariant(), value.Substring(1));
+        }
         static IEnumerable<string> SplitUpperCase(this string source)
         {
             Ensure.ArgumentNotNullOrEmptyString(source, "source");

--- a/Octokit/Helpers/WebHookConfigComparer.cs
+++ b/Octokit/Helpers/WebHookConfigComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Octokit
+{
+    public class WebHookConfigComparer : IEqualityComparer<KeyValuePair<string, string>>
+    {
+        public bool Equals(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
+        {
+            return x.Key == y.Key;
+        }
+
+        public int GetHashCode(KeyValuePair<string, string> obj)
+        {
+            return obj.Key.GetHashCode();
+        }
+    }
+}

--- a/Octokit/Models/Request/NewRepositoryHook.cs
+++ b/Octokit/Models/Request/NewRepositoryHook.cs
@@ -100,6 +100,11 @@ namespace Octokit
         /// </value>
         public bool Active { get; set; }
 
+        public virtual NewRepositoryHook ToRequest()
+        {
+            return this;
+        }
+         
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/NewRepositoryHook.cs
+++ b/Octokit/Models/Request/NewRepositoryHook.cs
@@ -18,8 +18,8 @@ namespace Octokit
     /// <item>
     ///   <term>content_type</term>
     ///   <description>
-    ///     An optional string defining the media type used to serialize the payloads.Supported values include json and
-    ///     form.The default is form.
+    ///     An optional string defining the media type used to serialize the payloads. Supported values include json and
+    ///     form. The default is form.
     ///   </description>
     /// </item>
     /// <item>
@@ -33,7 +33,7 @@ namespace Octokit
     ///   <term>insecure_ssl:</term>
     ///   <description>
     ///     An optional string that determines whether the SSL certificate of the host for url will be verified when 
-    ///     delivering payloads.Supported values include "0" (verification is performed) and "1" (verification is not 
+    ///     delivering payloads. Supported values include "0" (verification is performed) and "1" (verification is not 
     ///     performed). The default is "0".
     ///   </description>
     /// </item>

--- a/Octokit/Models/Request/NewRepositoryWebHook.cs
+++ b/Octokit/Models/Request/NewRepositoryWebHook.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -145,16 +144,4 @@ namespace Octokit
         Json
     }
 
-    public class WebHookConfigComparer : IEqualityComparer<KeyValuePair<string, string>>
-    {
-        public bool Equals(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
-        {
-            return x.Key == y.Key;
-        }
-
-        public int GetHashCode(KeyValuePair<string, string> obj)
-        {
-            return obj.Key.GetHashCode();
-        }
-    }
 }

--- a/Octokit/Models/Request/NewRepositoryWebHook.cs
+++ b/Octokit/Models/Request/NewRepositoryWebHook.cs
@@ -18,8 +18,8 @@ namespace Octokit
     /// <item>
     ///   <term>content_type</term>
     ///   <description>
-    ///     An optional string defining the media type used to serialize the payloads.Supported values include json and
-    ///     form.The default is form.
+    ///     An optional string defining the media type used to serialize the payloads. Supported values include json and
+    ///     form. The default is form.
     ///   </description>
     /// </item>
     /// <item>
@@ -33,7 +33,7 @@ namespace Octokit
     ///   <term>insecure_ssl:</term>
     ///   <description>
     ///     An optional string that determines whether the SSL certificate of the host for url will be verified when 
-    ///     delivering payloads.Supported values include "0" (verification is performed) and "1" (verification is not 
+    ///     delivering payloads. Supported values include "0" (verification is performed) and "1" (verification is not 
     ///     performed). The default is "0".
     ///   </description>
     /// </item>
@@ -46,10 +46,10 @@ namespace Octokit
     public class NewRepositoryWebHook : NewRepositoryHook
     {
         /// <summary>
-        /// Initializes a new instance of the<see cref="NewRepositoryWebHook"/> class.   
+        /// Initializes a new instance of the <see cref="NewRepositoryWebHook"/> class.   
         /// Using default values for ContentType, Secret and InsecureSsl.     
         /// </summary>
-        /// <param name="name">Use web for a webhook or use the name of a valid service. (See /hooks for the list of valid service names.)
+        /// <param name="name">
         /// Use "web" for a webhook or use the name of a valid service. (See 
         /// <see href="https://api.github.com/hooks">https://api.github.com/hooks</see> for the list of valid service
         /// names.)
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="config">
         /// Key/value pairs to provide settings for this hook. These settings vary between the services and are
         /// defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for
-        /// false. Any JSON true/false values will be converted automatically.
+        /// false. Any true/false values will be converted automatically.
         /// </param>
         /// <param name="url">
         /// A required string defining the URL to which the payloads will be delivered.
@@ -99,7 +99,7 @@ namespace Octokit
         public string Secret { get; set; }
         
         /// <summary>
-        /// Gets wether the SSL certificate of the host will be verified when 
+        /// Gets whether the SSL certificate of the host will be verified when 
         /// delivering payloads. The default is `false`.
         /// </summary>
         /// <value>

--- a/Octokit/Models/Request/NewRepositoryWebHook.cs
+++ b/Octokit/Models/Request/NewRepositoryWebHook.cs
@@ -1,0 +1,168 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Creates a Webhook for the repository.
+    /// </summary>
+    /// <remarks>
+    /// To create a webhook, the following fields are required by the config:
+    /// <list type="bullet">
+    /// <item>
+    ///   <term>url</term>
+    ///   <description>A required string defining the URL to which the payloads will be delivered.</description>
+    /// </item>
+    /// <item>
+    ///   <term>content_type</term>
+    ///   <description>
+    ///     An optional string defining the media type used to serialize the payloads.Supported values include json and
+    ///     form.The default is form.
+    ///   </description>
+    /// </item>
+    /// <item>
+    ///   <term>secret</term>
+    ///   <description>
+    ///     An optional string that’s passed with the HTTP requests as an X-Hub-Signature header. The value of this
+    ///     header is computed as the HMAC hex digest of the body, using the secret as the key.
+    ///   </description>
+    /// </item>
+    /// <item>
+    ///   <term>insecure_ssl:</term>
+    ///   <description>
+    ///     An optional string that determines whether the SSL certificate of the host for url will be verified when 
+    ///     delivering payloads.Supported values include "0" (verification is performed) and "1" (verification is not 
+    ///     performed). The default is "0".
+    ///   </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// API: https://developer.github.com/v3/repos/hooks/#create-a-hook
+    /// </para>
+    /// </remarks>   
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewRepositoryWebHook : NewRepositoryHook
+    {
+        /// <summary>
+        /// Initializes a new instance of the<see cref="NewRepositoryWebHook"/> class.   
+        /// Using default values for ContentType, Secret and InsecureSsl.     
+        /// </summary>
+        /// <param name="name">Use web for a webhook or use the name of a valid service. (See /hooks for the list of valid service names.)
+        /// Use "web" for a webhook or use the name of a valid service. (See 
+        /// <see href="https://api.github.com/hooks">https://api.github.com/hooks</see> for the list of valid service
+        /// names.)
+        /// </param>
+        /// <param name="config">
+        /// Key/value pairs to provide settings for this hook. These settings vary between the services and are
+        /// defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for
+        /// false. Any JSON true/false values will be converted automatically.
+        /// </param>
+        /// <param name="url">
+        /// A required string defining the URL to which the payloads will be delivered.
+        /// </param>
+        public NewRepositoryWebHook(string name, IReadOnlyDictionary<string, string> config, string url) : this(name, config, url, WebHookContentType.Form, string.Empty, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the<see cref="NewRepositoryWebHook"/> class.        
+        /// </summary>
+        /// <param name="name">Use web for a webhook or use the name of a valid service. (See /hooks for the list of valid service names.)
+        /// Use "web" for a webhook or use the name of a valid service. (See 
+        /// <see href="https://api.github.com/hooks">https://api.github.com/hooks</see> for the list of valid service
+        /// names.)
+        /// </param>
+        /// <param name="config">
+        /// Key/value pairs to provide settings for this hook. These settings vary between the services and are
+        /// defined in the github-services repository. Booleans are stored internally as “1” for true, and “0” for
+        /// false. Any JSON true/false values will be converted automatically.
+        /// </param>
+        /// <param name="url">
+        /// A required string defining the URL to which the payloads will be delivered.
+        /// </param>
+        /// <param name="contentType">
+        /// An optional string defining the media type used to serialize the payloads. 
+        /// Supported values include json and form. 
+        /// The default is form.
+        /// </param>
+        /// <param name="secret">
+        /// An optional string that’s passed with the HTTP requests as an X-Hub-Signature header. 
+        /// The value of this header is computed as the 
+        /// <see href="https://github.com/github/github-services/blob/f3bb3dd780feb6318c42b2db064ed6d481b70a1f/lib/service/http_helper.rb#L77">
+        /// HMAC hex digest of the body, using the secret as the key
+        /// </see>.
+        /// </param>
+        /// <param name="insecureSsl">
+        /// An optional string that determines whether the SSL certificate of the host for url will be verified when delivering payloads. 
+        /// Supported values include "0" (verification is performed) and "1" (verification is not performed). 
+        /// The default is "0".
+        /// </param>
+        public NewRepositoryWebHook(string name, IReadOnlyDictionary<string, string> config, string url, WebHookContentType contentType, string secret, bool insecureSsl)
+            : base(name, GetWebHookConfig(url, contentType, secret, insecureSsl, config))
+        {
+            Ensure.ArgumentNotNullOrEmptyString(url, "url");
+
+            Url = url;
+            ContentType = contentType;
+            Secret = secret;
+            InsecureSsl = insecureSsl;
+        }
+
+        static Dictionary<string, string> GetWebHookConfig(string url, WebHookContentType contentType, string secret, bool insecureSsl, IReadOnlyDictionary<string, string> config)
+        {
+            var webHookConfig = new Dictionary<string, string>
+            {
+                { "url", url },
+                { "content_type", contentType.ToParameter() },
+                { "secret", secret },
+                { "insecure_ssl", insecureSsl ? "1" : "0" }
+            };
+            return config.Union(webHookConfig).ToDictionary(k => k.Key, v => v.Value);
+        }
+
+        /// <summary>
+        /// Gets the URL of the hook to create.
+        /// </summary>
+        /// <value>
+        /// The URL.
+        /// </value>
+        public string Url { get; protected set; }
+        
+        /// <summary>
+        /// Gets the content type used to serialize the payload.
+        /// </summary>
+        /// <value>
+        /// The content type.
+        /// </value>
+        public WebHookContentType ContentType { get; set; }
+        
+        /// <summary>
+        /// Gets the secret used as the key for the HMAC hex digest
+        /// of the body passed with the HTTP requests as an X-Hub-Signature header.
+        /// </summary>
+        /// <value>
+        /// The secret.
+        /// </value>
+        public string Secret { get; set; }
+        
+        /// <summary>
+        /// Gets wether the SSL certificate of the host will be verified when 
+        /// delivering payloads.
+        /// </summary>
+        /// <value>
+        ///  <c>true</c> if SSL certificate verification is not performed; 
+        /// otherwise, <c>false</c>.
+        /// </value>
+        public bool InsecureSsl { get; set; }
+    }
+
+    /// <summary>
+    /// The supported content types for payload serialization.
+    /// </summary>
+    public enum WebHookContentType
+    {
+        Form,
+        Json
+    }
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -408,6 +408,7 @@
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -407,6 +407,7 @@
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -406,6 +406,7 @@
     <Compile Include="Models\Response\Meta.cs" />
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -415,6 +415,7 @@
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -414,6 +414,7 @@
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -413,6 +413,7 @@
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -411,6 +411,7 @@
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -410,6 +410,7 @@
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -403,6 +403,7 @@
     <Compile Include="Models\Response\Meta.cs" />
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -405,6 +405,7 @@
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -411,6 +411,7 @@
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -410,6 +410,7 @@
     <Compile Include="Models\Common\Committer.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />
+    <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
     <Compile Include="Models\Request\RepositoryForksListRequest.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />
     <Compile Include="Exceptions\RepositoryExistsException.cs" />
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
+    <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
     <Compile Include="Helpers\ApiErrorExtensions.cs" />
     <Compile Include="Helpers\ApiUrls.Authorizations.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Helpers\HttpClientExtensions.cs" />
     <Compile Include="Helpers\PropertyOrField.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
+    <Compile Include="Helpers\WebHookConfigComparer.cs" />
     <Compile Include="Http\HttpMessageHandlerFactory.cs" />
     <Compile Include="Http\IApiInfoProvider.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />


### PR DESCRIPTION
Introducing `NewRepositoryWebHook`, a new strongly typed class that derives from the existing `NewRepositoryHook` class but adds properties and constructor parameters for config settings that should be passed to the API when creating a new web hook. These settings are merged with the config settings that are specific to the web service the web hook will be interacting with (as per [https://api.github.com/hooks](https://api.github.com/hooks)).

Fixes octokit/octokit.net#914