### PR TITLE
Add Protected Branches API support

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -261,6 +261,16 @@ namespace Octokit.Reactive
         IObservable<Repository> Edit(string owner, string name, RepositoryUpdate update);
 
         /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
+
+        /// <summary>
         /// A client for GitHub's Repo Collaborators.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -381,6 +381,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
+        {
+            return _client.EditBranch(owner, name, branch, update).ToObservable();
+        }
+
+        /// <summary>
         /// Compare two references in a repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -85,6 +85,12 @@ namespace Octokit.Tests.Conventions
                         continue;
                     }
 
+                    // Let's skip collections that only have a private Setter
+                    if (property.SetMethod != null && property.SetMethod.IsPrivate)
+                    {
+                        continue;
+                    }
+
                     mutableCollectionProperties.Add(property);
                 }
             }

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -85,12 +85,6 @@ namespace Octokit.Tests.Conventions
                         continue;
                     }
 
-                    // Let's skip collections that only have a private Setter
-                    if (property.SetMethod != null && property.SetMethod.IsPrivate)
-                    {
-                        continue;
-                    }
-
                     mutableCollectionProperties.Add(property);
                 }
             }

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -22,22 +22,108 @@ public class BranchesClientTests
 
                 Assert.NotEmpty(branches);
                 Assert.Equal(branches[0].Name, "master");
+                Assert.NotNull(branches[0].Protection);
             }
+        }
+    }
+
+    public class TheEditBranchesMethod
+    {
+        private readonly IRepositoriesClient _fixture;
+        private readonly RepositoryContext _context;
+
+        public TheEditBranchesMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            _context = github.CreateRepositoryContext("source-repo").Result;
+            _fixture = github.Repository;
+        }
+
+        public async Task CreateTheWorld()
+        {
+            // Set master branch to be protected, with some status checks
+            var update = new BranchUpdate();
+            update.Protection.Enabled = true;
+            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
+            update.Protection.RequiredStatusChecks.AddContext("check1");
+            update.Protection.RequiredStatusChecks.AddContext("check2");
+
+            var newBranch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
         }
 
         [IntegrationTest]
-        public async Task ReturnsBranchesWithProtectionStatus()
+        public async Task ProtectsBranch()
         {
-            var github = Helper.GetAuthenticatedClient();
+            // Set master branch to be protected, with some status checks
+            var update = new BranchUpdate();
+            update.Protection.Enabled = true;
+            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
+            update.Protection.RequiredStatusChecks.AddContext("check1");
+            update.Protection.RequiredStatusChecks.AddContext("check2");
+            update.Protection.RequiredStatusChecks.AddContext("check3");
 
-            using (var context = await github.CreateRepositoryContext("public-repo"))
-            {
-                var branches = await github.Repository.GetAllBranches(context.Repository.Owner.Login, context.Repository.Name);
+            var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
 
-                Assert.NotEmpty(branches);
-                Assert.Equal(branches[0].Name, "master");
-                Assert.NotNull(branches[0].Protection);
-            }
+            // Ensure a branch object was returned
+            Assert.NotNull(branch);
+
+            // Retrieve master branch
+            branch = await _fixture.GetBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master");
+
+            // Assert the changes were made
+            Assert.Equal(branch.Protection.Enabled, true);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.EnforcementLevel, EnforcementLevel.Everyone);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.Contexts.Count, 3);
+        }
+
+        [IntegrationTest]
+        public async Task RemoveStatusCheckEnforcement()
+        {
+            await CreateTheWorld();
+
+            // Clear status checks
+            var update = new BranchUpdate();
+            update.Protection.Enabled = true;
+            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Off;
+            update.Protection.RequiredStatusChecks.AddContext("check1");
+            var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
+
+            // Ensure a branch object was returned
+            Assert.NotNull(branch);
+
+            // Retrieve master branch
+            branch = await _fixture.GetBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master");
+
+            // Assert the changes were made
+            Assert.Equal(branch.Protection.Enabled, true);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.EnforcementLevel, EnforcementLevel.Off);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.Contexts.Count, 1);
+        }
+
+        [IntegrationTest]
+        public async Task UnprotectsBranch()
+        {
+            await CreateTheWorld();
+
+            // Unprotect branch
+            var update = new BranchUpdate();
+            update.Protection.Enabled = false;
+
+            // Deliberately set Enforcement and Contexts to some values (these should be ignored)
+            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
+            update.Protection.RequiredStatusChecks.AddContext("check1");
+            var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
+
+            // Ensure a branch object was returned
+            Assert.NotNull(branch);
+
+            // Retrieve master branch
+            branch = await _fixture.GetBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master");
+
+            // Assert the branch is unprotected, and enforcement/contexts are cleared
+            Assert.Equal(branch.Protection.Enabled, false);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.EnforcementLevel, EnforcementLevel.Off);
+            Assert.Equal(branch.Protection.RequiredStatusChecks.Contexts.Count, 0);
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -24,5 +24,20 @@ public class BranchesClientTests
                 Assert.Equal(branches[0].Name, "master");
             }
         }
+
+        [IntegrationTest]
+        public async Task ReturnsBranchesWithProtectionStatus()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var branches = await github.Repository.GetAllBranches(context.Repository.Owner.Login, context.Repository.Name);
+
+                Assert.NotEmpty(branches);
+                Assert.Equal(branches[0].Name, "master");
+                Assert.NotNull(branches[0].Protection);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -42,11 +42,12 @@ public class BranchesClientTests
         public async Task CreateTheWorld()
         {
             // Set master branch to be protected, with some status checks
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
+            requiredStatusChecks.AddContext("check1");
+            requiredStatusChecks.AddContext("check2");
+
             var update = new BranchUpdate();
-            update.Protection.Enabled = true;
-            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
-            update.Protection.RequiredStatusChecks.AddContext("check1");
-            update.Protection.RequiredStatusChecks.AddContext("check2");
+            update.Protection = new BranchProtection(true, requiredStatusChecks);
 
             var newBranch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
         }
@@ -55,12 +56,13 @@ public class BranchesClientTests
         public async Task ProtectsBranch()
         {
             // Set master branch to be protected, with some status checks
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
+            requiredStatusChecks.AddContext("check1");
+            requiredStatusChecks.AddContext("check2");
+            requiredStatusChecks.AddContext("check3");
+
             var update = new BranchUpdate();
-            update.Protection.Enabled = true;
-            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
-            update.Protection.RequiredStatusChecks.AddContext("check1");
-            update.Protection.RequiredStatusChecks.AddContext("check2");
-            update.Protection.RequiredStatusChecks.AddContext("check3");
+            update.Protection = new BranchProtection(true, requiredStatusChecks);
 
             var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
 
@@ -81,11 +83,13 @@ public class BranchesClientTests
         {
             await CreateTheWorld();
 
-            // Clear status checks
+            // Remove status check enforcement
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Off, null);
+            requiredStatusChecks.AddContext("check1");
+
             var update = new BranchUpdate();
-            update.Protection.Enabled = true;
-            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Off;
-            update.Protection.RequiredStatusChecks.AddContext("check1");
+            update.Protection = new BranchProtection(true, requiredStatusChecks);
+
             var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
 
             // Ensure a branch object was returned
@@ -106,12 +110,13 @@ public class BranchesClientTests
             await CreateTheWorld();
 
             // Unprotect branch
-            var update = new BranchUpdate();
-            update.Protection.Enabled = false;
-
             // Deliberately set Enforcement and Contexts to some values (these should be ignored)
-            update.Protection.RequiredStatusChecks.EnforcementLevel = EnforcementLevel.Everyone;
-            update.Protection.RequiredStatusChecks.AddContext("check1");
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
+            requiredStatusChecks.AddContext("check1");
+
+            var update = new BranchUpdate();
+            update.Protection = new BranchProtection(false, requiredStatusChecks);
+                
             var branch = await _fixture.EditBranch(_context.Repository.Owner.Login, _context.Repository.Name, "master", update);
 
             // Ensure a branch object was returned

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -42,9 +43,7 @@ public class BranchesClientTests
         public async Task CreateTheWorld()
         {
             // Set master branch to be protected, with some status checks
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
-            requiredStatusChecks.AddContext("check1");
-            requiredStatusChecks.AddContext("check2");
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1", "check2" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
@@ -56,10 +55,7 @@ public class BranchesClientTests
         public async Task ProtectsBranch()
         {
             // Set master branch to be protected, with some status checks
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
-            requiredStatusChecks.AddContext("check1");
-            requiredStatusChecks.AddContext("check2");
-            requiredStatusChecks.AddContext("check3");
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1", "check2", "check3" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
@@ -84,9 +80,8 @@ public class BranchesClientTests
             await CreateTheWorld();
 
             // Remove status check enforcement
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Off, null);
-            requiredStatusChecks.AddContext("check1");
-
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Off, new List<string>() { "check1" });
+            
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
 
@@ -111,8 +106,7 @@ public class BranchesClientTests
 
             // Unprotect branch
             // Deliberately set Enforcement and Contexts to some values (these should be ignored)
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, null);
-            requiredStatusChecks.AddContext("check1");
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(false, requiredStatusChecks);

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -435,7 +435,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllBranches("owner", "name");
 
                 connection.Received()
-                    .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"));
+                    .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"), null, "application/vnd.github.loki-preview+json");
             }
 
             [Fact]
@@ -565,7 +565,7 @@ namespace Octokit.Tests.Clients
                 client.GetBranch("owner", "repo", "branch");
 
                 connection.Received()
-                    .Get<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), null);
+                    .Get<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), null, "application/vnd.github.loki-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -718,7 +718,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheProtectBranchMethod
+        public class TheEditBranchMethod
         {
             [Fact]
             public void GetsCorrectUrl()
@@ -728,24 +728,10 @@ namespace Octokit.Tests.Clients
                 var update = new BranchUpdate();
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.ProtectBranch("owner", "repo", "branch", update);
+                client.EditBranch("owner", "repo", "branch", update);
                 
                 connection.Received()
                     .Patch<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), Arg.Any<BranchUpdate>(), previewAcceptsHeader);
-            }
-
-            [Fact]
-            public void EnablesProtection()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                var update = new BranchUpdate();
-                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-
-                client.ProtectBranch("owner", "repo", "branch", update);
-                
-                connection.Received()
-                    .Patch<Branch>(Arg.Any<Uri>(), Arg.Is<BranchUpdate>(b => b.Protection.Enabled == true), previewAcceptsHeader);
             }
 
             [Fact]
@@ -754,55 +740,13 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
                 var update = new BranchUpdate();
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch(null, "repo", "branch", update));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", null, "branch", update));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", "repo", null, update));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", "repo", "branch", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("", "repo", "branch", update));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("owner", "", "branch", update));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("owner", "repo", "", update));
-            }
-        }
-
-        public class TheUnprotectBranchMethod
-        {
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-
-                client.UnprotectBranch("owner", "repo", "branch");
-
-                connection.Received()
-                    .Patch<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), Arg.Any<BranchUpdate>(), previewAcceptsHeader);
-            }
-
-            [Fact]
-            public void DisablesProtection()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-
-                client.UnprotectBranch("owner", "repo", "branch");
-
-                connection.Received()
-                    .Patch<Branch>(Arg.Any<Uri>(), Arg.Is<BranchUpdate>(b => b.Protection.Enabled == false), previewAcceptsHeader);
-            }
-
-            [Fact]
-            public async Task EnsuresNonNullArguments()
-            {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch(null, "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch("owner", null, "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch("owner", "repo", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("", "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("owner", "", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("owner", "repo", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch(null, "repo", "branch", update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", null, "branch", update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", "repo", null, update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", "repo", "branch", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("", "repo", "branch", update));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("owner", "", "branch", update));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("owner", "repo", "", update));
             }
         }
     }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -717,5 +717,93 @@ namespace Octokit.Tests.Clients
                     Arg.Any<Dictionary<string, string>>());
             }
         }
+
+        public class TheProtectBranchMethod
+        {
+            [Fact]
+            public void GetsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var update = new BranchUpdate();
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.ProtectBranch("owner", "repo", "branch", update);
+                
+                connection.Received()
+                    .Patch<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), Arg.Any<BranchUpdate>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public void EnablesProtection()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var update = new BranchUpdate();
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.ProtectBranch("owner", "repo", "branch", update);
+                
+                connection.Received()
+                    .Patch<Branch>(Arg.Any<Uri>(), Arg.Is<BranchUpdate>(b => b.Protection.Enabled == true), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var update = new BranchUpdate();
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch(null, "repo", "branch", update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", null, "branch", update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", "repo", null, update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ProtectBranch("owner", "repo", "branch", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("", "repo", "branch", update));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("owner", "", "branch", update));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.ProtectBranch("owner", "repo", "", update));
+            }
+        }
+
+        public class TheUnprotectBranchMethod
+        {
+            [Fact]
+            public void GetsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.UnprotectBranch("owner", "repo", "branch");
+
+                connection.Received()
+                    .Patch<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), Arg.Any<BranchUpdate>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public void DisablesProtection()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.UnprotectBranch("owner", "repo", "branch");
+
+                connection.Received()
+                    .Patch<Branch>(Arg.Any<Uri>(), Arg.Is<BranchUpdate>(b => b.Protection.Enabled == false), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UnprotectBranch("owner", "repo", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UnprotectBranch("owner", "repo", ""));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -463,6 +463,39 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheEditBranchMethod
+        {
+            [Fact]
+            public async Task EnsuresArguments()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var nonreactiveClient = new RepositoriesClient(Substitute.For<IApiConnection>());
+                github.Repository.Returns(nonreactiveClient);
+                var client = new ObservableRepositoriesClient(github);
+                var update = new BranchUpdate();
+
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch(null, "repo", "branch", update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", null, "branch", update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", null, update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", "branch", null));
+                Assert.Throws<ArgumentException>(() => client.EditBranch("", "repo", "branch", update));
+                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "", "branch", update));
+                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "repo", "", update));
+            }
+
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(github);
+                var update = new BranchUpdate();
+
+                client.EditBranch("owner", "repo", "branch", update);
+
+                github.Repository.Received(1).EditBranch("owner", "repo", "branch", update);
+            }
+        }
+
         static IResponse CreateResponseWithApiInfo(IDictionary<string, Uri> links)
         {
             var response = Substitute.For<IResponse>();

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -329,22 +329,13 @@ namespace Octokit
         Task<Repository> Edit(string owner, string name, RepositoryUpdate update);
 
         /// <summary>
-        /// Protects the specified branch with the values given in <paramref name="update"/>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repositoryName">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
-        /// <param name="update"></param>
+        /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        Task<Branch> ProtectBranch(string owner, string repositoryName, string branchName, BranchUpdate update);
-
-        /// <summary>
-        /// Unprotects the specified branch
-        /// </summary>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
-        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        Task<Branch> UnprotectBranch(string owner, string repositoryName, string branchName);
+        Task<Branch> EditBranch(string owner, string repositoryName, string branchName, BranchUpdate update);
     }
 }

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -327,5 +327,24 @@ namespace Octokit
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
         Task<Repository> Edit(string owner, string name, RepositoryUpdate update);
+
+        /// <summary>
+        /// Protects the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <param name="update"></param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        Task<Branch> ProtectBranch(string owner, string repositoryName, string branchName, BranchUpdate update);
+
+        /// <summary>
+        /// Unprotects the specified branch
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        Task<Branch> UnprotectBranch(string owner, string repositoryName, string branchName);
     }
 }

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -332,10 +332,10 @@ namespace Octokit
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        Task<Branch> EditBranch(string owner, string repositoryName, string branchName, BranchUpdate update);
+        Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
     }
 }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -505,5 +505,46 @@ namespace Octokit
             const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
             return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, previewAcceptsHeader);
         }
+
+        /// <summary>
+        /// Protects the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <param name="update"></param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public Task<Branch> ProtectBranch(string owner, string repositoryName, string branchName, BranchUpdate update)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+            Ensure.ArgumentNotNull(update, "update");
+
+            update.Protection.Enabled = true;
+
+            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), update, previewAcceptsHeader);
+        }
+
+        /// <summary>
+        /// Unprotects the specified branch
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public Task<Branch> UnprotectBranch(string owner, string repositoryName, string branchName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+
+            var update = new BranchUpdate();
+            update.Protection.Enabled = false;
+
+            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), update, previewAcceptsHeader);
+        }
     }
 }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -176,8 +176,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(branch, "branchName");
             Ensure.ArgumentNotNull(update, "update");
 
-            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, name, branch), update, previewAcceptsHeader);
+            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, name, branch), update, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
         /// <summary>
@@ -408,8 +407,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-            return ApiConnection.GetAll<Branch>(ApiUrls.RepoBranches(owner, name), null, previewAcceptsHeader);
+            return ApiConnection.GetAll<Branch>(ApiUrls.RepoBranches(owner, name), null, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
 
@@ -521,8 +519,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
 
-            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, previewAcceptsHeader);
+            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, AcceptHeaders.ProtectedBranchesApiPreview);
         }
     }
 }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -162,6 +162,25 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branchName");
+            Ensure.ArgumentNotNull(update, "update");
+
+            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, name, branch), update, previewAcceptsHeader);
+        }
+
+        /// <summary>
         /// Gets the specified repository.
         /// </summary>
         /// <remarks>
@@ -504,25 +523,6 @@ namespace Octokit
 
             const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
             return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, previewAcceptsHeader);
-        }
-
-        /// <summary>
-        /// Edit the specified branch with the values given in <paramref name="update"/>
-        /// </summary>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
-        /// <param name="update">New values to update the branch with</param>
-        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public Task<Branch> EditBranch(string owner, string repositoryName, string branchName, BranchUpdate update)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
-            Ensure.ArgumentNotNull(update, "update");
-
-            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), update, previewAcceptsHeader);
         }
     }
 }

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -507,41 +507,19 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Protects the specified branch with the values given in <paramref name="update"/>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repositoryName">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
-        /// <param name="update"></param>
+        /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public Task<Branch> ProtectBranch(string owner, string repositoryName, string branchName, BranchUpdate update)
+        public Task<Branch> EditBranch(string owner, string repositoryName, string branchName, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
             Ensure.ArgumentNotNull(update, "update");
-
-            update.Protection.Enabled = true;
-
-            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
-            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), update, previewAcceptsHeader);
-        }
-
-        /// <summary>
-        /// Unprotects the specified branch
-        /// </summary>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
-        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public Task<Branch> UnprotectBranch(string owner, string repositoryName, string branchName)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
-
-            var update = new BranchUpdate();
-            update.Protection.Enabled = false;
 
             const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
             return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), update, previewAcceptsHeader);

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -389,8 +389,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            var endpoint = ApiUrls.RepoBranches(owner, name);
-            return ApiConnection.GetAll<Branch>(endpoint);
+            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+            return ApiConnection.GetAll<Branch>(ApiUrls.RepoBranches(owner, name), null, previewAcceptsHeader);
         }
 
 
@@ -502,7 +502,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
 
-            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName));
+            const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, previewAcceptsHeader);
         }
     }
 }

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -1,0 +1,8 @@
+﻿namespace Octokit
+{
+    public static class AcceptHeaders
+    {
+        public const string ProtectedBranchesApiPreview = "application/vnd.github.loki-preview+json";
+    }
+}
+                      

--- a/Octokit/Models/Request/BranchUpdate.cs
+++ b/Octokit/Models/Request/BranchUpdate.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
@@ -17,6 +19,14 @@ namespace Octokit
         public BranchUpdate()
         {
             Protection = new BranchProtection();
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "Protection: {0}", Protection.DebuggerDisplay);
+            }
         }
     }
 }

--- a/Octokit/Models/Request/BranchUpdate.cs
+++ b/Octokit/Models/Request/BranchUpdate.cs
@@ -14,12 +14,7 @@ namespace Octokit
         /// <summary>
         /// The <see cref="BranchProtection"/> details
         /// </summary>
-        public BranchProtection Protection { get; private set; }
-
-        public BranchUpdate()
-        {
-            Protection = new BranchProtection();
-        }
+        public BranchProtection Protection { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/BranchUpdate.cs
+++ b/Octokit/Models/Request/BranchUpdate.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Specifies the values used to update a <see cref="Branch"/>.
+    /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class BranchUpdate
+    {
+        /// <summary>
+        /// The <see cref="BranchProtection"/> details
+        /// </summary>
+        public BranchProtection Protection { get; private set; }
+
+        public BranchUpdate()
+        {
+            Protection = new BranchProtection();
+        }
+    }
+}

--- a/Octokit/Models/Response/Branch.cs
+++ b/Octokit/Models/Response/Branch.cs
@@ -9,10 +9,11 @@ namespace Octokit
     {
         public Branch() { }
 
-        public Branch(string name, GitReference commit)
+        public Branch(string name, GitReference commit, BranchProtection protection)
         {
             Name = name;
             Commit = commit;
+            Protection = protection;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/Branch.cs
+++ b/Octokit/Models/Response/Branch.cs
@@ -21,6 +21,12 @@ namespace Octokit
         public string Name { get; protected set; }
 
         /// <summary>
+        /// The <see cref="BranchProtection"/> details for this <see cref="Branch"/>.
+        /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
+        /// </summary>
+        public BranchProtection Protection { get; protected set; }
+
+        /// <summary>
         /// The <see cref="GitReference"/> history for this <see cref="Branch"/>.
         /// </summary>
         public GitReference Commit { get; protected set; }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -15,16 +15,17 @@ namespace Octokit
         /// <summary>
         /// Should this branch be protected or not
         /// </summary>
-        public bool Enabled { get; set; }
+        public bool Enabled { get; protected set; }
 
         /// <summary>
         /// The <see cref="RequiredStatusChecks"/> information for this <see cref="Branch"/>.
         /// </summary>
         public RequiredStatusChecks RequiredStatusChecks { get; private set; }
 
-        public BranchProtection()
+        public BranchProtection(bool enabled, RequiredStatusChecks requiredStatusChecks)
         {
-            RequiredStatusChecks = new RequiredStatusChecks();
+            Enabled = enabled;
+            RequiredStatusChecks = requiredStatusChecks;
         }
 
         internal string DebuggerDisplay
@@ -42,12 +43,18 @@ namespace Octokit
         /// <summary>
         /// Who required status checks apply to
         /// </summary>
-        public EnforcementLevel EnforcementLevel { get; set; }
+        public EnforcementLevel EnforcementLevel { get; protected set; }
 
         /// <summary>
         /// The list of status checks to require in order to merge into this <see cref="Branch"/>
         /// </summary>
         public ICollection<string> Contexts { get; private set; }
+
+        public RequiredStatusChecks(EnforcementLevel enforcementLevel, ICollection<string> contexts)
+        {
+            EnforcementLevel = enforcementLevel;
+            Contexts = contexts;
+        }
 
         /// <summary>
         /// Adds the specified context to the required status checks.

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -56,37 +56,6 @@ namespace Octokit
             Contexts = contexts;
         }
 
-        /// <summary>
-        /// Adds the specified context to the required status checks.
-        /// </summary>
-        /// <param name="name">The name of the context.</param>
-        public void AddContext(string name)
-        {
-            // lazily create the contexts array
-            if (Contexts == null)
-            {
-                Contexts = new List<string>();
-            }
-
-            Contexts.Add(name);
-        }
-
-        /// <summary>
-        /// Clears all the contexts.
-        /// </summary>
-        public void ClearContexts()
-        {
-            // lazily create the contexts array
-            if (Contexts == null)
-            {
-                Contexts = new List<string>();
-            }
-            else
-            {
-                Contexts.Clear();
-            }
-        }
-
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
@@ -23,6 +25,14 @@ namespace Octokit
         public BranchProtection()
         {
             RequiredStatusChecks = new RequiredStatusChecks();
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "Enabled: {0}", Enabled);
+            }
         }
     }
 
@@ -67,6 +77,14 @@ namespace Octokit
             else
             {
                 Contexts.Clear();
+            }
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "EnforcementLevel: {0} Contexts: {1}", EnforcementLevel.ToString(), Contexts.Count);
             }
         }
     }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Protection details for a <see cref="Branch"/>.
+    /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class BranchProtection
+    {
+        /// <summary>
+        /// Should this branch be protected or not
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The <see cref="RequiredStatusChecks"/> information for this <see cref="Branch"/>.
+        /// </summary>
+        public RequiredStatusChecks RequiredStatusChecks { get; private set; }
+
+        public BranchProtection()
+        {
+            RequiredStatusChecks = new RequiredStatusChecks();
+        }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class RequiredStatusChecks
+    {
+        /// <summary>
+        /// Who required status checks apply to
+        /// </summary>
+        public EnforcementLevel EnforcementLevel { get; set; }
+
+        /// <summary>
+        /// The list of status checks to require in order to merge into this <see cref="Branch"/>
+        /// </summary>
+        public ICollection<string> Contexts { get; private set; }
+
+        /// <summary>
+        /// Adds the specified context to the required status checks.
+        /// </summary>
+        /// <param name="name">The name of the context.</param>
+        public void AddContext(string name)
+        {
+            // lazily create the contexts array
+            if (Contexts == null)
+            {
+                Contexts = new List<string>();
+            }
+
+            Contexts.Add(name);
+        }
+
+        /// <summary>
+        /// Clears all the contexts.
+        /// </summary>
+        public void ClearContexts()
+        {
+            // lazily create the contexts array
+            if (Contexts == null)
+            {
+                Contexts = new List<string>();
+            }
+            else
+            {
+                Contexts.Clear();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The enforcement levels that are available
+    /// </summary>
+    public enum EnforcementLevel
+    {
+        /// <summary>
+        /// Turn off required status checks for this <see cref="Branch"/>.
+        /// </summary>
+        Off,
+
+        /// <summary>
+        /// Required status checks will be enforeced for non-admins.
+        /// </summary>
+        NonAdmins,
+
+        /// <summary>
+        /// Required status checks will be enforced for everyone (including admins).
+        /// </summary>
+        Everyone
+    }
+}

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 
 namespace Octokit
 {
@@ -12,6 +14,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class BranchProtection
     {
+        public BranchProtection() { }
+
+        public BranchProtection(bool enabled, RequiredStatusChecks requiredStatusChecks)
+        {
+            Enabled = enabled;
+            RequiredStatusChecks = requiredStatusChecks;
+        }
+
         /// <summary>
         /// Should this branch be protected or not
         /// </summary>
@@ -21,12 +31,6 @@ namespace Octokit
         /// The <see cref="RequiredStatusChecks"/> information for this <see cref="Branch"/>.
         /// </summary>
         public RequiredStatusChecks RequiredStatusChecks { get; private set; }
-
-        public BranchProtection(bool enabled, RequiredStatusChecks requiredStatusChecks)
-        {
-            Enabled = enabled;
-            RequiredStatusChecks = requiredStatusChecks;
-        }
 
         internal string DebuggerDisplay
         {
@@ -40,6 +44,14 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RequiredStatusChecks
     {
+        public RequiredStatusChecks() { }
+
+        public RequiredStatusChecks(EnforcementLevel enforcementLevel, IEnumerable<string> contexts)
+        {
+            EnforcementLevel = enforcementLevel;
+            Contexts = new ReadOnlyCollection<string>(contexts.ToList());
+        }
+
         /// <summary>
         /// Who required status checks apply to
         /// </summary>
@@ -48,13 +60,7 @@ namespace Octokit
         /// <summary>
         /// The list of status checks to require in order to merge into this <see cref="Branch"/>
         /// </summary>
-        public ICollection<string> Contexts { get; private set; }
-
-        public RequiredStatusChecks(EnforcementLevel enforcementLevel, ICollection<string> contexts)
-        {
-            EnforcementLevel = enforcementLevel;
-            Contexts = contexts;
-        }
+        public IReadOnlyList<string> Contexts { get; private set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Clients\IAssigneesClient.cs" />
     <Compile Include="Clients\IIssuesClient.cs" />
     <Compile Include="Clients\IMilestonesClient.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
     <Compile Include="Helpers\ParameterAttribute.cs" />
     <Compile Include="Helpers\ReflectionExtensions.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Clients\IMilestonesClient.cs" />
     <Compile Include="Helpers\ParameterAttribute.cs" />
     <Compile Include="Helpers\ReflectionExtensions.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\GistRequest.cs" />
     <Compile Include="Models\Request\GistUpdate.cs" />

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Models\Response\ActivityPayloads\StarredEventPayload.cs" />
     <Compile Include="Models\Response\Author.cs" />
     <Compile Include="Models\Response\Branch.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Models\Response\Commit.cs" />
     <Compile Include="Models\Response\Activity.cs" />
     <Compile Include="Models\Response\Blob.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -420,6 +420,7 @@
     <Compile Include="Exceptions\PullRequestMismatchException.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Response\BranchProtection.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -418,6 +418,8 @@
     <Compile Include="Helpers\WebHookConfigComparer.cs" />
     <Compile Include="Exceptions\PullRequestNotMergeableException.cs" />
     <Compile Include="Exceptions\PullRequestMismatchException.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -416,6 +416,7 @@
     <Compile Include="Exceptions\PullRequestMismatchException.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Response\BranchProtection.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -414,6 +414,8 @@
     <Compile Include="Helpers\WebHookConfigComparer.cs" />
     <Compile Include="Exceptions\PullRequestNotMergeableException.cs" />
     <Compile Include="Exceptions\PullRequestMismatchException.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Http\IResponse.cs" />
     <Compile Include="Http\Request.cs" />
     <Compile Include="Models\Request\AuthorizationUpdate.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\EditRepositoryHook.cs" />
     <Compile Include="Models\Request\GistRequest.cs" />
     <Compile Include="Models\Request\GistUpdate.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Exceptions\NotFoundException.cs" />
     <Compile Include="Exceptions\TwoFactorChallengeFailedException.cs" />
     <Compile Include="Exceptions\TwoFactorRequiredException.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
     <Compile Include="Helpers\ApiExtensions.cs" />
     <Compile Include="Helpers\ApiUrls.cs" />
     <Compile Include="Helpers\AuthorizationExtensions.cs" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Models\Response\Authorization.cs" />
     <Compile Include="Models\Response\Blob.cs" />
     <Compile Include="Models\Response\Branch.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Models\Response\Commit.cs" />
     <Compile Include="Models\Response\CommitStatus.cs" />
     <Compile Include="Models\Response\RepositoryContributor.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Models\Response\Authorization.cs" />
     <Compile Include="Models\Response\Blob.cs" />
     <Compile Include="Models\Response\Branch.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Models\Response\Commit.cs" />
     <Compile Include="Models\Response\CommitStatus.cs" />
     <Compile Include="Models\Response\Contributor.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Helpers\IReadOnlyPagedCollection.cs" />
     <Compile Include="Helpers\ModelExtensions.cs" />
     <Compile Include="Helpers\ParameterAttribute.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
     <Compile Include="Helpers\ReflectionExtensions.cs" />
     <Compile Include="Helpers\TwoFactorChallengeResult.cs" />
     <Compile Include="Helpers\UriExtensions.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Http\IResponse.cs" />
     <Compile Include="Http\Request.cs" />
     <Compile Include="Models\Request\AuthorizationUpdate.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\GistRequest.cs" />
     <Compile Include="Models\Request\GistUpdate.cs" />
     <Compile Include="Models\Request\EditRepositoryHook.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Http\IApiInfoProvider.cs" />
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Http\RequestBody.cs" />
+    <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Exceptions\RepositoryFormatException.cs" />
     <Compile Include="Exceptions\RepositoryWebHookConfigException.cs" />
     <Compile Include="Exceptions\TwoFactorAuthorizationException.cs" />
+    <Compile Include="Helpers\AcceptHeaders.cs" />
     <Compile Include="Helpers\ApiErrorExtensions.cs" />
     <Compile Include="Helpers\ApiUrls.Authorizations.cs" />
     <Compile Include="Helpers\ApiUrls.Keys.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Models\Response\ActivityPayloads\PullRequestEventPayload.cs" />
     <Compile Include="Models\Response\ActivityPayloads\PushEventPayload.cs" />
     <Compile Include="Models\Response\ActivityPayloads\StarredEventPayload.cs" />
+    <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Models\Response\CombinedCommitStatus.cs" />
     <Compile Include="Models\Response\CommitContent.cs" />
     <Compile Include="Models\Response\GitIgnoreTemplate.cs" />


### PR DESCRIPTION
This Work-In-Progress PR adds support for the protected branches API, which is [currently in PREVIEW](https://developer.github.com/changes/2015-11-11-protected-branches-api/)

## Notes
This is our first contribution to octokit.net so just let us know if anything isn't as desired etc... I've tried to comply with existing similar implementations, coding/comment styles, unit and integration tests and so on, so hopefully it isn't too far off the mark

Since the protected branches API is in preview, I wasn't sure if it's OK to be added, but we need this support for tooling we are writing and would rather contribute to upstream than use a local fork, unless we have to!  I did notice a couple of other preview features in the codebase.  I also saw that octokit.rb has implemented the protected branches functions, so hopefully this is OK

## Implementation Details
At a high level the change involves:
- Create new models for Branch Protection details
- Add Protection element to existing Branch class
- Existing GetBranch() and GetAllBranches() calls specify new preview accepts header so this data is returned
- Added a new EditBranch() call, similar to other Edit() methods, that takes a BranchUpdate object specifying the protection settings/fields to change.  This is Patched into the Branch object/URI as per other similar examples
- Modified existing tests for GetBranch() and GetAllBranches() calls to handle the accepts parameter now being specified
- Added unit and integration tests for the branch protection features, which are all passing

## To Do List
- [X] ~~Haven't yet looked at what is required on the Octokit.Reactive project~~ Added new function, not sure if anything more to do?
