### PR TITLE
removed obsolete member AllowAutoRedirect

### DIFF
--- a/Octokit.Tests.Integration/HttpClientAdapterTests.cs
+++ b/Octokit.Tests.Integration/HttpClientAdapterTests.cs
@@ -19,7 +19,6 @@ public class HttpClientAdapterTests
             {
                 BaseAddress = new Uri("https://github.global.ssl.fastly.net/", UriKind.Absolute),
                 Endpoint = new Uri("/images/icons/emoji/poop.png?v=5", UriKind.RelativeOrAbsolute),
-                AllowAutoRedirect = true,
                 Method = HttpMethod.Get
             };
 
@@ -41,7 +40,6 @@ public class HttpClientAdapterTests
             {
                 BaseAddress = new Uri("https://github.global.ssl.fastly.net/", UriKind.Absolute),
                 Endpoint = new Uri("/images/icons/emoji/poop.png?v=5", UriKind.RelativeOrAbsolute),
-                AllowAutoRedirect = true,
                 Method = HttpMethod.Get,
                 Timeout = TimeSpan.FromMilliseconds(10)
             };

--- a/Octokit/Http/IRequest.cs
+++ b/Octokit/Http/IRequest.cs
@@ -14,7 +14,5 @@ namespace Octokit.Internal
         Uri Endpoint { get; }
         TimeSpan Timeout { get; }
         string ContentType { get; }
-        [Obsolete("This value is no longer respected due to the necessary redirect work")]
-        bool AllowAutoRedirect { get; }
     }
 }

--- a/Octokit/Http/Request.cs
+++ b/Octokit/Http/Request.cs
@@ -22,8 +22,5 @@ namespace Octokit.Internal
         public Uri Endpoint { get; set; }
         public TimeSpan Timeout { get; set; }
         public string ContentType { get; set; }
-
-        [Obsolete("This value is no longer respected due to the necessary redirect work")]
-        public bool AllowAutoRedirect { get; set; }
     }
 }


### PR DESCRIPTION
This is no longer supported due to the redirect work implemented in #808 and shipped in `v0.14` - and given `v0.17` is now shipping let's :fire: this member finally...