### PR TITLE
obsolete GetArchiveLink endpoint

### DIFF
--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -56,60 +56,6 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetArchiveLinkMethod
-        {
-            [Fact]
-            public async Task ReturnsArchiveLinkWithDefaults()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                connection.GetRedirect(Args.Uri).Returns(Task.FromResult("https://codeload.github.com/fake/repo/legacy.tar.gz/master"));
-                var contentsClient = new RepositoryContentsClient(connection);
-
-                var archiveLink = await contentsClient.GetArchiveLink("fake", "repo");
-
-                connection.Received().GetRedirect(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/tarball/"));
-                Assert.Equal("https://codeload.github.com/fake/repo/legacy.tar.gz/master", archiveLink);
-            }
-
-            [Fact]
-            public async Task ReturnsArchiveLinkAsZipball()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                connection.GetRedirect(Args.Uri).Returns(Task.FromResult("https://codeload.github.com/fake/repo/legacy.tar.gz/master"));
-                var contentsClient = new RepositoryContentsClient(connection);
-
-                var archiveLink = await contentsClient.GetArchiveLink("fake", "repo", ArchiveFormat.Zipball);
-
-                connection.Received().GetRedirect(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/zipball/"));
-                Assert.Equal("https://codeload.github.com/fake/repo/legacy.tar.gz/master", archiveLink);
-            }
-
-            [Fact]
-            public async Task ReturnsArchiveLinkWithSpecifiedValues()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                connection.GetRedirect(Args.Uri).Returns(Task.FromResult("https://codeload.github.com/fake/repo/legazy.zip/release"));
-                var contentsClient = new RepositoryContentsClient(connection);
-
-                var archiveLink = await contentsClient.GetArchiveLink("fake", "repo", ArchiveFormat.Zipball, "release");
-
-                connection.Received().GetRedirect(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/zipball/release"));
-                Assert.Equal("https://codeload.github.com/fake/repo/legazy.zip/release", archiveLink);
-            }
-
-            [Fact]
-            public async Task EnsuresArgumentsNotNull()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var contentsClient = new RepositoryContentsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => contentsClient.GetArchiveLink(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => contentsClient.GetArchiveLink("owner", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => contentsClient.GetArchiveLink("", "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => contentsClient.GetArchiveLink("owner", ""));
-            }
-        }
-
         public class TheGetContentsMethod
         {
             [Fact]

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -116,6 +116,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
+        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public Task<string> GetArchiveLink(string owner, string name)
         {
             return GetArchiveLink(owner, name, ArchiveFormat.Tarball, string.Empty);
@@ -144,6 +145,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <returns></returns>
+        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public Task<string> GetArchiveLink(string owner, string name, ArchiveFormat archiveFormat)
         {
             return GetArchiveLink(owner, name, archiveFormat, string.Empty);
@@ -174,6 +176,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <returns></returns>
+        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public Task<string> GetArchiveLink(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -90,6 +90,7 @@ namespace Octokit
             return connection.Get<T>(uri, null, null);
         }
 
+        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public static Task<IApiResponse<T>> GetRedirect<T>(this IConnection connection, Uri uri)
         {
             Ensure.ArgumentNotNull(connection, "connection");

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -408,6 +408,7 @@ namespace Octokit
         /// <param name="uri">URI of the API resource to get</param>
         /// <returns>The URL returned by the API in the Location header</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs, or the API does not respond with a 302 Found</exception>
+        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public async Task<string> GetRedirect(Uri uri)
         {
             Ensure.ArgumentNotNull(uri, "uri");

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -43,6 +43,7 @@ namespace Octokit
         /// <param name="allowAutoRedirect">To follow redirect links automatically or not</param>
         /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        [Obsolete("allowAutoRedirect is no longer respected and will be deprecated in a future release")]
         Task<IApiResponse<T>> Get<T>(Uri uri, IDictionary<string, string> parameters, string accepts, bool allowAutoRedirect);
 
         /// <summary>


### PR DESCRIPTION
This should have been picked up earlier, but I didn't `[Obsolete]` the interface so the message didn't flow through the internals to reach the `GetArchiveLink` overloads.

So let's get this into the next release:

 - [x] rebase once `master` is green again