### PR TITLE
Json serialization for Unicode

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -69,21 +69,28 @@ namespace Octokit.Tests
             [Fact]
             public void HandleUnicodeCharacters()
             {
+                const string backspace = "\b";
+                const string tab = "\t";
+
                 var sb = new StringBuilder();
                 sb.Append("My name has Unicode characters");
                 Enumerable.Range(0, 19).Select(e => System.Convert.ToChar(e))
                 .Aggregate(sb, (a, b) => a.Append(b));
-                var backspace = "\b";
-                var tab = "\t";
                 sb.Append(backspace).Append(tab);
-                sb.Append("With non Unicode data at the end.");
                 var data = sb.ToString();
 
-                var sample = new Sample()  { FirstName = data  };
-                var json = new SimpleJsonSerializer().Serialize(sample);
-                var deserializeObject = new SimpleJsonSerializer().Deserialize<Sample>(json);
-                Assert.True(deserializeObject.FirstName.Equals(data));
-                
+                var json = new SimpleJsonSerializer().Serialize(data);
+                var lastTabCharacter = (json
+                        .Reverse()
+                        .Skip(1)
+                        .Take(2)
+                        .Reverse()
+                    .Aggregate(new StringBuilder(),(a,b) =>a.Append(b)));
+
+                var deserializeData = new SimpleJsonSerializer().Deserialize<string>(json);
+
+                Assert.True(lastTabCharacter.ToString().Equals("\\t"));
+                Assert.Equal(data,deserializeData );
             }
 
             [Fact]

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -1,5 +1,7 @@
 ﻿using Octokit.Helpers;
 using Octokit.Internal;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Octokit.Tests
@@ -62,6 +64,26 @@ namespace Octokit.Tests
                 var json = new SimpleJsonSerializer().Serialize(item);
 
                 Assert.Equal("{\"int\":42,\"bool\":true}", json);
+            }
+
+            [Fact]
+            public void HandleUnicodeCharacters()
+            {
+                var sb = new StringBuilder();
+                sb.Append("My name has Unicode characters");
+                Enumerable.Range(0, 19).Select(e => System.Convert.ToChar(e))
+                .Aggregate(sb, (a, b) => a.Append(b));
+                var backspace = "\b";
+                var tab = "\t";
+                sb.Append(backspace).Append(tab);
+                sb.Append("With non Unicode data at the end.");
+                var data = sb.ToString();
+
+                var sample = new Sample()  { FirstName = data  };
+                var json = new SimpleJsonSerializer().Serialize(sample);
+                var deserializeObject = new SimpleJsonSerializer().Deserialize<Sample>(json);
+                Assert.True(deserializeObject.FirstName.Equals(data));
+                
             }
 
             [Fact]

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -6,10 +6,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersionAttribute("0.17.0")]
 [assembly: AssemblyFileVersionAttribute("0.17.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System
-{
-    internal static class AssemblyVersionInformation
-    {
+namespace System {
+    internal static class AssemblyVersionInformation {
         internal const string Version = "0.17.0";
     }
 }


### PR DESCRIPTION
This will fix the Unicode Json serialization bug https://github.com/octokit/octokit.net/issues/967.

When I was looking at the code I realized there was already a fix with a PR https://github.com/facebook-csharp-sdk/simple-json/pull/66 .Reused the same code for this fix.

 