### PR TITLE
remove Get<T> extension method to make tests more clear

### DIFF
--- a/Octokit.Tests/Clients/BlobClientTests.cs
+++ b/Octokit.Tests/Clients/BlobClientTests.cs
@@ -21,8 +21,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", "123456ABCD");
 
-                connection.Received().Get<Blob>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/blobs/123456ABCD"),
-                    null);
+                connection.Received().Get<Blob>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/blobs/123456ABCD"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Clients
                 client.GetCombined("fake", "repo", "sha");
 
                 connection.Received()
-                    .Get<CombinedCommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/status"), null);
+                    .Get<CombinedCommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/status"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -32,7 +32,7 @@ public class CommitsClientTests
 
             client.Get("owner", "repo", "reference");
 
-            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"), null);
+            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"));
         }
     }
 

--- a/Octokit.Tests/Clients/FeedsClientTests.cs
+++ b/Octokit.Tests/Clients/FeedsClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
 
                 feedsClient.GetFeeds();
 
-                connection.Received().Get<Feed>(Arg.Is<Uri>(u => u.ToString() == "feeds"), null);
+                connection.Received().Get<Feed>(Arg.Is<Uri>(u => u.ToString() == "feeds"));
             }
         }
     }

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -26,7 +26,7 @@ public class GistCommentsClientTests
 
             await client.Get("24", 1337);
 
-            connection.Received().Get<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"), null);
+            connection.Received().Get<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
         }
     }
 

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -20,7 +20,7 @@ public class GistsClientTests
 
             client.Get("1");
 
-            connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), null);
+            connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
         }
     }
 

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -20,8 +20,7 @@ public class IssueCommentsClientTests
 
             client.Get("fake", "repo", 42);
 
-            connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"),
-                null);
+            connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -21,8 +21,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"),
-                    null);
+                connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -64,8 +64,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"),
-                    null);
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -67,8 +67,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", "label");
 
-                connection.Received().Get<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels/label"),
-                    null);
+                connection.Received().Get<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels/label"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -19,8 +19,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42"),
-                    null);
+                connection.Received().Get<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
 
                 orgsClient.Get("orgName");
 
-                client.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"), null);
+                client.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -180,8 +180,7 @@ public class PullRequestReviewCommentsClientTests
 
             client.GetComment("fakeOwner", "fakeRepoName", 53);
 
-            connection.Received().Get<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments/53"),
-                null);
+            connection.Received().Get<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments/53"));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -18,8 +18,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42"),
-                    null);
+                connection.Received().Get<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Get("owner", "repo", "heads/develop");
 
-                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"), null);
+                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
             }
         }
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -44,8 +44,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 1);
 
-                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1"),
-                    null);
+                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1"));
             }
 
             [Fact]
@@ -228,7 +227,7 @@ namespace Octokit.Tests.Clients
 
                 client.GetAsset("fake", "repo", 1);
 
-                connection.Received().Get<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"), null);
+                connection.Received().Get<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -245,7 +245,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo");
 
-                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo"), null);
+                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo"));
             }
 
             [Fact]
@@ -487,7 +487,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllLanguages("owner", "name");
 
                 connection.Received()
-                    .Get<Dictionary<string, long>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/languages"), null);
+                    .Get<Dictionary<string, long>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/languages"));
             }
 
             [Fact]
@@ -641,7 +641,7 @@ namespace Octokit.Tests.Clients
                 client.Compare("owner", "repo", "base", "head");
 
                 connection.Received()
-                    .Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/compare/base...head"), null);
+                    .Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/compare/base...head"));
             }
 
             [Fact]
@@ -654,7 +654,7 @@ namespace Octokit.Tests.Clients
                 client.Compare("owner", "repo", "base", "shiftkey/my-cool-branch");
 
                 connection.Received()
-                    .Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/compare/base...shiftkey%2Fmy-cool-branch"), null);
+                    .Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/compare/base...shiftkey%2Fmy-cool-branch"));
             }
         }
 
@@ -684,7 +684,7 @@ namespace Octokit.Tests.Clients
                 client.Get("owner", "name", "reference");
 
                 connection.Received()
-                    .Get<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/commits/reference"), null);
+                    .Get<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/commits/reference"));
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -20,8 +20,7 @@ public class RepositoryCommentsClientTests
 
             client.Get("fake", "repo", 42);
 
-            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"),
-                null);
+            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -30,8 +30,7 @@ namespace Octokit.Tests.Clients
 
                 deployKeysClient.Get("user", "repo", 42);
 
-                apiConnection.Received().Get<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys/42"),
-                    null);
+                apiConnection.Received().Get<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys/42"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Clients
 
                 client.Hooks.Get("fake", "repo", 12345678);
 
-                connection.Received().Get<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678"), null);
+                connection.Received().Get<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -17,7 +17,7 @@ public class TagsClientTests
 
             client.Get("owner", "repo", "reference");
 
-            connection.Received().Get<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/tags/reference"), null);
+            connection.Received().Get<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/tags/reference"));
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get(1);
 
-                connection.Received().Get<Team>(Arg.Is<Uri>(u => u.ToString() == "teams/1"), null);
+                connection.Received().Get<Team>(Arg.Is<Uri>(u => u.ToString() == "teams/1"));
             }
         }
 

--- a/Octokit.Tests/Clients/TreesClientTests.cs
+++ b/Octokit.Tests/Clients/TreesClientTests.cs
@@ -21,8 +21,7 @@ namespace Octokit.Tests
 
                 client.Get("fake", "repo", "123456ABCD");
 
-                connection.Received().Get<TreeResponse>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/trees/123456ABCD"),
-                    null);
+                connection.Received().Get<TreeResponse>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/trees/123456ABCD"));
             }
 
             [Fact]
@@ -49,8 +48,7 @@ namespace Octokit.Tests
 
                 client.GetRecursive("fake", "repo", "123456ABCD");
 
-                connection.Received().Get<TreeResponse>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/trees/123456ABCD?recursive=1"),
-                    null);
+                connection.Received().Get<TreeResponse>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/trees/123456ABCD?recursive=1"));
             }
 
             [Fact]

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -14,22 +14,6 @@ namespace Octokit
     public static class ApiExtensions
     {
         /// <summary>
-        /// Gets the API resource at the specified URI.
-        /// </summary>
-        /// <typeparam name="T">Type of the API resource to get.</typeparam>
-        /// <param name="connection">The connection to use</param>
-        /// <param name="uri">URI of the API resource to get</param>
-        /// <returns>The API resource.</returns>
-        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public static Task<T> Get<T>(this IApiConnection connection, Uri uri)
-        {
-            Ensure.ArgumentNotNull(connection, "connection");
-            Ensure.ArgumentNotNull(uri, "uri");
-
-            return connection.Get<T>(uri, null);
-        }
-
-        /// <summary>
         /// Gets all API resources in the list at the specified URI.
         /// </summary>
         /// <typeparam name="T">Type of the API resource in the list.</typeparam>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -48,6 +48,20 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">Type of the API resource to get.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <returns>The API resource.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        public Task<T> Get<T>(Uri uri)
+        {
+            Ensure.ArgumentNotNull(uri, "uri");
+
+            return Get<T>(uri, null);
+        }
+
+        /// <summary>
+        /// Gets the API resource at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource to get.</typeparam>
+        /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
         /// <returns>The API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -23,6 +23,16 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">Type of the API resource to get.</typeparam>
         /// <param name="uri">URI of the API resource to get</param>
+        /// <returns>The API resource.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<T> Get<T>(Uri uri);
+
+        /// <summary>
+        /// Gets the API resource at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource to get.</typeparam>
+        /// <param name="uri">URI of the API resource to get</param>
         /// <param name="parameters">Parameters to add to the API request</param>
         /// <returns>The API resource.</returns>
         /// <exception cref="ApiException">Thrown when an API error occurs.</exception>


### PR DESCRIPTION
Fixes #1062

As part of #1062 I found that an extension methods for `Get<T>(uri)` is interfering with some of our unit tests - as it's an extension method contributors can't verify it was invoked correctly, and when that doesn't work blindly add the second parameter to get the test to pass. 

This is done in a lot of tests, and it's a trivial extension, so why not just make it a feature of the interface?

I'm happy to leave the other methods in `ApiExtensions` as-is, they're not used as broadly.

cc @Haacked for feels and any potential quirks about switching from extension method to interface method.