### PR TITLE
Fix common redundancies by resharper

### DIFF
--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         IObservableReleasesClient Release { get; }
         IObservableSshKeysClient SshKey { get; }
         IObservableUsersClient User { get; }
-        [System.Obsolete("Notifications are now available under the Activities client. This will be removed in a future update.")]
+        [Obsolete("Notifications are now available under the Activities client. This will be removed in a future update.")]
         IObservableNotificationsClient Notification { get; }
         IObservableGitDatabaseClient Git { get; }
         [Obsolete("Use Git instead")]

--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -10,8 +9,6 @@ public class BranchesClientTests
 {
     public class TheGetBranchesMethod
     {
-        public TheGetBranchesMethod() { }
-
         [IntegrationTest]
         public async Task ReturnsBranches()
         {

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration.Helpers;
 using Octokit.Tests.Integration;
@@ -7,8 +6,6 @@ using Xunit;
 
 public class CommitsClientTests
 {
-    public CommitsClientTests() { }
-
     [IntegrationTest]
     public async Task CanCreateAndRetrieveCommit()
     {

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 using Octokit.Tests.Integration.Helpers;
@@ -348,7 +347,7 @@ public class IssuesClientTests : IDisposable
     [IntegrationTest]
     public async Task CanAccessUrls()
     {
-        var expctedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
+        var expectedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
 
         var newIssue = new NewIssue("A test issue")
         {
@@ -358,9 +357,9 @@ public class IssuesClientTests : IDisposable
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
 
         Assert.NotNull(issue.CommentsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "comments")), issue.CommentsUrl);
+        Assert.Equal(new Uri(string.Format(expectedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "comments")), issue.CommentsUrl);
         Assert.NotNull(issue.EventsUrl);
-        Assert.Equal(new Uri(string.Format(expctedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "events")), issue.EventsUrl);
+        Assert.Equal(new Uri(string.Format(expectedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "events")), issue.EventsUrl);
     }
 
     public void Dispose()

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -42,7 +42,7 @@ namespace Octokit.Tests.Integration.Clients
 
                 // There shouldnt be any members that are in both groups if the role filter works correctly
                 var membersInBoth = adminMembers.Select(a => a.Id).Intersect(normalMembers.Select(n => n.Id));
-                Assert.True(!membersInBoth.Any());
+                Assert.NotEmpty(membersInBoth);
             }
 
             [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
-using Octokit;
-using Octokit.Tests.Integration;
-using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
@@ -47,7 +42,7 @@ namespace Octokit.Tests.Integration.Clients
 
                 // There shouldnt be any members that are in both groups if the role filter works correctly
                 var membersInBoth = adminMembers.Select(a => a.Id).Intersect(normalMembers.Select(n => n.Id));
-                Assert.True(membersInBoth.Count() == 0);
+                Assert.True(!membersInBoth.Any());
             }
 
             [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -42,7 +42,7 @@ namespace Octokit.Tests.Integration.Clients
 
                 // There shouldnt be any members that are in both groups if the role filter works correctly
                 var membersInBoth = adminMembers.Select(a => a.Id).Intersect(normalMembers.Select(n => n.Id));
-                Assert.NotEmpty(membersInBoth);
+                Assert.Empty(membersInBoth);
             }
 
             [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]

--- a/Octokit.Tests/Authentication/CredentialsTests.cs
+++ b/Octokit.Tests/Authentication/CredentialsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Octokit.Internal;
 using Xunit;
 
 namespace Octokit.Tests.Authentication
@@ -23,7 +22,7 @@ namespace Octokit.Tests.Authentication
             }
 
             [Fact]
-            public void ReturnsOuthWhenProvidedToken()
+            public void ReturnsOAuthWhenProvidedToken()
             {
                 var credentials = new Credentials("token");
                 Assert.Equal(AuthenticationType.Oauth, credentials.AuthenticationType);

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                     "text/plain");
             }
         }
-        public class TheRenderArbitrryMarkdownMethod
+        public class TheRenderArbitraryMarkdownMethod
         {
             [Fact]
             public async Task RequestsTheEmojiEndpoint()

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -2,7 +2,6 @@
 using System.Text;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 using System.Collections.Generic;
 
@@ -61,7 +60,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ReturnsContentsByRef()
             {
-                List<RepositoryContent> result = new List<RepositoryContent>() { new RepositoryContent() { } };
+                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
@@ -77,7 +76,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ReturnsContents()
             {
-                List<RepositoryContent> result = new List<RepositoryContent>() { new RepositoryContent() { } };
+                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Octokit.Tests.Clients
 {
@@ -111,7 +110,7 @@ namespace Octokit.Tests.Clients
             [InlineData(HttpStatusCode.OK, false)]
             public async Task ReturnsCorrectResultBasedOnStatus(HttpStatusCode status, bool expected)
             {
-                var response = Task.Factory.StartNew<HttpStatusCode>(() => status);
+                var response = Task.Factory.StartNew(() => status);
 
                 var connection = Substitute.For<IConnection>();
                 connection.Delete(Arg.Is<Uri>(u => u.ToString() == "user/starred/yes/no"))

--- a/Octokit.Tests/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests/Clients/UserAdministrationClientTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -141,7 +139,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Post<Authorization>(
                     Arg.Any<Uri>(),
                     Arg.Is<NewImpersonationToken>(a =>
-                        a.Scopes.Count() == scopes.Count() &&
+                        a.Scopes.Count() == scopes.Length &&
                         a.Scopes.ToList().All(s => scopes.Contains(s)) &&
                         scopes.ToList().All(s => a.Scopes.Contains(s))));
             }

--- a/Octokit.Tests/Exceptions/ForbiddenExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ForbiddenExceptionTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Exceptions
         public class TheConstructor
         {
             [Fact]
-            public void IdentifiesMaxLoginAttepmtsExceededReason()
+            public void IdentifiesMaxLoginAttemptsExceededReason()
             {
                 const string responseBody = "{\"message\":\"YOU SHALL NOT PASS!\"," +
                                             "\"documentation_url\":\"http://developer.github.com/v3\"}";

--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Octokit.Internal;
@@ -181,7 +178,7 @@ namespace Octokit.Tests.Http
     {
         readonly HttpResponseMessage _response1;
         readonly HttpResponseMessage _response2;
-        private bool _Response1Sent = false;
+        private bool _Response1Sent;
 
         public MockRedirectHandler(HttpResponseMessage response1, HttpResponseMessage response2 = null)
         {

--- a/Octokit.Tests/Reactive/AuthorizationExtensionsTests.cs
+++ b/Octokit.Tests/Reactive/AuthorizationExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Reactive
         public class TheGetOrCreateApplicationAuthenticationMethod
         {
             [Fact]
-            public async Task UsesCallbackToRetrievTwoFactorCode()
+            public async Task UsesCallbackToRetrieveTwoFactorCode()
             {
                 var firstResponse = new TwoFactorRequiredException(TwoFactorType.AuthenticatorApp);
                 var twoFactorChallengeResult = new TwoFactorChallengeResult("two-factor-code");

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NSubstitute;
+﻿using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
 
@@ -17,12 +16,12 @@ namespace Octokit.Tests
 
                 client.Queue("org");
                 github.Enterprise.SearchIndexing.Received(1).
-                    Queue(Arg.Is<string>("org"));
+                    Queue(Arg.Is("org"));
 
                 client.Queue("org", "repo");
                 github.Enterprise.SearchIndexing.Received(1).
-                    Queue(Arg.Is<string>("org"),
-                          Arg.Is<string>("repo"));
+                    Queue(Arg.Is("org"),
+                          Arg.Is("repo"));
             }
         }
 
@@ -36,7 +35,7 @@ namespace Octokit.Tests
 
                 client.QueueAll("org");
                 github.Enterprise.SearchIndexing.Received(1).
-                    QueueAll(Arg.Is<string>("org"));
+                    QueueAll(Arg.Is("org"));
             }
         }
 
@@ -50,12 +49,12 @@ namespace Octokit.Tests
 
                 client.QueueAllCode("org");
                 github.Enterprise.SearchIndexing.Received(1).
-                    QueueAllCode(Arg.Is<string>("org"));
+                    QueueAllCode(Arg.Is("org"));
 
                 client.QueueAllCode("org", "repo");
                 github.Enterprise.SearchIndexing.Received(1).
-                    QueueAllCode(Arg.Is<string>("org"),
-                                 Arg.Is<string>("repo"));
+                    QueueAllCode(Arg.Is("org"),
+                                 Arg.Is("repo"));
             }
         }
 
@@ -69,12 +68,12 @@ namespace Octokit.Tests
 
                 client.QueueAllIssues("org");
                 github.Enterprise.SearchIndexing.Received(1).
-                    QueueAllIssues(Arg.Is<string>("org"));
+                    QueueAllIssues(Arg.Is("org"));
 
                 client.QueueAllIssues("org", "repo");
                 github.Enterprise.SearchIndexing.Received(1).
-                    QueueAllIssues(Arg.Is<string>("org"),
-                                   Arg.Is<string>("repo"));
+                    QueueAllIssues(Arg.Is("org"),
+                                   Arg.Is("repo"));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -15,7 +12,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtorMethod
         {
             [Fact]
-            public void EnsuresArgumentIsNotNulll()
+            public void EnsuresArgumentIsNotNull()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableCommitsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
@@ -50,7 +50,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableUserAdministrationClient(gitHubClient);
 
-                client.CreateImpersonationToken("auser", new NewImpersonationToken(new string[] { "public_repo" }));
+                client.CreateImpersonationToken("auser", new NewImpersonationToken(new[] { "public_repo" }));
 
                 gitHubClient.User.Administration.Received().CreateImpersonationToken(
                     "auser",

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/comments/">Repository Comments API documentation</a> for more information.
         /// </remarks>
-        [System.Obsolete("Comment information is now available under the Comment property. This will be removed in a future update.")]
+        [Obsolete("Comment information is now available under the Comment property. This will be removed in a future update.")]
         IRepositoryCommentsClient RepositoryComments { get; }
 
         /// <summary>
@@ -226,7 +226,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/">Collaborators API documentation</a> for more details
         /// </remarks>
-        [System.Obsolete("Collaborator information is now available under the Collaborator property. This will be removed in a future update.")]
+        [Obsolete("Collaborator information is now available under the Collaborator property. This will be removed in a future update.")]
         IRepoCollaboratorsClient RepoCollaborators { get; }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/commits/">Commits API documentation</a> for more details
         ///</remarks>
-        [System.Obsolete("Commit information is now available under the Commit property. This will be removed in a future update.")]
+        [Obsolete("Commit information is now available under the Commit property. This will be removed in a future update.")]
         IRepositoryCommitsClient Commits { get; }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -348,7 +348,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/">Collaborators API documentation</a> for more details
         /// </remarks>
-        [System.Obsolete("Collaborator information is now available under the Collaborator property. This will be removed in a future update.")]
+        [Obsolete("Collaborator information is now available under the Collaborator property. This will be removed in a future update.")]
         public IRepoCollaboratorsClient RepoCollaborators { get; private set; }
 
         /// <summary>

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -119,7 +119,7 @@ namespace Octokit
         /// <remarks>
         /// Refer to the API documentation for more information: https://developer.github.com/v3/activity/notifications/
         /// </remarks>
-        [System.Obsolete("Notifications are now available under the Activities client. This will be removed in a future update.")]
+        [Obsolete("Notifications are now available under the Activities client. This will be removed in a future update.")]
         INotificationsClient Notification { get; }
 
         /// <summary>

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -203,7 +203,7 @@ namespace Octokit
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public RepositoryCollection Repos { get; set; }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public override IReadOnlyList<string> MergedQualifiers()
         {
             var parameters = new List<string>();

--- a/Octokit/Models/Response/CodeFrequency.cs
+++ b/Octokit/Models/Response/CodeFrequency.cs
@@ -42,7 +42,7 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "Number of weeks: {0}", AdditionsAndDeletionsByWeek.Count());
+                    "Number of weeks: {0}", AdditionsAndDeletionsByWeek.Count);
             }
         }
     }

--- a/Octokit/Models/Response/CommitActivity.cs
+++ b/Octokit/Models/Response/CommitActivity.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -29,7 +28,7 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "Weeks of activity: {0}", Activity.Count());
+                    "Weeks of activity: {0}", Activity.Count);
             }
         }
     }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1762,7 +1762,7 @@ namespace Octokit
                 if (typeof(IDictionary<,>).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
                     return true;
 #else
-                if (typeof(System.Collections.IDictionary).IsAssignableFrom(type))
+                if (typeof(IDictionary).IsAssignableFrom(type))
                     return true;
 #endif
                 if (!GetTypeInfo(type).IsGenericType)
@@ -2166,7 +2166,7 @@ namespace Octokit
                     return _dictionary.GetEnumerator();
                 }
 
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+                IEnumerator IEnumerable.GetEnumerator()
                 {
                     return _dictionary.GetEnumerator();
                 }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1457,9 +1457,9 @@ namespace Octokit
                         {
                             var ctorType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType);
                             var genericReadonlyType = typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType);
-                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, new [] { ctorType });
+                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, ctorType);
                             Debug.Assert(ctor != null);
-                            obj = ctor.Invoke(new[] { obj });
+                            obj = ctor.Invoke(obj);
                         }
 #endif
                     }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1457,7 +1457,7 @@ namespace Octokit
                         {
                             var ctorType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType);
                             var genericReadonlyType = typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType);
-                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, new Type[] { ctorType });
+                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, new [] { ctorType });
                             Debug.Assert(ctor != null);
                             obj = ctor.Invoke(new[] { obj });
                         }
@@ -2011,7 +2011,7 @@ namespace Octokit
                 ParameterExpression value = Expression.Parameter(typeof(object), "value");
                 UnaryExpression instanceCast = (!IsValueType(propertyInfo.DeclaringType)) ? Expression.TypeAs(instance, propertyInfo.DeclaringType) : Expression.Convert(instance, propertyInfo.DeclaringType);
                 UnaryExpression valueCast = (!IsValueType(propertyInfo.PropertyType)) ? Expression.TypeAs(value, propertyInfo.PropertyType) : Expression.Convert(value, propertyInfo.PropertyType);
-                Action<object, object> compiled = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setMethodInfo, valueCast), new ParameterExpression[] { instance, value }).Compile();
+                Action<object, object> compiled = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setMethodInfo, valueCast), instance, value).Compile();
                 return delegate (object source, object val) { compiled(source, val); };
             }
 

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1457,9 +1457,9 @@ namespace Octokit
                         {
                             var ctorType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType);
                             var genericReadonlyType = typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType);
-                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, ctorType);
+                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, new Type[] { ctorType });
                             Debug.Assert(ctor != null);
-                            obj = ctor.Invoke(obj);
+                            obj = ctor.Invoke(new[] { obj });
                         }
 #endif
                     }
@@ -1762,7 +1762,7 @@ namespace Octokit
                 if (typeof(IDictionary<,>).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
                     return true;
 #else
-                if (typeof(IDictionary).IsAssignableFrom(type))
+                if (typeof(System.Collections.IDictionary).IsAssignableFrom(type))
                     return true;
 #endif
                 if (!GetTypeInfo(type).IsGenericType)
@@ -2011,7 +2011,7 @@ namespace Octokit
                 ParameterExpression value = Expression.Parameter(typeof(object), "value");
                 UnaryExpression instanceCast = (!IsValueType(propertyInfo.DeclaringType)) ? Expression.TypeAs(instance, propertyInfo.DeclaringType) : Expression.Convert(instance, propertyInfo.DeclaringType);
                 UnaryExpression valueCast = (!IsValueType(propertyInfo.PropertyType)) ? Expression.TypeAs(value, propertyInfo.PropertyType) : Expression.Convert(value, propertyInfo.PropertyType);
-                Action<object, object> compiled = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setMethodInfo, valueCast), instance, value).Compile();
+                Action<object, object> compiled = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setMethodInfo, valueCast), new ParameterExpression[] { instance, value }).Compile();
                 return delegate (object source, object val) { compiled(source, val); };
             }
 
@@ -2166,7 +2166,7 @@ namespace Octokit
                     return _dictionary.GetEnumerator();
                 }
 
-                IEnumerator IEnumerable.GetEnumerator()
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
                 {
                     return _dictionary.GetEnumerator();
                 }


### PR DESCRIPTION
I've removed some common redundancies of code from Octokit.Net.

List of redundancies:

1. Redundant explicit array creation in argument of 'params' parameter.
2. Redundant type qualifiers.
3. Empty constructors.
4.  Redundant explicit array type specification.
5. Redundant member initializers.
6.  Redundant collection list initializers.
7.  Unused "using" directives were removed (in modified files).
8. Some misspellings were fixed.

This PR was made in order to support code quality in Octokit.Net.