### PR TITLE
Generate nuget packages on appveyor 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 init:
   - git config --global core.autocrlf input
 build_script:
-  - cmd: build.cmd CreatePackages
+  - cmd: build.cmd BuildApp
   - cmd: build.cmd UnitTests
   - cmd: build.cmd ConventionTests
+  - cmd: build.cmd CreatePackages
 test: off
 nuget:
   account_feed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,9 @@
 init:
   - git config --global core.autocrlf input
 build_script:
-  - cmd: build.cmd BuildApp
+  - cmd: build.cmd CreatePackages
   - cmd: build.cmd UnitTests
   - cmd: build.cmd ConventionTests
-  - cmd: build.cmd CreatePackages
 test: off
 nuget:
   account_feed: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,5 @@ test: off
 nuget:
   account_feed: true
   project_feed: true
-  disable_publish_on_pr: true
 artifacts:
 - path: '**\octokit*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,4 +4,11 @@ build_script:
   - cmd: build.cmd BuildApp
   - cmd: build.cmd UnitTests
   - cmd: build.cmd ConventionTests
+  - cmd: build.cmd CreatePackages
 test: off
+nuget:
+  account_feed: true
+  project_feed: true
+  disable_publish_on_pr: true
+artifacts:
+- path: '**\octokit*.nupkg'


### PR DESCRIPTION
Generate nuget packages on appveyor is something that will help consuming the latest master build without waiting for a release 

For example in this  https://github.com/octokit/octokit.net/issues/967#issuecomment-162253541 the consumer of the package had to go through the hazzle of building nuget locally to test this. 

I was enable to enable the nuget packages on my appveyor builds 
https://ci.appveyor.com/nuget/octokit-net-naveen


As part of this PR the main appveyor build settings page has to be updated with a meaningful nuget name which I think is owned by @Haacked 

Here is mine
https://ci.appveyor.com/project/naveensrinivasan/octokit-net/settings/nuget

![image](https://cloud.githubusercontent.com/assets/172697/11611429/eeabc3a2-9b9a-11e5-8ac3-0aee1c5ed68b.png)

After updating that we could include that in the README.md so that anyone can consume the latest builds.