### PR TITLE
Redundant "this." qualifier was removed.

### DIFF
--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -66,7 +66,7 @@ namespace Octokit
             return new ApiInfo(Links.Clone(),
                                 OauthScopes.Clone(),
                                 AcceptedOauthScopes.Clone(),
-                                new string(this.Etag.ToCharArray()),
+                                new string(Etag.ToCharArray()),
                                 RateLimit.Clone());
         }
     }


### PR DESCRIPTION
Resharper has some useful code analysis that used to eliminate code redundancies. I used Resharper to find redundant "this." qualifiers and delete them.

Also, I want to deliver a few PR that are connected with some of redundancies in Octokit.Net, Have I open issue for each of them? Or I could create just PR without appropriate issue?

/cc @shiftkey 