### PR TITLE
ToString for ApiException should contain response payload

### DIFF
--- a/Octokit.Tests/Exceptions/ApiErrorTests.cs
+++ b/Octokit.Tests/Exceptions/ApiErrorTests.cs
@@ -10,10 +10,7 @@ namespace Octokit.Tests.Exceptions
 {
     public class ApiErrorTests
     {
-        [Fact]
-        public void CanBeDeserialized()
-        {
-            const string json = @"{
+        const string json = @"{
    ""message"": ""Validation Failed"",
    ""errors"": [
      {
@@ -23,6 +20,9 @@ namespace Octokit.Tests.Exceptions
      }
    ]
  }";
+        [Fact]
+        public void CanBeDeserialized()
+        {
             var serializer = new SimpleJsonSerializer();
 
             var apiError = serializer.Deserialize<ApiError>(json);
@@ -32,6 +32,21 @@ namespace Octokit.Tests.Exceptions
             Assert.Equal("Issue", apiError.Errors[0].Resource);
             Assert.Equal("title", apiError.Errors[0].Field);
             Assert.Equal("missing_field", apiError.Errors[0].Code);
+        }
+
+        public class TheToStringMethod
+        {
+            [Fact]
+            public void FormatsErrors()
+            {
+                var serializer = new SimpleJsonSerializer();
+
+                var apiError = serializer.Deserialize<ApiError>(json);
+                var stringRepresentation = apiError.ToString();
+                Assert.Contains("Field: title", stringRepresentation);
+                Assert.Contains("Code: title", stringRepresentation);
+                Assert.Contains("Resource: title", stringRepresentation);
+            }
         }
     }
 }

--- a/Octokit.Tests/Exceptions/ApiErrorTests.cs
+++ b/Octokit.Tests/Exceptions/ApiErrorTests.cs
@@ -33,20 +33,5 @@ namespace Octokit.Tests.Exceptions
             Assert.Equal("title", apiError.Errors[0].Field);
             Assert.Equal("missing_field", apiError.Errors[0].Code);
         }
-
-        public class TheToStringMethod
-        {
-            [Fact]
-            public void FormatsErrors()
-            {
-                var serializer = new SimpleJsonSerializer();
-
-                var apiError = serializer.Deserialize<ApiError>(json);
-                var stringRepresentation = apiError.ToString();
-                Assert.Contains("Field: title", stringRepresentation);
-                Assert.Contains("Code: missing_field", stringRepresentation);
-                Assert.Contains("Resource: Issue", stringRepresentation);
-            }
-        }
     }
 }

--- a/Octokit.Tests/Exceptions/ApiErrorTests.cs
+++ b/Octokit.Tests/Exceptions/ApiErrorTests.cs
@@ -44,8 +44,8 @@ namespace Octokit.Tests.Exceptions
                 var apiError = serializer.Deserialize<ApiError>(json);
                 var stringRepresentation = apiError.ToString();
                 Assert.Contains("Field: title", stringRepresentation);
-                Assert.Contains("Code: title", stringRepresentation);
-                Assert.Contains("Resource: title", stringRepresentation);
+                Assert.Contains("Code: missing_field", stringRepresentation);
+                Assert.Contains("Resource: Issue", stringRepresentation);
             }
         }
     }

--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -120,5 +120,24 @@ namespace Octokit.Tests.Exceptions
             }
 #endif
         }
+
+        public class TheToStringMethod
+        {
+            [Fact]
+            public void ContainsErrorDetails()
+            {
+                var response = new Response(
+                    HttpStatusCode.GatewayTimeout,
+                    @"{""errors"":[{""code"":""custom"",""field"":""key"",""message"":""key is " +
+                           @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}",
+                    new Dictionary<string, string>(),
+                    "application/json"
+                );
+
+                var exception = new ApiException(response);
+                var stringRepresentation = exception.ToString();
+                Assert.Contains("key is already in use", stringRepresentation);
+            }
+        }
     }
 }

--- a/Octokit.Tests/Exceptions/ApiExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiExceptionTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 using NSubstitute;
 using Octokit.Internal;
 using Xunit;
@@ -124,19 +125,67 @@ namespace Octokit.Tests.Exceptions
         public class TheToStringMethod
         {
             [Fact]
-            public void ContainsErrorDetails()
+            public void ContainsResponseBody()
+            {
+                const string responseBody = @"{""errors"":[{""code"":""custom"",""field"":""key"",""message"":""key is " +
+                                            @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}";
+                var response = new Response(
+                    HttpStatusCode.GatewayTimeout,
+                    responseBody,
+                    new Dictionary<string, string>(),
+                    "application/json"
+                    );
+
+                var exception = new ApiException(response);
+                var stringRepresentation = exception.ToString();
+                Assert.Contains(responseBody, stringRepresentation);
+            }
+
+            [Fact]
+            public void DoesNotThrowIfBodyIsNotDefined()
             {
                 var response = new Response(
                     HttpStatusCode.GatewayTimeout,
-                    @"{""errors"":[{""code"":""custom"",""field"":""key"",""message"":""key is " +
-                           @"already in use"",""resource"":""PublicKey""}],""message"":""Validation Failed""}",
+                    null,
                     new Dictionary<string, string>(),
                     "application/json"
                 );
 
                 var exception = new ApiException(response);
                 var stringRepresentation = exception.ToString();
-                Assert.Contains("key is already in use", stringRepresentation);
+                Assert.NotNull(stringRepresentation);
+            }
+
+            [Fact]
+            public void DoesNotPrintImageContent()
+            { 
+                var responceBody = new byte[0];
+                var response = new Response(
+                    HttpStatusCode.GatewayTimeout,
+                    responceBody,
+                    new Dictionary<string, string>(),
+                    "image/*"
+                );
+
+                var exception = new ApiException(response);
+                var stringRepresentation = exception.ToString();
+                Assert.NotNull(stringRepresentation);
+            }
+
+            [Fact]
+            public void DoesNotPrintNonStringContent()
+            {
+                var responceBody = new byte[0];
+                var response = new Response(
+                    HttpStatusCode.GatewayTimeout,
+                    responceBody,
+                    new Dictionary<string, string>(),
+                    "application/json"
+                );
+
+                var exception = new ApiException(response);
+                var stringRepresentation = exception.ToString();
+                Assert.NotNull(stringRepresentation);
             }
         }
     }

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -179,5 +179,11 @@ namespace Octokit
                 return ApiError != null ? ApiError.Message : null;
             }
         }
+
+        public override string ToString()
+        {
+            var original = base.ToString();
+            return original + Environment.NewLine + ApiError;
+        }
     }
 }

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -180,10 +180,28 @@ namespace Octokit
             }
         }
 
+        /// <summary>
+        /// Get the inner http response body from the API response
+        /// </summary>
+        /// <remarks>
+        /// Returns empty string if HttpResponse is not populated or if
+        /// response body is not a string
+        /// </remarks>
+        protected string HttpResponseBodySafe
+        {
+            get
+            {
+                return HttpResponse != null
+                       && !HttpResponse.ContentType.StartsWith("image/")
+                       && HttpResponse.Body is string
+                    ? (string)HttpResponse.Body : string.Empty;
+            }
+        }
+
         public override string ToString()
         {
             var original = base.ToString();
-            return original + Environment.NewLine + ApiError;
+            return original + Environment.NewLine + HttpResponseBodySafe ;
         }
     }
 }

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -192,7 +192,7 @@ namespace Octokit
             get
             {
                 return HttpResponse != null
-                       && !HttpResponse.ContentType.StartsWith("image/")
+                       && !HttpResponse.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
                        && HttpResponse.Body is string
                     ? (string)HttpResponse.Body : string.Empty;
             }

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Octokit
 {
@@ -39,5 +40,32 @@ namespace Octokit
         /// Additional details about the error
         /// </summary>
         public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
+
+        public override string ToString()
+        {
+            var original = base.ToString();
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append("Message: ");
+            stringBuilder.AppendLine(Message);
+            stringBuilder.Append("Documentation url: ");
+            stringBuilder.AppendLine(DocumentationUrl);
+
+            if (Errors != null)
+            {
+                stringBuilder.AppendLine("Errors:");
+                foreach (var apiErrorDetail in Errors)
+                {
+                    stringBuilder.Append("Message: ");
+                    stringBuilder.AppendLine(apiErrorDetail.Message);
+                    stringBuilder.Append("Code: ");
+                    stringBuilder.AppendLine(apiErrorDetail.Code);
+                    stringBuilder.Append("Field: ");
+                    stringBuilder.AppendLine(apiErrorDetail.Field);
+                    stringBuilder.Append("Resource: ");
+                    stringBuilder.AppendLine(apiErrorDetail.Resource);
+                }
+            }
+            return original + stringBuilder;
+        }
     }
 }

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -41,31 +41,5 @@ namespace Octokit
         /// </summary>
         public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
 
-        public override string ToString()
-        {
-            var original = base.ToString();
-            var stringBuilder = new StringBuilder();
-            stringBuilder.Append("Message: ");
-            stringBuilder.AppendLine(Message);
-            stringBuilder.Append("Documentation url: ");
-            stringBuilder.AppendLine(DocumentationUrl);
-
-            if (Errors != null)
-            {
-                stringBuilder.AppendLine("Errors:");
-                foreach (var apiErrorDetail in Errors)
-                {
-                    stringBuilder.Append("Message: ");
-                    stringBuilder.AppendLine(apiErrorDetail.Message);
-                    stringBuilder.Append("Code: ");
-                    stringBuilder.AppendLine(apiErrorDetail.Code);
-                    stringBuilder.Append("Field: ");
-                    stringBuilder.AppendLine(apiErrorDetail.Field);
-                    stringBuilder.Append("Resource: ");
-                    stringBuilder.AppendLine(apiErrorDetail.Resource);
-                }
-            }
-            return original + stringBuilder;
-        }
     }
 }

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Octokit
 {
@@ -40,6 +39,5 @@ namespace Octokit
         /// Additional details about the error
         /// </summary>
         public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
-
     }
 }


### PR DESCRIPTION
Overrided `ToString` methods for `ApiException` and `ApiError`
Fixes #945 

I'm not really sure about format though. Right now `ToString` produces the following output: 

```
Octokit.ApiException: Validation Failed
Octokit.ApiErrorMessage: Validation Failed
Documentation url: 
Errors:
Message: key is already in use
Code: custom
Field: key
Resource: PublicKey
```

- [x] agree on message format
- [x] update current message format if needed