### PR TITLE
Issue comments are identified by Id instead of Number

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -7,16 +7,16 @@ namespace Octokit.Reactive
     public interface IObservableIssueCommentsClient
     {
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue comment number</param>
+        /// <param name="id">The issue comment id</param>
         /// <returns>The <see cref="IssueComment"/>s for the specified Issue Comment.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<IssueComment> Get(string owner, string name, int number);
+        IObservable<IssueComment> Get(string owner, string name, int id);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -54,10 +54,10 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns>The <see cref="IssueComment"/> that was just updated.</returns>
-        IObservable<IssueComment> Update(string owner, string name, int number, string commentUpdate);
+        IObservable<IssueComment> Update(string owner, string name, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -65,8 +65,8 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string name, int number);
+        IObservable<Unit> Delete(string owner, string name, int id);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -19,19 +19,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue comment number</param>
+        /// <param name="id">The issue comment id</param>
         /// <returns>The <see cref="IssueComment"/>s for the specified Issue Comment.</returns>
-        public IObservable<IssueComment> Get(string owner, string name, int number)
+        public IObservable<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, id).ToObservable();
         }
 
         /// <summary>
@@ -89,16 +89,16 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns>The <see cref="IssueComment"/> that was just updated.</returns>
-        public IObservable<IssueComment> Update(string owner, string name, int number, string commentUpdate)
+        public IObservable<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
-            return _client.Update(owner, name, number, commentUpdate).ToObservable();
+            return _client.Update(owner, name, id, commentUpdate).ToObservable();
         }
 
         /// <summary>
@@ -107,14 +107,14 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string name, int number)
+        public IObservable<Unit> Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Delete(owner, name, number).ToObservable();
+            return _client.Delete(owner, name, id).ToObservable();
         }
     }
 }

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -13,16 +13,16 @@ namespace Octokit
     public interface IIssueCommentsClient
     {
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="id">The issue comment id</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<IssueComment> Get(string owner, string name, int number);
+        Task<IssueComment> Get(string owner, string name, int id);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -60,10 +60,10 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns></returns>
-        Task<IssueComment> Update(string owner, string name, int number, string commentUpdate);
+        Task<IssueComment> Update(string owner, string name, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -71,8 +71,8 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        Task Delete(string owner, string name, int number);
+        Task Delete(string owner, string name, int id);
     }
 }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="id">The issue id</param>
+        /// <param name="id">The issue comment id</param>
         /// <returns></returns>
         public Task<IssueComment> Get(string owner, string name, int id)
         {

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -20,19 +20,19 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets a single Issue Comment by number.
+        /// Gets a single Issue Comment by id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue number</param>
+        /// <param name="id">The issue id</param>
         /// <returns></returns>
-        public Task<IssueComment> Get(string owner, string name, int number)
+        public Task<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, number));
+            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id));
         }
 
         /// <summary>
@@ -90,16 +90,16 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#edit-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <returns></returns>
-        public Task<IssueComment> Update(string owner, string name, int number, string commentUpdate)
+        public Task<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
-            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, number), new BodyWrapper(commentUpdate));
+            return ApiConnection.Patch<IssueComment>(ApiUrls.IssueComment(owner, name, id), new BodyWrapper(commentUpdate));
         }
 
         /// <summary>
@@ -108,14 +108,14 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public Task Delete(string owner, string name, int number)
+        public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Delete(ApiUrls.IssueComment(owner, name, number));
+            return ApiConnection.Delete(ApiUrls.IssueComment(owner, name, id));
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -285,11 +285,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment number</param>
+        /// <param name="id">The comment id</param>
         /// <returns></returns>
-        public static Uri IssueComment(string owner, string name, int number)
+        public static Uri IssueComment(string owner, string name, int id)
         {
-            return "repos/{0}/{1}/issues/comments/{2}".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/issues/comments/{2}".FormatUri(owner, name, id);
         }
 
         /// <summary>


### PR DESCRIPTION
As described in the documentation:

 - https://developer.github.com/v3/issues/comments/#get-a-single-comment
 - https://developer.github.com/v3/issues/comments/#edit-a-comment
 - https://developer.github.com/v3/issues/comments/#delete-a-comment

Issue comments are identified by `Id` instead of `Number`. I didn't add any tests as I only renamed parameters and modified XML comments,