### PR TITLE
Add link to corefx coding conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ being addressed.
 Some things that will increase the chance that your pull request is accepted.
 
 * Follow existing code conventions. Most of what we do follows [standard .NET
-  <!--conventions](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) except in a few places. We include a ReSharper team settings file.-->
+  conventions](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) except in a few places. We include a ReSharper team settings file.
 * Include unit tests that would otherwise fail without your code, but pass with 
   it.
 * Update the documentation, the surrounding one, examples elsewhere, guides, 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ being addressed.
 
 Some things that will increase the chance that your pull request is accepted.
 
-* Follow existing code conventions. Most of what we do follows standard .NET
-  conventions except in a few places. We include a ReSharper team settings file.
+* Follow existing code conventions. Most of what we do follows [standard .NET
+  <!--conventions](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) except in a few places. We include a ReSharper team settings file.-->
 * Include unit tests that would otherwise fail without your code, but pass with 
   it.
 * Update the documentation, the surrounding one, examples elsewhere, guides, 


### PR DESCRIPTION
I am working in gitter to understand what to put in a seperate file of custom coding conventions for the project.
But this should be here either way