### PR TITLE
Correct spelling: docmentation -> documentation

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -328,7 +328,7 @@ namespace Octokit.Reactive
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         IObservableReleasesClient Release { get; }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -475,7 +475,7 @@ namespace Octokit.Reactive
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         public IObservableReleasesClient Release { get; private set; }
 

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -274,7 +274,7 @@ namespace Octokit
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         IReleasesClient Release { get; }
 

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -396,7 +396,7 @@ namespace Octokit
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         public IReleasesClient Release { get; private set; }
 

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -147,7 +147,7 @@ namespace Octokit
         /// Access GitHub's Authorization API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/oauth_authorizations/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/oauth_authorizations/
         /// </remarks>
         public IAuthorizationsClient Authorization { get; private set; }
 
@@ -155,7 +155,7 @@ namespace Octokit
         /// Access GitHub's Activity API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/activity/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/
         /// </remarks>
         public IActivitiesClient Activity { get; private set; }
 
@@ -163,7 +163,7 @@ namespace Octokit
         /// Access GitHub's Issue API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/issues/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/issues/
         /// </remarks>
         public IIssuesClient Issue { get; private set; }
 
@@ -171,7 +171,7 @@ namespace Octokit
         /// Access GitHub's Miscellaneous API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/misc/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/misc/
         /// </remarks>
         public IMiscellaneousClient Miscellaneous { get; private set; }
 
@@ -179,7 +179,7 @@ namespace Octokit
         /// Access GitHub's OAuth API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/oauth/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/oauth/
         /// </remarks>
         public IOauthClient Oauth { get; private set; }
 
@@ -187,7 +187,7 @@ namespace Octokit
         /// Access GitHub's Organizations API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/orgs/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/orgs/
         /// </remarks>
         public IOrganizationsClient Organization { get; private set; }
 
@@ -195,7 +195,7 @@ namespace Octokit
         /// Access GitHub's Pull Requests API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/pulls/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/pulls/
         /// </remarks>
         public IPullRequestsClient PullRequest { get; private set; }
 
@@ -203,7 +203,7 @@ namespace Octokit
         /// Access GitHub's Repositories API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/
         /// </remarks>
         public IRepositoriesClient Repository { get; private set; }
 
@@ -211,7 +211,7 @@ namespace Octokit
         /// Access GitHub's Gists API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/gists/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/gists/
         /// </remarks>
         public IGistsClient Gist { get; private set; }
 
@@ -219,7 +219,7 @@ namespace Octokit
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         [Obsolete("Use Repository.Release instead")]
         public IReleasesClient Release
@@ -233,7 +233,7 @@ namespace Octokit
         /// Access GitHub's Public Keys API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/users/keys/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/users/keys/
         /// </remarks>
         public ISshKeysClient SshKey { get; private set; }
 
@@ -241,7 +241,7 @@ namespace Octokit
         /// Access GitHub's Users API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/users/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/users/
         /// </remarks>
         public IUsersClient User { get; private set; }
 
@@ -250,7 +250,7 @@ namespace Octokit
         /// Access GitHub's Notifications API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/activity/notifications/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/notifications/
         /// </remarks>
         public INotificationsClient Notification { get; private set; }
 
@@ -258,7 +258,7 @@ namespace Octokit
         /// Access GitHub's Git Data API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/git/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/git/
         /// </remarks>
         [Obsolete("Use Git instead")]
         public IGitDatabaseClient GitDatabase { get { return Git; } }
@@ -267,7 +267,7 @@ namespace Octokit
         /// Access GitHub's Git Data API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/git/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/git/
         /// </remarks>
         public IGitDatabaseClient Git { get; private set; }
 
@@ -275,7 +275,7 @@ namespace Octokit
         /// Access GitHub's Search API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/search/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/search/
         /// </remarks>
         public ISearchClient Search { get; private set; }
 
@@ -284,7 +284,7 @@ namespace Octokit
         /// Access GitHub's Deployments API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/deployments/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/deployments/
         /// </remarks>
         public IDeploymentsClient Deployment { get; private set; }
 
@@ -292,7 +292,7 @@ namespace Octokit
         /// Access GitHub's Enterprise API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/enterprise/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/enterprise/
         /// </remarks>
         public IEnterpriseClient Enterprise { get; private set; }
 

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -16,7 +16,7 @@ namespace Octokit
         /// Access GitHub's Authorization API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/oauth_authorizations/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/oauth_authorizations/
         /// </remarks>
         IAuthorizationsClient Authorization { get; }
 
@@ -24,7 +24,7 @@ namespace Octokit
         /// Access GitHub's Activity API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/activity/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/
         /// </remarks>
         IActivitiesClient Activity { get; }
 
@@ -32,7 +32,7 @@ namespace Octokit
         /// Access GitHub's Issue API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/issues/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/issues/
         /// </remarks>
         IIssuesClient Issue { get; }
 
@@ -40,7 +40,7 @@ namespace Octokit
         /// Access GitHub's Miscellaneous API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/misc/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/misc/
         /// </remarks>
         IMiscellaneousClient Miscellaneous { get; }
 
@@ -48,7 +48,7 @@ namespace Octokit
         /// Access GitHub's OAuth API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/oauth/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/oauth/
         /// </remarks>
         IOauthClient Oauth { get; }
 
@@ -56,7 +56,7 @@ namespace Octokit
         /// Access GitHub's Organizations API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/orgs/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/orgs/
         /// </remarks>
         IOrganizationsClient Organization { get; }
 
@@ -64,7 +64,7 @@ namespace Octokit
         /// Access GitHub's Pull Requests API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/pulls/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/pulls/
         /// </remarks>
         IPullRequestsClient PullRequest { get; }
 
@@ -72,7 +72,7 @@ namespace Octokit
         /// Access GitHub's Repositories API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/
         /// </remarks>
         IRepositoriesClient Repository { get; }
 
@@ -80,7 +80,7 @@ namespace Octokit
         /// Access GitHub's Gists API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/gists/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/gists/
         /// </remarks>
         IGistsClient Gist { get; }
 
@@ -89,7 +89,7 @@ namespace Octokit
         /// Access GitHub's Releases API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/repos/releases/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/repos/releases/
         /// </remarks>
         [Obsolete("Use Repository.Release instead")]
         IReleasesClient Release { get; }
@@ -100,7 +100,7 @@ namespace Octokit
         /// Access GitHub's Public Keys API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/users/keys/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/users/keys/
         /// </remarks>
         ISshKeysClient SshKey { get; }
 
@@ -108,7 +108,7 @@ namespace Octokit
         /// Access GitHub's Users API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/users/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/users/
         /// </remarks>
         IUsersClient User { get; }
 
@@ -117,7 +117,7 @@ namespace Octokit
         /// Access GitHub's Notifications API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/activity/notifications/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/notifications/
         /// </remarks>
         [System.Obsolete("Notifications are now available under the Activities client. This will be removed in a future update.")]
         INotificationsClient Notification { get; }
@@ -126,7 +126,7 @@ namespace Octokit
         /// Access GitHub's Git Data API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/git/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/git/
         /// </remarks>
         [Obsolete("Use Git instead")]
         IGitDatabaseClient GitDatabase { get; }
@@ -135,7 +135,7 @@ namespace Octokit
         /// Access GitHub's Git Data API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/git/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/git/
         /// </remarks>
         IGitDatabaseClient Git { get; }
 
@@ -143,7 +143,7 @@ namespace Octokit
         /// Access GitHub's Search API.
         /// </summary>
         /// <remarks>
-        /// Refer to the API docmentation for more information: https://developer.github.com/v3/search/
+        /// Refer to the API documentation for more information: https://developer.github.com/v3/search/
         /// </remarks>
         ISearchClient Search { get; }
 


### PR DESCRIPTION
Fixes #1202.

`docmentation -> doc'u'mentation`

Minor issue. Few files changed.
