### PR TITLE
Implement Repository Pages client

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -347,5 +347,12 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/">Repository Deploy Keys API documentation</a> for more information.
         /// </remarks>
         IObservableRepositoryDeployKeysClient DeployKeys { get; }
+        /// <summary>
+        /// A client for GitHub's Repository Pages API.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+        /// </remarks>
+        IObservableRepositoryPagesClient Page { get; }
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        IObservable<PagesBuild> GetBuilds(string owner, string repositoryName);
+        IObservable<PagesBuild> GetAllBuilds(string owner, string repositoryName);
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        IObservable<PagesBuild> GetAllBuilds(string owner, string repositoryName);
+        IObservable<PagesBuild> GetAll(string owner, string repositoryName);
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
@@ -35,6 +35,6 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        IObservable<PagesBuild> GetLatestBuild(string owner, string repositoryName);
+        IObservable<PagesBuild> GetLatest(string owner, string repositoryName);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -9,7 +9,7 @@ namespace Octokit.Reactive
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    public interface IObservableRepositoryPagesClient
+    {
+        /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<Page> Get(string owner, string repositoryName);
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
+        IObservable<PagesBuild> GetBuilds(string owner, string repositoryName);
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
+        IObservable<PagesBuild> GetLatestBuild(string owner, string repositoryName);
+    }
+}

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Octokit.Reactive
 {

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -41,6 +41,7 @@ namespace Octokit.Reactive
             DeployKeys = new ObservableRepositoryDeployKeysClient(client);
             Content = new ObservableRepositoryContentsClient(client);
             Merging = new ObservableMergingClient(client);
+            Page = new ObservableRepositoryPagesClient(client);
         }
 
         /// <summary>
@@ -493,5 +494,12 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/">Repository Deploy Keys API documentation</a> for more information.
         /// </remarks>
         public IObservableRepositoryDeployKeysClient DeployKeys { get; private set; }
+        /// <summary>
+        /// A client for GitHub's Repository Pages API.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+        /// </remarks>
+        public IObservableRepositoryPagesClient Page { get; private set; }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -1,5 +1,6 @@
 ﻿using Octokit.Reactive.Internal;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
@@ -17,6 +18,16 @@ namespace Octokit.Reactive
             _connection = client.Connection;
         }
 
+        /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         public IObservable<Page> Get(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -25,6 +36,15 @@ namespace Octokit.Reactive
             return _client.Get(owner, repositoryName).ToObservable();
         }
 
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetBuilds(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -33,6 +53,15 @@ namespace Octokit.Reactive
             return _connection.GetAndFlattenAllPages<PagesBuild>(ApiUrls.RepositoryPageBuilds(owner, repositoryName));
         }
 
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetLatestBuild(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -1,10 +1,6 @@
 ﻿using Octokit.Reactive.Internal;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reactive.Threading.Tasks;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Octokit.Reactive
 {

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -1,0 +1,48 @@
+﻿using Octokit.Reactive.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    public class ObservableRepositoryPagesClient : IObservableRepositoryPagesClient
+    {
+        readonly IRepositoryPagesClient _client;
+        readonly IConnection _connection;
+
+        public ObservableRepositoryPagesClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, "client");
+
+            _client = client.Repository.Page;
+            _connection = client.Connection;
+        }
+
+        public IObservable<Page> Get(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return _client.Get(owner, repositoryName).ToObservable();
+        }
+
+        public IObservable<PagesBuild> GetBuilds(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return _connection.GetAndFlattenAllPages<PagesBuild>(ApiUrls.RepositoryPageBuilds(owner, repositoryName));
+        }
+
+        public IObservable<PagesBuild> GetLatestBuild(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return _client.GetLatestBuild(owner, repositoryName).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        public IObservable<PagesBuild> GetAllBuilds(string owner, string repositoryName)
+        public IObservable<PagesBuild> GetAll(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        public IObservable<PagesBuild> GetLatestBuild(string owner, string repositoryName)
+        public IObservable<PagesBuild> GetLatest(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        public IObservable<PagesBuild> GetBuilds(string owner, string repositoryName)
+        public IObservable<PagesBuild> GetAllBuilds(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return _client.GetLatestBuild(owner, repositoryName).ToObservable();
+            return _client.GetLatest(owner, repositoryName).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Octokit.Reactive-Mono.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Mono.csproj
@@ -157,6 +157,8 @@
     <Compile Include="Clients\ObservableRepositoryContentsClient.cs" />
     <Compile Include="Clients\IObservableMergingClient.cs" />
     <Compile Include="Clients\ObservableMergingClient.cs" />
+    <Compile Include="Clients\IObservableRepositoryPagesClient.cs" />
+    <Compile Include="Clients\ObservableRepositoryPagesClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
@@ -165,6 +165,8 @@
     <Compile Include="Clients\ObservableRepositoryContentsClient.cs" />
     <Compile Include="Clients\IObservableMergingClient.cs" />
     <Compile Include="Clients\ObservableMergingClient.cs" />
+    <Compile Include="Clients\IObservableRepositoryPagesClient.cs" />
+    <Compile Include="Clients\ObservableRepositoryPagesClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
@@ -161,6 +161,8 @@
     <Compile Include="Clients\ObservableRepositoryContentsClient.cs" />
     <Compile Include="Clients\IObservableMergingClient.cs" />
     <Compile Include="Clients\ObservableMergingClient.cs" />
+    <Compile Include="Clients\IObservableRepositoryPagesClient.cs" />
+    <Compile Include="Clients\ObservableRepositoryPagesClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Clients\IObservableOauthClient.cs" />
     <Compile Include="Clients\IObservableRepositoryCommitsClients.cs" />
     <Compile Include="Clients\IObservableRepositoryDeployKeysClient.cs" />
+    <Compile Include="Clients\IObservableRepositoryPagesClient.cs" />
     <Compile Include="Clients\IObservableUserKeysClient.cs" />
     <Compile Include="Clients\ObservableMergingClient.cs" />
     <Compile Include="Clients\ObservableRepositoryDeployKeysClient.cs" />
@@ -102,6 +103,7 @@
     <Compile Include="Clients\ObservableIssuesLabelsClient.cs" />
     <Compile Include="Clients\ObservableRepositoryCommitsClients.cs" />
     <Compile Include="Clients\ObservableRepositoryContentsClient.cs" />
+    <Compile Include="Clients\ObservableRepositoryPagesClient.cs" />
     <Compile Include="Clients\ObservableSearchClient.cs" />
     <Compile Include="Clients\IObservableBlobsClient.cs" />
     <Compile Include="Clients\IObservableGistCommentsClient.cs" />

--- a/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
@@ -1,0 +1,85 @@
+﻿using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class RepositoryPagesClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                client.Get("fake", "repo");
+
+                connection.Received().Get<Page>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages"), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
+            }
+        }
+
+        public class TheGetBuildsMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                client.GetBuilds("fake", "repo");
+
+                connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
+            }
+        }
+
+        public class TheGetLatestBuildMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                client.GetLatestBuild("fake", "repo");
+
+                connection.Received().Get<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds/latest"), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
@@ -1,8 +1,5 @@
 ﻿using NSubstitute;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
@@ -39,7 +39,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryPagesClient(connection);
 
-                client.GetBuilds("fake", "repo");
+                client.GetAllBuilds("fake", "repo");
 
                 connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds"));
             }

--- a/Octokit.Tests/OctoKit.Tests-NetCore45.csproj
+++ b/Octokit.Tests/OctoKit.Tests-NetCore45.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Clients\RepositoryForksClientTests.cs" />
     <Compile Include="Clients\RepositoryHooksClientTest.cs" />
     <Compile Include="Clients\RepositoryDeployKeysClientTests.cs" />
+    <Compile Include="Clients\RepositoryPagesClientTests.cs" />
     <Compile Include="Clients\SshKeysClientTests.cs" />
     <Compile Include="Clients\StarredClientTests.cs" />
     <Compile Include="Clients\StatisticsClientTests.cs" />

--- a/Octokit.Tests/Octokit.Tests-Portable.csproj
+++ b/Octokit.Tests/Octokit.Tests-Portable.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Clients\RepositoryCommentsClientTests.cs" />
     <Compile Include="Clients\RepositoryContentsClientTests.cs" />
     <Compile Include="Clients\RepositoryDeployKeysClientTests.cs" />
+    <Compile Include="Clients\RepositoryPagesClientTests.cs" />
     <Compile Include="Clients\SshKeysClientTests.cs" />
     <Compile Include="Clients\StarredClientTests.cs" />
     <Compile Include="Clients\StatisticsClientTests.cs" />

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Clients\FeedsClientTests.cs" />
     <Compile Include="Clients\RepositoryDeployKeysClientTests.cs" />
     <Compile Include="Clients\RepositoryContentsClientTests.cs" />
+    <Compile Include="Clients\RepositoryPagesClientTests.cs" />
     <Compile Include="Clients\SearchClientTests.cs" />
     <Compile Include="Clients\GistCommentsClientTests.cs" />
     <Compile Include="Clients\GistsClientTests.cs" />

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -269,7 +269,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/commits/">Commits API documentation</a> for more details
         ///</remarks>
         IRepositoryCommitsClient Commit { get; }
- 
+
         /// <summary>
         /// Access GitHub's Releases API.
         /// </summary>
@@ -384,5 +384,13 @@ namespace Octokit
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
+
+        /// <summary>
+        /// A client for GitHub's Repository Pages API.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+        /// </remarks>
+        IRepositoryPagesClient Page { get; }
     }
 }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        Task<IReadOnlyList<PagesBuild>> GetBuilds(string owner, string repositoryName);
+        Task<IReadOnlyList<PagesBuild>> GetAllBuilds(string owner, string repositoryName);
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -1,0 +1,40 @@
+﻿using Octokit.Models.Response;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Clients
+{
+    /// <summary>
+    /// A client for GitHub's Repository Pages API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/pages//">Repository Pages API documentation</a> for more information.
+    /// </remarks>
+    interface IRepositoryPagesClient
+    {
+        /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Page>> Get(string owner, string repositoryName);
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<PagesBuild>> GetBuilds(string owner, string repositoryName);
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        Task<PagesBuild> GetLatestBuild(string owner, string repositoryName);
+    }
+}

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -16,7 +16,7 @@ namespace Octokit
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
@@ -27,7 +27,7 @@ namespace Octokit
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
@@ -37,7 +37,7 @@ namespace Octokit
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Octokit

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -44,6 +44,7 @@ namespace Octokit
             DeployKeys = new RepositoryDeployKeysClient(apiConnection);
             Merging = new MergingClient(apiConnection);
             Content = new RepositoryContentsClient(apiConnection);
+            Page = new RepositoryPagesClient(apiConnection);
         }
 
         /// <summary>
@@ -577,5 +578,13 @@ namespace Octokit
 
             return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, AcceptHeaders.ProtectedBranchesApiPreview);
         }
+
+        /// <summary>
+        /// A client for GitHub's Repository Pages API.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+        /// </remarks>
+        public IRepositoryPagesClient Page { get; private set; }
     }
 }

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -46,7 +46,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        public Task<IReadOnlyList<PagesBuild>> GetBuilds(string owner, string repositoryName)
+        public Task<IReadOnlyList<PagesBuild>> GetAllBuilds(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
@@ -41,7 +41,7 @@ namespace Octokit
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
@@ -58,7 +58,7 @@ namespace Octokit
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryName">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -54,7 +54,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return ApiConnection.GetAll<PagesBuild>(ApiUrls.RepositoryBuilds(owner, repositoryName));
+            return ApiConnection.GetAll<PagesBuild>(ApiUrls.RepositoryPageBuilds(owner, repositoryName));
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryBuildsLatest(owner, repositoryName));
+            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(owner, repositoryName));
         }
     }
 }

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,8 +12,17 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
     /// </remarks>
-    public interface IRepositoryPagesClient
+    public class RepositoryPagesClient : ApiClient, IRepositoryPagesClient
     {
+        /// <summary>
+        /// Initializes a new GitHub Repository Pages API client.
+        /// </summary>
+        /// <param name="apiConnection">An API connection.</param>
+        public RepositoryPagesClient(IApiConnection apiConnection) : base(apiConnection)
+        {
+
+        }
+
         /// <summary>
         /// Gets the page metadata for a given repository
         /// </summary>
@@ -24,8 +32,14 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Page> Get(string owner, string repositoryName);
+        public Task<Page> Get(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(owner, repositoryName));
+        }
+
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
@@ -35,7 +49,14 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        Task<IReadOnlyList<PagesBuild>> GetBuilds(string owner, string repositoryName);
+        public Task<IReadOnlyList<PagesBuild>> GetBuilds(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return ApiConnection.GetAll<PagesBuild>(ApiUrls.RepositoryBuilds(owner, repositoryName));
+        }
+
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
@@ -45,6 +66,12 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
-        Task<PagesBuild> GetLatestBuild(string owner, string repositoryName);
+        public Task<PagesBuild> GetLatestBuild(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryBuildsLatest(owner, repositoryName));
+        }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1554,5 +1554,20 @@ namespace Octokit
         {
             return "repos/{0}/{1}/contents/{2}?ref={3}".FormatUri(owner, name, path, reference);
         }
+
+        public static Uri RepositoryPage(string owner, string name)
+        {
+            return "repos/{0}/{1}/pages".FormatUri(owner, name);
+        }
+
+        public static Uri RepositoryBuilds(string owner, string name)
+        {
+            return "repos/{0}/{1}/pages/builds".FormatUri(owner, name);
+        }
+
+        public static Uri RepositoryBuildsLatest(string owner, string name)
+        {
+            return "repos/{0}/{1}/pages/builds/latest".FormatUri(owner, name);
+        }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1560,12 +1560,12 @@ namespace Octokit
             return "repos/{0}/{1}/pages".FormatUri(owner, name);
         }
 
-        public static Uri RepositoryBuilds(string owner, string name)
+        public static Uri RepositoryPageBuilds(string owner, string name)
         {
             return "repos/{0}/{1}/pages/builds".FormatUri(owner, name);
         }
 
-        public static Uri RepositoryBuildsLatest(string owner, string name)
+        public static Uri RepositoryPageBuildsLatest(string owner, string name)
         {
             return "repos/{0}/{1}/pages/builds/latest".FormatUri(owner, name);
         }

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
@@ -9,6 +11,7 @@ namespace Octokit
 #if !NETFX_CORE
     [Serializable]
 #endif
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ApiError
     {
         public ApiError() { }
@@ -39,5 +42,13 @@ namespace Octokit
         /// Additional details about the error
         /// </summary>
         public IReadOnlyList<ApiErrorDetail> Errors { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Message: {0}", Message);
+            }
+        }
     }
 }

--- a/Octokit/Models/Response/ApiErrorDetail.cs
+++ b/Octokit/Models/Response/ApiErrorDetail.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
 #if !NETFX_CORE
     [Serializable]
 #endif
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ApiErrorDetail
     {
         public ApiErrorDetail() { }
@@ -24,5 +27,13 @@ namespace Octokit
         public string Field { get; protected set; }
 
         public string Resource { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Message: {0}, Code: {1}, Field: {2}", Message, Code, Field);
+            }
+        }
     }
 }

--- a/Octokit/Models/Response/Page.cs
+++ b/Octokit/Models/Response/Page.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Octokit
 {

--- a/Octokit/Models/Response/Page.cs
+++ b/Octokit/Models/Response/Page.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Octokit.Models.Response
+namespace Octokit
 {
     public enum PagesBuildStatus
     {

--- a/Octokit/Models/Response/Page.cs
+++ b/Octokit/Models/Response/Page.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Models.Response
+{
+    public enum PagesBuildStatus
+    {
+        /// <summary>
+        ///  The site has yet to be built
+        /// </summary>
+        Null,
+        /// <summary>
+        /// The build is in progress
+        /// </summary>
+        Building,
+        /// <summary>
+        /// The site has been built
+        /// </summary>
+        Built,
+        /// <summary>
+        /// An error occurred during the build
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Errored")]
+        Errored,
+    }
+
+    ///<summary>
+    /// Information about your GitHub Pages configuration
+    ///</summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class Page
+    {
+        public Page() { }
+
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "cname")]
+        public Page(string url, PagesBuildStatus status, string cname, bool custom404)
+        {
+            Url = url;
+            Status = status;
+            CName = cname;
+            Custom404 = custom404;
+        }
+
+        /// <summary>
+        /// The pages's API URL.
+        /// </summary>
+        public string Url { get; protected set; }
+        /// <summary>
+        /// Build status of the pages site.
+        /// </summary>
+        public PagesBuildStatus Status { get; protected set; }
+        /// <summary>
+        /// CName of the pages site. Will be null if no CName was provided by the user.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "CName")]
+        public string CName { get; protected set; }
+        /// <summary>
+        /// Is a custom 404 page provided.
+        /// </summary>
+        public bool Custom404 { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "CName: {0}, Status: {1}", CName, Status.ToString());
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Octokit.Models.Response
+namespace Octokit
 {
     /// <summary>
     /// Metadata of a Github Pages build.
@@ -16,10 +16,11 @@ namespace Octokit.Models.Response
     {
         public PagesBuild() { }
 
-        public PagesBuild(string url, PagesBuildStatus status, User pusher, Commit commit, TimeSpan duration, DateTime createdAt, DateTime updatedAt)
+        public PagesBuild(string url, PagesBuildStatus status, ApiError error, User pusher, Commit commit, TimeSpan duration, DateTime createdAt, DateTime updatedAt)
         {
             Url = url;
             Status = status;
+            Error = error;
             Pusher = pusher;
             Commit = commit;
             Duration = duration;
@@ -35,6 +36,7 @@ namespace Octokit.Models.Response
         /// The status of the build.
         /// </summary>
         public PagesBuildStatus Status { get; protected set; }
+        public ApiError Error { get; set; }
         /// <summary>
         /// The user whose commit intiated the build.
         /// </summary>

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
@@ -31,7 +32,10 @@ namespace Octokit
         /// The status of the build.
         /// </summary>
         public PagesBuildStatus Status { get; protected set; }
-        public ApiError Error { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public ApiError Error { get; protected set; }
         /// <summary>
         /// The user whose commit intiated the build.
         /// </summary>
@@ -46,5 +50,13 @@ namespace Octokit
         public TimeSpan Duration { get; protected set; }
         public DateTime CreatedAt { get; protected set; }
         public DateTime UpdatedAt { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Pusher: {0}, Status: {1}, Duration: {2}", Pusher.Name, Status.ToString(), Duration.TotalMilliseconds);
+            }
+        }
     }
 }

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Models.Response
+{
+    /// <summary>
+    /// Metadata of a Github Pages build.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class PagesBuild
+    {
+        public PagesBuild() { }
+
+        public PagesBuild(string url, PagesBuildStatus status, User pusher, Commit commit, TimeSpan duration, DateTime createdAt, DateTime updatedAt)
+        {
+            Url = url;
+            Status = status;
+            Pusher = pusher;
+            Commit = commit;
+            Duration = duration;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+        }
+
+        /// <summary>
+        /// The pages's API URL.
+        /// </summary>
+        public string Url { get; protected set; }
+        /// <summary>
+        /// The status of the build.
+        /// </summary>
+        public PagesBuildStatus Status { get; protected set; }
+        /// <summary>
+        /// The user whose commit intiated the build.
+        /// </summary>
+        public User Pusher { get; protected set; }
+        /// <summary>
+        /// Commit SHA.
+        /// </summary>
+        public Commit Commit { get; protected set; }
+        /// <summary>
+        /// Duration of the build
+        /// </summary>
+        public TimeSpan Duration { get; protected set; }
+        public DateTime CreatedAt { get; protected set; }
+        public DateTime UpdatedAt { get; protected set; }
+    }
+}

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// </summary>
         public PagesBuildStatus Status { get; protected set; }
         /// <summary>
-        /// 
+        /// Error details - if there was one.
         /// </summary>
         public ApiError Error { get; protected set; }
         /// <summary>

--- a/Octokit/Models/Response/PagesBuild.cs
+++ b/Octokit/Models/Response/PagesBuild.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Octokit
 {

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Clients\IPullRequestsClient.cs" />
     <Compile Include="Clients\IRepositoryForksClient.cs" />
     <Compile Include="Clients\IRepositoryHooksClient.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
     <Compile Include="Clients\IssueCommentsClient.cs" />
     <Compile Include="Clients\IssuesClient.cs" />
     <Compile Include="Clients\IssuesEventsClient.cs" />
@@ -85,6 +86,7 @@
     <Compile Include="Clients\ReferencesClient.cs" />
     <Compile Include="Clients\RepositoryForksClient.cs" />
     <Compile Include="Clients\RepositoryHooksClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
     <Compile Include="Clients\StarredClient.cs" />
     <Compile Include="Clients\PullRequestsClient.cs" />
     <Compile Include="Clients\StatisticsClient.cs" />
@@ -172,6 +174,8 @@
     <Compile Include="Models\Request\NewIssue.cs" />
     <Compile Include="Models\Response\Notification.cs" />
     <Compile Include="Models\Response\NotificationInfo.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
     <Compile Include="Models\Response\PullRequest.cs" />
     <Compile Include="Models\Request\RepositoryIssueRequest.cs" />
     <Compile Include="Models\Request\MilestoneRequest.cs" />

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -421,6 +421,10 @@
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Helpers\AcceptHeaders.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -417,6 +417,10 @@
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Helpers\AcceptHeaders.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Clients\AuthorizationsClient.cs" />
     <Compile Include="Clients\BlobsClient.cs" />
     <Compile Include="Clients\CommitsClient.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
     <Compile Include="Clients\MergingClient.cs" />
     <Compile Include="Clients\CommitStatusClient.cs" />
     <Compile Include="Clients\EventsClient.cs" />
@@ -116,6 +117,7 @@
     <Compile Include="Clients\RepositoryContentsClient.cs" />
     <Compile Include="Clients\RepositoryForksClient.cs" />
     <Compile Include="Clients\RepositoryHooksClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
     <Compile Include="Clients\SshKeysClient.cs" />
     <Compile Include="Clients\StarredClient.cs" />
     <Compile Include="Clients\StatisticsClient.cs" />
@@ -241,6 +243,8 @@
     <Compile Include="Models\Response\BranchProtection.cs" />
     <Compile Include="Models\Response\Commit.cs" />
     <Compile Include="Models\Response\CommitStatus.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
     <Compile Include="Models\Response\RepositoryContributor.cs" />
     <Compile Include="Models\Response\Contributor.cs" />
     <Compile Include="Models\Response\EmailAddress.cs" />

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Clients\IActivitiesClient.cs" />
     <Compile Include="Clients\IPullRequestReviewCommentsClient.cs" />
     <Compile Include="Clients\IPullRequestsClient.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
     <Compile Include="Clients\PullRequestReviewCommentsClient.cs" />
     <Compile Include="Clients\PullRequestsClient.cs" />
     <Compile Include="Clients\IAssigneesClient.cs" />
@@ -123,6 +124,7 @@
     <Compile Include="Clients\RepositoriesClient.cs" />
     <Compile Include="Clients\RepositoryForksClient.cs" />
     <Compile Include="Clients\RepositoryHooksClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
     <Compile Include="Clients\SshKeysClient.cs" />
     <Compile Include="Clients\StarredClient.cs" />
     <Compile Include="Clients\StatisticsClient.cs" />
@@ -270,6 +272,8 @@
     <Compile Include="Models\Response\Notification.cs" />
     <Compile Include="Models\Response\NotificationInfo.cs" />
     <Compile Include="Models\Response\Organization.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
     <Compile Include="Models\Response\Plan.cs" />
     <Compile Include="Models\Response\PullRequest.cs" />
     <Compile Include="Models\Response\PullRequestMerge.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Clients\IFeedsClient.cs" />
     <Compile Include="Clients\RepositoryCommitsClient.cs" />
     <Compile Include="Clients\RepositoryDeployKeysClient.cs" />
+    <Compile Include="Clients\RepositoryPagesClient.cs" />
     <Compile Include="Clients\UserKeysClient.cs" />
     <Compile Include="Clients\RepositoryContentsClient.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Clients\IOAuthClient.cs" />
     <Compile Include="Clients\IRepositoryCommitsClient.cs" />
     <Compile Include="Clients\IRepositoryDeployKeysClient.cs" />
+    <Compile Include="Clients\IRepositoryPagesClient.cs" />
     <Compile Include="Clients\IUserKeysClient.cs" />
     <Compile Include="Clients\MergingClient.cs" />
     <Compile Include="Clients\OAuthClient.cs" />
@@ -133,6 +134,8 @@
     <Compile Include="Models\Response\GitHubCommitFile.cs" />
     <Compile Include="Models\Response\Meta.cs" />
     <Compile Include="Models\Response\MiscellaneousRateLimit.cs" />
+    <Compile Include="Models\Response\Page.cs" />
+    <Compile Include="Models\Response\PagesBuild.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
     <Compile Include="Models\Response\ResourceRateLimit.cs" />


### PR DESCRIPTION
Fixes #1033 
**TODO:**
- [x] :lipstick: usings
- [x] Tests: unit
- [x] Implementation of the client
- [x] IObservables + impl

**Questions:**
- The following is an undocumented endpoint.
```
 - GET /repos/:owner/:repo/pages/builds:buildID
```
Should it be included?

- The response includes an error field which seems to be mapped to the `ApiError` class. Does that get included in the model?

**Drawing attention**
- Do enums get their own file?
- Is an implementation *needed* for `DebuggerDisplay`?
- What is the level of importance of integration tests for such a client?