### PR TITLE
add System to required framework assemblies for net45

### DIFF
--- a/Octokit.nuspec
+++ b/Octokit.nuspec
@@ -26,6 +26,7 @@
       </group>
     </dependencies>
     <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" targetFramework="net45" />
       <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net45, netcore45" />
     </frameworkAssemblies>
   </metadata>


### PR DESCRIPTION
Currently, installing Octokit into a project which does not have a reference to `System` fails like so:

![image](https://cloud.githubusercontent.com/assets/677704/10204552/b82ae52c-67bc-11e5-93e1-f6155b0d114f.png)

I always strip out all references from a project and only add back in what is required (it's surprising how often something like a simple business logic lib doesn't even need a reference to `System`).

Anyhow, this nasty looking error can be avoided by declaring `System` as a required framework assembly reference.

I've no idea if this is also required for `netcore45`. I tried it out in a sample `netcore45` project but the whole notion of referencing framework assemblies explicitly doesn't even seem to exist there.