### PR TITLE
Provided a httpclient timeout option

### DIFF
--- a/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubClientTests.cs
@@ -36,6 +36,15 @@ public class GitHubClientTests
             }
         }
 
+
+        [IntegrationTest]
+        public async Task WillFailWithHttpTimeout()
+        {
+            var github = Helper.GetAnonymousClient(TimeSpan.FromMilliseconds(5));
+
+           await Assert.ThrowsAnyAsync<System.Threading.Tasks.TaskCanceledException>(async () => await github.Repository.GetAllContributors("octokit", "octokit.net"));
+        }
+
         [IntegrationTest]
         public async Task CanRetrieveLastApiInfoWithLinks()
         {

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -131,6 +131,7 @@ namespace Octokit.Tests.Integration
         {
             return new GitHubClient(new ProductHeaderValue("OctokitTests"));
         }
+        
         public static IGitHubClient GetAnonymousClient(TimeSpan httpTimeout)
         {
             return new GitHubClient(new ProductHeaderValue("OctokitTests"),httpTimeout);

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -118,6 +118,7 @@ namespace Octokit.Tests.Integration
             };
         }
 
+
         public static GitHubClient GetAuthenticatedApplicationClient()
         {
             return new GitHubClient(new ProductHeaderValue("OctokitTests"))
@@ -129,6 +130,10 @@ namespace Octokit.Tests.Integration
         public static IGitHubClient GetAnonymousClient()
         {
             return new GitHubClient(new ProductHeaderValue("OctokitTests"));
+        }
+        public static IGitHubClient GetAnonymousClient(TimeSpan httpTimeout)
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"),httpTimeout);
         }
 
         public static IGitHubClient GetBadCredentialsClient()

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -27,7 +27,6 @@ namespace Octokit
         {
         }
 
-
         /// <summary>
         /// Create a new instance of the GitHub API v3 client pointing to 
         /// https://api.github.com/

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -27,6 +27,23 @@ namespace Octokit
         {
         }
 
+
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to 
+        /// https://api.github.com/
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public GitHubClient(ProductHeaderValue productInformation,TimeSpan httpTimeout)
+            : this(new Connection(productInformation, GitHubApiUrl,httpTimeout))
+        {
+        }
+
         /// <summary>
         /// Create a new instance of the GitHub API v3 client pointing to 
         /// https://api.github.com/
@@ -38,6 +55,22 @@ namespace Octokit
         /// <param name="credentialStore">Provides credentials to the client when making requests</param>
         public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore)
             : this(new Connection(productInformation, credentialStore))
+        {
+        }
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to 
+        /// https://api.github.com/
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests</param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore,TimeSpan httpTimeout)
+            : this(new Connection(productInformation, credentialStore,httpTimeout))
         {
         }
 
@@ -56,6 +89,25 @@ namespace Octokit
         {
         }
 
+
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="baseAddress">
+        /// The address to point this client to. Typically used for GitHub Enterprise 
+        /// instances</param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public GitHubClient(ProductHeaderValue productInformation, Uri baseAddress,TimeSpan httpTimeout)
+            : this(new Connection(productInformation, FixUpBaseUri(baseAddress),httpTimeout))
+        {
+        }
+
         /// <summary>
         /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
         /// </summary>
@@ -69,6 +121,25 @@ namespace Octokit
         /// instances</param>
         public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore, Uri baseAddress)
             : this(new Connection(productInformation, FixUpBaseUri(baseAddress), credentialStore))
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests</param>
+        /// <param name="baseAddress">
+        /// The address to point this client to. Typically used for GitHub Enterprise 
+        /// instances</param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public GitHubClient(ProductHeaderValue productInformation, ICredentialStore credentialStore, Uri baseAddress,TimeSpan httpTimeout)
+            : this(new Connection(productInformation, FixUpBaseUri(baseAddress), credentialStore,httpTimeout))
         {
         }
 

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -89,7 +89,6 @@ namespace Octokit
         {
         }
 
-
         /// <summary>
         /// Create a new instance of the GitHub API v3 client pointing to the specified baseAddress.
         /// </summary>

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -56,6 +56,7 @@ namespace Octokit
             : this(new Connection(productInformation, credentialStore))
         {
         }
+        
         /// <summary>
         /// Create a new instance of the GitHub API v3 client pointing to 
         /// https://api.github.com/

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -43,6 +43,21 @@ namespace Octokit
         /// The name (and optionally version) of the product using this library. This is sent to the server as part of
         /// the user agent for analytics purposes.
         /// </param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public Connection(ProductHeaderValue productInformation,TimeSpan httpTimeout)
+            : this(productInformation, _defaultGitHubApiUrl, _anonymousCredentials,httpTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub API.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
         /// <param name="httpClient">
         /// The client to use for executing requests
         /// </param>
@@ -66,6 +81,25 @@ namespace Octokit
         {
         }
 
+
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub API.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="baseAddress">
+        /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise 
+        /// instance</param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public Connection(ProductHeaderValue productInformation, Uri baseAddress,TimeSpan httpTimeout)
+            : this(productInformation, baseAddress, _anonymousCredentials,httpTimeout)
+        {
+        }
+
         /// <summary>
         /// Creates a new connection instance used to make requests of the GitHub API.
         /// </summary>
@@ -86,6 +120,21 @@ namespace Octokit
         /// The name (and optionally version) of the product using this library. This is sent to the server as part of
         /// the user agent for analytics purposes.
         /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests</param>
+        /// <param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        public Connection(ProductHeaderValue productInformation, ICredentialStore credentialStore,TimeSpan httpTimeout)
+            : this(productInformation, _defaultGitHubApiUrl, credentialStore,httpTimeout)
+        {
+        }
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub API.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
         /// <param name="baseAddress">
         /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise 
         /// instance</param>
@@ -93,6 +142,27 @@ namespace Octokit
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public Connection(ProductHeaderValue productInformation, Uri baseAddress, ICredentialStore credentialStore)
             : this(productInformation, baseAddress, credentialStore, new HttpClientAdapter(HttpMessageHandlerFactory.CreateDefault), new SimpleJsonSerializer())
+        {
+        }
+
+
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub API.
+        /// </summary>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library. This is sent to the server as part of
+        /// the user agent for analytics purposes.
+        /// </param>
+        /// <param name="baseAddress">
+        /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise 
+        /// instance</param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests</param>
+        ///<param name="httpTimeout">
+        /// The number of milliseconds to wait before the request times out. The default HTTP timeout is 100000.
+        /// </param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public Connection(ProductHeaderValue productInformation, Uri baseAddress, ICredentialStore credentialStore,TimeSpan httpTimeout)
+            : this(productInformation, baseAddress, credentialStore, new HttpClientAdapter(HttpMessageHandlerFactory.CreateDefault,httpTimeout), new SimpleJsonSerializer())
         {
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -21,13 +21,21 @@ namespace Octokit.Internal
         readonly HttpClient _http;
 
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        public HttpClientAdapter(Func<HttpMessageHandler> getHandler)
+        public HttpClientAdapter(Func<HttpMessageHandler> getHandler) 
         {
             Ensure.ArgumentNotNull(getHandler, "getHandler");
-
             _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });
         }
 
+        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public HttpClientAdapter(Func<HttpMessageHandler> getHandler,TimeSpan httpTimeout)
+        {
+            Ensure.ArgumentNotNull(getHandler, "getHandler");
+            Ensure.GreaterThanZero(httpTimeout, "httpTimeout");
+
+            _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });
+            _http.Timeout = httpTimeout;
+        }
         /// <summary>
         /// Sends the specified request and returns a response.
         /// </summary>
@@ -37,8 +45,9 @@ namespace Octokit.Internal
         public async Task<IResponse> Send(IRequest request, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNull(request, "request");
-
+           
             var cancellationTokenForRequest = GetCancellationTokenForRequest(request, cancellationToken);
+
 
             using (var requestMessage = BuildRequestMessage(request))
             {
@@ -60,6 +69,7 @@ namespace Octokit.Internal
                 var unifiedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellation.Token);
 
                 cancellationTokenForRequest = unifiedCancellationToken.Token;
+                
             }
             return cancellationTokenForRequest;
         }

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -6,10 +6,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersionAttribute("0.17.0")]
 [assembly: AssemblyFileVersionAttribute("0.17.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System
-{
-    internal static class AssemblyVersionInformation
-    {
+namespace System {
+    internal static class AssemblyVersionInformation {
         internal const string Version = "0.17.0";
     }
 }


### PR DESCRIPTION
The `HttpClient` does not take the `Timeout` argument which by default is 100 seconds. Implemented a change where the user has an option to provide the timeout. This is to address the #963.