### PR TITLE
StatisticsClient should not clobber /api/v3/ in path

### DIFF
--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -24,7 +24,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RetrievesContributorsForCorrectUrl()
             {
-                var expectedEndPoint = new Uri("/repos/username/repositoryName/stats/contributors", UriKind.Relative);
+                var expectedEndPoint = new Uri("repos/username/repositoryName/stats/contributors", UriKind.Relative);
                 var client = Substitute.For<IApiConnection>();
                 IReadOnlyList<Contributor> contributors = new ReadOnlyCollection<Contributor>(new[] { new Contributor() });
                 client.GetQueuedOperation<Contributor>(expectedEndPoint, Args.CancellationToken)
@@ -56,7 +56,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsCorrectUrl()
             {
-                var expectedEndPoint = new Uri("/repos/username/repositoryName/stats/commit_activity", UriKind.Relative);
+                var expectedEndPoint = new Uri("repos/username/repositoryName/stats/commit_activity", UriKind.Relative);
 
                 var data = new WeeklyCommitActivity(new[] { 1, 2 }, 100, 42);
                 IReadOnlyList<WeeklyCommitActivity> response = new ReadOnlyCollection<WeeklyCommitActivity>(new[] { data });
@@ -94,7 +94,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsCorrectUrl()
             {
-                var expectedEndPoint = new Uri("/repos/username/repositoryName/stats/code_frequency", UriKind.Relative);
+                var expectedEndPoint = new Uri("repos/username/repositoryName/stats/code_frequency", UriKind.Relative);
 
                 long firstTimestamp = 159670861;
                 long secondTimestamp = 0;
@@ -139,7 +139,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void RequestsCorrectUrl()
             {
-                var expectedEndPoint = new Uri("/repos/username/repositoryName/stats/participation", UriKind.Relative);
+                var expectedEndPoint = new Uri("repos/username/repositoryName/stats/participation", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
                 var statisticsClient = new StatisticsClient(client);
@@ -169,7 +169,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RetrievesPunchCard()
             {
-                var expectedEndPoint = new Uri("/repos/username/repositoryName/stats/punch_card", UriKind.Relative);
+                var expectedEndPoint = new Uri("repos/username/repositoryName/stats/punch_card", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
                 IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -44,7 +44,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            var endpoint = "/repos/{0}/{1}/stats/contributors".FormatUri(owner, repositoryName);
+            var endpoint = "repos/{0}/{1}/stats/contributors".FormatUri(owner, repositoryName);
             return await ApiConnection.GetQueuedOperation<Contributor>(endpoint, cancellationToken);
         }
 
@@ -71,7 +71,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            var endpoint = "/repos/{0}/{1}/stats/commit_activity".FormatUri(owner, repositoryName);
+            var endpoint = "repos/{0}/{1}/stats/commit_activity".FormatUri(owner, repositoryName);
             var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(endpoint, cancellationToken);
             return new CommitActivity(activity);
         }
@@ -99,7 +99,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            var endpoint = "/repos/{0}/{1}/stats/code_frequency".FormatUri(owner, repositoryName);
+            var endpoint = "repos/{0}/{1}/stats/code_frequency".FormatUri(owner, repositoryName);
             var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(endpoint, cancellationToken);
             return new CodeFrequency(rawFrequencies);
         }
@@ -127,7 +127,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            var endpoint = "/repos/{0}/{1}/stats/participation".FormatUri(owner, repositoryName);
+            var endpoint = "repos/{0}/{1}/stats/participation".FormatUri(owner, repositoryName);
             var result = await ApiConnection.GetQueuedOperation<Participation>(endpoint, cancellationToken);
             return result.FirstOrDefault();
         }
@@ -155,7 +155,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            var endpoint = "/repos/{0}/{1}/stats/punch_card".FormatUri(owner, repositoryName);
+            var endpoint = "repos/{0}/{1}/stats/punch_card".FormatUri(owner, repositoryName);
             var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(endpoint, cancellationToken);
             return new PunchCard(punchCardData);
         }


### PR DESCRIPTION
Fixes #822

All other routes - e.g. `ApiUrls` - are defined without a leading slash.

Except these. This fixes that.

 - [x] fix the tests - you're better than this