### PR TITLE
Complete PullRequest Merged field changes

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -35,9 +35,7 @@ public class PullRequestsClientTests : IDisposable
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
-
         Assert.Equal("a pull request", result.Title);
-        Assert.False(result.Merged);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1046,7 +1046,7 @@ namespace Octokit.Tests.Clients
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+created:2014-01-01..2014-02-02"));
             }
 
-            [Fact]
+            /*[Fact]
             public void TestingTheMergedQualifier_GreaterThan()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -1119,7 +1119,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+merged:2014-01-01..2014-02-02"));
-            }
+            }*/
 
             [Fact]
             public void TestingTheUpdatedQualifier_GreaterThan()

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1046,7 +1046,7 @@ namespace Octokit.Tests.Clients
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+created:2014-01-01..2014-02-02"));
             }
 
-            /*[Fact]
+            [Fact]
             public void TestingTheMergedQualifier_GreaterThan()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -1119,7 +1119,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+merged:2014-01-01..2014-02-02"));
-            }*/
+            }
 
             [Fact]
             public void TestingTheUpdatedQualifier_GreaterThan()

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -35,7 +35,7 @@ namespace Octokit
             User = user;
             Assignee = assignee;
             MergeCommitSha = mergeCommitSha;
-            Merged = merged;
+            Merged = merged || MergedAt.HasValue;
             Mergeable = mergeable;
             MergedBy = mergedBy;
             Comments = comments;

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, string mergeCommitSha, bool merged, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles)
+        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, string mergeCommitSha, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -35,7 +35,6 @@ namespace Octokit
             User = user;
             Assignee = assignee;
             MergeCommitSha = mergeCommitSha;
-            Merged = merged || MergedAt.HasValue;
             Mergeable = mergeable;
             MergedBy = mergedBy;
             Comments = comments;
@@ -139,11 +138,6 @@ namespace Octokit
         /// The SHA of the merge commit.
         /// </summary>
         public string MergeCommitSha { get; protected set; }
-
-        /// <summary>
-        /// Whether or not the pull request has been merged.
-        /// </summary>
-        public bool Merged { get; protected set; }
 
         /// <summary>
         /// Whether or not the pull request can be merged.

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, string mergeCommitSha, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles)
+        public PullRequest(Uri url, Uri htmlUrl, Uri diffUrl, Uri patchUrl, Uri issueUrl, Uri statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, bool? mergeable, User mergedBy, int comments, int commits, int additions, int deletions, int changedFiles)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -34,7 +34,6 @@ namespace Octokit
             Base = @base;
             User = user;
             Assignee = assignee;
-            MergeCommitSha = mergeCommitSha;
             Mergeable = mergeable;
             MergedBy = mergedBy;
             Comments = comments;
@@ -135,9 +134,12 @@ namespace Octokit
         public User Assignee { get; protected set; }
 
         /// <summary>
-        /// The SHA of the merge commit.
+        /// Whether or not the pull request has been merged.
         /// </summary>
-        public string MergeCommitSha { get; protected set; }
+        public bool Merged
+        {
+            get { return MergedAt.HasValue; }
+        }
 
         /// <summary>
         /// Whether or not the pull request can be merged.


### PR DESCRIPTION
This replaces #970 (which replaced #936)

As well as the original changes that removed the Merged property, Ive also removed MergeCommitSha as mentioned by @Haacked in #936 

Ive actually added the ```bool Merged ``` property back, with only a getter that returns ```MergedAt.HasValue```  

Happy with this?  Otherwise I could remove this property entirely and all consumers would have to do their own check for ```MergedAt.HasValue```