### PR TITLE
VS2015 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tools/xunit.runner.console
 # New VS Test Runner creates arbitrary folders with PDBs
 *.pdb
 pingme.txt
+
+# it's 2015, no need to keep this around when migrating projects
+Backup/

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -39,6 +39,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release\Net45\Octokit.Reactive.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -167,11 +167,21 @@ namespace Octokit
         Task DeleteFile(string owner, string name, string path, DeleteFileRequest request);
     }
 
+    /// <summary>
+    /// The archive format to return from the server
+    /// </summary>
     public enum ArchiveFormat
     {
+        /// <summary>
+        /// The TAR archive format
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Tarball")]
         [Parameter(Value = "tarball")]
         Tarball,
+
+        /// <summary>
+        /// The ZIP archive format
+        /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Zipball")]
         [Parameter(Value = "zipball")]
         Zipball

--- a/Octokit/Clients/OAuthClient.cs
+++ b/Octokit/Clients/OAuthClient.cs
@@ -12,6 +12,10 @@ namespace Octokit
         readonly IConnection connection;
         readonly Uri hostAddress;
 
+        /// <summary>
+        /// Create an instance of the OauthClient
+        /// </summary>
+        /// <param name="connection">The underlying connection to use</param>
         public OauthClient(IConnection connection)
         {
             Ensure.ArgumentNotNull(connection, "connection");

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -9,6 +9,10 @@ namespace Octokit
     /// </summary>
     public class RepositoryContentsClient : ApiClient, IRepositoryContentsClient
     {
+        /// <summary>
+        /// Create an instance of the RepositoryContentsClient
+        /// </summary>
+        /// <param name="apiConnection">The underlying connection to use</param>
         public RepositoryContentsClient(IApiConnection apiConnection) : base(apiConnection)
         {
         }

--- a/Octokit/Http/ApiResponse.cs
+++ b/Octokit/Http/ApiResponse.cs
@@ -1,11 +1,24 @@
 ﻿namespace Octokit.Internal
 {
+    /// <summary>
+    /// Wrapper for a response from the API
+    /// </summary>
+    /// <typeparam name="T">Payload contained in the response</typeparam>
     public class ApiResponse<T> : IApiResponse<T>
     {
+        /// <summary>
+        /// Create a ApiResponse from an existing request
+        /// </summary>
+        /// <param name="response">An existing request to wrap</param>
         public ApiResponse(IResponse response) : this(response, GetBodyAsObject(response))
         {
         }
 
+        /// <summary>
+        /// Create a ApiResponse from an existing request and object
+        /// </summary>
+        /// <param name="response">An existing request to wrap</param>
+        /// <param name="bodyAsObject">The payload from an existing request</param>
         public ApiResponse(IResponse response, T bodyAsObject)
         {
             Ensure.ArgumentNotNull(response, "response");
@@ -14,8 +27,14 @@
             Body = bodyAsObject;
         }
 
+        /// <summary>
+        /// The payload of the response
+        /// </summary>
         public T Body { get; private set; }
 
+        /// <summary>
+        /// The context of the response
+        /// </summary>
         public IResponse HttpResponse { get; private set; }
 
         static T GetBodyAsObject(IResponse response)

--- a/Octokit/Http/HttpVerb.cs
+++ b/Octokit/Http/HttpVerb.cs
@@ -2,11 +2,11 @@
 
 namespace Octokit.Internal
 {
-    public static class HttpVerb
+    internal static class HttpVerb
     {
         static readonly HttpMethod patch = new HttpMethod("PATCH");
 
-        public static HttpMethod Patch
+        internal static HttpMethod Patch
         {
             get { return patch; }
         }

--- a/Octokit/Http/ICredentialStore.cs
+++ b/Octokit/Http/ICredentialStore.cs
@@ -3,8 +3,15 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Abstraction for interacting with credentials
+    /// </summary>
     public interface ICredentialStore
     {
+        /// <summary>
+        /// Retrieve the credentials from the underlying store
+        /// </summary>
+        /// <returns>A continuation containing credentials</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification="Nope")]
         Task<Credentials> GetCredentials();
     }

--- a/Octokit/Http/InMemoryCredentialStore.cs
+++ b/Octokit/Http/InMemoryCredentialStore.cs
@@ -2,10 +2,17 @@
 
 namespace Octokit.Internal
 {
+    /// <summary>
+    /// Abstraction for interacting with credentials
+    /// </summary>
     public class InMemoryCredentialStore : ICredentialStore
     {
         readonly Credentials _credentials;
 
+        /// <summary>
+        /// Create an instance of the InMemoryCredentialStore
+        /// </summary>
+        /// <param name="credentials"></param>
         public InMemoryCredentialStore(Credentials credentials)
         {
             Ensure.ArgumentNotNull(credentials, "credentials");
@@ -13,6 +20,10 @@ namespace Octokit.Internal
             _credentials = credentials;
         }
 
+        /// <summary>
+        /// Retrieve the credentials from the underlying store
+        /// </summary>
+        /// <returns>A continuation containing credentials</returns>
         public Task<Credentials> GetCredentials()
         {
             return Task.FromResult(_credentials);

--- a/Octokit/Models/Request/NewArbitraryMarkDown.cs
+++ b/Octokit/Models/Request/NewArbitraryMarkDown.cs
@@ -49,7 +49,6 @@ namespace Octokit
         /// </summary>
         /// <param name="text">The Markdown text to render</param>
         /// <param name="mode">The rendering mode. Can be either markdown by default or gfm</param>
-        /// </param>
         public NewArbitraryMarkdown(string text, string mode)
             : this(text, mode, null)
         { 

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -310,8 +310,6 @@ namespace Octokit
         /// <summary>
         /// Matches repositories with regards to both the <param name="from"/> and <param name="to"/> dates.
         /// </summary>
-        /// <param name="from">earlier date of the two</param>
-        /// <param name="to">latter date of the two</param>
         public DateRange(DateTime from, DateTime to)
         {
             query = string.Format(CultureInfo.InvariantCulture, "{0:yyyy-MM-dd}..{1:yyyy-MM-dd}", from, to);

--- a/Octokit/Models/Response/Meta.cs
+++ b/Octokit/Models/Response/Meta.cs
@@ -11,10 +11,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class Meta
     {
+        /// <summary>
+        /// Create an instance of the Meta
+        /// </summary>
         public Meta()
         {
         }
 
+        /// <summary>
+        /// Create an instance of the Meta
+        /// </summary>
+        /// <param name="verifiablePasswordAuthentication">Whether authentication with username and password is supported.</param>
+        /// <param name="gitHubServicesSha">The currently-deployed SHA of github-services.</param>
+        /// <param name="hooks">An array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from on GitHub.com.</param>
+        /// <param name="git">An array of IP addresses in CIDR format specifying the Git servers for the GitHub server</param>
+        /// <param name="pages">An array of IP addresses in CIDR format specifying the A records for GitHub Pages.</param>
         public Meta(
             bool verifiablePasswordAuthentication,
             string gitHubServicesSha,

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -33,6 +33,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <DocumentationFile>bin\Release\Mono\Octokit.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -38,6 +38,7 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release\Portable\Octokit.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -410,7 +410,7 @@
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v12.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v14.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -45,6 +45,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release\NetCore45\Octokit.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -11,12 +11,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Octokit</RootNamespace>
     <AssemblyName>Octokit</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>
+    </TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
     <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <DefaultLanguage>en-US</DefaultLanguage>
     <LangVersion>5</LangVersion>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
+    <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -41,6 +41,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Octokit.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release\Net45\Octokit.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![logo](octokit-dotnet_2.png)
 
-
 Octokit is a client library targeting .NET 4.5 and above that provides an easy
 way to interact with the [GitHub API](http://developer.github.com/v3/).
 
@@ -63,10 +62,6 @@ cd Octokit
 
 Visit the [Contributor Guidelines](https://github.com/octokit/octokit.net/blob/master/CONTRIBUTING.md) 
 for more details.
-
-## Build Server
-
-The builds and tests for Octokit.net are run on [AppVeyor](http://www.appveyor.com). This enables us to build and test incoming pull requests: https://ci.appveyor.com/project/Haacked15676/octokit-net
 
 ## Problems?
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Please see https://github.com/octokit/octokit.net/blob/master/docs/index.md for 
 Octokit is a single assembly designed to be easy to deploy anywhere. If you 
 prefer to compile it yourself, you’ll need:
 
-* Visual Studio 2013, or Xamarin Studio
-* Windows 8 or higher to build and test the WinRT projects
+* Visual Studio 2015, or Xamarin Studio
+* Windows 8.1 or higher to build and test the WinRT projects
 
 To clone it locally click the "Clone in Windows" button above or run the 
 following git commands.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Please see https://github.com/octokit/octokit.net/blob/master/docs/index.md for 
 Octokit is a single assembly designed to be easy to deploy anywhere. If you 
 prefer to compile it yourself, you’ll need:
 
-* Visual Studio 2015, or Xamarin Studio
+* Visual Studio 2015 or Xamarin Studio
 * Windows 8.1 or higher to build and test the WinRT projects
 
-To clone it locally click the "Clone in Windows" button above or run the 
+To clone it locally click the "Clone in Desktop" button above or run the 
 following git commands.
 
 ```

--- a/build.fsx
+++ b/build.fsx
@@ -125,7 +125,7 @@ Target "SourceLink" (fun _ ->
 
 Target "CreateOctokitPackage" (fun _ ->
     let net45Dir = packagingDir @@ "lib/net45/"
-    let netcore45Dir = packagingDir @@ "lib/netcore45/"
+    let netcore45Dir = packagingDir @@ "lib/netcore451/"
     let portableDir = packagingDir @@ "lib/portable-net45+wp80+win+wpa81/"
     CleanDirs [net45Dir; netcore45Dir; portableDir]
 

--- a/build.fsx
+++ b/build.fsx
@@ -31,7 +31,7 @@ let buildMode = getBuildParamOrDefault "buildMode" "Release"
 
 MSBuildDefaults <- { 
     MSBuildDefaults with 
-        ToolsVersion = Some "12.0"
+        ToolsVersion = Some "14.0"
         Verbosity = Some MSBuildVerbosity.Minimal }
 
 Target "Clean" (fun _ ->
@@ -67,7 +67,7 @@ Target "FixProjects" (fun _ ->
 
 let setParams defaults = {
     defaults with
-        ToolsVersion = Some("12.0")
+        ToolsVersion = Some("14.0")
         Targets = ["Build"]
         Properties =
             [


### PR DESCRIPTION
- [x] can build under VS2015 locally
- [x] can build on AppVeyor
- [x] `netcore45` -> `netcore451` target it any more
- [x] test and verify standard version can build and test this
- [x] docs
- [x] CI back to green
- [x] run integration tests
- [x] test preview package in a Store app