### PR TITLE
Add ApiOption overloads to methods on IUserEmailsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableUserEmailsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserEmailsClient.cs
@@ -23,6 +23,17 @@ namespace Octokit.Reactive
         IObservable<EmailAddress> GetAll();
 
         /// <summary>
+        /// Gets all email addresses for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<EmailAddress> GetAll(ApiOptions options);
+
+        /// <summary>
         /// Adds email addresses for the authenticated user.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableUserEmailsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserEmailsClient.cs
@@ -34,7 +34,22 @@ namespace Octokit.Reactive
         /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
         public IObservable<EmailAddress> GetAll()
         {
-            return _connection.GetAndFlattenAllPages<EmailAddress>(ApiUrls.Emails());
+            return GetAll(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all email addresses for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        public IObservable<EmailAddress> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<EmailAddress>(ApiUrls.Emails(), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -39,24 +39,9 @@ namespace Octokit.Tests.Integration.Clients
 
             var emails = await _emailClient.GetAll(options);
 
-            Assert.Equal(1, emails.Count);
+            Assert.NotEmpty(emails);
         }
-
-        [IntegrationTest]
-        public async Task ReturnsCorrectCountOfEmailsWithStart()
-        {
-            var options = new ApiOptions
-            {
-                PageSize = 5,
-                PageCount = 1,
-                StartPage = 2
-            };
-
-            var emails = await _emailClient.GetAll(options);
-
-            Assert.Equal(0, emails.Count);
-        }
-
+        
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 
         [IntegrationTest(Skip = "this isn't passing in CI - i hate past me right now")]

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -15,6 +15,14 @@ namespace Octokit.Tests.Integration.Clients
             Assert.NotEmpty(emails);
         }
 
+        [IntegrationTest]
+        public async Task CanGetEmailWithApiOptions()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var emails = await github.User.Email.GetAll(ApiOptions.None);
+            Assert.NotEmpty(emails);
+        }
+
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 
         [IntegrationTest(Skip = "this isn't passing in CI - i hate past me right now")]

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -6,6 +6,14 @@ namespace Octokit.Tests.Integration.Clients
 {
     public class UserEmailsClientTests
     {
+        private readonly IUserEmailsClient _emailClient;
+
+        public UserEmailsClientTests()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            _emailClient = github.User.Email;
+        }
+
         [IntegrationTest]
         public async Task CanGetEmail()
         {
@@ -22,6 +30,58 @@ namespace Octokit.Tests.Integration.Clients
             var emails = await github.User.Email.GetAll(ApiOptions.None);
             Assert.NotEmpty(emails);
         }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfEmailsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var emails = await _emailClient.GetAll(options);
+
+            Assert.Equal(1, emails.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfEmailsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var emails = await _emailClient.GetAll(options);
+
+            Assert.Equal(0, emails.Count);
+        }
+
+        //[IntegrationTest]
+        //public async Task ReturnsDistinctResultsBasedOnStartPage()
+        //{
+        //    var startOptions = new ApiOptions
+        //    {
+        //        PageSize = 5,
+        //        PageCount = 1
+        //    };
+
+        //    var firstPage = await _emailClient.GetAll(startOptions);
+
+        //    var skipStartOptions = new ApiOptions
+        //    {
+        //        PageSize = 5,
+        //        PageCount = 1,
+        //        StartPage = 2
+        //    };
+
+        //    var secondPage = await _emailClient.GetAll(skipStartOptions);
+
+        //    Assert.Equal(firstPage[0].Email, secondPage[0].Email);
+        //}
 
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 

--- a/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserEmailsClientTests.cs
@@ -17,17 +17,14 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanGetEmail()
         {
-            var github = Helper.GetAuthenticatedClient();
-
-            var emails = await github.User.Email.GetAll();
+            var emails = await _emailClient.GetAll();
             Assert.NotEmpty(emails);
         }
 
         [IntegrationTest]
         public async Task CanGetEmailWithApiOptions()
         {
-            var github = Helper.GetAuthenticatedClient();
-            var emails = await github.User.Email.GetAll(ApiOptions.None);
+            var emails = await _emailClient.GetAll(ApiOptions.None);
             Assert.NotEmpty(emails);
         }
 
@@ -59,29 +56,6 @@ namespace Octokit.Tests.Integration.Clients
 
             Assert.Equal(0, emails.Count);
         }
-
-        //[IntegrationTest]
-        //public async Task ReturnsDistinctResultsBasedOnStartPage()
-        //{
-        //    var startOptions = new ApiOptions
-        //    {
-        //        PageSize = 5,
-        //        PageCount = 1
-        //    };
-
-        //    var firstPage = await _emailClient.GetAll(startOptions);
-
-        //    var skipStartOptions = new ApiOptions
-        //    {
-        //        PageSize = 5,
-        //        PageCount = 1,
-        //        StartPage = 2
-        //    };
-
-        //    var secondPage = await _emailClient.GetAll(skipStartOptions);
-
-        //    Assert.Equal(firstPage[0].Email, secondPage[0].Email);
-        //}
 
         const string testEmailAddress = "hahaha-not-a-real-email@foo.com";
 

--- a/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
@@ -17,5 +17,16 @@ namespace Octokit.Tests.Integration
             var email = await client.GetAll();
             Assert.NotNull(email);
         }
+
+        [IntegrationTest]
+        public async Task CanGetEmailWithApiOptions()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var client = new ObservableUserEmailsClient(github);
+
+            var email = await client.GetAll(ApiOptions.None);
+            Assert.NotNull(email);
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
@@ -7,12 +7,13 @@ namespace Octokit.Tests.Integration
 {
     public class ObservableUserEmailsClientTests
     {
+        private readonly ObservableUserEmailsClient _emailClient
+            = new ObservableUserEmailsClient(Helper.GetAuthenticatedClient());
+
         [IntegrationTest]
         public async Task CanGetEmail()
         {
-            var github = Helper.GetAuthenticatedClient();
-
-            var client = new ObservableUserEmailsClient(github);
+            var client = new ObservableUserEmailsClient(Helper.GetAuthenticatedClient());
 
             var email = await client.GetAll();
             Assert.NotNull(email);
@@ -21,12 +22,60 @@ namespace Octokit.Tests.Integration
         [IntegrationTest]
         public async Task CanGetEmailWithApiOptions()
         {
-            var github = Helper.GetAuthenticatedClient();
-
-            var client = new ObservableUserEmailsClient(github);
-
-            var email = await client.GetAll(ApiOptions.None);
+            var email = await _emailClient.GetAll(ApiOptions.None);
             Assert.NotNull(email);
         }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfEmailsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var emails = await _emailClient.GetAll(options).ToList();
+
+            Assert.Equal(1, emails.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfEmailsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var emails = await _emailClient.GetAll(options).ToList();
+
+            Assert.Equal(0, emails.Count);
+        }
+
+        //[IntegrationTest]
+        //public async Task ReturnsDistinctResultsBasedOnStartPage()
+        //{
+        //    var startOptions = new ApiOptions
+        //    {
+        //        PageSize = 5,
+        //        PageCount = 1
+        //    };
+
+        //    var firstPage = await _emailClient.GetAll(startOptions);
+
+        //    var skipStartOptions = new ApiOptions
+        //    {
+        //        PageSize = 5,
+        //        PageCount = 1,
+        //        StartPage = 2
+        //    };
+
+        //    var secondPage = await _emailClient.GetAll(skipStartOptions);
+
+        //    Assert.Equal(firstPage[0].Email, secondPage[0].Email);
+        //}
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
@@ -54,28 +54,5 @@ namespace Octokit.Tests.Integration
 
             Assert.Equal(0, emails.Count);
         }
-
-        //[IntegrationTest]
-        //public async Task ReturnsDistinctResultsBasedOnStartPage()
-        //{
-        //    var startOptions = new ApiOptions
-        //    {
-        //        PageSize = 5,
-        //        PageCount = 1
-        //    };
-
-        //    var firstPage = await _emailClient.GetAll(startOptions);
-
-        //    var skipStartOptions = new ApiOptions
-        //    {
-        //        PageSize = 5,
-        //        PageCount = 1,
-        //        StartPage = 2
-        //    };
-
-        //    var secondPage = await _emailClient.GetAll(skipStartOptions);
-
-        //    Assert.Equal(firstPage[0].Email, secondPage[0].Email);
-        //}
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
@@ -37,22 +37,7 @@ namespace Octokit.Tests.Integration
 
             var emails = await _emailClient.GetAll(options).ToList();
 
-            Assert.Equal(1, emails.Count);
-        }
-
-        [IntegrationTest]
-        public async Task ReturnsCorrectCountOfEmailsWithStart()
-        {
-            var options = new ApiOptions
-            {
-                PageSize = 5,
-                PageCount = 1,
-                StartPage = 2
-            };
-
-            var emails = await _emailClient.GetAll(options).ToList();
-
-            Assert.Equal(0, emails.Count);
+            Assert.NotEmpty(emails);
         }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserEmailsClientTests.cs
@@ -7,15 +7,19 @@ namespace Octokit.Tests.Integration
 {
     public class ObservableUserEmailsClientTests
     {
-        private readonly ObservableUserEmailsClient _emailClient
-            = new ObservableUserEmailsClient(Helper.GetAuthenticatedClient());
+        readonly ObservableUserEmailsClient _emailClient;
+
+        public ObservableUserEmailsClientTests()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _emailClient = new ObservableUserEmailsClient(github);
+        }
 
         [IntegrationTest]
         public async Task CanGetEmail()
         {
-            var client = new ObservableUserEmailsClient(Helper.GetAuthenticatedClient());
-
-            var email = await client.GetAll();
+            var email = await _emailClient.GetAll();
             Assert.NotNull(email);
         }
 
@@ -36,7 +40,6 @@ namespace Octokit.Tests.Integration
             };
 
             var emails = await _emailClient.GetAll(options).ToList();
-
             Assert.NotEmpty(emails);
         }
     }

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -8,7 +8,7 @@ namespace Octokit.Tests.Clients
 {
     public class UserEmailsClientTests
     {
-        public class TheGetAllMethod
+        public class TheGetAllMethods
         {
             [Fact]
             public void GetsCorrectUrl()
@@ -19,7 +19,26 @@ namespace Octokit.Tests.Clients
                 client.GetAll();
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"));
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), 
+                    Arg.Is(ApiOptions.None));
+            }
+
+            [Fact]
+            public void GetsCorrectUrlWithApiOptions()
+            {
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1
+                };
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new UserEmailsClient(connection);
+
+                client.GetAll(options);
+
+                connection.Received(1)
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Is<ApiOptions>(apiOptions => apiOptions == options));
             }
         }
 

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -26,19 +26,13 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void GetsCorrectUrlWithApiOptions()
             {
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1
-                };
-
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserEmailsClient(connection);
 
-                client.GetAll(options);
+                client.GetAll(ApiOptions.None);
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Is<ApiOptions>(apiOptions => apiOptions == options));
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Is<ApiOptions>(apiOptions => apiOptions == ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll(ApiOptions.None);
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Is<ApiOptions>(apiOptions => apiOptions == ApiOptions.None));
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Any<ApiOptions>());
             }
         }
 

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -1,7 +1,7 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -19,8 +19,8 @@ namespace Octokit.Tests.Clients
                 client.GetAll();
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), 
-                    Arg.Is(ApiOptions.None));
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"),
+                        Arg.Is(ApiOptions.None));
             }
 
             [Fact]
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll(ApiOptions.None);
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Arg.Any<ApiOptions>());
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Args.ApiOptions);
             }
         }
 

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received(1)
                     .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"),
-                        Arg.Is(ApiOptions.None));
+                        Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -8,7 +8,7 @@ namespace Octokit.Tests.Clients
 {
     public class UserEmailsClientTests
     {
-        public class TheGetAllMethods
+        public class TheGetAllMethod
         {
             [Fact]
             public void GetsCorrectUrl()

--- a/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
@@ -1,7 +1,7 @@
-﻿using NSubstitute;
-using Octokit.Reactive;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using NSubstitute;
+using Octokit.Reactive;
 using Xunit;
 
 namespace Octokit.Tests
@@ -18,25 +18,41 @@ namespace Octokit.Tests
 
         public class TheGetAllMethod
         {
+            private static readonly Uri _expectedUri = new Uri("user/emails", UriKind.Relative);
+
             [Fact]
             public void GetsCorrectUrl()
             {
-                var expectedUri = new Uri("user/emails", UriKind.Relative);
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserEmailsClient(github);
 
                 client.GetAll();
 
-                github.Connection.Received(1).GetResponse<List<EmailAddress>>(expectedUri);
+                github.Connection.Received(1).GetResponse<List<EmailAddress>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0));
+            }
+
+            [Fact]
+            public void GetsCorrectUrlWithApiOption()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableUserEmailsClient(github);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1
+                };
+
+                client.GetAll(options);
+
+                github.Connection.Received(1).GetResponse<List<EmailAddress>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 1));
             }
         }
 
         public class TheAddMethod
         {
-            public IGitHubClient GitHubClient;
-
-            public ObservableUserEmailsClient Client;
-
             [Fact]
             public void CallsAddOnClient()
             {

--- a/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
@@ -38,16 +38,10 @@ namespace Octokit.Tests
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserEmailsClient(github);
 
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1
-                };
-
-                client.GetAll(options);
+                client.GetAll(ApiOptions.None);
 
                 github.Connection.Received(1).GetResponse<List<EmailAddress>>(_expectedUri,
-                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 1));
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserEmailsClientTests.cs
@@ -28,8 +28,8 @@ namespace Octokit.Tests
 
                 client.GetAll();
 
-                github.Connection.Received(1).GetResponse<List<EmailAddress>>(_expectedUri,
-                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0));
+                github.Connection.Received(1).Get<List<EmailAddress>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
 
             [Fact]
@@ -40,8 +40,8 @@ namespace Octokit.Tests
 
                 client.GetAll(ApiOptions.None);
 
-                github.Connection.Received(1).GetResponse<List<EmailAddress>>(_expectedUri,
-                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0));
+                github.Connection.Received(1).Get<List<EmailAddress>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
         }
 

--- a/Octokit/Clients/IUserEmailsClient.cs
+++ b/Octokit/Clients/IUserEmailsClient.cs
@@ -23,6 +23,17 @@ namespace Octokit
         Task<IReadOnlyList<EmailAddress>> GetAll();
 
         /// <summary>
+        /// Gets all email addresses for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<EmailAddress>> GetAll(ApiOptions options);
+
+        /// <summary>
         /// Adds email addresses for the authenticated user.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/UserEmailsClient.cs
+++ b/Octokit/Clients/UserEmailsClient.cs
@@ -30,7 +30,21 @@ namespace Octokit
         /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
         public Task<IReadOnlyList<EmailAddress>> GetAll()
         {
-            return ApiConnection.GetAll<EmailAddress>(ApiUrls.Emails());
+            return GetAll(ApiOptions.None);
+        }
+        
+        /// <summary>
+        /// Gets all email addresses for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
+        /// </remarks>
+        /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        public Task<IReadOnlyList<EmailAddress>> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<EmailAddress>(ApiUrls.Emails(), options);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -74,6 +74,23 @@ namespace Octokit
             return connection.Get<T>(uri, null, null);
         }
 
+        /// <summary>
+        /// Gets the API resource at the specified URI.
+        /// </summary>
+        /// <typeparam name="T">Type of the API resource to get.</typeparam>
+        /// <param name="connection">The connection to use</param>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <returns>The API resource.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        public static Task<IApiResponse<T>> GetResponse<T>(this IConnection connection, Uri uri, Dictionary<string, string> parameters)
+        {
+            Ensure.ArgumentNotNull(connection, "connection");
+            Ensure.ArgumentNotNull(uri, "uri");
+
+            return connection.Get<T>(uri, parameters, null);
+        }
+
         [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public static Task<IApiResponse<T>> GetRedirect<T>(this IConnection connection, Uri uri)
         {

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -74,23 +74,6 @@ namespace Octokit
             return connection.Get<T>(uri, null, null);
         }
 
-        /// <summary>
-        /// Gets the API resource at the specified URI.
-        /// </summary>
-        /// <typeparam name="T">Type of the API resource to get.</typeparam>
-        /// <param name="connection">The connection to use</param>
-        /// <param name="uri">URI of the API resource to get</param>
-        /// <param name="parameters">Querystring parameters for the request</param>
-        /// <returns>The API resource.</returns>
-        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
-        public static Task<IApiResponse<T>> GetResponse<T>(this IConnection connection, Uri uri, Dictionary<string, string> parameters)
-        {
-            Ensure.ArgumentNotNull(connection, "connection");
-            Ensure.ArgumentNotNull(uri, "uri");
-
-            return connection.Get<T>(uri, parameters, null);
-        }
-
         [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
         public static Task<IApiResponse<T>> GetRedirect<T>(this IConnection connection, Uri uri)
         {

--- a/Octokit/Models/Request/ApiOptions.cs
+++ b/Octokit/Models/Request/ApiOptions.cs
@@ -7,9 +7,32 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ApiOptions
     {
+        private class ApiOptionsSingleton
+        {
+            private static readonly ApiOptions _instance = new ApiOptions();
+
+            // Explicit static constructor to tell C# compiler
+            // not to mark type as beforefieldinit
+            static ApiOptionsSingleton()
+            {
+            }
+
+            private ApiOptionsSingleton()
+            {
+            }
+
+            public static ApiOptions Instance
+            {
+                get
+                {
+                    return _instance;
+                }
+            }
+        }
+        
         public static ApiOptions None
         {
-            get { return new ApiOptions(); }
+            get { return ApiOptionsSingleton.Instance; }
         }
 
         /// <summary>

--- a/Octokit/Models/Request/ApiOptions.cs
+++ b/Octokit/Models/Request/ApiOptions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace Octokit
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class ApiOptions 
+    public class ApiOptions
     {
         public static ApiOptions None
         {

--- a/Octokit/Models/Request/ApiOptions.cs
+++ b/Octokit/Models/Request/ApiOptions.cs
@@ -5,26 +5,11 @@ using System.Diagnostics;
 namespace Octokit
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class ApiOptions
+    public class ApiOptions 
     {
-        private sealed class ApiOptionsSingleton
-        {
-            private static readonly Lazy<ApiOptions> _lazy =
-                new Lazy<ApiOptions>(() => new ApiOptions());
-
-            public static ApiOptions Instance
-            {
-                get { return _lazy.Value; }
-            }
-
-            private ApiOptionsSingleton()
-            {
-            }
-        }
-
         public static ApiOptions None
         {
-            get { return ApiOptionsSingleton.Instance; }
+            get { return new ApiOptions(); }
         }
 
         /// <summary>

--- a/Octokit/Models/Request/ApiOptions.cs
+++ b/Octokit/Models/Request/ApiOptions.cs
@@ -7,29 +7,21 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ApiOptions
     {
-        private class ApiOptionsSingleton
+        private sealed class ApiOptionsSingleton
         {
-            private static readonly ApiOptions _instance = new ApiOptions();
+            private static readonly Lazy<ApiOptions> _lazy =
+                new Lazy<ApiOptions>(() => new ApiOptions());
 
-            // Explicit static constructor to tell C# compiler
-            // not to mark type as beforefieldinit
-            static ApiOptionsSingleton()
+            public static ApiOptions Instance
             {
+                get { return _lazy.Value; }
             }
 
             private ApiOptionsSingleton()
             {
             }
-
-            public static ApiOptions Instance
-            {
-                get
-                {
-                    return _instance;
-                }
-            }
         }
-        
+
         public static ApiOptions None
         {
             get { return ApiOptionsSingleton.Instance; }
@@ -81,5 +73,4 @@ namespace Octokit
             }
         }
     }
-
 }


### PR DESCRIPTION
Refer #1182 .

To-do:

- [x]  Add an overload for Task<IReadOnlyList<EmailAddress>> GetAll() on IUserEmailsClient that use ApiOptions parameter.
- [x]  Add unit and integration tests for this new method (need some clarification)
- [x]  Add an overload for IObservable<EmailAddress> on IObservableUserEmailsClient that use ApiOptions parameter.
- [x]  Add unit and integration tests for this new method (need some clarification)

/cc @shiftkey 