### PR TITLE
Implement Additional Enterprise methods on User Administration Client 

### DIFF
--- a/Octokit.Reactive/Clients/IObservableUserAdministrationClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserAdministrationClient.cs
@@ -5,7 +5,7 @@ using System.Reactive;
 namespace Octokit.Reactive
 {
     /// <summary>
-    /// A client for GitHub's User Administration API.
+    /// A client for GitHub's User Administration API (GitHub Enterprise)
     /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/users/administration/">Administration API documentation</a> for more details.
@@ -13,43 +13,126 @@ namespace Octokit.Reactive
     public interface IObservableUserAdministrationClient
     {
         /// <summary>
-        /// Promotes ordinary user to a site administrator.
+        /// Create a new user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-a-new-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="newUser">The <see cref="NewUser"/> object describing the user to create</param>
+        /// <returns>The created <see cref="User"/> object</returns>
+        IObservable<User> Create(NewUser newUser);
+
+        /// <summary>
+        /// Rename an existing user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#rename-an-existing-user">API documentation</a>
+        /// for more information.
+        /// Note that this queues a request to rename a user, rather than execute it straight away
+        /// </remarks>
+        /// <param name="login">The username to rename</param>
+        /// <param name="userRename">The <see cref="UserRename"/> request, specifying the new login</param>
+        /// <returns>A <see cref="UserRenameResponse"/> object indicating the queued task message and Url to the user</returns>
+        IObservable<UserRenameResponse> Rename(string login, UserRename userRename);
+
+        /// <summary>
+        /// Create an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to impersonate</param>
+        /// <param name="newImpersonationToken">The <see cref="NewImpersonationToken"/> request specifying the required scopes</param>
+        /// <returns>An <see cref="Authorization"/> object containing the impersonation token</returns>
+        IObservable<Authorization> CreateImpersonationToken(string login, NewImpersonationToken newImpersonationToken);
+
+        /// <summary>
+        /// Deletes an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to remove impersonation token from</param>
+        /// <returns></returns>
+        IObservable<Unit> DeleteImpersonationToken(string login);
+
+        /// <summary>
+        /// Promotes ordinary user to a site administrator (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to promote to administrator.</param>
         /// <returns></returns>
         IObservable<Unit> Promote(string login);
 
         /// <summary>
-        /// Demotes a site administrator to an ordinary user.
+        /// Demotes a site administrator to an ordinary user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to demote from administrator.</param>
         /// <returns></returns>
         IObservable<Unit> Demote(string login);
 
         /// <summary>
-        /// Suspends a user.
+        /// Suspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#suspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#suspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to suspend.</param>
         /// <returns></returns>
         IObservable<Unit> Suspend(string login);
 
         /// <summary>
-        /// Unsuspends a user.
+        /// Unsuspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#unsuspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#unsuspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to unsuspend.</param>
         /// <returns></returns>
         IObservable<Unit> Unsuspend(string login);
+
+        /// <summary>
+        /// List all public keys (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#list-all-public-keys">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <returns></returns>
+        IObservable<PublicKey> ListAllPublicKeys();
+
+        /// <summary>
+        /// Delete a user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to delete</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(string login);
+
+        /// <summary>
+        /// Delete a public key (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-public-key">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="keyId">The key to delete</param>
+        /// <returns></returns>
+        IObservable<Unit> DeletePublicKey(int keyId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableUserAdministrationClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserAdministrationClient.cs
@@ -7,9 +7,16 @@ using System.Reactive.Linq;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's User Administration API (GitHub Enterprise)
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/users/administration/">Administration API documentation</a> for more details.
+    /// </remarks>
     public class ObservableUserAdministrationClient : IObservableUserAdministrationClient
     {
         readonly IUserAdministrationClient _client;
+        readonly IConnection _connection;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableUserAdministrationClient"/> class.
@@ -20,13 +27,74 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(client, "client");
 
             _client = client.User.Administration;
+            _connection = client.Connection;
         }
 
         /// <summary>
-        /// Promotes ordinary user to a site administrator.
+        /// Create a new user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-a-new-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="newUser">The <see cref="NewUser"/> object describing the user to create</param>
+        /// <returns>The created <see cref="User"/> object</returns>
+        public IObservable<User> Create(NewUser newUser)
+        {
+            return _client.Create(newUser).ToObservable();
+        }
+
+        /// <summary>
+        /// Rename an existing user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#rename-an-existing-user">API documentation</a>
+        /// for more information.
+        /// Note that this queues a request to rename a user, rather than execute it straight away
+        /// </remarks>
+        /// <param name="login">The username to rename</param>
+        /// <param name="userRename">The <see cref="UserRename"/> request, specifying the new login</param>
+        /// <returns>A <see cref="UserRenameResponse"/> object indicating the queued task message and Url to the user</returns>
+        public IObservable<UserRenameResponse> Rename(string login, UserRename userRename)
+        {
+            return _client.Rename(login, userRename).ToObservable();
+        }
+
+        /// <summary>
+        /// Create an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to impersonate</param>
+        /// <param name="newImpersonationToken">The <see cref="NewImpersonationToken"/> request specifying the required scopes</param>
+        /// <returns>An <see cref="Authorization"/> object containing the impersonation token</returns>
+        public IObservable<Authorization> CreateImpersonationToken(string login, NewImpersonationToken newImpersonationToken)
+        {
+            return _client.CreateImpersonationToken(login, newImpersonationToken).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to remove impersonation token from</param>
+        /// <returns></returns>
+        public IObservable<Unit> DeleteImpersonationToken(string login)
+        {
+            return _client.DeleteImpersonationToken(login).ToObservable();
+        }
+
+        /// <summary>
+        /// Promotes ordinary user to a site administrator (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to promote to administrator.</param>
         /// <returns></returns>
@@ -36,10 +104,11 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Demotes a site administrator to an ordinary user.
+        /// Demotes a site administrator to an ordinary user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to demote from administrator.</param>
         /// <returns></returns>
@@ -49,10 +118,11 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Suspends a user.
+        /// Suspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#suspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#suspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to suspend.</param>
         /// <returns></returns>
@@ -62,16 +132,58 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Unsuspends a user.
+        /// Unsuspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#unsuspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#unsuspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to unsuspend.</param>
         /// <returns></returns>
         public IObservable<Unit> Unsuspend(string login)
         {
             return _client.Unsuspend(login).ToObservable();
+        }
+
+        /// <summary>
+        /// List all public keys (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#list-all-public-keys">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <returns></returns>
+        public IObservable<PublicKey> ListAllPublicKeys()
+        {
+            return _connection.GetAndFlattenAllPages<PublicKey>(ApiUrls.UserAdministrationPublicKeys());
+        }
+
+        /// <summary>
+        /// Delete a user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to delete</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(string login)
+        {
+            return _client.Delete(login).ToObservable();
+        }
+
+        /// <summary>
+        /// Delete a public key (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-public-key">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="keyId">The key to delete</param>
+        /// <returns></returns>
+        public IObservable<Unit> DeletePublicKey(int keyId)
+        {
+            return _client.DeletePublicKey(keyId).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserAdministrationClientTests.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit.Tests.Integration.Helpers;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class UserAdministrationClientTests
+    {
+        readonly IGitHubClient _github;
+
+        public UserAdministrationClientTests()
+        {
+            _github = EnterpriseHelper.GetAuthenticatedClient();
+        }
+
+        private NewUser GenerateNewUserDetails()
+        {
+            string username = Helper.MakeNameWithTimestamp("user");
+            string email = string.Concat(username, "@company.com");
+            return new NewUser(username, email);
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanCreateAndDelete()
+        {
+            User checkUser = null;
+
+            // Create a new user
+            var newUser = GenerateNewUserDetails();
+
+            var user = await
+                _github.User.Administration.Create(newUser);
+
+            // Check returned object (cant check email as it isn't public)
+            Assert.NotNull(user);
+            Assert.Equal(user.Login, newUser.Login);
+
+            // Get user to check they exist
+            checkUser = await _github.User.Get(newUser.Login);
+            Assert.Equal(checkUser.Login, newUser.Login);
+
+            // Delete the user
+            await _github.User.Administration.Delete(newUser.Login);
+
+            // Ensure user doesnt exist
+            try
+            {
+                checkUser = await _github.User.Get(newUser.Login);
+                if (checkUser != null)
+                {
+                    throw new Exception("User still exists!");
+                }
+            }
+            catch (ApiException e)
+            {
+                if (e.StatusCode != System.Net.HttpStatusCode.NotFound)
+                {
+                    throw;
+                }
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanRename()
+        {
+            string renamedUsername = Helper.MakeNameWithTimestamp("user-renamed");
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                var response = await _github.User.Administration.Rename(
+                    context.UserLogin,
+                    new UserRename(renamedUsername));
+
+                Assert.NotNull(response);
+                Assert.StartsWith("Job queued to rename user", response.Message);
+                Assert.EndsWith(context.UserId.ToString(), response.Url);
+            }
+
+            // Remove user if it was already renamed
+            EnterpriseHelper.DeleteUser(renamedUsername);
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanAddAndDeleteImpersonationToken()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Create Impersonation token
+                var token = await _github.User.Administration.CreateImpersonationToken(
+                    context.UserLogin,
+                    new NewImpersonationToken(new string[] { "public_repo" }));
+
+                Assert.NotNull(token);
+                Assert.True(
+                    token.Scopes.Count() == 1 && 
+                    token.Scopes.All(s => s == "public_repo"));
+
+                // Delete Impersonation token
+                await _github.User.Administration.DeleteImpersonationToken(context.UserLogin);
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanPromoteAndDemote()
+        {
+            User checkUser = null;
+
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user is not site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.SiteAdmin);
+
+                // Promote to site admin
+                await _github.User.Administration.Promote(context.UserLogin);
+
+                // Ensure user is site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.True(checkUser.SiteAdmin);
+
+                // Demote user
+                await _github.User.Administration.Demote(context.UserLogin);
+
+                // Ensure user is not site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.SiteAdmin);
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanSuspendAndUnsuspend()
+        {
+            User checkUser = null;
+
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user is not suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.Suspended);
+
+                // Suspend user
+                await _github.User.Administration.Suspend(context.UserLogin);
+
+                // Ensure user is suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.True(checkUser.Suspended);
+
+                // Unsuspend user
+                await _github.User.Administration.Unsuspend(context.UserLogin);
+
+                // Ensure user is not suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.Suspended);
+            }
+        }
+
+        [GitHubEnterpriseTest(Skip = "Currently no way to add keys, so cant test listing keys")]
+        public async Task CanListAllPublicKeys()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user has a key
+                //var key = await _github.User.Keys.Create(new NewPublicKey("title", "key"));
+
+                // Get public keys
+                var keys = await _github.User.Administration.ListAllPublicKeys();
+
+                Assert.NotNull(keys);
+                Assert.True(keys.Count > 0);
+
+                // Delete key
+                //await _github.User.Administration.DeletePublicKey(key.Id);
+            }
+        }
+
+        [GitHubEnterpriseTest(Skip = "Currently no way to add keys, so cant test deleting keys")]
+        public async Task CanDeletePublicKey()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user has a key
+                //var key = await _github.User.Keys.Create(new NewPublicKey("title", "key"));
+                
+                // Delete key
+                //await _github.User.Administration.DeletePublicKey(key.Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/EnterpriseHelper.cs
+++ b/Octokit.Tests.Integration/EnterpriseHelper.cs
@@ -140,6 +140,22 @@ namespace Octokit.Tests.Integration
             catch { }
         }
 
+        public static void DeleteUser(User user)
+        {
+            if (user != null)
+                DeleteUser(user.Login);
+        }
+
+        public static void DeleteUser(string username)
+        {
+            var api = GetAuthenticatedClient();
+            try
+            {
+                api.User.Administration.Delete(username).Wait(TimeSpan.FromSeconds(15));
+            }
+            catch { }
+        }
+
         public static IGitHubClient GetAuthenticatedClient()
         {
             return new GitHubClient(new ProductHeaderValue("OctokitEnterpriseTests"), GitHubEnterpriseUrl)

--- a/Octokit.Tests.Integration/Helpers/EnterpriseUserContext.cs
+++ b/Octokit.Tests.Integration/Helpers/EnterpriseUserContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Octokit.Tests.Integration.Helpers
+{
+    internal sealed class EnterpriseUserContext : IDisposable
+    {
+        internal EnterpriseUserContext(User user)
+        {
+            User = user;
+            UserId = user.Id;
+            UserLogin = user.Login;
+            UserEmail = user.Email;
+        }
+
+        internal int UserId { get; private set; }
+        internal string UserLogin { get; private set; }
+        internal string UserEmail { get; private set; }
+
+        internal User User { get; private set; }
+
+        public void Dispose()
+        {
+            EnterpriseHelper.DeleteUser(User);
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -36,5 +36,12 @@ namespace Octokit.Tests.Integration.Helpers
 
             return new EnterpriseTeamContext(team);
         }
+
+        internal async static Task<EnterpriseUserContext> CreateEnterpriseUserContext(this IGitHubClient client, NewUser newUser)
+        {
+            var user = await client.User.Administration.Create(newUser);
+
+            return new EnterpriseUserContext(user);
+        }
     }
 }

--- a/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
@@ -27,5 +27,19 @@ namespace Octokit.Tests.Integration.Helpers
 
             return new RepositoryContext(repo);
         }
+
+        internal async static Task<EnterpriseTeamContext> CreateEnterpriseTeamContext(this IObservableGitHubClient client, string organization, NewTeam newTeam)
+        {
+            var team = await client.Organization.Team.Create(organization, newTeam);
+
+            return new EnterpriseTeamContext(team);
+        }
+
+        internal async static Task<EnterpriseUserContext> CreateEnterpriseUserContext(this IObservableGitHubClient client, NewUser newUser)
+        {
+            var user = await client.User.Administration.Create(newUser);
+
+            return new EnterpriseUserContext(user);
+        }
     }
 }

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Clients\StarredClientTests.cs" />
     <Compile Include="Clients\StatisticsClientTests.cs" />
     <Compile Include="Clients\TreeClientTests.cs" />
+    <Compile Include="Clients\UserAdministrationClientTests.cs" />
     <Compile Include="Clients\UserEmailsClientTests.cs" />
     <Compile Include="Clients\FollowersClientTests.cs" />
     <Compile Include="Clients\UserKeysClientTests.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="fixtures\RepositoriesHooksFixture.cs" />
     <Compile Include="EnterpriseHelper.cs" />
     <Compile Include="Helpers\ApplicationTestAttribute.cs" />
+    <Compile Include="Helpers\EnterpriseUserContext.cs" />
     <Compile Include="Helpers\GithubClientExtensions.cs" />
     <Compile Include="Helpers\ObservableGithubClientExtensions.cs" />
     <Compile Include="Helpers\BasicAuthenticationTestAttribute.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Helper.cs" />
     <Compile Include="Clients\UsersClientTests.cs" />
     <Compile Include="Reactive\ObservableRespositoryDeployKeysClientTests.cs" />
+    <Compile Include="Reactive\ObservableUserAdministrationClientTests.cs" />
     <Compile Include="Reactive\ObservableUserEmailsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />
     <Compile Include="RedirectTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
@@ -20,11 +20,10 @@ namespace Octokit.Tests.Integration
         
         public ObservableEnterpriseLdapClientTests()
         {
-            var gitHub = EnterpriseHelper.GetAuthenticatedClient();
-            _github = new ObservableGitHubClient(gitHub);
+            _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
 
             NewTeam newTeam = new NewTeam(Helper.MakeNameWithTimestamp("test-team")) { Description = "Test Team" };
-            _context = gitHub.CreateEnterpriseTeamContext(EnterpriseHelper.Organization, newTeam).Result;
+            _context = _github.CreateEnterpriseTeamContext(EnterpriseHelper.Organization, newTeam).Result;
         }
 
         [GitHubEnterpriseTest]

--- a/Octokit.Tests.Integration/Reactive/ObservableUserAdministrationClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserAdministrationClientTests.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Octokit.Tests.Integration.Helpers;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class ObservableUserAdministrationClientTests
+    {
+        readonly IObservableGitHubClient _github;
+
+        public ObservableUserAdministrationClientTests()
+        {
+            _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
+        }
+
+        private NewUser GenerateNewUserDetails()
+        {
+            string username = Helper.MakeNameWithTimestamp("user");
+            string email = string.Concat(username, "@company.com");
+            return new NewUser(username, email);
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanCreateAndDelete()
+        {
+            User checkUser = null;
+
+            // Create a new user
+            var newUser = GenerateNewUserDetails();
+
+            var observable = _github.User.Administration.Create(newUser);
+            var user = await observable;
+
+            // Check returned object (cant check email as it isn't public)
+            Assert.NotNull(user);
+            Assert.Equal(user.Login, newUser.Login);
+
+            // Get user to check they exist
+            checkUser = await _github.User.Get(newUser.Login);
+            Assert.Equal(checkUser.Login, newUser.Login);
+
+            // Delete the user
+            await _github.User.Administration.Delete(newUser.Login);
+
+            // Ensure user doesnt exist
+            try
+            {
+                checkUser = await _github.User.Get(newUser.Login);
+                if (checkUser != null)
+                {
+                    throw new Exception("User still exists!");
+                }
+            }
+            catch (ApiException e)
+            {
+                if (e.StatusCode != System.Net.HttpStatusCode.NotFound)
+                {
+                    throw;
+                }
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanRename()
+        {
+            string renamedUsername = Helper.MakeNameWithTimestamp("user-renamed");
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                var observable = _github.User.Administration.Rename(
+                    context.UserLogin,
+                    new UserRename(renamedUsername));
+                var response = await observable;
+
+                Assert.NotNull(response);
+                Assert.StartsWith("Job queued to rename user", response.Message);
+                Assert.EndsWith(context.UserId.ToString(), response.Url);
+            }
+
+            // Remove user if it was already renamed
+            EnterpriseHelper.DeleteUser(renamedUsername);
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanAddAndDeleteImpersonationToken()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Create Impersonation token
+                var observable = _github.User.Administration.CreateImpersonationToken(
+                    context.UserLogin,
+                    new NewImpersonationToken(new string[] { "public_repo" }));
+                var token = await observable;
+
+                Assert.NotNull(token);
+                Assert.True(
+                    token.Scopes.Count() == 1 &&
+                    token.Scopes.All(s => s == "public_repo"));
+
+                // Delete Impersonation token
+                await _github.User.Administration.DeleteImpersonationToken(context.UserLogin);
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanPromoteAndDemote()
+        {
+            User checkUser = null;
+
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user is not site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.SiteAdmin);
+
+                // Promote to site admin
+                await _github.User.Administration.Promote(context.UserLogin);
+
+                // Ensure user is site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.True(checkUser.SiteAdmin);
+
+                // Demote user
+                await _github.User.Administration.Demote(context.UserLogin);
+
+                // Ensure user is not site admin
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.SiteAdmin);
+            }
+        }
+
+        [GitHubEnterpriseTest]
+        public async Task CanSuspendAndUnsuspend()
+        {
+            User checkUser = null;
+
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user is not suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.Suspended);
+
+                // Suspend user
+                await _github.User.Administration.Suspend(context.UserLogin);
+
+                // Ensure user is suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.True(checkUser.Suspended);
+
+                // Unsuspend user
+                await _github.User.Administration.Unsuspend(context.UserLogin);
+
+                // Ensure user is not suspended
+                checkUser = await _github.User.Get(context.UserLogin);
+                Assert.False(checkUser.Suspended);
+            }
+        }
+
+        [GitHubEnterpriseTest(Skip = "Currently no way to add keys, so cant test listing keys")]
+        public async Task CanListAllPublicKeys()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user has a key
+                //var key = await _github.User.Keys.Create(new NewPublicKey("title", "key"));
+
+                // Get public keys
+                var observable = _github.User.Administration.ListAllPublicKeys();
+                var keys = await (observable.ToList());
+
+                Assert.NotNull(keys);
+                Assert.True(keys.Count > 0);
+
+                // Delete key
+                //await _github.User.Administration.DeletePublicKey(key.Id);
+            }
+        }
+
+        [GitHubEnterpriseTest(Skip = "Currently no way to add keys, so cant test deleting keys")]
+        public async Task CanDeletePublicKey()
+        {
+            // Create a disposable user for the test
+            using (var context = _github.CreateEnterpriseUserContext(GenerateNewUserDetails()).Result)
+            {
+                // Ensure user has a key
+                //var key = await _github.User.Keys.Create(new NewPublicKey("title", "key"));
+
+                // Delete key
+                //await _github.User.Administration.DeletePublicKey(key.Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests/Clients/UserAdministrationClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Tests.Helpers;
@@ -9,6 +10,174 @@ namespace Octokit.Tests.Clients
 {
     public class UserAdministrationClientTests
     {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null));
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/users";
+                client.Create(new NewUser("name", "email@company.com"));
+
+                connection.Received().Post<User>(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri), 
+                    Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+                
+                client.Create(new NewUser("name", "email@company.com"));
+
+                connection.Received().Post<User>(
+                    Arg.Any<Uri>(), 
+                    Arg.Is<NewUser>(a =>
+                        a.Login == "name" && 
+                        a.Email == "email@company.com"));
+            }
+        }
+
+        public class TheRenameMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Rename(null, new UserRename("newlogin")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Rename("login", null));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyString()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() => client.Rename("", new UserRename()));
+                Assert.Equal("login", exception.ParamName);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/users/auser";
+                client.Rename("auser", new UserRename());
+
+                connection.Received().Patch<UserRenameResponse>(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri),
+                    Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                client.Rename("auser", new UserRename("newlogin"));
+
+                connection.Received().Patch<UserRenameResponse>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UserRename>(a =>
+                        a.Login == "newlogin"));
+            }
+        }
+
+        public class TheCreateImpersonationTokenMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateImpersonationToken(null, new NewImpersonationToken()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateImpersonationToken("login", null));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyString()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() => client.CreateImpersonationToken("", new NewImpersonationToken()));
+                Assert.Equal("login", exception.ParamName);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/users/auser/authorizations";
+
+                client.CreateImpersonationToken("auser", new NewImpersonationToken());
+
+                connection.Received().Post<Authorization>(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri),
+                    Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                string[] scopes = new string[] { "public-repo" };
+                client.CreateImpersonationToken("auser", new NewImpersonationToken(scopes));
+
+                connection.Received().Post<Authorization>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<NewImpersonationToken>(a =>
+                        a.Scopes.Count() == scopes.Count() &&
+                        a.Scopes.ToList().All(s => scopes.Contains(s)) &&
+                        scopes.ToList().All(s => a.Scopes.Contains(s))));
+            }
+        }
+
+        public class TheDeleteImpersonationTokenMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteImpersonationToken(null));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyString()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() => client.DeleteImpersonationToken(""));
+                Assert.Equal("login", exception.ParamName);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/users/auser/authorizations";
+                client.DeleteImpersonationToken("auser");
+
+                connection.Connection.Received().Delete(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+            }
+        }
+
         public class ThePromoteMethod
         {
             [Fact]
@@ -32,11 +201,14 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserAdministrationClient(connection);
 
+                var expectedUri = "users/auser/site_admin";
                 client.Promote("auser");
 
-                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "/users/auser/site_admin"));
+                connection.Received().Put(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
+
         public class TheDemoteMethod
         {
             [Fact]
@@ -60,9 +232,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserAdministrationClient(connection);
 
+                var expectedUri = "users/auser/site_admin";
                 client.Demote("auser");
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "/users/auser/site_admin"));
+                connection.Received().Delete(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
 
@@ -89,9 +263,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserAdministrationClient(connection);
 
+                var expectedUri = "users/auser/suspended";
                 client.Suspend("auser");
 
-                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "/users/auser/suspended"));
+                connection.Received().Put(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
 
@@ -118,9 +294,74 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserAdministrationClient(connection);
 
+                var expectedUri = "users/auser/suspended";
                 client.Unsuspend("auser");
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "/users/auser/suspended"));
+                connection.Received().Delete(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+            }
+        }
+
+        public class TheListAllPublicKeysMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/keys";
+                client.ListAllPublicKeys();
+
+                connection.Received().GetAll<PublicKey>(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyString()
+            {
+                var client = new UserAdministrationClient(Substitute.For<IApiConnection>());
+                var exception = await Assert.ThrowsAsync<ArgumentException>(() => client.Delete(""));
+                Assert.Equal("login", exception.ParamName);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/users/auser";
+                client.Delete("auser");
+
+                connection.Connection.Received().Delete(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+            }
+        }
+
+        public class TheDeletePublicKeyMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserAdministrationClient(connection);
+
+                var expectedUri = "admin/keys/1";
+                client.DeletePublicKey(1);
+
+                connection.Connection.Received().Delete(
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -7,10 +8,75 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableUserAdministrationClientTests
     {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.Create(new NewUser("auser", "email@company.com"));
+
+                gitHubClient.User.Administration.Received().Create(
+                    Arg.Is<NewUser>(a => 
+                        a.Login == "auser" &&
+                        a.Email == "email@company.com"));
+            }
+        }
+
+        public class TheRenameMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.Rename("auser", new UserRename("renamed-user"));
+
+                gitHubClient.User.Administration.Received().Rename(
+                    "auser",
+                    Arg.Is<UserRename>(a =>
+                        a.Login == "renamed-user"));
+            }
+        }
+
+        public class TheCreateImpersonationTokenMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.CreateImpersonationToken("auser", new NewImpersonationToken(new string[] { "public_repo" }));
+
+                gitHubClient.User.Administration.Received().CreateImpersonationToken(
+                    "auser",
+                    Arg.Is<NewImpersonationToken>(a =>
+                        a.Scopes.ToList()[0] == "public_repo"));
+            }
+        }
+
+        public class TheDeleteImpersonationTokenMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.DeleteImpersonationToken("auser");
+
+                gitHubClient.User.Administration.Received().DeleteImpersonationToken("auser");
+            }
+        }
+
         public class ThePromoteMethod
         {
             [Fact]
-            public void GetsFromClientPromtePromote()
+            public void CallsIntoClient()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserAdministrationClient(gitHubClient);
@@ -24,7 +90,7 @@ namespace Octokit.Tests.Reactive
         public class TheDemoteMethod
         {
             [Fact]
-            public void GetsFromClientDemoteDemote()
+            public void CallsIntoClient()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserAdministrationClient(gitHubClient);
@@ -38,7 +104,7 @@ namespace Octokit.Tests.Reactive
         public class TheSuspendMethod
         {
             [Fact]
-            public void GetsFromClientSuspendSuspend()
+            public void CallsIntoClient()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserAdministrationClient(gitHubClient);
@@ -52,7 +118,7 @@ namespace Octokit.Tests.Reactive
         public class TheUnsuspendMethod
         {
             [Fact]
-            public void GetsFromClientUnsuspendUnsuspend()
+            public void CallsIntoClient()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserAdministrationClient(gitHubClient);
@@ -60,6 +126,54 @@ namespace Octokit.Tests.Reactive
                 client.Unsuspend("auser");
 
                 gitHubClient.User.Administration.Received().Unsuspend("auser");
+            }
+        }
+
+        public class TheListAllPublicKeysMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                var expectedUri = "admin/keys";
+
+                client.ListAllPublicKeys();
+
+                gitHubClient.Connection.Received().Get<System.Collections.Generic.List<PublicKey>>(
+                    Arg.Is<Uri>(a =>
+                        a.ToString() == expectedUri),
+                    null,
+                    null);
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.Delete("auser");
+
+                gitHubClient.User.Administration.Received().Delete("auser");
+            }
+        }
+
+        public class TheDeletePublicKeyMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserAdministrationClient(gitHubClient);
+
+                client.DeletePublicKey(1);
+
+                gitHubClient.User.Administration.Received().DeletePublicKey(1);
             }
         }
 

--- a/Octokit/Clients/IUserAdministrationClient.cs
+++ b/Octokit/Clients/IUserAdministrationClient.cs
@@ -1,56 +1,137 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
-{    /// <summary>
-     /// A client for GitHub's User Administration API.
-     /// </summary>
-     /// <remarks>
-     /// See the <a href="https://developer.github.com/v3/users/administration/">Administration API documentation</a> for more details.
-     /// </remarks>
+{
+    /// <summary>
+    /// A client for GitHub's User Administration API (GitHub Enterprise)
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/users/administration/">Administration API documentation</a> for more details.
+    /// </remarks>
     public interface IUserAdministrationClient
     {
         /// <summary>
-        /// Promotes ordinary user to a site administrator.
+        /// Create a new user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-a-new-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="newUser">The <see cref="NewUser"/> object describing the user to create</param>
+        /// <returns>The created <see cref="User"/> object</returns>
+        Task<User> Create(NewUser newUser);
+
+        /// <summary>
+        /// Rename an existing user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#rename-an-existing-user">API documentation</a>
+        /// for more information.
+        /// Note that this queues a request to rename a user, rather than execute it straight away
+        /// </remarks>
+        /// <param name="login">The username to rename</param>
+        /// <param name="userRename">The <see cref="UserRename"/> request, specifying the new login</param>
+        /// <returns>A <see cref="UserRenameResponse"/> object indicating the queued task message and Url to the user</returns>
+        Task<UserRenameResponse> Rename(string login, UserRename userRename);
+
+        /// <summary>
+        /// Create an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to impersonate</param>
+        /// <param name="newImpersonationToken">The <see cref="NewImpersonationToken"/> request specifying the required scopes</param>
+        /// <returns>An <see cref="Authorization"/> object containing the impersonation token</returns>
+        Task<Authorization> CreateImpersonationToken(string login, NewImpersonationToken newImpersonationToken);
+
+        /// <summary>
+        /// Deletes an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to remove impersonation token from</param>
+        /// <returns></returns>
+        Task DeleteImpersonationToken(string login);
+
+        /// <summary>
+        /// Promotes ordinary user to a site administrator (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to promote to administrator.</param>
         /// <returns></returns>
         Task Promote(string login);
 
         /// <summary>
-        /// Demotes a site administrator to an ordinary user.
+        /// Demotes a site administrator to an ordinary user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to demote from administrator.</param>
         /// <returns></returns>
         Task Demote(string login);
 
         /// <summary>
-        /// Suspends a user.
+        /// Suspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#suspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#suspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to suspend.</param>
         /// <returns></returns>
         Task Suspend(string login);
 
         /// <summary>
-        /// Unsuspends a user.
+        /// Unsuspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#unsuspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#unsuspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to unsuspend.</param>
         /// <returns></returns>
         Task Unsuspend(string login);
+
+        /// <summary>
+        /// List all public keys (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#list-all-public-keys">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <returns></returns>
+        Task<IReadOnlyList<PublicKey>> ListAllPublicKeys();
+
+        /// <summary>
+        /// Delete a user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to delete</param>
+        /// <returns></returns>
+        Task Delete(string login);
+
+        /// <summary>
+        /// Delete a public key (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-public-key">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="keyId">The key to delete</param>
+        /// <returns></returns>
+        Task DeletePublicKey(int keyId);
     }
 }

--- a/Octokit/Clients/UserAdministrationClient.cs
+++ b/Octokit/Clients/UserAdministrationClient.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Octokit
 {
     /// <summary>
-    /// A client for GitHub's User Administration API.
+    /// A client for GitHub's User Administration API (GitHub Enterprise)
     /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/users/administration/">Administration API documentation</a> for more details.
@@ -24,63 +22,210 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Promotes ordinary user to a site administrator.
+        /// Create a new user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-a-new-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="newUser">The <see cref="NewUser"/> object describing the user to create</param>
+        /// <returns>The created <see cref="User"/> object</returns>
+        public Task<User> Create(NewUser newUser)
+        {
+            Ensure.ArgumentNotNull(newUser, "newUser");
+
+            var endpoint = ApiUrls.UserAdministration();
+
+            return ApiConnection.Post<User>(endpoint, newUser);
+        }
+
+        /// <summary>
+        /// Rename an existing user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#rename-an-existing-user">API documentation</a>
+        /// for more information.
+        /// Note that this queues a request to rename a user, rather than execute it straight away
+        /// </remarks>
+        /// <param name="login">The username to rename</param>
+        /// <param name="userRename">The <see cref="UserRename"/> request, specifying the new login</param>
+        /// <returns>A <see cref="UserRenameResponse"/> object indicating the queued task message and Url to the user</returns>
+        public Task<UserRenameResponse> Rename(string login, UserRename userRename)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(userRename, "userRename");
+
+            var endpoint = ApiUrls.UserAdministration(login);
+
+            return ApiConnection.Patch<UserRenameResponse>(endpoint, userRename);
+        }
+
+        /// <summary>
+        /// Create an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#create-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to impersonate</param>
+        /// <param name="newImpersonationToken">The <see cref="NewImpersonationToken"/> request specifying the required scopes</param>
+        /// <returns>An <see cref="Authorization"/> object containing the impersonation token</returns>
+        public Task<Authorization> CreateImpersonationToken(string login, NewImpersonationToken newImpersonationToken)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(newImpersonationToken, "newImpersonationToken");
+
+            var endpoint = ApiUrls.UserAdministrationAuthorization(login);
+
+            return ApiConnection.Post<Authorization>(endpoint, newImpersonationToken);
+        }
+
+        /// <summary>
+        /// Deletes an impersonation OAuth token (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-an-impersonation-oauth-token">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to remove impersonation token from</param>
+        /// <returns></returns>
+        public async Task DeleteImpersonationToken(string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
+            var endpoint = ApiUrls.UserAdministrationAuthorization(login);
+
+            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            if (response != HttpStatusCode.NoContent)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 204", response);
+            }
+
+            return;
+        }
+
+        /// <summary>
+        /// Promotes ordinary user to a site administrator (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/users/administration/#promote-an-ordinary-user-to-a-site-administrator">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to promote to administrator.</param>
         /// <returns></returns>
         public Task Promote(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
-            var endpoint = ApiUrls.UserAdministration(login);
+            var endpoint = ApiUrls.UserAdministrationSiteAdmin(login);
             return ApiConnection.Put(endpoint);
         }
 
         /// <summary>
-        /// Demotes a site administrator to an ordinary user.
+        /// Demotes a site administrator to an ordinary user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#demote-a-site-administrator-to-an-ordinary-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to demote from administrator.</param>
         /// <returns></returns>
         public Task Demote(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
-            var endpoint = ApiUrls.UserAdministration(login);
+            var endpoint = ApiUrls.UserAdministrationSiteAdmin(login);
             return ApiConnection.Delete(endpoint);
         }
 
         /// <summary>
-        /// Suspends a user.
+        /// Suspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#suspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#suspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to suspend.</param>
         /// <returns></returns>
         public Task Suspend(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
-            var endpoint = ApiUrls.UserSuspension(login);
+            var endpoint = ApiUrls.UserAdministrationSuspension(login);
             return ApiConnection.Put(endpoint);
         }
 
         /// <summary>
-        /// Unsuspends a user.
+        /// Unsuspends a user (must be Site Admin user).
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/users/administration/#unsuspend-a-user
+        /// See the <a href="https://developer.github.com/v3/users/administration/#unsuspend-a-user">API documentation</a>
+        /// for more information.
         /// </remarks>
         /// <param name="login">The user to unsuspend.</param>
         /// <returns></returns>
         public Task Unsuspend(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
-            var endpoint = ApiUrls.UserSuspension(login);
+            var endpoint = ApiUrls.UserAdministrationSuspension(login);
             return ApiConnection.Delete(endpoint);
+        }
+
+        /// <summary>
+        /// List all public keys (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#list-all-public-keys">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <returns></returns>
+        public Task<IReadOnlyList<PublicKey>> ListAllPublicKeys()
+        {
+            var endpoint = ApiUrls.UserAdministrationPublicKeys();
+            return ApiConnection.GetAll<PublicKey>(endpoint);
+        }
+
+        /// <summary>
+        /// Delete a user (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-user">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="login">The user to delete</param>
+        /// <returns></returns>
+        public async Task Delete(string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            var endpoint = ApiUrls.UserAdministration(login);
+
+            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            if (response != HttpStatusCode.NoContent)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 204", response);
+            }
+
+            return;
+        }
+
+        /// <summary>
+        /// Delete a public key (must be Site Admin user).
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/enterprise/2.5/v3/users/administration/#delete-a-public-key">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="keyId">The key to delete</param>
+        /// <returns></returns>
+        public async Task DeletePublicKey(int keyId)
+        {
+            Ensure.ArgumentNotNull(keyId, "keyId");
+            var endpoint = ApiUrls.UserAdministrationPublicKeys(keyId);
+            
+            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            if (response != HttpStatusCode.NoContent)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 204", response);
+            }
+
+            return;
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1699,14 +1699,39 @@ namespace Octokit
             return "staff/indexing_jobs".FormatUri();
         }
 
+        public static Uri UserAdministration()
+        {
+            return "admin/users".FormatUri();
+        }
+
+        public static Uri UserAdministration(string login)
+        {
+            return "admin/users/{0}".FormatUri(login);
+        }
+
+        public static Uri UserAdministrationAuthorization(string login)
+        {
+            return "admin/users/{0}/authorizations".FormatUri(login);
+        }
+
+        public static Uri UserAdministrationPublicKeys()
+        {
+            return "admin/keys".FormatUri();
+        }
+
+        public static Uri UserAdministrationPublicKeys(int keyId)
+        {
+            return "admin/keys/{0}".FormatUri(keyId);
+        }
+
         /// <summary>
         /// Creates the relative <see cref="Uri"/> for altering administration status of a user.
         /// </summary>
         /// <param name="login">The login for the intended user.</param>
         /// <returns></returns>
-        public static Uri UserAdministration(string login)
+        public static Uri UserAdministrationSiteAdmin(string login)
         {
-            return "/users/{0}/site_admin".FormatUri(login);
+            return "users/{0}/site_admin".FormatUri(login);
         }
 
         /// <summary>
@@ -1714,9 +1739,9 @@ namespace Octokit
         /// </summary>
         /// <param name="login">The login for the intended user.</param>
         /// <returns></returns>
-        public static Uri UserSuspension(string login)
+        public static Uri UserAdministrationSuspension(string login)
         {
-            return "/users/{0}/suspended".FormatUri(login);
+            return "users/{0}/suspended".FormatUri(login);
         }
     }
 }

--- a/Octokit/Models/Request/NewImpersonationToken.cs
+++ b/Octokit/Models/Request/NewImpersonationToken.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes a new Impersonation Token to create via the <see cref="IUserAdministrationClient.CreateImpersonationToken(string, NewImpersonationToken)"/> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewImpersonationToken
+    {
+        public NewImpersonationToken() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewImpersonationToken"/> class.
+        /// </summary>
+        /// <param name="scopes">The scopes for the token.</param>
+        public NewImpersonationToken(IEnumerable<string> scopes)
+        {
+            Scopes = scopes;
+        }
+
+        /// <summary>
+        /// The scopes for the token
+        /// </summary>
+        public IEnumerable<string> Scopes { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Scopes: {0}", string.Join("\r\n", Scopes));
+            }
+        }
+    }
+}

--- a/Octokit/Models/Request/NewUser.cs
+++ b/Octokit/Models/Request/NewUser.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes a new user to create via the <see cref="IUserAdministrationClient.Create(NewUser)"/> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class NewUser
+    {
+        public NewUser() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewUser"/> class.
+        /// </summary>
+        /// <param name="login">The login for the user.</param>
+        /// <param name="email">The email address of the user</param>
+        public NewUser(string login, string email)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNullOrEmptyString(email, "email");
+
+            Login = login;
+            Email = email;
+        }
+
+        /// <summary>
+        /// Login of the user
+        /// </summary>
+        public string Login { get; protected set; }
+
+        /// <summary>
+        /// Email address of the user
+        /// </summary>
+        public string Email { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Login: {0} Email: {1}", Login, Email);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Request/UserRename.cs
+++ b/Octokit/Models/Request/UserRename.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Describes the new login when renaming a user via the <see cref="IUserAdministrationClient.Rename(string, UserRename)"/> method.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class UserRename
+    {
+        public UserRename() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserRename"/> class.
+        /// </summary>
+        /// <param name="login">The new login for the user.</param>
+        public UserRename(string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
+            Login = login;
+        }
+
+        /// <summary>
+        /// The new username for the user
+        /// </summary>
+        public string Login { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Login: {0}", Login);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -14,17 +14,28 @@ namespace Octokit
     {
         public User() { }
 
-        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, bool siteAdmin, string ldapDistinguishedName)
+        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
             : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
         {
             SiteAdmin = siteAdmin;
             LdapDistinguishedName = ldapDistinguishedName;
+            SuspendedAt = suspendedAt;
         }
 
         /// <summary>
         /// Whether or not the user is an administrator of the site
         /// </summary>
         public bool SiteAdmin { get; protected set; }
+
+        /// <summary>
+        /// When the user was suspended, if at all (GitHub Enterprise)
+        /// </summary>
+        public DateTimeOffset? SuspendedAt { get; protected set; }
+
+        /// <summary>
+        /// Whether or not the user is currently suspended
+        /// </summary>
+        public bool Suspended { get { return SuspendedAt.HasValue; } }
 
         /// <summary>
         /// LDAP Binding (GitHub Enterprise only)

--- a/Octokit/Models/Response/UserRenameResponse.cs
+++ b/Octokit/Models/Response/UserRenameResponse.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Represents the response information from a <see cref="UserAdministrationClient.Rename(string, UserRename)"/> operation
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class UserRenameResponse
+    {
+        public UserRenameResponse() { }
+
+        public UserRenameResponse(string message, string url)
+        {
+            Message = message;
+            Url = url;
+        }
+
+        /// <summary>
+        /// Message indiating if the Rename request was queued
+        /// </summary>
+        public string Message { get; protected set; }
+
+        /// <summary>
+        /// Url to the user that will be renamed
+        /// </summary>
+        public string Url { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Message: {0}", Message);
+            }
+        }
+    }
+}

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -452,6 +452,10 @@
     <Compile Include="Clients\Enterprise\IEnterpriseLdapClient.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Response\Enterprise\LdapSyncResponse.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -460,6 +460,10 @@
     <Compile Include="Clients\Enterprise\IEnterpriseLdapClient.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Response\Enterprise\LdapSyncResponse.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -456,6 +456,10 @@
     <Compile Include="Clients\Enterprise\IEnterpriseLdapClient.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Response\Enterprise\LdapSyncResponse.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -449,6 +449,10 @@
     <Compile Include="Clients\Enterprise\IEnterpriseLdapClient.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Response\Enterprise\LdapSyncResponse.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -456,6 +456,10 @@
     <Compile Include="Clients\Enterprise\IEnterpriseLdapClient.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Response\Enterprise\LdapSyncResponse.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -113,12 +113,14 @@
     <Compile Include="Http\ProductHeaderValue.cs" />
     <Compile Include="Http\RequestBody.cs" />
     <Compile Include="Models\Request\BranchUpdate.cs" />
+    <Compile Include="Models\Request\NewImpersonationToken.cs" />
     <Compile Include="Models\Request\Enterprise\NewLdapMapping.cs" />
     <Compile Include="Models\Request\GistFileUpdate.cs" />
     <Compile Include="Models\Request\NewArbitraryMarkDown.cs" />
     <Compile Include="Models\Request\Enterprise\NewOrganization.cs" />
     <Compile Include="Models\Request\NewMerge.cs" />
     <Compile Include="Models\Request\NewRepositoryWebHook.cs" />
+    <Compile Include="Models\Request\NewUser.cs" />
     <Compile Include="Models\Request\PublicRepositoryRequest.cs" />
     <Compile Include="Models\Request\ReleaseAssetUpload.cs" />
     <Compile Include="Models\Request\RepositoryForksListRequest.cs" />
@@ -132,6 +134,7 @@
     <Compile Include="Models\Request\NewRelease.cs" />
     <Compile Include="Models\Request\NotificationsRequest.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
+    <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\ActivityPayloads\ActivityPayload.cs" />
     <Compile Include="Models\Response\ActivityPayloads\CommitCommentPayload.cs" />
     <Compile Include="Models\Response\ActivityPayloads\ForkEventPayload.cs" />
@@ -171,6 +174,7 @@
     <Compile Include="Models\Response\PagesBuild.cs" />
     <Compile Include="Models\Response\PublicKey.cs" />
     <Compile Include="Models\Response\PullRequestFile.cs" />
+    <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Response\ResourceRateLimit.cs" />
     <Compile Include="Models\Response\RepositoryContent.cs" />
     <Compile Include="Models\Response\RepositoryContentChangeSet.cs" />


### PR DESCRIPTION
## Status
:rocket: Ready to merge

~~This is built on top of #1099 which is not yet merged.~~

~~Only the last 4 commits are actually relating to this PR.  I will rebase this as soon as #1099  is merged.~~

~~Here's a diff link showing the consolidated changes for what will be in just this PR:~~
~~https://github.com/TattsGroup/octokit.net/compare/8be8c41966b57de0d994120e733ff02c9d111438...enterprise-useradministration~~

## Implement Additional Enterprise methods on User Administration Client 
https://developer.github.com/enterprise/2.5/v3/users/administration/
Includes normal and reactive implementations plus unit and integration tests for both, including integration tests for the 4 previously implemented methods in #1068 

### Notes
Differences in the API docs between github.com and github enterprise are few and far between however one of the major ones I found was that on GitHub Enterprise the UserAdministration API has several additional methods over github.com - methods for Create/Rename/Delete user, Create/Delete Impersonation Tokens and List/Delete Public Keys
https://developer.github.com/v3/users/administration/
vs
https://developer.github.com/enterprise/2.5/v3/users/administration/

#### SuspendedAt property on User
I found that the SuspendedAt property is returned by the API (at least on GitHub Enterprise) and whether this value is null or not indicates whether a user is suspended.  This seemed useful to know (and also was required in order to assert the Integration tests for the Suspend/Unsuspend methods) so Ive added this field to the ```User``` response object (I also checked whether it should be put on the base ```Account``` object, but ```Organization``` can't be suspended so ```User``` seems to be the correct place for it

#### ImpersonationToken method
Im not exactly sure how to actually use these!  As a GHE admin through the site admin section on the webUI we can "impersonate" a user and login/interact as them, however through the API you have to specify scopes on this call, so Im not sure if this is the same thing or not.  The calls as implemented do work, but Im not sure what to do with the ImperstonationToken once it's retrieved~
I also wasn't sure whether there should be a new Response type for the call or if the existing ```Authorization``` type is appropriate.  The only field the response contains that ```Authorization``` doesn't have, is "token" however I believe that may be being deprecated anyway.  For now I've just used ```Authorization``` as the return type.

As an aside, it looks to me like there is an issue with the ```Authorization``` object in that the field named [```Application```](https://github.com/octokit/octokit.net/blob/master/Octokit/Models/Response/Authorization.cs#L46) is actually ```app``` in the [API response](https://developer.github.com/v3/oauth_authorizations/#get-a-single-authorization) and thus always null.  Ill raise an issue for this tomorrow...

#### Naming Things (tm)
Given that this API now had a mix of methods acting on both Users, ImpersonationTokens and PublicKeys I originally wanted to name the methods ```CreateUser``` ```RenameUser``` ```DeleteUser```.  However given that the ```Suspend``` ```Unsuspend``` ```Promote``` ```Demote``` methods were already implemented with that naming (ie, no "User" suffix) and went live in the latest release, I decided for consistency to not include "User" in the ```Create``` ```Rename``` and ```Delete``` either.

#### Added ```CreateUserContext``` helper
Similar to the ```RepositoryContext``` and ```TeamContext``` helpers, I added a helper that allows the integration tests to create a user to run the tests, then clean it up afterwards.

## Tests
The integration tests require a GitHub enterprise instance so wont run as part of Octokit builds currently.  The ```CreateUserContext``` helper is working a treat, after running stacks of tests my test GHE server doesn't have any extraneious users hanging around :grinning: 

I set a couple of tests to Skip at the moment due to #1106 which I plan to fix up in the near future and then unskip the 2 integration tests.