### PR TITLE
Linqpad example fixes for SignatureResponse

### DIFF
--- a/samples/linqpad-samples/6-create-repository.linq
+++ b/samples/linqpad-samples/6-create-repository.linq
@@ -71,7 +71,7 @@ async Task Main(string[] args)
 	  "Hello World!",
 	  createdTree.Sha,
 	  new[] { master.Object.Sha })
-	{ Author = new SignatureResponse(owner,email,DateTime.UtcNow)};
+	{ Author = new Committer(owner,email,DateTime.UtcNow)};
 	
 	var createdCommit = await client.GitDatabase.Commit
 		.Create(owner, reponame, newCommit);


### PR DESCRIPTION
Linqpad example fixes had reference to `SignatureResponse` which is now changed to `Committer` #983. This only fixes the specific file that is causing the build to fail.