### PR TITLE
fixing the build

### DIFF
--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -69,8 +69,7 @@ namespace Octokit.Tests.Clients
 
                 client.GetLatest("fake", "repo");
 
-                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/latest"),
-                    null);
+                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/latest"));
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -76,7 +76,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetLatest("fake", "repo");
 
-                gitHubClient.Release.Received(1).GetLatest("fake", "repo");
+                gitHubClient.Repository.Release.Received(1).GetLatest("fake", "repo");
             }
 
             [Fact]


### PR DESCRIPTION
Merging #975 caught a couple of API changes in v0.18 which weren't available to the tests at the time of writing. Oops.