### PR TITLE
sssh nuget.exe, there is no upset

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,9 +1,9 @@
 @echo off
 
-"tools\nuget\nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.1.0"
-"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.4.2"
-"tools\nuget\nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0"
-"tools\nuget\nuget.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre
+"tools\nuget\nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.1.0" -verbosity quiet
+"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.4.2" -verbosity quiet
+"tools\nuget\nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0" -verbosity quiet
+"tools\nuget\nuget.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre -verbosity quiet
 
 :Build
 cls


### PR DESCRIPTION
This tweaks the output of the bootstrapping steps we do with NuGet packages to be less noist.

So no more of this noise when you run `.\build *`

```
Attempting to gather dependencies information for package 'xunit.runner.console.2.1.0' with respect to project 'tools', targeting 'Any,Version=v0.0'
Using credentials from config. UserName: nuget
Attempting to resolve dependencies for package 'xunit.runner.console.2.1.0' with DependencyBehavior 'Lowest'
Resolving actions to install package 'xunit.runner.console.2.1.0'
Resolved actions to install package 'xunit.runner.console.2.1.0'
Adding package 'xunit.runner.console.2.1.0' to folder 'C:\projects\octokit-net\tools'
Added package 'xunit.runner.console.2.1.0' to folder 'C:\projects\octokit-net\tools'
Successfully installed 'xunit.runner.console 2.1.0' to tools
Feeds used:
  C:\Users\appveyor\AppData\Local\NuGet\Cache
  https://www.nuget.org/api/v2
  https://ci.appveyor.com/nuget/github-windows-yenytfg8kekv
  https://ci.appveyor.com/nuget/octokit-net
``` 
