### PR TITLE
Add member role filter to OrganizationMembersClient.GetAll() functions

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
@@ -60,6 +60,53 @@ namespace Octokit.Reactive
         IObservable<User> GetAll(string org, string filter);
 
         /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, OrganizationMembersRole role);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role);
+
+        /// <summary>
         /// List all users who have publicized their membership of the organization.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>

--- a/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
@@ -93,6 +93,63 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersRole role)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, role));
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter, role));
+        }
+
+        /// <summary>
         /// List all users who have publicized their membership of the organization.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class OrganizationMembersClientTests
+    {
+        public class TheGetAllMethod
+        {
+            private IGitHubClient _gitHub;
+            private string _organizationFixture;
+
+            public TheGetAllMethod()
+            {
+                _gitHub = Helper.GetAuthenticatedClient();
+                _organizationFixture = "octokit";
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsMembers()
+            {
+                var members = _gitHub.Organization.Member.GetAll(_organizationFixture);
+                Assert.NotNull(members);
+            }
+
+            [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]
+            public async Task ReturnsMembersWithFilter()
+            {
+                var no2FAMembers = await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersFilter.TwoFactorAuthenticationDisabled);
+                Assert.NotNull(no2FAMembers);
+            }
+
+            [IntegrationTest(Skip = "Admin/Member filter doesn't work unless the requester is an organization member")]
+            public async Task ReturnsMembersWithRole()
+            {
+                var adminMembers = await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersRole.Admin);
+                Assert.NotNull(adminMembers);
+
+                var normalMembers = await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersRole.Member);
+                Assert.NotNull(normalMembers);
+
+                // There shouldnt be any members that are in both groups if the role filter works correctly
+                var membersInBoth = adminMembers.Select(a => a.Id).Intersect(normalMembers.Select(n => n.Id));
+                Assert.True(membersInBoth.Count() == 0);
+            }
+
+            [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]
+            public async Task ReturnsMembersWthFilterAndRole()
+            {
+                // Get count of admin/normal members
+                var adminCount = (await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersRole.Admin)).Count;
+                var memberCount = (await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersRole.Member)).Count;
+
+                // Ensure that there are less admins with no 2 factor, than there are total admins
+                var adminsWithNo2FA = await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Admin);
+                Assert.NotNull(adminsWithNo2FA);
+                Assert.True(adminsWithNo2FA.Count <= adminCount);
+
+                // Ensure that there are less members with no 2 factor, than there are total admins
+                var membersWithNo2FA = await _gitHub.Organization.Member.GetAll(_organizationFixture, OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Member);
+                Assert.NotNull(membersWithNo2FA);
+                Assert.True(membersWithNo2FA.Count <= memberCount);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Clients\GistsClientTests.cs" />
     <Compile Include="Clients\IssuesEventsClientTests.cs" />
     <Compile Include="Clients\MilestonesClientTests.cs" />
+    <Compile Include="Clients\OrganizationMembersClientTests.cs" />
     <Compile Include="Clients\PullRequestsClientTests.cs" />
     <Compile Include="Clients\ReferencesClientTests.cs" />
     <Compile Include="Clients\RepositoryCommitsClientTests.cs" />

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -67,6 +67,105 @@ namespace Octokit.Tests.Clients
 
                 client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled"));
             }
+
+            [Fact]
+            public void AllRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersRole.All);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=all"));
+            }
+
+            [Fact]
+            public void AdminRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersRole.Admin);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=admin"));
+            }
+
+            [Fact]
+            public void MemberRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersRole.Member);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=member"));
+            }
+
+            [Fact]
+            public void AllFilterPlusAllRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.All);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=all"));
+            }
+
+            [Fact]
+            public void AllFilterPlusAdminRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Admin);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=admin"));
+            }
+
+            [Fact]
+            public void AllFilterPlusMemberRoleFilterRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Member);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=member"));
+            }
+
+            [Fact]
+            public void TwoFactorFilterPlusAllRoleRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.All);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=all"));
+            }
+
+            [Fact]
+            public void TwoFactorFilterPlusAdminRoleRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Admin);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=admin"));
+            }
+
+            [Fact]
+            public void TwoFactorFilterPlusMemberRoleRequestTheCorrectUrl()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Member);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=member"));
+            }
         }
 
         public class TheGetPublicMethod

--- a/Octokit/Clients/IOrganizationMembersClient.cs
+++ b/Octokit/Clients/IOrganizationMembersClient.cs
@@ -67,6 +67,53 @@ namespace Octokit
         Task<IReadOnlyList<User>> GetAll(string org, string filter);
 
         /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role);
+
+        /// <summary>
         /// List all users who have publicized their membership of the organization.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -26,6 +26,18 @@ namespace Octokit
         TwoFactorAuthenticationDisabled
     }
 
+    public enum OrganizationMembersRole
+    {
+        [Parameter(Value = "all")]
+        All,
+
+        [Parameter(Value = "admin")]
+        Admin,
+
+        [Parameter(Value = "member")]
+        Member
+    }
+
     /// <summary>
     /// A client for GitHub's Organization Members API.
     /// </summary>
@@ -110,6 +122,63 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(filter, "filter");
 
             return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter));
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org, role));
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter, role));
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -388,7 +388,7 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns all of the members of the organization
         /// </summary>
         /// <param name="org">The organization</param>
-        /// <param name="filter">The member filter, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The correct uri</returns>
         public static Uri Members(string org, OrganizationMembersRole role)
         {
@@ -400,6 +400,7 @@ namespace Octokit
         /// </summary>
         /// <param name="org">The organization</param>
         /// <param name="filter">The member filter, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The correct uri</returns>
         public static Uri Members(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
         {

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -385,6 +385,28 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the members of the organization
+        /// </summary>
+        /// <param name="org">The organization</param>
+        /// <param name="filter">The member filter, <see cref="OrganizationMembersFilter"/></param>
+        /// <returns>The correct uri</returns>
+        public static Uri Members(string org, OrganizationMembersRole role)
+        {
+            return "orgs/{0}/members?role={1}".FormatUri(org, role.ToParameter());
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all of the members of the organization
+        /// </summary>
+        /// <param name="org">The organization</param>
+        /// <param name="filter">The member filter, <see cref="OrganizationMembersFilter"/></param>
+        /// <returns>The correct uri</returns>
+        public static Uri Members(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
+        {
+            return "orgs/{0}/members?filter={1}&role={2}".FormatUri(org, filter.ToParameter(), role.ToParameter());
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the public members of the organization
         /// </summary>
         /// <param name="org">Organization</param>


### PR DESCRIPTION
While working on implementing GitHub Enterprise APIs I came across the fact that the OrganizationMembers API implementation was missing the "Role" filter option (all, admin, member).  
https://developer.github.com/v3/orgs/members/#parameters

I also added integration tests for the GetAll method (previously there were none for this whole API) and all work fine in my integration tests... 

however I found that querying for Admin/Member role only returns correct results when the requester is a member of the organization.  When the requester is not in the organization, the member and admin filters just return all users in the org.  

I also found that with the existing "filter" attribute (2fa_disabled, all) only owners of an organization are allowed to use the ```2fa_disabled``` filter, and octokit throws an exception if the requester is not an org owner.

Im not sure what settings you guys run the integration tests under for octokit.net so I have set the integration tests that would have triggered these conditions, to SKIP for now.  If the integration tests on AppVeyor/Travis do run as an org member or org admin, let me know and I can un-skip the tests (i also need to know the name of the org to use in the queries... currently "octokit" is used).
