### PR TITLE
RepositoriesClient.GetAllPublic() fails on GitHub Enterprise due to incorrect endpoint Uri

### DIFF
--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -269,7 +269,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllPublic();
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories"));
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories"));
             }
         }
 
@@ -285,7 +285,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories?since=364"));
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));
             }
 
             [Fact]
@@ -297,7 +297,7 @@ namespace Octokit.Tests.Clients
                 client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
-                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "/repositories?since=364"));
+                    .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -163,7 +163,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task ReturnsEveryPageOfRepositories()
             {
-                var firstPageUrl = new Uri("/repositories?since=364", UriKind.Relative);
+                var firstPageUrl = new Uri("repositories?since=364", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 IApiResponse<List<Repository>> firstPageResponse = new ApiResponse<List<Repository>>(

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// </summary>
         public static Uri AllPublicRepositories()
         {
-            return "/repositories".FormatUri();
+            return "repositories".FormatUri();
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit
         /// <param name="since">The integer ID of the last Repository that you’ve seen.</param>
         public static Uri AllPublicRepositories(long since)
         {
-            return "/repositories?since={0}".FormatUri(since);
+            return "repositories?since={0}".FormatUri(since);
         }
 
         /// <summary>

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -109,7 +109,15 @@ namespace Octokit.Internal
             HttpRequestMessage requestMessage = null;
             try
             {
-                var fullUri = new Uri(request.BaseAddress, request.Endpoint);
+                // Remove any leading slash from endpoint Uri (otherwise it clobbers the /api/v3/ in BaseAddress)
+                var endpoint = request.Endpoint;
+                if (!endpoint.IsAbsoluteUri && 
+                    endpoint.ToString().StartsWith("/", StringComparison.OrdinalIgnoreCase))
+                {
+                    endpoint = new Uri(endpoint.ToString().TrimStart('/'), UriKind.Relative);
+                }
+
+                var fullUri = new Uri(request.BaseAddress, endpoint);
                 requestMessage = new HttpRequestMessage(request.Method, fullUri);
 
                 foreach (var header in request.Headers)

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -109,15 +109,7 @@ namespace Octokit.Internal
             HttpRequestMessage requestMessage = null;
             try
             {
-                // Remove any leading slash from endpoint Uri (otherwise it clobbers the /api/v3/ in BaseAddress)
-                var endpoint = request.Endpoint;
-                if (!endpoint.IsAbsoluteUri && 
-                    endpoint.ToString().StartsWith("/", StringComparison.OrdinalIgnoreCase))
-                {
-                    endpoint = new Uri(endpoint.ToString().TrimStart('/'), UriKind.Relative);
-                }
-
-                var fullUri = new Uri(request.BaseAddress, endpoint);
+                var fullUri = new Uri(request.BaseAddress, request.Endpoint);
                 requestMessage = new HttpRequestMessage(request.Method, fullUri);
 
                 foreach (var header in request.Headers)


### PR DESCRIPTION
Due to shenanigans with the way dotnet joins`Uri` objects together, if any relative `Uri` endpoint starts with a leading slash, this "wipes out" the `/api/v3/` component of the `BaseAddress` for GitHub Enterprise.  

There were 2 occurrences of endpoint Uri's being set in `ApiUrls` helper class that had incorrect leading slashes on them, causing these calls (both for `RepositoriesClient.GetAllPublic()`) to return HTTP 406 "NotAccepted" errors when run against GitHub Enterprise due to the Url being incorrect.  These have now been corrected.

Additionally I have added a safety in `HttpClientAdapter` class, when constructing the full uri, to trim any leading slashes off relative Uri endpoint before joining it to `BaseAddress`.  
@shiftkey is this OK or is there another way you'd prefer to guard against this?