### PR TITLE
Fixes #1001 CannotBeMergedDueNotInMergeableState

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -246,7 +246,8 @@ public class PullRequestsClientTests : IDisposable
 
         var master = await _github.GitDatabase.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/master");
         var newMasterTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World, we meet again!" } });
-        await CreateCommit("baseline for pull request", newMasterTree.Sha, master.Object.Sha);
+        var masterCommit = await CreateCommit("Commit in master", newMasterTree.Sha, master.Object.Sha);
+        await _github.GitDatabase.Reference.Update(Helper.UserName, _context.RepositoryName, "heads/master", new ReferenceUpdate(masterCommit.Sha));
 
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
-        public Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
+        public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -118,7 +118,7 @@ namespace Octokit
 
             try
             {
-                return ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest);
+                return await ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest);
             }
             catch (ApiException ex)
             {

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -118,7 +118,9 @@ namespace Octokit
 
             try
             {
-                return await ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest);
+                return await ApiConnection
+                    .Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest)
+                    .ConfigureAwait(false);
             }
             catch (ApiException ex)
             {


### PR DESCRIPTION
Fixes #1001 

I made two changes:

 1. I updated `master` head with the new commit so that the PR is not mergeable (not sure if it's the best way to do this.
 2. The `Merge` method wasn't awaiting the API call so the exception couldn't be caught, I made the method `async` and I'm now awaiting the `PUT` request.