### PR TITLE
[WIK] Activity -> Events - unclear usage

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -54,10 +54,10 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns>The <see cref="IssueComment"/> that was just updated.</returns>
-        IObservable<IssueComment> Update(string owner, string name, int number, string commentUpdate);
+        IObservable<IssueComment> Update(string owner, string name, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -65,8 +65,8 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string name, int number);
+        IObservable<Unit> Delete(string owner, string name, int id);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -19,19 +19,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue comment number</param>
+        /// <param name="id">The issue comment id</param>
         /// <returns>The <see cref="IssueComment"/>s for the specified Issue Comment.</returns>
-        public IObservable<IssueComment> Get(string owner, string name, int number)
+        public IObservable<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, id).ToObservable();
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="number">The issue id</param>
         /// <returns>The list of <see cref="IssueComment"/>s for the specified Issue.</returns>
         public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number)
         {
@@ -71,7 +71,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="number">The id of the issue</param>
         /// <param name="newComment">The text of the new comment</param>
         /// <returns>The <see cref="IssueComment"/> that was just created.</returns>
         public IObservable<IssueComment> Create(string owner, string name, int number, string newComment)
@@ -89,16 +89,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns>The <see cref="IssueComment"/> that was just updated.</returns>
-        public IObservable<IssueComment> Update(string owner, string name, int number, string commentUpdate)
+        public IObservable<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
-            return _client.Update(owner, name, number, commentUpdate).ToObservable();
+            return _client.Update(owner, name, id, commentUpdate).ToObservable();
         }
 
         /// <summary>
@@ -107,14 +107,14 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string name, int number)
+        public IObservable<Unit> Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Delete(owner, name, number).ToObservable();
+            return _client.Delete(owner, name, id).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 using Octokit.Tests.Integration.Helpers;
@@ -20,6 +19,16 @@ public class IssuesClientTests : IDisposable
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
         _issuesClient = github.Issue;
         _context = github.CreateRepositoryContext(new NewRepository(repoName)).Result;
+    }
+
+    [IntegrationTest]
+    public async Task CanDeserializeIssue()
+    {
+        var issue = await _issuesClient.Get("octokit", "octokit.net", 760);
+
+        Assert.NotNull(issue);
+        Assert.Equal(62915215, issue.Id);
+        Assert.Equal(false, issue.Locked);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"));
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/events"));
             }
 
             [Fact]
@@ -360,18 +360,18 @@ namespace Octokit.Tests.Clients
                 {
                     "payload", new
                     {
-                        action = "assigned",
+                        action = "created",
                         issue = new
                         {
-                            number = 1337
-                        },
-                        assignee = new
-                        {
-                            id = 1337
-                        },
-                        label = new
-                        {
-                            name = "bug"
+                            number = 1337,
+                            assignee = new
+                            {
+                                id = 1337
+                            },
+                            labels = new[]
+                            {
+                               new { name = "bug"}
+                            }
                         }
                     }
                 }
@@ -382,10 +382,10 @@ namespace Octokit.Tests.Clients
             Assert.Equal(1, activities.Count);
 
             var payload = activities.FirstOrDefault().Payload as IssueEventPayload;
-            Assert.Equal("assigned", payload.Action);
+            Assert.Equal("created", payload.Action);
             Assert.Equal(1337, payload.Issue.Number);
-            Assert.Equal(1337, payload.Assignee.Id);
-            Assert.Equal("bug", payload.Label.Name);
+            Assert.Equal(1337, payload.Issue.Assignee.Id);
+            Assert.Equal("bug", payload.Issue.Labels.First().Name);
         }
 
         [Fact]

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
         /// Gets all the events for a given repository
         /// </summary>
         /// <remarks>
-        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// https://developer.github.com/v3/activity/events/#list-repository-events
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -46,7 +46,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(owner, name));
+            return ApiConnection.GetAll<Activity>(ApiUrls.RepositoryEvents(owner, name));
         }
 
         /// <summary>

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -13,16 +13,16 @@ namespace Octokit
     public interface IIssueCommentsClient
     {
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="id">The issue id</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<IssueComment> Get(string owner, string name, int number);
+        Task<IssueComment> Get(string owner, string name, int id);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -39,7 +39,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="number">The issue id</param>
         /// <returns></returns>
         Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number);
 
@@ -49,7 +49,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="number">The id of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         /// <returns></returns>
         Task<IssueComment> Create(string owner, string name, int number, string newComment);
@@ -60,10 +60,10 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns></returns>
-        Task<IssueComment> Update(string owner, string name, int number, string commentUpdate);
+        Task<IssueComment> Update(string owner, string name, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -71,8 +71,8 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        Task Delete(string owner, string name, int number);
+        Task Delete(string owner, string name, int id);
     }
 }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -20,19 +20,19 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="id">The issue id</param>
         /// <returns></returns>
-        public Task<IssueComment> Get(string owner, string name, int number)
+        public Task<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, number));
+            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id));
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="number">The issue id</param>
         /// <returns></returns>
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number)
         {
@@ -72,7 +72,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
+        /// <param name="number">The id of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         /// <returns></returns>
         public Task<IssueComment> Create(string owner, string name, int number, string newComment)
@@ -90,16 +90,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns></returns>
-        public Task<IssueComment> Update(string owner, string name, int number, string commentUpdate)
+        public Task<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
-            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, number), new BodyWrapper(commentUpdate));
+            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, id), new BodyWrapper(commentUpdate));
         }
 
         /// <summary>
@@ -108,14 +108,14 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public Task Delete(string owner, string name, int number)
+        public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Delete(ApiUrls.IssueComment(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.IssueComment(owner, name, id));
         }
     }
 }

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -208,10 +208,9 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
-        /// issue.
+        /// Updates an issue for the specified repository. Issue owners and users with push access can edit an issue.
         /// </summary>
-        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <remarks>https://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -91,6 +91,9 @@ namespace Octokit
         /// <summary>
         /// Watches a repository for the authenticated user.
         /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
+        /// </remarks>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -285,11 +285,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public static Uri IssueComment(string owner, string name, int number)
+        public static Uri IssueComment(string owner, string name, int id)
         {
-            return "repos/{0}/{1}/issues/comments/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/comments/{2}".FormatUri(owner, name, id);
         }
 
         /// <summary>
@@ -297,11 +297,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public static Uri CommitComment(string owner, string name, int number)
+        public static Uri CommitComment(string owner, string name, int id)
         {
-            return "repos/{0}/{1}/comments/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/comments/{2}".FormatUri(owner, name, id);
         }
 
         /// <summary>
@@ -956,6 +956,17 @@ namespace Octokit
         public static Uri CreateMerge(string owner, string name)
         {
             return "repos/{0}/{1}/merges".FormatUri(owner, name);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> for getting the repository's events.
+        /// </summary>
+        /// <param name="owner"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static Uri RepositoryEvents(string owner, string name)
+        {
+            return "repos/{0}/{1}/events".FormatUri(owner, name);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
@@ -7,7 +7,5 @@ namespace Octokit
     {
         public string Action { get; protected set; }
         public Issue Issue { get; protected set; }
-        public User Assignee { get; protected set; }
-        public Label Label { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public Issue() { }
 
-        public Issue(Uri url, Uri htmlUrl, Uri commentsUrl, Uri eventsUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        public Issue(Uri url, Uri htmlUrl, Uri commentsUrl, Uri eventsUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt, int id, bool locked)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -29,7 +29,14 @@ namespace Octokit
             ClosedAt = closedAt;
             CreatedAt = createdAt;
             UpdatedAt = updatedAt;
+            Id = id;
+            Locked = locked;
         }
+
+        /// <summary>
+        /// The Id for this issue
+        /// </summary>
+        public int Id { get; protected set; }
 
         /// <summary>
         /// The URL for this issue.
@@ -112,6 +119,11 @@ namespace Octokit
         /// The date the issue was last updated.
         /// </summary>
         public DateTimeOffset? UpdatedAt { get; protected set; }
+
+        /// <summary>
+        /// If the issue is locked or not
+        /// </summary>
+        public bool Locked { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue)
+        public IssueEvent(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, Uri commitUrl)
         {
             Id = id;
             Url = url;
@@ -20,6 +20,7 @@ namespace Octokit
             CommitId = commitId;
             CreatedAt = createdAt;
             Issue = issue;
+            CommitUrl = commitUrl;
         }
 
         /// <summary>
@@ -56,6 +57,11 @@ namespace Octokit
         /// The String SHA of a commit that referenced this Issue.
         /// </summary>
         public string CommitId { get; protected set; }
+
+        /// <summary>
+        /// The commit URL of a commit that referenced this issue.
+        /// </summary>
+        public Uri CommitUrl { get; protected set; }
 
         /// <summary>
         /// Date the event occurred for the issue/pull request.


### PR DESCRIPTION
Fixes #1016 

I discovered that `/repos/:owner/:repo/issues/events` was actually implemented in `IssuesEventsClient.GetAllForRepository` while `/repos/:owner/:repo/events` is implemented in `EventsClient.GetAllForRepository`.

**Do we want to implement those two endpoints in the same class or are we happy to keep them separated as they're now?**

I modified some entities:
 - `Issue` also has an `Id` and `Locked` [properties](https://developer.github.com/v3/issues/#get-a-single-issue).
 - `IssueEventPayload` doesn't have a property `Assignee` or `Label.`. GitHub only fire an events when an issue is opened, closed or re-opened. GitHub does not fire an even when assigning someone to the issue, assigning a label or a milestone.
 - `IssueEvents` has a `CommitUrl` [property](https://developer.github.com/v3/issues/events/#get-a-single-event).

Issue comments are identified by `Id`, not `Number`. I took the liberty to rename this wherever I found it.

I'm testing the deserialization of the repository events in `EventsClientTests`. At the moment I'm also testing that some events are **not** being fired by GitHub so that those tests would break if GitHub started to fire them and we could implement them straight away. Concrete example: GitHub doesn't fire an event when un-starring a repository, in the test I star and unstar and test that I get only one event. **Is that over specification?**