### PR TITLE
let's do CI right

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Octokit - GitHub API Client Library for .NET 
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/octokit/octokit.net?branch=master)](https://ci.appveyor.com/project/Haacked15676/octokit-net) [![Join the chat at https://gitter.im/octokit/octokit.net](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/octokit/octokit.net?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build status](https://ci.appveyor.com/api/projects/status/cego2g42yw26th26/branch/master?svg=true)](https://ci.appveyor.com/project/github-windows/octokit-net/branch/master)) [![Join the chat at https://gitter.im/octokit/octokit.net](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/octokit/octokit.net?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ![logo](octokit-dotnet_2.png)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,4 +10,5 @@ nuget:
   account_feed: true
   project_feed: true
 artifacts:
-- path: '**\octokit*.nupkg'
+- path: 'packaging\octokit*.nupkg'
+  name: OctokitPackages

--- a/build.fsx
+++ b/build.fsx
@@ -222,7 +222,6 @@ Target "CreatePackages" DoNothing
 "Clean"
    ==> "AssemblyInfo"
    ==> "CheckProjects"
-   ==> "ValidateLINQPadSamples"
    ==> "BuildApp"
 
 "Clean"
@@ -248,6 +247,7 @@ Target "CreatePackages" DoNothing
 "CreateOctokitReactivePackage"
    ==> "CreatePackages"
 
-
+"ValidateLINQPadSamples"
+   ==> "CreatePackages"
 
 RunTargetOrDefault "Default"


### PR DESCRIPTION
This is some parity work as part of moving our OSS projects over to some dedicated resources on AppVeyor. I wanted to do this later in the week but it looks like webhooks weren't being delivered over the weekend, so let's fix this:

- [x] moved this webhook to the `github-windows` org on AppVeyor
- [x] verify builds are configured correctly
- [x] verify PR is triggered
- [x] confirm NuGet feed in README is correct
- [x] filter out rogue `tools` package from being published
- [ ] :fire: old build configuration

cc @haacked