### PR TITLE
Inconsistent modifiers declaration order was fixed.

### DIFF
--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -189,7 +189,7 @@ namespace Octokit.Tests.Http
             _response2 = response2;
         }
 
-        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (!_Response1Sent)
             {

--- a/Octokit/Http/Credentials.cs
+++ b/Octokit/Http/Credentials.cs
@@ -6,7 +6,7 @@ namespace Octokit
     {
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes"
             , Justification = "Credentials is immutable")]
-        public readonly static Credentials Anonymous = new Credentials();
+        public static readonly Credentials Anonymous = new Credentials();
 
         private Credentials()
         {

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -64,7 +64,7 @@ namespace Octokit.Internal
             return cancellationTokenForRequest;
         }
 
-        protected async virtual Task<IResponse> BuildResponse(HttpResponseMessage responseMessage)
+        protected virtual async Task<IResponse> BuildResponse(HttpResponseMessage responseMessage)
         {
             Ensure.ArgumentNotNull(responseMessage, "responseMessage");
 


### PR DESCRIPTION
Resharper has some useful code analysis that used to eliminate code redundancies. I used Resharper to find "Inconsistent modifiers declaration order" issues and fix them.