### PR TITLE
Add ApiOptions overloads to ITeamsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -27,9 +27,19 @@ namespace Octokit.Reactive
         /// <summary>
         /// Returns all <see cref="Team" />s for the current org.
         /// </summary>
+        /// <param name="org">Organization to list all teams of.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
         IObservable<Team> GetAll(string org);
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current org.
+        /// </summary>
+        /// <param name="org">Organization to list all teams of.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        IObservable<Team> GetAll(string org, ApiOptions options);
 
         /// <summary>
         /// Returns all <see cref="Team" />s for the current user.
@@ -40,15 +50,36 @@ namespace Octokit.Reactive
         IObservable<Team> GetAllForCurrent();
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<Team> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
+        /// <param name="id">The team identifier</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         IObservable<User> GetAllMembers(int id);
+
+        /// <summary>
+        /// Returns all members of the given team. 
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        IObservable<User> GetAllMembers(int id, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
@@ -116,9 +147,19 @@ namespace Octokit.Reactive
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>
+        /// <param name="id">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
         IObservable<Repository> GetAllRepositories(int id);
+
+        /// <summary>
+        /// Returns all team's repositories.
+        /// </summary>
+        /// <param name="id">Team Id.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The team's repositories</returns>
+        IObservable<Repository> GetAllRepositories(int id, ApiOptions options);
 
         /// <summary>
         /// Remove a repository from the team

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -47,6 +47,8 @@ namespace Octokit.Reactive
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
         public IObservable<Team> GetAll(string org)
         {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+
             return GetAll(org, ApiOptions.None);
         }
 
@@ -126,6 +128,9 @@ namespace Octokit.Reactive
         /// <returns>Newly created <see cref="Team"/></returns>
         public IObservable<Team> Create(string org, NewTeam team)
         {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(team, "team");
+
             return _client.Create(org, team).ToObservable();
         }
 
@@ -136,6 +141,8 @@ namespace Octokit.Reactive
         /// <returns>Updated <see cref="Team"/></returns>
         public IObservable<Team> Update(int id, UpdateTeam team)
         {
+            Ensure.ArgumentNotNull(team, "team");
+
             return _client.Update(id, team).ToObservable();
         }
 
@@ -161,6 +168,8 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public IObservable<TeamMembership> AddMembership(int id, string login)
         {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
             return _client.AddMembership(id, login).ToObservable();
         }
 
@@ -175,6 +184,8 @@ namespace Octokit.Reactive
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
         public IObservable<bool> RemoveMembership(int id, string login)
         {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
             return _client.RemoveMembership(id, login).ToObservable();
         }
 
@@ -188,6 +199,8 @@ namespace Octokit.Reactive
         [Obsolete("Use GetMembership(id, login) to detect pending memberships")]
         public IObservable<bool> IsMember(int id, string login)
         {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
             return _client.IsMember(id, login).ToObservable();
         }
 
@@ -200,6 +213,8 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public IObservable<TeamMembership> GetMembership(int id, string login)
         {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
             return _client.GetMembership(id, login).ToObservable();
         }
 
@@ -240,6 +255,9 @@ namespace Octokit.Reactive
         /// <returns><see langword="true"/> if the repository was added to the team; <see langword="false"/> otherwise.</returns>
         public IObservable<bool> AddRepository(int id, string organization, string repoName)
         {
+            Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
+            Ensure.ArgumentNotNullOrEmptyString(repoName, "repoName");
+
             return _client.AddRepository(id, organization, repoName).ToObservable();
         }
 
@@ -251,6 +269,9 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<bool> RemoveRepository(int id, string organization, string repoName)
         {
+            Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
+            Ensure.ArgumentNotNullOrEmptyString(repoName, "repoName");
+
             return _client.RemoveRepository(id, organization, repoName).ToObservable();
         }
 
@@ -266,6 +287,8 @@ namespace Octokit.Reactive
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
         public IObservable<bool> IsRepositoryManagedByTeam(int id, string owner, string repo)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
             return _client.IsRepositoryManagedByTeam(id, owner, repo).ToObservable();
         }
     }

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -47,8 +47,22 @@ namespace Octokit.Reactive
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
         public IObservable<Team> GetAll(string org)
         {
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current org.
+        /// </summary>
+        /// <param name="org">Organization to list all teams of.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        public IObservable<Team> GetAll(string org, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
-            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.OrganizationTeams(org));
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.OrganizationTeams(org), options);
         }
 
         /// <summary>
@@ -58,7 +72,20 @@ namespace Octokit.Reactive
         /// <returns>A list of the user's <see cref="Team"/>s.</returns>
         public IObservable<Team> GetAllForCurrent()
         {
-            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.UserTeams());
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        public IObservable<Team> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.UserTeams(), options);
         }
 
         /// <summary>
@@ -72,7 +99,24 @@ namespace Octokit.Reactive
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         public IObservable<User> GetAllMembers(int id)
         {
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.TeamMembers(id));
+            return GetAllMembers(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all members of the given team. 
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        public IObservable<User> GetAllMembers(int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.TeamMembers(id), options);
         }
 
         /// <summary>
@@ -166,7 +210,21 @@ namespace Octokit.Reactive
         /// <returns>The team's repositories</returns>
         public IObservable<Repository> GetAllRepositories(int id)
         {
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.TeamRepositories(id));
+            return GetAllRepositories(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all team's repositories.
+        /// </summary>
+        /// <param name="id">Team Id.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The team's repositories</returns>
+        public IObservable<Repository> GetAllRepositories(int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.TeamRepositories(id), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -48,7 +48,7 @@ public class TeamsClientTests
     public class TheGetAllForCurrentMethod
     {
         [IntegrationTest]
-        public async Task GetsIsMemberWhenAuthenticated()
+        public async Task GetsAllForCurrentWhenAuthenticated()
         {
             var github = Helper.GetAuthenticatedClient();
             var teams = await github.Organization.Team.GetAllForCurrent();

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -10,13 +10,13 @@ public class ObservableTeamsClientTests
 {
     public class TheGetMembersMethod
     {
-        readonly Team team;
+        readonly Team _team;
 
         public TheGetMembersMethod()
         {
             var github = Helper.GetAuthenticatedClient();
 
-            team = github.Organization.Team.GetAll(Helper.Organization).Result.First();
+            _team = github.Organization.Team.GetAll(Helper.Organization).Result.First();
         }
 
         [OrganizationTest]
@@ -26,7 +26,7 @@ public class ObservableTeamsClientTests
 
             var client = new ObservableTeamsClient(github);
 
-            var member = await client.GetAllMembers(team.Id, ApiOptions.None);
+            var member = await client.GetAllMembers(_team.Id, ApiOptions.None);
 
             Assert.Equal(Helper.UserName, member.Login);
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -26,7 +26,7 @@ public class ObservableTeamsClientTests
 
             var client = new ObservableTeamsClient(github);
 
-            var member = await client.GetAllMembers(team.Id);
+            var member = await client.GetAllMembers(team.Id, ApiOptions.None);
 
             Assert.Equal(Helper.UserName, member.Login);
         }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -46,7 +46,9 @@ namespace Octokit.Tests.Clients
 
                 client.GetAll("orgName");
 
-                connection.Received().GetAll<Team>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName/teams"));
+                connection.Received().GetAll<Team>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/orgName/teams"),
+                    Args.ApiOptions);
             }
 
             [Fact]
@@ -55,6 +57,7 @@ namespace Octokit.Tests.Clients
                 var teams = new TeamsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => teams.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.GetAll("orgName", null));
             }
         }
 
@@ -68,7 +71,9 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllMembers(1);
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "teams/1/members"));
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/members"),
+                    Args.ApiOptions);
             }
         }
 
@@ -189,7 +194,9 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForCurrent();
 
-                connection.Received().GetAll<Team>(Arg.Is<Uri>(u => u.ToString() == "user/teams"));
+                connection.Received().GetAll<Team>(
+                    Arg.Is<Uri>(u => u.ToString() == "user/teams"),
+                    Args.ApiOptions);
             }
         }
 
@@ -244,13 +251,12 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
-                client.GetAllRepositories(1);
-
-                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"));
 
                 client.GetAllRepositories(1);
 
-                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"));
+                connection.Received().GetAll<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"),
+                    Args.ApiOptions);
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Reactive\ObservableGistsTests.cs" />
     <Compile Include="Reactive\ObservableStarredClientTests.cs" />
     <Compile Include="Reactive\ObservableStatisticsClientTests.cs" />
+    <Compile Include="Reactive\ObservableTeamsClientTests.cs" />
     <Compile Include="Reactive\ObservableTreesClientTests.cs" />
     <Compile Include="Reactive\ObservableFollowersTest.cs" />
     <Compile Include="Reactive\ObservableUserKeysClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableTeamsClientTests
+    {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var team = new NewTeam("avengers");
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                client.Create("shield", team);
+
+                github.Organization.Team.Received().Create("shield", team);
+            }
+
+            [Fact]
+            public void EnsuresNotNullAndNonEmptyArguments()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("shield", null).ToTask());
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, new NewTeam("avengers")).ToTask());
+                Assert.ThrowsAsync<ArgumentException>(() => client.Create("", new NewTeam("avengers")).ToTask());
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNotNullGitHubClient()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableTeamsClient(null));
+            }
+        } 
+    }
+}

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -30,9 +30,19 @@ namespace Octokit
         /// <summary>
         /// Returns all <see cref="Team" />s for the current org.
         /// </summary>
+        /// <param name="org">Organization for which to list all teams.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
         Task<IReadOnlyList<Team>> GetAll(string org);
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current org.
+        /// </summary>
+        /// <param name="org">Organization for which to list all teams.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        Task<IReadOnlyList<Team>> GetAll(string org, ApiOptions options);
 
         /// <summary>
         /// Returns all <see cref="Team" />s for the current user.
@@ -43,6 +53,15 @@ namespace Octokit
         Task<IReadOnlyList<Team>> GetAllForCurrent();
 
         /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<Team>> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
         /// <param name="id">The team identifier</param>
@@ -51,6 +70,17 @@ namespace Octokit
         /// </remarks>
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         Task<IReadOnlyList<User>> GetAllMembers(int id);
+
+        /// <summary>
+        /// Returns all members of the given team. 
+        /// </summary>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
@@ -118,9 +148,19 @@ namespace Octokit
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>
+        /// <param name="id">Team Id to list repos.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
         Task<IReadOnlyList<Repository>> GetAllRepositories(int id);
+
+        /// <summary>
+        /// Returns all team's repositories.
+        /// </summary>
+        /// <param name="id">Team Id to list repos.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The team's repositories</returns>
+        Task<IReadOnlyList<Repository>> GetAllRepositories(int id, ApiOptions options);
 
         /// <summary>
         /// Add a repository to the team

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -42,14 +42,28 @@ namespace Octokit
         /// <summary>
         /// Returns all <see cref="Team" />s for the current org.
         /// </summary>
+        /// <param name="org">Organization to list teams of.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
         public Task<IReadOnlyList<Team>> GetAll(string org)
         {
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current org.
+        /// </summary>
+        /// <param name="org">Organization to list teams of.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        public Task<IReadOnlyList<Team>> GetAll(string org, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
 
             var endpoint = ApiUrls.OrganizationTeams(org);
-            return ApiConnection.GetAll<Team>(endpoint);
+            return ApiConnection.GetAll<Team>(endpoint, options);
         }
 
         /// <summary>
@@ -59,8 +73,22 @@ namespace Octokit
         /// <returns>A list of the user's <see cref="Team"/>s.</returns>
         public Task<IReadOnlyList<Team>> GetAllForCurrent()
         {
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Team" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        public Task<IReadOnlyList<Team>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             var endpoint = ApiUrls.UserTeams();
-            return ApiConnection.GetAll<Team>(endpoint);
+
+            return ApiConnection.GetAll<Team>(endpoint, options);
         }
 
         /// <summary>
@@ -73,9 +101,25 @@ namespace Octokit
         /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         public Task<IReadOnlyList<User>> GetAllMembers(int id)
         {
+            return GetAllMembers(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all members of the given team. 
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        public Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             var endpoint = ApiUrls.TeamMembers(id);
 
-            return ApiConnection.GetAll<User>(endpoint);
+            return ApiConnection.GetAll<User>(endpoint, options);
         }
 
         /// <summary>
@@ -236,13 +280,28 @@ namespace Octokit
         /// <summary>
         /// Returns all team's repositories.
         /// </summary>
+        /// <param name="id">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
         public Task<IReadOnlyList<Repository>> GetAllRepositories(int id)
         {
+            return GetAllRepositories(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all team's repositories.
+        /// </summary>
+        /// <param name="id">Team Id.</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The team's repositories</returns>
+        public Task<IReadOnlyList<Repository>> GetAllRepositories(int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             var endpoint = ApiUrls.TeamRepositories(id);
 
-            return ApiConnection.GetAll<Repository>(endpoint);
+            return ApiConnection.GetAll<Repository>(endpoint, options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1181 .

Checklist:

- [x] Add an overload for this method on `ITeamsClient` with a new parameter `ApiOptions`
- [x] Implement the new method on the class which implements `ITeamsClient`
- [x] Add an overload for this method on `IObservableTeamsClient` with a new parameter `ApiOptions`
- [x] Implement the new method on the class which implements `IObservableTeamsClient`
- [x] Reactive client tests.
- [x] Integration tests.

As I was doing this, a couple of questions sprung up in my mind:

- ~~After adding `ApiOptions` overload to the methods, we change the implementation of the old method to just call the new one with `ApiOptions.None`. Why don't we just write one method and use default values of `ApiOptions.None`?~~ see discussion
- ~~Secondly, modifying the test for the overloads requires you to check for `Args.ApiOptions`, neither `ApiOptions.None` nor `Arg.Any<ApiOptions>(ApiOptions.None)` work. Why is that so?~~ see discussion

/cc @shiftkey @ryangribble 