### PR TITLE
Add ApiOption overloads to methods on IAuthorizationsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
@@ -19,6 +19,19 @@ namespace Octokit.Reactive
         IObservable<Authorization> GetAll();
 
         /// <summary>
+        /// Get all <see cref="Authorization"/>s for the authenticated user. This method requires basic auth.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more
+        /// details.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>An <see cref="Authorization"/></returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
+            Justification = "It's an API call, so it's not a property.")]
+        IObservable<Authorization> GetAll(ApiOptions options);
+
+        /// <summary>
         /// Get a specific <see cref="Authorization"/> for the authenticated user. This method requires basic auth.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
@@ -13,7 +13,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more
         /// details.
         /// </remarks>
-        /// <returns>An <see cref="Authorization"/></returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "It's an API call, so it's not a property.")]
         IObservable<Authorization> GetAll();
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// details.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>An <see cref="Authorization"/></returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "It's an API call, so it's not a property.")]
         IObservable<Authorization> GetAll(ApiOptions options);

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -25,10 +25,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<User> GetAllForRepository(string owner, string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Assignees(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more
         /// details.
         /// </remarks>
-        /// <returns>An <see cref="Authorization"/></returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         public IObservable<Authorization> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -39,7 +39,7 @@ namespace Octokit.Reactive
         /// details.
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>An <see cref="Authorization"/></returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         public IObservable<Authorization> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -28,7 +28,23 @@ namespace Octokit.Reactive
         /// <returns>An <see cref="Authorization"/></returns>
         public IObservable<Authorization> GetAll()
         {
-            return _connection.GetAndFlattenAllPages<Authorization>(ApiUrls.Authorizations());
+            return GetAll(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all <see cref="Authorization"/>s for the authenticated user. This method requires basic auth.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more
+        /// details.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>An <see cref="Authorization"/></returns>
+        public IObservable<Authorization> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Authorization>(ApiUrls.Authorizations(), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
@@ -13,7 +12,7 @@ namespace Octokit.Tests.Integration.Clients
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
                 note,
-                new string[] { "user" });
+                new[] { "user" });
 
             var created = await github.Authorization.Create(newAuthorization);
 
@@ -28,13 +27,46 @@ namespace Octokit.Tests.Integration.Clients
         }
 
         [IntegrationTest]
+        public async Task CanGetAuthorization()
+        {
+            var github = Helper.GetBasicAuthClient();
+            
+            var authorizations = await github.Authorization.GetAll();
+            Assert.NotEmpty(authorizations);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetAuthorizationWithApiOptions()
+        {
+            var github = Helper.GetBasicAuthClient();
+
+            var authorizations = await github.Authorization.GetAll(ApiOptions.None);
+            Assert.NotEmpty(authorizations);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsNotEmptyAuthorizationsWithoutStart()
+        {
+            var github = Helper.GetBasicAuthClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var authorizations = await github.Authorization.GetAll(options);
+            Assert.NotEmpty(authorizations);
+        }
+
+        [IntegrationTest]
         public async Task CannotCreatePersonalTokenWhenUsingOauthTokenCredentials()
         {
             var github = Helper.GetAuthenticatedClient();
             var note = Helper.MakeNameWithTimestamp("Testing authentication");
             var newAuthorization = new NewAuthorization(
                 note,
-                new string[] { "user" });
+                new[] { "user" });
 
             var error = Assert.ThrowsAsync<ForbiddenException>(() => github.Authorization.Create(newAuthorization));
             Assert.True(error.Result.Message.Contains("username and password Basic Auth"));

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
+    <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
     <Compile Include="Reactive\ObservableReleaseClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableAuthorizationsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableAuthorizationsClientTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableAuthorizationsClientTests
+    {
+        readonly ObservableAuthorizationsClient _authorizationsClient;
+
+        public ObservableAuthorizationsClientTests()
+        {
+            var github = Helper.GetBasicAuthClient();
+
+            _authorizationsClient = new ObservableAuthorizationsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetAuthorization()
+        {
+            var authorization = await _authorizationsClient.GetAll();
+            Assert.NotNull(authorization);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetAuthorizationWithApiOptions()
+        {
+            var authorization = await _authorizationsClient.GetAll(ApiOptions.None);
+            Assert.NotNull(authorization);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsNotEmptyAuthorizationsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var authorizations = await _authorizationsClient.GetAll(options).ToList();
+            Assert.NotEmpty(authorizations);
+        }
+    }
+}

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -4,14 +4,13 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class AssigneesClientTests
     {
-        public class TheGetForRepositoryMethod
+        public class TheGetAllMethod
         {
             [Fact]
             public void RequestsCorrectUrl()
@@ -29,6 +28,28 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new AssigneesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/assignees"),
+                    null,
+                    AcceptHeaders.StableVersion,
+                    options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new AssigneesClient(Substitute.For<IApiConnection>());
@@ -37,6 +58,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, ""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
             }
         }
 

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -43,12 +43,28 @@ namespace Octokit.Tests.Clients
             {
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
-                
-                authEndpoint.GetAll(ApiOptions.None);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                authEndpoint.GetAll(options);
 
                 client.Received().GetAll<Authorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations"),
-                    Args.ApiOptions);
+                    options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var authEndpoint = new AuthorizationsClient(client);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.GetAll(null));
             }
         }
 

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -37,6 +37,19 @@ namespace Octokit.Tests.Clients
                     Arg.Is<Uri>(u => u.ToString() == "authorizations"),
                     Args.ApiOptions);
             }
+
+            [Fact]
+            public void GetsAListOfAuthorizationsWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var authEndpoint = new AuthorizationsClient(client);
+                
+                authEndpoint.GetAll(ApiOptions.None);
+
+                client.Received().GetAll<Authorization>(
+                    Arg.Is<Uri>(u => u.ToString() == "authorizations"),
+                    Args.ApiOptions);
+            }
         }
 
         public class TheGetMethod

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void GetsAListOfAuthorizations()
+            public void RequestsCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);
@@ -39,7 +39,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsAListOfAuthorizationsWithApiOptions()
+            public void RequestsCorrectUrlWithApiOptions()
             {
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -25,12 +25,34 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var releasesClient = new ReleasesClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                releasesClient.GetAll("fake", "repo", options);
+
+                client.Received().GetAll<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
+                    null,
+                    "application/vnd.github.v3",
+                    options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var releasesClient = new ReleasesClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll("owner", "name", null));
             }
         }
 

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserEmailsClient(connection);
@@ -24,15 +24,31 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsCorrectUrlWithApiOptions()
+            public void RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new UserEmailsClient(connection);
 
-                client.GetAll(ApiOptions.None);
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(options);
 
                 connection.Received(1)
-                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"), Args.ApiOptions);
+                    .GetAll<EmailAddress>(Arg.Is<Uri>(u => u.ToString() == "user/emails"),
+                        options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var releasesClient = new UserEmailsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.GetAll(null));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
+    <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableAuthorizationsClientTests
+    {
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void GetsCorrectUrl()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var authEndpoint = new ObservableAuthorizationsClient(client);
+
+                authEndpoint.GetAll();
+
+                client.Connection.Received(1).Get<List<Authorization>>(Arg.Is<Uri>(u => u.ToString() == "authorizations"),
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+            }
+
+            [Fact]
+            public void GetsCorrectUrlWithApiOption()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var authEndpoint = new ObservableAuthorizationsClient(client);
+
+                authEndpoint.GetAll(ApiOptions.None);
+
+                client.Connection.Received(1).Get<List<Authorization>>(Arg.Is<Uri>(u => u.ToString() == "authorizations"),
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableAuthorizationsClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -27,11 +29,20 @@ namespace Octokit.Tests.Reactive
             {
                 var client = Substitute.For<IGitHubClient>();
                 var authEndpoint = new ObservableAuthorizationsClient(client);
-
+                
                 authEndpoint.GetAll(ApiOptions.None);
 
                 client.Connection.Received(1).Get<List<Authorization>>(Arg.Is<Uri>(u => u.ToString() == "authorizations"),
                     Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var authEndpoint = new ObservableAuthorizationsClient(client);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => authEndpoint.GetAll(null).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAuthorizationsClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsCorrectUrl()
             {
                 var client = Substitute.For<IGitHubClient>();
                 var authEndpoint = new ObservableAuthorizationsClient(client);
@@ -23,7 +23,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void GetsCorrectUrlWithApiOption()
+            public void RequestsCorrectUrlWithApiOption()
             {
                 var client = Substitute.For<IGitHubClient>();
                 var authEndpoint = new ObservableAuthorizationsClient(client);

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -36,7 +36,27 @@ namespace Octokit
         /// <returns>A list of <see cref="Authorization"/>s.</returns>
         public Task<IReadOnlyList<Authorization>> GetAll()
         {
-            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), ApiOptions.None);
+            return GetAll(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Authorization"/>s for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// This method requires authentication.
+        /// See the <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">
+        /// Thrown when the current user does not have permission to make the request.
+        /// </exception>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        public Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Authorization>(ApiUrls.Authorizations(), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         public Task<IReadOnlyList<Authorization>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -51,7 +51,7 @@ namespace Octokit
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         public Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "It's an API call, so it's not a property.")]
         Task<IReadOnlyList<Authorization>> GetAll();
@@ -43,7 +43,7 @@ namespace Octokit
         /// Thrown when the current user does not have permission to make the request.
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
             Justification = "It's an API call, so it's not a property.")]
         Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options);

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -32,6 +32,23 @@ namespace Octokit
         Task<IReadOnlyList<Authorization>> GetAll();
 
         /// <summary>
+        /// Gets all <see cref="Authorization"/>s for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// This method requires authentication.
+        /// See the <a href="http://developer.github.com/v3/oauth/#list-your-authorizations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">
+        /// Thrown when the current user does not have permission to make the request.
+        /// </exception>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of <see cref="Authorization"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
+            Justification = "It's an API call, so it's not a property.")]
+        Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options);
+
+        /// <summary>
         /// Gets a specific <see cref="Authorization"/> for the authenticated user.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Refer #1149  .

To-do:

- [x]  Add overload Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options) on IAuthorizationsClient.
- [x]  Add overload IObservable<Authorization> GetAll(ApiOptions options) on IObservableAuthorizationsClient.
- [x]  Add unit tests for these new methods.
- [x] Add integration tests for these new methods.

I have one question about integration tests for (Observable)AuthorizationsClient. There are no any integration tests for these clients, so should I add it?