### PR TITLE
Add ApiOption overloads to methods on Assignees API

### DIFF
--- a/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
@@ -13,6 +13,15 @@ namespace Octokit.Reactive
         IObservable<User> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">The options to change API's behaviour.</param>
+        /// <returns></returns>
+        IObservable<User> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -36,6 +36,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        /// <param name="options">The options to change API's behaviour</param>
         /// <returns></returns>
         public IObservable<User> GetAllForRepository(string owner, string name, ApiOptions options)
         {

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -32,6 +32,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        public IObservable<User> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Assignees(owner, name), options);
+        }
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
+    <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
     <Compile Include="Reactive\ObservableReleaseClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableAssigneesClientTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableAssigneesClientTests
+    {
+        public class TheGetAllMethod
+        {
+            readonly ObservableAssigneesClient _assigneesClient;
+            const string owner = "octokit";
+            const string name = "octokit.net";
+
+            public TheGetAllMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _assigneesClient = new ObservableAssigneesClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsAssignees()
+            {
+                var assignees = await _assigneesClient.GetAllForRepository(owner, name).ToList();
+
+                Assert.NotEmpty(assignees);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfAssigneesWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var assignees = await _assigneesClient.GetAllForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, assignees.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfAssigneesWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var releases = await _assigneesClient.GetAllForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, releases.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstPage = await _assigneesClient.GetAllForRepository(owner, name, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await _assigneesClient.GetAllForRepository(owner, name, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+                Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
+                Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -21,7 +21,11 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/assignees"), null, AcceptHeaders.StableVersion, Args.ApiOptions);
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/assignees"),
+                    null,
+                    AcceptHeaders.StableVersion,
+                    Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -21,7 +21,7 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/assignees"));
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/assignees"), null, AcceptHeaders.StableVersion, Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Assignees(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.Assignees(owner, name);
 
-            return ApiConnection.GetAll<User>(endpoint, null, options);
+            return ApiConnection.GetAll<User>(endpoint, null, AcceptHeaders.StableVersion, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -34,6 +34,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">The options to change API's response.</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            var endpoint = ApiUrls.Assignees(owner, name);
+
+            return ApiConnection.GetAll<User>(endpoint, null, options);
+        }
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -20,6 +20,15 @@ namespace Octokit
         Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">The options to chagne API's response.</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Checks to see if a user is an assignee for a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
Fixes #1148.

I have added the necessary overloads and corresponding tests. But one test is failing: 

`AssigneesClientTests+TheGetForRepositoryMethod.RequestsCorrectUrl()`

[Here](https://github.com/octokit/octokit.net/pull/1186/files#diff-a41fcaa8133dfe3db5942c64690de5adR24) are the changes I made. All other tests including integration tests are passing.

/cc @shiftkey 