### PR TITLE
added new rule for VS local cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bin/**/*.pdb
 
 # Roslyn cache directories
 *.ide/
+*.vs/
 
 # Visual C++ cache files
 ipch/


### PR DESCRIPTION
This was renamed from `.ide` when VS2015 was released, but for some reason I've only noticed it now.

I'll leave the old rule around for now, because it's harmless.