### PR TITLE
Implement GitHub Enterprise License and Organization API's

### DIFF
--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
@@ -23,5 +23,13 @@
         /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
         ///</remarks>
         IObservableEnterpriseLicenseClient License { get; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise Organization API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+        ///</remarks>
+        IObservableEnterpriseOrganizationClient Organization { get; }
     }
 }

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseClient.cs
@@ -15,5 +15,13 @@
         /// See the <a href="http://developer.github.com/v3/enterprise/admin_stats/">Enterprise Admin Stats API documentation</a> for more information.
         ///</remarks>
         IObservableEnterpriseAdminStatsClient AdminStats { get; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise License API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+        ///</remarks>
+        IObservableEnterpriseLicenseClient License { get; }
     }
 }

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLicenseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLicenseClient.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise License API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+    ///</remarks>
+    public interface IObservableEnterpriseLicenseClient
+    {
+        /// <summary>
+        /// Gets GitHub Enterprise License Information (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/license/#get-license-information
+        /// </remarks>
+        /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<LicenseInfo> Get();
+    }
+}
+            

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLicenseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseLicenseClient.cs
@@ -23,4 +23,3 @@ namespace Octokit.Reactive
         IObservable<LicenseInfo> Get();
     }
 }
-            

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseOrganizationClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseOrganizationClient.cs
@@ -23,4 +23,3 @@ namespace Octokit.Reactive
         IObservable<Organization> Create(NewOrganization newOrganization);
     }
 }
-            

--- a/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseOrganizationClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/IObservableEnterpriseOrganizationClient.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Threading.Tasks;
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise Organization API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+    ///</remarks>
+    public interface IObservableEnterpriseOrganizationClient
+    {
+        /// <summary>
+        /// Creates an Organization on a GitHub Enterprise appliance (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/orgs/#create-an-organization
+        /// </remarks>
+        /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
+        /// <returns>The <see cref="Organization"/> created.</returns>
+        IObservable<Organization> Create(NewOrganization newOrganization);
+    }
+}
+            

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
@@ -13,6 +13,7 @@
             Ensure.ArgumentNotNull(client, "client");
 
             AdminStats = new ObservableEnterpriseAdminStatsClient(client);
+            License = new ObservableEnterpriseLicenseClient(client);
         }
 
         /// <summary>
@@ -22,5 +23,13 @@
         /// See the <a href="http://developer.github.com/v3/enterprise/admin_stats/">Enterprise Admin Stats API documentation</a> for more information.
         ///</remarks>
         public IObservableEnterpriseAdminStatsClient AdminStats { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise License API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+        ///</remarks>
+        public IObservableEnterpriseLicenseClient License { get; private set; }
     }
 }

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseClient.cs
@@ -14,6 +14,7 @@
 
             AdminStats = new ObservableEnterpriseAdminStatsClient(client);
             License = new ObservableEnterpriseLicenseClient(client);
+            Organization = new ObservableEnterpriseOrganizationClient(client);
         }
 
         /// <summary>
@@ -31,5 +32,13 @@
         /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
         ///</remarks>
         public IObservableEnterpriseLicenseClient License { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise Organization API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+        ///</remarks>
+        public IObservableEnterpriseOrganizationClient Organization { get; private set; }
     }
 }

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseLicenseClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseLicenseClient.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reactive.Threading.Tasks;
+using Octokit;
+
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise License API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+    ///</remarks>
+    public class ObservableEnterpriseLicenseClient : IObservableEnterpriseLicenseClient
+    {
+        readonly IEnterpriseLicenseClient _client;
+
+        public ObservableEnterpriseLicenseClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, "client");
+
+            _client = client.Enterprise.License;
+        }
+
+        /// <summary>
+        /// Gets GitHub Enterprise License Information (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/license/#get-license-information
+        /// </remarks>
+        /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
+        public IObservable<LicenseInfo> Get()
+        {
+            return _client.Get().ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseOrganizationClient.cs
+++ b/Octokit.Reactive/Clients/Enterprise/ObservableEnterpriseOrganizationClient.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reactive.Threading.Tasks;
+using Octokit;
+
+
+namespace Octokit.Reactive
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise Organization API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+    ///</remarks>
+    public class ObservableEnterpriseOrganizationClient : IObservableEnterpriseOrganizationClient
+    {
+        readonly IEnterpriseOrganizationClient _client;
+
+        public ObservableEnterpriseOrganizationClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, "client");
+
+            _client = client.Enterprise.Organization;
+        }
+
+        /// <summary>
+        /// Creates an Organization on a GitHub Enterprise appliance (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/orgs/#create-an-organization
+        /// </remarks>
+        /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
+        /// <returns>The <see cref="Organization"/> created.</returns>
+        public IObservable<Organization> Create(NewOrganization newOrganization)
+        {
+            return _client.Create(newOrganization).ToObservable();
+        }
+    }
+}

--- a/Octokit.Reactive/Octokit.Reactive-Mono.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Mono.csproj
@@ -163,6 +163,8 @@
     <Compile Include="Clients\Enterprise\IObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-Mono.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Mono.csproj
@@ -165,6 +165,8 @@
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseOrganizationClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
@@ -173,6 +173,8 @@
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseOrganizationClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-MonoAndroid.csproj
@@ -171,6 +171,8 @@
     <Compile Include="Clients\Enterprise\IObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
@@ -169,6 +169,8 @@
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseOrganizationClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
@@ -167,6 +167,8 @@
     <Compile Include="Clients\Enterprise\IObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -75,11 +75,13 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseOrganizationClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseOrganizationClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\IObservableMergingClient.cs" />
     <Compile Include="Clients\IObservableOauthClient.cs" />

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -75,10 +75,12 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Clients\Enterprise\IObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IObservableEnterpriseClient.cs" />
     <Compile Include="Clients\Enterprise\ObservableEnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\ObservableEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\IObservableMergingClient.cs" />
     <Compile Include="Clients\IObservableOauthClient.cs" />
     <Compile Include="Clients\IObservableRepositoryCommitsClients.cs" />

--- a/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseAdminStatsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseAdminStatsClientTests.cs
@@ -9,7 +9,7 @@ public class EnterpriseAdminStatsClientTests
 
     public EnterpriseAdminStatsClientTests()
     {
-        _github = Helper.GetAuthenticatedClient();
+        _github = EnterpriseHelper.GetAuthenticatedClient();
     }
 
     [GitHubEnterpriseTest]

--- a/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseLicenseClientTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
+using Xunit;
+
+public class EnterpriseLicenseClientTests
+{
+    readonly IGitHubClient _github;
+
+    public EnterpriseLicenseClientTests()
+    {
+        _github = EnterpriseHelper.GetAuthenticatedClient();
+    }
+
+    [GitHubEnterpriseTest]
+    public async Task CanGetLicense()
+    {
+        var licenseInfo = await
+            _github.Enterprise.License.Get();
+
+        Assert.NotNull(licenseInfo);
+    }
+}

--- a/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
@@ -20,7 +20,7 @@ public class EnterpriseOrganizationClientTests
         string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
         string orgName = String.Concat(orgLogin, " Display Name");
 
-        var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.GHEUserName, orgName);
+        var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.UserName, orgName);
         var organization = await
             _github.Enterprise.Organization.Create(newOrganization);
 

--- a/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
+using Xunit;
+
+public class EnterpriseOrganizationClientTests
+{
+    readonly IGitHubClient _github;
+
+    public EnterpriseOrganizationClientTests()
+    {
+        _github = EnterpriseHelper.GetAuthenticatedClient();
+    }
+
+    [GitHubEnterpriseTest]
+    public async Task CanCreateOrganization()
+    {
+        string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
+        string orgName = String.Concat(orgLogin, " Display Name");
+
+        var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.GHEUserName, orgName);
+        var organization = await
+            _github.Enterprise.Organization.Create(newOrganization);
+
+        Assert.NotNull(organization);
+
+        // Get organization and check login/name
+        var checkOrg = await _github.Organization.Get(orgLogin);
+        Assert.Equal(checkOrg.Login, orgLogin);
+        Assert.Equal(checkOrg.Name, orgName);
+    }
+}

--- a/Octokit.Tests.Integration/EnterpriseHelper.cs
+++ b/Octokit.Tests.Integration/EnterpriseHelper.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Octokit.Tests.Integration
+{
+    public static class EnterpriseHelper
+    {
+        static readonly Lazy<Credentials> _credentialsThunk = new Lazy<Credentials>(() =>
+        {
+            var githubUsername = Environment.GetEnvironmentVariable("OCTOKIT_GHE_USERNAME");
+            GHEUserName = githubUsername;
+            GHEOrganization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
+
+            var githubToken = Environment.GetEnvironmentVariable("OCTOKIT_GHE_OAUTHTOKEN");
+
+            if (githubToken != null)
+                return new Credentials(githubToken);
+
+            var githubPassword = Environment.GetEnvironmentVariable("OCTOKIT_GHE_PASSWORD");
+
+            if (githubUsername == null || githubPassword == null)
+                return null;
+
+            return new Credentials(githubUsername, githubPassword);
+        });
+
+        static readonly Lazy<Credentials> _oauthApplicationCredentials = new Lazy<Credentials>(() =>
+        {
+            var applicationClientId = ClientId;
+            var applicationClientSecret = ClientSecret;
+
+            if (applicationClientId == null || applicationClientSecret == null)
+                return null;
+
+            return new Credentials(applicationClientId, applicationClientSecret);
+        });
+
+        static readonly Lazy<Credentials> _basicAuthCredentials = new Lazy<Credentials>(() =>
+        {
+            var githubUsername = Environment.GetEnvironmentVariable("OCTOKIT_GHE_USERNAME");
+            GHEUserName = githubUsername;
+            GHEOrganization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
+
+            var githubPassword = Environment.GetEnvironmentVariable("OCTOKIT_GHE_PASSWORD");
+
+            if (githubUsername == null || githubPassword == null)
+                return null;
+
+            return new Credentials(githubUsername, githubPassword);
+        });
+
+        static readonly Lazy<bool> _gitHubEnterpriseEnabled = new Lazy<bool>(() =>
+        {
+            string enabled = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ENABLED");
+            return !String.IsNullOrWhiteSpace(enabled);
+        });
+        
+        static readonly Lazy<Uri> _gitHubEnterpriseUrl = new Lazy<Uri>(() =>
+        {
+            string uri = Environment.GetEnvironmentVariable("OCTOKIT_GHE_URL");
+
+            if (uri != null)
+                return new Uri(uri);
+
+            return null;
+        });
+
+        static EnterpriseHelper()
+        {
+            // Force reading of environment variables.
+            // This wasn't happening if UserName/Organization were 
+            // retrieved before Credentials.
+            Debug.WriteIf(GHECredentials == null, "No credentials specified.");
+        }
+
+        public static string GHEUserName { get; private set; }
+        public static string GHEOrganization { get; private set; }
+      
+        /// <summary>
+        /// These credentials should be set to a test GitHub account using the powershell script configure-integration-tests.ps1
+        /// </summary>
+        public static Credentials GHECredentials { get { return _credentialsThunk.Value; } }
+
+        public static Credentials GHEApplicationCredentials { get { return _oauthApplicationCredentials.Value; } }
+
+        public static Credentials GHEBasicAuthCredentials { get { return _basicAuthCredentials.Value; } }
+
+        public static bool IsGitHubEnterpriseEnabled { get { return _gitHubEnterpriseEnabled.Value; } }
+
+        public static Uri GitHubEnterpriseUrl {  get { return _gitHubEnterpriseUrl.Value; } }
+        
+        public static bool IsUsingToken
+        {
+            get
+            {
+                return !String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OCTOKIT_GHE_OAUTHTOKEN"));
+            }
+        }
+
+        public static string ClientId
+        {
+            get { return Environment.GetEnvironmentVariable("OCTOKIT_GHE_CLIENTID"); }
+        }
+
+        public static string ClientSecret
+        {
+            get { return Environment.GetEnvironmentVariable("OCTOKIT_GHE_CLIENTSECRET"); }
+        }
+
+        public static void DeleteRepo(Repository repository)
+        {
+            if (repository != null)
+                DeleteRepo(repository.Owner.Login, repository.Name);
+        }
+
+        public static void DeleteRepo(string owner, string name)
+        {
+            var api = GetAuthenticatedClient();
+            try
+            {
+                api.Repository.Delete(owner, name).Wait(TimeSpan.FromSeconds(15));
+            }
+            catch { }
+        }
+
+        public static IGitHubClient GetAuthenticatedClient()
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
+            {
+                Credentials = GHECredentials
+            };
+        }
+
+        public static IGitHubClient GetBasicAuthClient()
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
+            {
+                Credentials = GHEBasicAuthCredentials
+            };
+        }
+
+        public static GitHubClient GetAuthenticatedApplicationClient()
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
+            {
+                Credentials = GHEApplicationCredentials
+            };
+        }
+
+        public static IGitHubClient GetAnonymousClient()
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl);
+        }
+
+        public static IGitHubClient GetBadCredentialsClient()
+        {
+            return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
+            {
+                Credentials = new Credentials(Guid.NewGuid().ToString(), "bad-password")
+            };
+        }
+    }
+}

--- a/Octokit.Tests.Integration/EnterpriseHelper.cs
+++ b/Octokit.Tests.Integration/EnterpriseHelper.cs
@@ -9,8 +9,8 @@ namespace Octokit.Tests.Integration
         static readonly Lazy<Credentials> _credentialsThunk = new Lazy<Credentials>(() =>
         {
             var githubUsername = Environment.GetEnvironmentVariable("OCTOKIT_GHE_USERNAME");
-            GHEUserName = githubUsername;
-            GHEOrganization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
+            UserName = githubUsername;
+            Organization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
 
             var githubToken = Environment.GetEnvironmentVariable("OCTOKIT_GHE_OAUTHTOKEN");
 
@@ -39,8 +39,8 @@ namespace Octokit.Tests.Integration
         static readonly Lazy<Credentials> _basicAuthCredentials = new Lazy<Credentials>(() =>
         {
             var githubUsername = Environment.GetEnvironmentVariable("OCTOKIT_GHE_USERNAME");
-            GHEUserName = githubUsername;
-            GHEOrganization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
+            UserName = githubUsername;
+            Organization = Environment.GetEnvironmentVariable("OCTOKIT_GHE_ORGANIZATION");
 
             var githubPassword = Environment.GetEnvironmentVariable("OCTOKIT_GHE_PASSWORD");
 
@@ -71,20 +71,20 @@ namespace Octokit.Tests.Integration
             // Force reading of environment variables.
             // This wasn't happening if UserName/Organization were 
             // retrieved before Credentials.
-            Debug.WriteIf(GHECredentials == null, "No credentials specified.");
+            Debug.WriteIf(Credentials == null, "No credentials specified.");
         }
 
-        public static string GHEUserName { get; private set; }
-        public static string GHEOrganization { get; private set; }
+        public static string UserName { get; private set; }
+        public static string Organization { get; private set; }
       
         /// <summary>
         /// These credentials should be set to a test GitHub account using the powershell script configure-integration-tests.ps1
         /// </summary>
-        public static Credentials GHECredentials { get { return _credentialsThunk.Value; } }
+        public static Credentials Credentials { get { return _credentialsThunk.Value; } }
 
-        public static Credentials GHEApplicationCredentials { get { return _oauthApplicationCredentials.Value; } }
+        public static Credentials ApplicationCredentials { get { return _oauthApplicationCredentials.Value; } }
 
-        public static Credentials GHEBasicAuthCredentials { get { return _basicAuthCredentials.Value; } }
+        public static Credentials BasicAuthCredentials { get { return _basicAuthCredentials.Value; } }
 
         public static bool IsGitHubEnterpriseEnabled { get { return _gitHubEnterpriseEnabled.Value; } }
 
@@ -128,7 +128,7 @@ namespace Octokit.Tests.Integration
         {
             return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
             {
-                Credentials = GHECredentials
+                Credentials = Credentials
             };
         }
 
@@ -136,7 +136,7 @@ namespace Octokit.Tests.Integration
         {
             return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
             {
-                Credentials = GHEBasicAuthCredentials
+                Credentials = BasicAuthCredentials
             };
         }
 
@@ -144,7 +144,7 @@ namespace Octokit.Tests.Integration
         {
             return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)
             {
-                Credentials = GHEApplicationCredentials
+                Credentials = ApplicationCredentials
             };
         }
 

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -50,9 +50,9 @@ namespace Octokit.Tests.Integration
             return new Credentials(githubUsername, githubPassword);
         });
 
-        static readonly Lazy<Uri> _gitHubEnterpriseUrl = new Lazy<Uri>(() =>
+        static readonly Lazy<Uri> _customUrl = new Lazy<Uri>(() =>
         {
-            string uri = Environment.GetEnvironmentVariable("OCTOKIT_GITHUBENTERPRISEURL");
+            string uri = Environment.GetEnvironmentVariable("OCTOKIT_CUSTOMURL");
 
             if (uri != null)
                 return new Uri(uri);
@@ -80,7 +80,9 @@ namespace Octokit.Tests.Integration
 
         public static Credentials BasicAuthCredentials { get { return _basicAuthCredentials.Value; } }
 
-        public static Uri GitHubEnterpriseUrl {  get { return _gitHubEnterpriseUrl.Value; } }
+        public static Uri CustomUrl {  get { return _customUrl.Value; } }
+
+        public static Uri TargetUrl {  get { return CustomUrl ?? GitHubClient.GitHubApiUrl; } }
 
         public static bool IsUsingToken
         {
@@ -95,14 +97,6 @@ namespace Octokit.Tests.Integration
             get
             {
                 return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OCTOKIT_PRIVATEREPOSITORIES"));
-            }
-        }
-
-        public static bool IsGitHubEnterprise
-        {
-            get
-            {
-                return GitHubEnterpriseUrl != null;
             }
         }
 
@@ -151,7 +145,7 @@ namespace Octokit.Tests.Integration
 
         public static IGitHubClient GetAuthenticatedClient()
         {
-            return new GitHubClient(new ProductHeaderValue("OctokitTests"), GitHubEnterpriseUrl ?? GitHubClient.GitHubApiUrl)
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"), TargetUrl)
             {
                 Credentials = Credentials
             };
@@ -159,7 +153,7 @@ namespace Octokit.Tests.Integration
 
         public static IGitHubClient GetBasicAuthClient()
         {
-            return new GitHubClient(new ProductHeaderValue("OctokitTests"), GitHubEnterpriseUrl ?? GitHubClient.GitHubApiUrl)
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"), TargetUrl)
             {
                 Credentials = BasicAuthCredentials
             };
@@ -167,7 +161,7 @@ namespace Octokit.Tests.Integration
 
         public static GitHubClient GetAuthenticatedApplicationClient()
         {
-            return new GitHubClient(new ProductHeaderValue("OctokitTests"), GitHubEnterpriseUrl ?? GitHubClient.GitHubApiUrl)
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"), TargetUrl)
             {
                 Credentials = ApplicationCredentials
             };
@@ -175,12 +169,12 @@ namespace Octokit.Tests.Integration
 
         public static IGitHubClient GetAnonymousClient()
         {
-            return new GitHubClient(new ProductHeaderValue("OctokitTests"), GitHubEnterpriseUrl ?? GitHubClient.GitHubApiUrl);
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"), TargetUrl);
         }
 
         public static IGitHubClient GetBadCredentialsClient()
         {
-            return new GitHubClient(new ProductHeaderValue("OctokitTests"), GitHubEnterpriseUrl ?? GitHubClient.GitHubApiUrl)
+            return new GitHubClient(new ProductHeaderValue("OctokitTests"), TargetUrl)
             {
                 Credentials = new Credentials(Guid.NewGuid().ToString(), "bad-password")
             };

--- a/Octokit.Tests.Integration/Helpers/GitHubEnterpriseTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/GitHubEnterpriseTestAttribute.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Integration
             if (Helper.Credentials == null)
                 return Enumerable.Empty<IXunitTestCase>();
 
-            if (!Helper.IsGitHubEnterprise)
+            if (!EnterpriseHelper.IsGitHubEnterpriseEnabled)
                 return Enumerable.Empty<IXunitTestCase>();
 
             return new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Clients\BranchesClientTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClientTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClientTests.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClientTests.cs" />
     <Compile Include="Clients\GitHubClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />
     <Compile Include="Clients\CommitsClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Clients\AuthorizationClientTests.cs" />
     <Compile Include="Clients\BlobClientTests.cs" />
     <Compile Include="Clients\BranchesClientTests.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClientTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClientTests.cs" />
     <Compile Include="Clients\GitHubClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -124,8 +124,9 @@
     <Compile Include="Clients\IssuesClientTests.cs" />
     <Compile Include="Clients\MiscellaneousClientTests.cs" />
     <Compile Include="Helpers\OrganizationTestAttribute.cs" />
-    <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseAdminStatsClientTests.cs" />
+    <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
+    <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Clients\IssuesClientTests.cs" />
     <Compile Include="Clients\MiscellaneousClientTests.cs" />
     <Compile Include="Helpers\OrganizationTestAttribute.cs" />
+    <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseAdminStatsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Clients\UserKeysClientTests.cs" />
     <Compile Include="fixtures\RepositoriesHooksCollection.cs" />
     <Compile Include="fixtures\RepositoriesHooksFixture.cs" />
+    <Compile Include="EnterpriseHelper.cs" />
     <Compile Include="Helpers\ApplicationTestAttribute.cs" />
     <Compile Include="Helpers\GithubClientExtensions.cs" />
     <Compile Include="Helpers\BasicAuthenticationTestAttribute.cs" />

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseAdminStatsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseAdminStatsClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Integration
 
         public ObservableEnterpriseAdminStatsClientTests()
         {
-            _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
+            _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
         }
 
         [GitHubEnterpriseTest]

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration
+{
+    public class ObservableEnterpriseLicenseClientTests
+    {
+        readonly IObservableGitHubClient _github;
+
+        public ObservableEnterpriseLicenseClientTests()
+        {
+            _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanGet()
+        {
+            var observable = _github.Enterprise.License.Get();
+            var licenseInfo = await observable;
+
+            Assert.NotNull(licenseInfo);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
@@ -21,7 +21,7 @@ namespace Octokit.Tests.Integration
             string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
             string orgName = String.Concat(orgLogin, " Display Name");
 
-            var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.GHEUserName, orgName);
+            var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.UserName, orgName);
             var observable = _github.Enterprise.Organization.Create(newOrganization);
             var organization = await observable;
 

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration
+{
+    public class ObservableEnterpriseOrganizationClientTests
+    {
+        readonly IObservableGitHubClient _github;
+
+        public ObservableEnterpriseOrganizationClientTests()
+        {
+            _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanCreateOrganization()
+        {
+            string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
+            string orgName = String.Concat(orgLogin, " Display Name");
+
+            var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.GHEUserName, orgName);
+            var observable = _github.Enterprise.Organization.Create(newOrganization);
+            var organization = await observable;
+
+            Assert.NotNull(organization);
+
+            // Get organization and check login/name
+            var checkOrg = await _github.Organization.Get(orgLogin);
+            Assert.Equal(checkOrg.Login, orgLogin);
+            Assert.Equal(checkOrg.Name, orgName);
+        }
+    }
+}

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseLicenseClientTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class EnterpriseLicenseClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EnterpriseLicenseClient(connection);
+
+                string expectedUri = "enterprise/settings/license";
+                client.Get();
+                connection.Received().Get<LicenseInfo>(Arg.Is<Uri>(u => u.ToString() == expectedUri));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class EnterpriseOrganizationClientTests
+    {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EnterpriseOrganizationClient(connection);
+
+                string expectedUri = "admin/organizations";
+                client.Create(new NewOrganization("org", "admin", "org name"));
+                
+                connection.Received().Post<Organization>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EnterpriseOrganizationClient(connection);
+
+                client.Create(new NewOrganization("org", "admin", "org name"));
+
+                connection.Received().Post<Organization>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<NewOrganization>(a =>
+                        a.Login == "org"
+                        && a.Admin == "admin"
+                        && a.ProfileName == "org name"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EnterpriseOrganizationClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="Authentication\CredentialsTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClientTests.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClientTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />
     <Compile Include="Clients\OauthClientTests.cs" />

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -188,6 +188,7 @@
     <Compile Include="Helpers\StringExtensionsTests.cs" />
     <Compile Include="Clients\RepositoriesClientTests.cs" />
     <Compile Include="Reactive\AuthorizationExtensionsTests.cs" />
+    <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="Authentication\CredentialsTests.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClientTests.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />
     <Compile Include="Clients\OauthClientTests.cs" />
     <Compile Include="Clients\RepositoryCommentsClientTests.cs" />

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Helpers\StringExtensionsTests.cs" />
     <Compile Include="Clients\RepositoriesClientTests.cs" />
     <Compile Include="Reactive\AuthorizationExtensionsTests.cs" />
+    <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
@@ -12,7 +12,6 @@ namespace Octokit.Tests
             [Fact]
             public void CallsIntoClient()
             {
-
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableEnterpriseLicenseClient(github);
 

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests
+{
+    public class ObservableEnterpriseLicenseClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableEnterpriseLicenseClient(github);
+
+                client.Get();
+                github.Enterprise.License.Received(1).Get();
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests
+{
+    public class ObservableEnterpriseOrganizationClientTests
+    {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableEnterpriseOrganizationClient(github);
+
+                client.Create(new NewOrganization("org", "admin", "org name"));
+                github.Enterprise.Organization.Received(1).Create(
+                    Arg.Is<NewOrganization>(a => 
+                        a.Login == "org" 
+                        && a.Admin == "admin" 
+                        && a.ProfileName == "org name"));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
@@ -12,7 +12,6 @@ namespace Octokit.Tests
             [Fact]
             public void CallsIntoClient()
             {
-
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableEnterpriseOrganizationClient(github);
 

--- a/Octokit/Clients/Enterprise/EnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseClient.cs
@@ -15,6 +15,7 @@
         public EnterpriseClient(IApiConnection apiConnection) : base(apiConnection)
         {
             AdminStats = new EnterpriseAdminStatsClient(apiConnection);
+            License = new EnterpriseLicenseClient(apiConnection);
         }
 
         /// <summary>
@@ -24,5 +25,13 @@
         /// See the <a href="http://developer.github.com/v3/enterprise/admin_stats/">Enterprise Admin Stats API documentation</a> for more information.
         ///</remarks>
         public IEnterpriseAdminStatsClient AdminStats { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise License API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+        ///</remarks>
+        public IEnterpriseLicenseClient License { get; private set; }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseClient.cs
@@ -16,6 +16,7 @@
         {
             AdminStats = new EnterpriseAdminStatsClient(apiConnection);
             License = new EnterpriseLicenseClient(apiConnection);
+            Organization = new EnterpriseOrganizationClient(apiConnection);
         }
 
         /// <summary>
@@ -33,5 +34,13 @@
         /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
         ///</remarks>
         public IEnterpriseLicenseClient License { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise Organization API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+        ///</remarks>
+        public IEnterpriseOrganizationClient Organization { get; private set; }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise License API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+    ///</remarks>
+    public class EnterpriseLicenseClient : ApiClient, IEnterpriseLicenseClient
+    {
+        public EnterpriseLicenseClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        { }
+
+        /// <summary>
+        /// Gets GitHub Enterprise License Information (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/license/#get-license-information
+        /// </remarks>
+        /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
+        public async Task<LicenseInfo> Get()
+        {
+            var endpoint = ApiUrls.EnterpriseLicense();
+
+            return await ApiConnection.Get<LicenseInfo>(endpoint)
+                                                    .ConfigureAwait(false);
+        }
+    }
+}

--- a/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise Organization API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+    ///</remarks>
+    public class EnterpriseOrganizationClient : ApiClient, IEnterpriseOrganizationClient
+    {
+        public EnterpriseOrganizationClient(IApiConnection apiConnection)
+            : base(apiConnection)
+        { }
+
+        /// <summary>
+        /// Creates an Organization on a GitHub Enterprise appliance (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/orgs/#create-an-organization
+        /// </remarks>
+        /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
+        /// <returns>The <see cref="Organization"/> created.</returns>
+        public async Task<Organization> Create(NewOrganization newOrganization)
+        {
+            Ensure.ArgumentNotNull(newOrganization, "newOrganization");
+
+            var endpoint = ApiUrls.EnterpriseOrganization();
+
+            return await ApiConnection.Post<Organization>(endpoint, newOrganization);
+        }
+    }
+}

--- a/Octokit/Clients/Enterprise/IEnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseClient.cs
@@ -23,5 +23,13 @@
         /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
         ///</remarks>
         IEnterpriseLicenseClient License { get; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise Organization API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+        ///</remarks>
+        IEnterpriseOrganizationClient Organization { get; }
     }
 }

--- a/Octokit/Clients/Enterprise/IEnterpriseClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseClient.cs
@@ -15,5 +15,13 @@
         /// See the <a href="http://developer.github.com/v3/enterprise/admin_stats/">Enterprise Admin Stats API documentation</a> for more information.
         ///</remarks>
         IEnterpriseAdminStatsClient AdminStats { get; }
+
+        /// <summary>
+        /// A client for GitHub's Enterprise License API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+        ///</remarks>
+        IEnterpriseLicenseClient License { get; }
     }
 }

--- a/Octokit/Clients/Enterprise/IEnterpriseLicenseClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseLicenseClient.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise License API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/license/">Enterprise License API documentation</a> for more information.
+    ///</remarks>
+    public interface IEnterpriseLicenseClient
+    {
+        /// <summary>
+        /// Gets GitHub Enterprise License Information (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/license/#get-license-information
+        /// </remarks>
+        /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<LicenseInfo> Get();
+    }
+}

--- a/Octokit/Clients/Enterprise/IEnterpriseOrganizationClient.cs
+++ b/Octokit/Clients/Enterprise/IEnterpriseOrganizationClient.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+
+namespace Octokit
+{
+    /// <summary>
+    /// A client for GitHub's Enterprise Organization API
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/enterprise/orgs/">Enterprise Organization API documentation</a> for more information.
+    ///</remarks>
+    public interface IEnterpriseOrganizationClient
+    {
+        /// <summary>
+        /// Creates an Organization on a GitHub Enterprise appliance (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/enterprise/orgs/#create-an-organization
+        /// </remarks>
+        /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
+        /// <returns>The <see cref="Organization"/> created.</returns>
+        Task<Organization> Create(NewOrganization newOrganization);
+    }
+}

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1652,5 +1652,10 @@ namespace Octokit
         {
             return EnterpriseAdminStats("all");
         }
+
+        public static Uri EnterpriseLicense()
+        {
+            return "enterprise/settings/license".FormatUri();
+        }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1657,5 +1657,10 @@ namespace Octokit
         {
             return "enterprise/settings/license".FormatUri();
         }
+
+        public static Uri EnterpriseOrganization()
+        {
+            return "admin/organizations".FormatUri();
+        }
     }
 }

--- a/Octokit/Models/Request/NewOrganization.cs
+++ b/Octokit/Models/Request/NewOrganization.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes a new organization to create via the <see cref="IEnterpriseOrganizationClient.Create(NewOrganization)" /> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewOrganization
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewOrganization"/> class.
+        /// </summary>
+        /// <param name="login">The organization's username</param>
+        /// <param name="admin">The login of the user who will manage this organization</param>
+        public NewOrganization(string login, string admin) : this(login, admin, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewOrganization"/> class.
+        /// </summary>
+        /// <param name="login">The organization's username</param>
+        /// <param name="admin">The login of the user who will manage this organization</param>
+        /// <param name="profileName">The organization's display name</param>
+        public NewOrganization(string login, string admin, string profileName)
+        {
+            Login = login;
+            Admin = admin;
+            ProfileName = profileName;
+        }
+
+        /// <summary>
+        /// The organization's username (required)
+        /// </summary>
+        public string Login { get; private set; }
+
+        /// <summary>
+        /// The login of the user who will manage this organization (required)
+        /// </summary>
+        public string Admin { get; private set; }
+
+        /// <summary>
+        /// The organization's display name
+        /// </summary>
+        public string ProfileName { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Login: {0} Admin: {1} ProfileName: {2}", Login, Admin, ProfileName ?? "");
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/Enterprise/LicenseInfo.cs
+++ b/Octokit/Models/Response/Enterprise/LicenseInfo.cs
@@ -19,7 +19,6 @@ namespace Octokit
             ExpireAt = expireAt;
         }
 
-
         public int Seats
         {
             get;

--- a/Octokit/Models/Response/Enterprise/LicenseInfo.cs
+++ b/Octokit/Models/Response/Enterprise/LicenseInfo.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class LicenseInfo
+    {
+        public LicenseInfo() { }
+
+        public LicenseInfo(int seats, int seatsUsed, int seatsAvailable, string kind, int daysUntilExpiration, DateTimeOffset expireAt)
+        {
+            Seats = seats;
+            SeatsUsed = seatsUsed;
+            SeatsAvailable = seatsAvailable;
+            Kind = kind;
+            DaysUntilExpiration = daysUntilExpiration;
+            ExpireAt = expireAt;
+        }
+
+
+        public int Seats
+        {
+            get;
+            private set;
+        }
+
+        public int SeatsUsed
+        {
+            get;
+            private set;
+        }
+
+        public int SeatsAvailable
+        {
+            get;
+            private set;
+        }
+
+        public string Kind
+        {
+            get;
+            private set;
+        }
+
+        public int DaysUntilExpiration
+        {
+            get;
+            private set;
+        }
+
+        public DateTimeOffset ExpireAt
+        {
+            get;
+            private set;
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "Seats: {0} SeatsUsed: {1} DaysUntilExpiration: {2}", Seats, SeatsUsed, DaysUntilExpiration);
+            }
+        }
+    }
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -438,6 +438,9 @@
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -435,6 +435,9 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -445,6 +445,9 @@
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -442,6 +442,9 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -438,6 +438,9 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -441,6 +441,9 @@
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -432,6 +432,9 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -435,6 +435,9 @@
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -442,6 +442,9 @@
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -439,6 +439,9 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -59,8 +59,10 @@
     </Compile>
     <Compile Include="Clients\ActivitiesClient.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClient.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseClient.cs" />
@@ -106,6 +108,7 @@
     <Compile Include="Models\Request\BranchUpdate.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
+    <Compile Include="Models\Request\NewOrganization.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -59,7 +59,9 @@
     </Compile>
     <Compile Include="Clients\ActivitiesClient.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseAdminStatsClient.cs" />
+    <Compile Include="Clients\Enterprise\EnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseClient.cs" />
+    <Compile Include="Clients\Enterprise\IEnterpriseLicenseClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseAdminStatsClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseClient.cs" />
     <Compile Include="Clients\IMergingClient.cs" />
@@ -140,6 +142,7 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsPages.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsPulls.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsRepos.cs" />
+    <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
     <Compile Include="Models\Response\GitIgnoreTemplate.cs" />
     <Compile Include="Models\Response\License.cs" />

--- a/script/configure-integration-tests.ps1
+++ b/script/configure-integration-tests.ps1
@@ -19,6 +19,8 @@ function AskYesNoQuestion([string]$question, [string]$key)
   }
 
   Write-Host
+
+  return ($answer -eq "Y")
 }
 
 function VerifyEnvironmentVariable([string]$friendlyName, [string]$key, [bool]$optional = $false)
@@ -71,11 +73,26 @@ VerifyEnvironmentVariable "account name" "OCTOKIT_GITHUBUSERNAME"
 VerifyEnvironmentVariable "account password" "OCTOKIT_GITHUBPASSWORD" $true
 VerifyEnvironmentVariable "OAuth token" "OCTOKIT_OAUTHTOKEN"
 
-AskYesNoQuestion "Do you have private repositories associated with your test account?" "OCTOKIT_PRIVATEREPOSITORIES"
+AskYesNoQuestion "Do you have private repositories associated with your test account?" "OCTOKIT_PRIVATEREPOSITORIES" | Out-Null
 
 VerifyEnvironmentVariable "organization name" "OCTOKIT_GITHUBORGANIZATION" $true
 
-VerifyEnvironmentVariable "GitHub Enterprise Server URL" "OCTOKIT_GITHUBENTERPRISEURL" $true
+VerifyEnvironmentVariable "Override GitHub URL" "OCTOKIT_CUSTOMURL" $true
 
 VerifyEnvironmentVariable "application ClientID" "OCTOKIT_CLIENTID" $true
 VerifyEnvironmentVariable "application Secret" "OCTOKIT_CLIENTSECRET" $true
+
+
+if (AskYesNoQuestion "Do you wish to enable GitHub Enterprise (GHE) Integration Tests?" "OCTOKIT_GHE_ENABLED")
+{
+    VerifyEnvironmentVariable "GitHub Enterprise account name" "OCTOKIT_GHE_USERNAME"
+    VerifyEnvironmentVariable "GitHub Enterprise account password" "OCTOKIT_GHE_PASSWORD" $true
+    VerifyEnvironmentVariable "GitHub Enterprise OAuth token" "OCTOKIT_GHE_OAUTHTOKEN"
+
+    VerifyEnvironmentVariable "GitHub Enterprise organization name" "OCTOKIT_GHE_ORGANIZATION" $true
+
+    VerifyEnvironmentVariable "GitHub Enterprise URL" "OCTOKIT_GHE_URL" $true
+
+    VerifyEnvironmentVariable "GitHub Enterprise application ClientID" "OCTOKIT_GHE_CLIENTID" $true
+    VerifyEnvironmentVariable "GitHub Enterprise application Secret" "OCTOKIT_GHE_CLIENTSECRET" $true
+}


### PR DESCRIPTION
## Status
:rocket:Ready to merge:rocket:

## Enhance integration test support for GitHub Enterprise
https://github.com/tattsgroup/octokit.net/commit/535709c3689eaa6b6a4556757c11d0d50b0aae0e
Added a new EnterpriseHelper class for creating enterprise clients, using a new set of environment variables for this purpose.  Enhanced the powershell script to assist in setting up these GitHub Enterprise integration test variables if desired

## Implement Enterprise License Client 
https://developer.github.com/v3/enterprise/license/
Fixes #1023
Includes normal and reactive implementations plus unit and integration tests for both

## Implement Enterprise Organization Client 
https://developer.github.com/v3/enterprise/orgs/
Fixes #1025
Includes normal and reactive implementations plus unit and integration tests for both


## Tests
Obviously the integration tests require a GitHub enterprise instance so wont run as part of Octokit builds currently.  Integration tests are passing on my GHE instance