### PR TITLE
Added missing fields from API and removed fields that are not returned by API

### DIFF
--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -23,6 +23,22 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanDeserializeIssue()
+    {
+        const string title = "a test issue";
+        const string description = "A new unassigned issue";
+        var newIssue = new NewIssue(title) { Body = description };
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+        var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+
+        Assert.NotNull(retrieved);
+        Assert.NotEqual(0, issue.Id);
+        Assert.Equal(false, issue.Locked);
+        Assert.Equal(title, retrieved.Title);
+        Assert.Equal(description, retrieved.Body);
+    }
+
+    [IntegrationTest]
     public async Task CanCreateRetrieveAndCloseIssue()
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -9,7 +9,7 @@ using Octokit.Tests.Integration.Helpers;
 
 public class IssuesEventsClientTests : IDisposable
 {
-    private readonly IIssuesEventsClient _issuesEventsClientClient;
+    private readonly IIssuesEventsClient _issuesEventsClient;
     private readonly IIssuesClient _issuesClient;
     private readonly RepositoryContext _context;
 
@@ -17,7 +17,7 @@ public class IssuesEventsClientTests : IDisposable
     {
         var github = Helper.GetAuthenticatedClient();
 
-        _issuesEventsClientClient = github.Issue.Events;
+        _issuesEventsClient = github.Issue.Events;
         _issuesClient = github.Issue;
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
@@ -30,13 +30,13 @@ public class IssuesEventsClientTests : IDisposable
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
-        var issueEventInfo = await _issuesEventsClientClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        var issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.Empty(issueEventInfo);
 
         var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
             .Result;
         Assert.NotNull(closed);
-        issueEventInfo = await _issuesEventsClientClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         Assert.Equal(1, issueEventInfo.Count);
         Assert.Equal(EventInfoState.Closed, issueEventInfo[0].Event);
@@ -67,7 +67,7 @@ public class IssuesEventsClientTests : IDisposable
             .Result;
         Assert.NotNull(closed2);
 
-        var issueEvents = await _issuesEventsClientClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
+        var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.Equal(3, issueEvents.Count);
         Assert.Equal(2, issueEvents.Count(issueEvent => issueEvent.Issue.Body == "Everything's coming up Millhouse"));
@@ -81,10 +81,10 @@ public class IssuesEventsClientTests : IDisposable
         var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
             .Result;
         Assert.NotNull(closed);
-        var issueEvents = await _issuesEventsClientClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
+        var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
         int issueEventId = issueEvents[0].Id;
 
-        var issueEventLookupById = await _issuesEventsClientClient.Get(_context.RepositoryOwner, _context.RepositoryName, issueEventId);
+        var issueEventLookupById = await _issuesEventsClient.Get(_context.RepositoryOwner, _context.RepositoryName, issueEventId);
 
         Assert.Equal(issueEventId, issueEventLookupById.Id);
         Assert.Equal(issueEvents[0].Event, issueEventLookupById.Event);
@@ -96,6 +96,17 @@ public class IssuesEventsClientTests : IDisposable
         var client = Helper.GetAuthenticatedClient();
         var issue = await client.Issue.Events.Get("waffleio", "waffle.io", 142230057);
         Assert.Equal(EventInfoState.Unsubscribed, issue.Event);
+    }
+
+    [IntegrationTest]
+    public async Task CanDeserializeMergedEvent()
+    {
+        var issueEvent = await _issuesEventsClient.Get("octokit", "octokit.net", 490490630);
+
+        Assert.NotNull(issueEvent);
+        Assert.Equal(EventInfoState.Merged, issueEvent.Event);
+        Assert.Equal("0bb8747a0ad1a9efff201ea017a0a6a4f69b797e", issueEvent.CommitId);
+        Assert.Equal(new Uri("https://api.github.com/repos/octokit/octokit.net/commits/0bb8747a0ad1a9efff201ea017a0a6a4f69b797e"), issueEvent.CommitUrl);
     }
 
     public void Dispose()

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -360,18 +360,18 @@ namespace Octokit.Tests.Clients
                 {
                     "payload", new
                     {
-                        action = "assigned",
+                        action = "created",
                         issue = new
                         {
-                            number = 1337
-                        },
-                        assignee = new
-                        {
-                            id = 1337
-                        },
-                        label = new
-                        {
-                            name = "bug"
+                            number = 1337,
+                            assignee = new
+                            {
+                                id = 1337
+                            },
+                            labels = new[]
+                            {
+                                new { name = "bug"}
+                            }
                         }
                     }
                 }
@@ -382,10 +382,10 @@ namespace Octokit.Tests.Clients
             Assert.Equal(1, activities.Count);
 
             var payload = activities.FirstOrDefault().Payload as IssueEventPayload;
-            Assert.Equal("assigned", payload.Action);
+            Assert.Equal("created", payload.Action);
             Assert.Equal(1337, payload.Issue.Number);
-            Assert.Equal(1337, payload.Assignee.Id);
-            Assert.Equal("bug", payload.Label.Name);
+            Assert.Equal(1337, payload.Issue.Assignee.Id);
+            Assert.Equal("bug", payload.Issue.Labels.First().Name);
         }
 
         [Fact]

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -208,10 +208,9 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
-        /// issue.
+        /// Updates an issue for the specified repository. Issue owners and users with push access can edit an issue.
         /// </summary>
-        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <remarks>https://developer.github.com/v3/issues/#edit-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>

--- a/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/IssueEventPayload.cs
@@ -7,7 +7,5 @@ namespace Octokit
     {
         public string Action { get; protected set; }
         public Issue Issue { get; protected set; }
-        public User Assignee { get; protected set; }
-        public Label Label { get; protected set; }
     }
 }

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -10,8 +10,9 @@ namespace Octokit
     {
         public Issue() { }
 
-        public Issue(Uri url, Uri htmlUrl, Uri commentsUrl, Uri eventsUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        public Issue(Uri url, Uri htmlUrl, Uri commentsUrl, Uri eventsUrl, int number, ItemState state, string title, string body, User user, IReadOnlyList<Label> labels, User assignee, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt, int id, bool locked)
         {
+            Id = id;
             Url = url;
             HtmlUrl = htmlUrl;
             CommentsUrl = commentsUrl;
@@ -29,7 +30,13 @@ namespace Octokit
             ClosedAt = closedAt;
             CreatedAt = createdAt;
             UpdatedAt = updatedAt;
+            Locked = locked;
         }
+
+        /// <summary>
+        /// The Id for this issue
+        /// </summary>
+        public int Id { get; protected set; }
 
         /// <summary>
         /// The URL for this issue.
@@ -112,6 +119,11 @@ namespace Octokit
         /// The date the issue was last updated.
         /// </summary>
         public DateTimeOffset? UpdatedAt { get; protected set; }
+
+        /// <summary>
+        /// If the issue is locked or not
+        /// </summary>
+        public bool Locked { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue)
+        public IssueEvent(int id, Uri url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, Uri commitUrl)
         {
             Id = id;
             Url = url;
@@ -20,6 +20,7 @@ namespace Octokit
             CommitId = commitId;
             CreatedAt = createdAt;
             Issue = issue;
+            CommitUrl = commitUrl;
         }
 
         /// <summary>
@@ -56,6 +57,11 @@ namespace Octokit
         /// The String SHA of a commit that referenced this Issue.
         /// </summary>
         public string CommitId { get; protected set; }
+
+        /// <summary>
+        /// The commit URL of a commit that referenced this issue.
+        /// </summary>
+        public Uri CommitUrl { get; protected set; }
 
         /// <summary>
         /// Date the event occurred for the issue/pull request.


### PR DESCRIPTION
### Issue

Also has an `Id` and `Locked` [properties](https://developer.github.com/v3/issues/#get-a-single-issue). I tested the change in the `CanDeserializeIssue` method.

### IssueEventPayload

Doesn't have a property `Assignee` or `Label`. GitHub only fire an event when an issue is opened, closed or re-opened. GitHub does not fire an event when assigning someone to the issue, assigning a label or a milestone (I tested manually on my test repository).

### IssueEvents

Has a `CommitUrl` [property](https://developer.github.com/v3/issues/events/#get-a-single-event). I tested the change in the `CanDeserializeMergedEvent` method.

**Note**: the documentation doesn't have the `CommitUrl` property yet but it is being returned by the API (I used `Fiddler` as my proxy to inspect what was returned).