### PR TITLE
Fix Json deserializion of string containing hyphens to List<string> property

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Octokit.Helpers;
 using Octokit.Internal;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -117,6 +118,34 @@ namespace Octokit.Tests
             {
                 const string json = "{\"event\":\"head_ref_deleted\"}";
                 new SimpleJsonSerializer().Deserialize<EventInfo>(json);
+            }
+
+            public class MessageSingle
+            {
+                public string Message { get; private set; }
+            }
+
+            [Fact]
+            public void DeserializesStringsWithHyphensAndUnderscoresIntoString()
+            {
+                const string json = @"{""message"":""-my-test-string_with_underscores_""}";
+
+                var response = new SimpleJsonSerializer().Deserialize<MessageSingle>(json);
+                Assert.Equal("-my-test-string_with_underscores_", response.Message);
+            }
+
+            public class MessageList
+            {
+                public IReadOnlyList<string> Message { get; private set; }
+            }
+
+            [Fact]
+            public void DeserializesStringsWithHyphensAndUnderscoresIntoStringList()
+            {
+                const string json = @"{""message"":""-my-test-string_with_underscores_""}";
+
+                var response = new SimpleJsonSerializer().Deserialize<MessageList>(json);
+                Assert.Equal("-my-test-string_with_underscores_", response.Message[0]);
             }
 
             [Fact]

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -90,7 +90,6 @@ namespace Octokit.Internal
                 var jsonValue = value as JsonObject;
                 if (stringValue != null)
                 {
-                    stringValue = stringValue.Replace("-", "");
                     if (ReflectionUtils.GetTypeInfo(type).IsEnum)
                     {
                         // remove '-' from values coming in to be able to enum utf-8


### PR DESCRIPTION
### Issue
As discussed in [#1026](https://github.com/octokit/octokit.net/issues/1026#issuecomment-178856752), there is an issue with the Json parser in a specific edge case.

When deserialising a ```string``` property into a class where that property is declared as a ```List<string>``` (as is the case with the responses from the Enterprise SearchIndexing API), hyphens in the string are stripped during deserialization.

Json
```{ "message":"User \"ryan-gribble\" was added to the indexing queue" }```

Class
```public class MessageList { public IReadOnlyList<string> Message { get; private set; } }```

Result
```"User \"ryangribble\" was added to the indexing queue"```

Expected Result
```"User \"ryan-gribble\" was added to the indexing queue"```

### Resolution
[This line](https://github.com/octokit/octokit.net/blob/master/Octokit/Http/SimpleJsonSerializer.cs#L93) (introduced in #727) was identified as responsible for the removal of the hyphens in the input string.  Code inspection indicates the line appears to be unnecessary for the actual ```Enum``` and ```Nullable Enum``` cases mentioned when the change was made, as they already had code to remove hyphens in their if blocks.

Unit tests were added to assert expected behaviour when deserializing a string attribute containing hyphens (and underscores for good measure) into ```string``` and ```<IReadOnlyList<string>``` properties.

After confirming the latter test failed, the offending line was removed and the tests then passed.

All other unit and integration tests were then also passed, indicating that no other known/tested functionality are impacted by the removal.
