### PR TITLE
[RFC] [WIP] IJsonSerializer parameter in Connection.cs wasn't being used

### DIFF
--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -306,7 +306,8 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task RunsConfiguredAppWithAppropriateEnv()
             {
-                string data = SimpleJson.SerializeObject(new object());
+                var serializer = Substitute.For<IJsonSerializer>();
+                string data = serializer.Serialize(new object());
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -350,7 +351,8 @@ namespace Octokit.Tests.Http
             public async Task MakesPutRequestWithData()
             {
                 var body = new object();
-                var expectedBody = SimpleJson.SerializeObject(body);
+                var serializer = Substitute.For<IJsonSerializer>();
+                var expectedBody = serializer.Serialize(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -374,7 +376,8 @@ namespace Octokit.Tests.Http
             public async Task MakesPutRequestWithNoData()
             {
                 var body = RequestBody.Empty;
-                var expectedBody = SimpleJson.SerializeObject(body);
+                var serializer = Substitute.For<IJsonSerializer>();
+                var expectedBody = serializer.Serialize(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -397,7 +400,8 @@ namespace Octokit.Tests.Http
             public async Task MakesPutRequestWithDataAndTwoFactor()
             {
                 var body = new object();
-                var expectedBody = SimpleJson.SerializeObject(body);
+                var serializer = Substitute.For<IJsonSerializer>();
+                var expectedBody = serializer.Serialize(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -422,7 +426,8 @@ namespace Octokit.Tests.Http
             public async Task MakesPutRequestWithNoDataAndTwoFactor()
             {
                 var body = RequestBody.Empty;
-                var expectedBody = SimpleJson.SerializeObject(body);
+                var serializer = Substitute.For<IJsonSerializer>();
+                string expectedBody = serializer.Serialize(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -448,7 +453,8 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task SendsProperlyFormattedPostRequest()
             {
-                string data = SimpleJson.SerializeObject(new object());
+                var serializer = Substitute.For<IJsonSerializer>();
+                string data = serializer.Serialize(new object());
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -306,22 +306,30 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task RunsConfiguredAppWithAppropriateEnv()
             {
+                var body = new object();
+                var expectedData = SimpleJson.SerializeObject(body);
+
                 var serializer = Substitute.For<IJsonSerializer>();
-                string data = serializer.Serialize(new object());
-                var httpClient = Substitute.For<IHttpClient>();
+                serializer.Serialize(body).Returns(expectedData);
+
                 IResponse response = new Response();
-                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Args.Request, Args.CancellationToken)
+                    .Returns(Task.FromResult(response));
+
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
-                await connection.Patch<string>(new Uri("endpoint", UriKind.Relative), new object());
+                await connection.Patch<string>(new Uri("endpoint", UriKind.Relative), body);
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
-                    (string)req.Body == data &&
+                    (string)req.Body == expectedData &&
                     req.Method == HttpVerb.Patch &&
                     req.ContentType == "application/x-www-form-urlencoded" &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
@@ -352,17 +360,22 @@ namespace Octokit.Tests.Http
             {
                 var body = new object();
                 var serializer = Substitute.For<IJsonSerializer>();
-                var expectedBody = serializer.Serialize(body);
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
+
+                serializer.Serialize(body).Returns(expectedBody);
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
                 await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body);
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
@@ -377,17 +390,23 @@ namespace Octokit.Tests.Http
             {
                 var body = RequestBody.Empty;
                 var serializer = Substitute.For<IJsonSerializer>();
-                var expectedBody = serializer.Serialize(body);
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
+
+                serializer.Serialize(body).Returns(expectedBody);
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
                 await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body);
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
@@ -401,17 +420,22 @@ namespace Octokit.Tests.Http
             {
                 var body = new object();
                 var serializer = Substitute.For<IJsonSerializer>();
-                var expectedBody = serializer.Serialize(body);
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
+
+                serializer.Serialize(body).Returns(expectedBody);
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
                 await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body, "two-factor");
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
@@ -427,17 +451,22 @@ namespace Octokit.Tests.Http
             {
                 var body = RequestBody.Empty;
                 var serializer = Substitute.For<IJsonSerializer>();
-                string expectedBody = serializer.Serialize(body);
+                var expectedBody = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
+
+                serializer.Serialize(body).Returns(expectedBody);
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
                 await connection.Put<string>(new Uri("endpoint", UriKind.Relative), body, "two-factor");
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&
@@ -453,18 +482,24 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task SendsProperlyFormattedPostRequest()
             {
+                var body = new object();
                 var serializer = Substitute.For<IJsonSerializer>();
-                string data = serializer.Serialize(new object());
+                var data = SimpleJson.SerializeObject(body);
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();
+
+                serializer.Serialize(body).Returns(data);
+
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),
                     _exampleUri,
                     Substitute.For<ICredentialStore>(),
                     httpClient,
-                    Substitute.For<IJsonSerializer>());
+                    serializer);
 
-                await connection.Post<string>(new Uri("endpoint", UriKind.Relative), new object(), null, null);
+                await connection.Post<string>(new Uri("endpoint", UriKind.Relative), body, null, null);
+
+                serializer.Received(1).Serialize(body);
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req =>
                     req.BaseAddress == _exampleUri &&

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -133,7 +133,7 @@ namespace Octokit
             BaseAddress = baseAddress;
             _authenticator = new Authenticator(credentialStore);
             _httpClient = httpClient;
-            _jsonPipeline = new JsonHttpPipeline();
+            _jsonPipeline = new JsonHttpPipeline(serializer);
         }
 
         /// <summary>


### PR DESCRIPTION
Passing on serialize argument to Connection's ctor, wasn't passing on before. Breaks tests. Cannot merge.

Refer #1119 

This breaks six tests in total, one of them being [this](https://github.com/octokit/octokit.net/blob/master/Octokit.Tests%2FHttp%2FConnectionTests.cs#L38), I guess that's because, the `IJsonSerializer` in the test is a substitute, it doesn't actually provide a serialization strategy. I don't know much about unit testing and mocking frameworks.

@shiftkey @M-Zuber thoughts?