### PR TITLE
Revoke All Authentications no longer supported by the API

### DIFF
--- a/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
@@ -209,6 +209,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <returns></returns>
+        [Obsolete("This feature is no longer supported in the GitHub API and will be removed in a future release")]
         IObservable<Unit> RevokeAllApplicationAuthentications(string clientId);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -294,6 +294,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <returns></returns>
+        [Obsolete("This feature is no longer supported in the GitHub API and will be removed in a future release")]
         public IObservable<Unit> RevokeAllApplicationAuthentications(string clientId)
         {
             Ensure.ArgumentNotNullOrEmptyString("clientId", clientId);

--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -204,7 +204,7 @@ namespace Octokit.Tests.Integration.Clients
             Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
-        [BasicAuthenticationTest]
+        [BasicAuthenticationTest(Skip = "See https://github.com/octokit/octokit.net/issues/1078 for explanation of why this is now obsolete")]
         public async Task CanRevokeAllApplicationAuthentications()
         {
             var github = Helper.GetBasicAuthClient();

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using System;
 #if NET_45
 using System.Collections.Generic;
 #endif
@@ -380,6 +381,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
+        [Obsolete("This feature is no longer supported in the GitHub API and will be removed in a future release")]
         public Task RevokeAllApplicationAuthentications(string clientId)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using System;
 #if NET_45
 using System.Collections.Generic;
 #endif
@@ -229,6 +230,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
+        [Obsolete("This feature is no longer supported in the GitHub API and will be removed in a future release")]
         Task RevokeAllApplicationAuthentications(string clientId);
 
         /// <summary>


### PR DESCRIPTION
As we've done with other breaking changes for this release, we're `[Obsolete]`-ing this method to indicate the behaviour is no longer available.

Fixes #1078 