### PR TITLE
Add ApiOption overloads to methods on ICommitStatusClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -16,6 +16,18 @@ namespace Octokit.Reactive
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>        
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options);
+
+        /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -31,8 +31,8 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
-                        
-            return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference));
+
+            return GetAll(owner, name ,reference, ApiOptions.None);                  
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -28,7 +28,31 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+                        
             return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference));
+        }
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>        
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options"); 
+
+            return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference),options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<Release>(ApiUrls.Releases(owner, name));
+            return GetAll(owner, name, ApiOptions.None);            
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
+    <Compile Include="Reactive\ObservableCommitStatusClientTests.cs" />
     <Compile Include="Reactive\ObservableReleaseClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />
     <Compile Include="Clients\ReleasesClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
@@ -1,0 +1,88 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableCommitStatusClientTests
+    {
+        public class TheGetAllMethod
+        {
+            readonly ObservableCommitStatusClient _commitStatusClient;
+            const string owner = "octokit";
+            const string name = "octokit.net";
+            const string reference = "master";
+
+            public TheGetAllMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                _commitStatusClient = new ObservableCommitStatusClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnCommitStatus()
+            {
+                var commitStatus = await _commitStatusClient.GetAll(owner, name, reference).ToList();
+
+                Assert.NotEmpty(commitStatus);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfCommitStatusWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var commitStatus = await _commitStatusClient.GetAll(owner, name ,reference , options).ToList();
+
+                Assert.Equal(5, commitStatus.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfCommitStatusWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var commitStatus = await _commitStatusClient.GetAll(owner, name, reference, options).ToList();
+
+                Assert.Equal(5, commitStatus.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstPage = await _commitStatusClient.GetAll(owner, name, reference, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await _commitStatusClient.GetAll(owner, name, reference,skipStartOptions).ToList();             
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+                Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
+                Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Integration.Reactive
             readonly ObservableCommitStatusClient _commitStatusClient;
             const string owner = "octokit";
             const string name = "octokit.net";
-            const string reference = "master";
+            const string reference = "1335f37";   
 
             public TheGetAllMethod()
             {
@@ -33,7 +33,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var options = new ApiOptions
                 {
-                    PageSize = 5,
+                    PageSize = 2,
                     PageCount = 1
                 };
 
@@ -47,14 +47,14 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var options = new ApiOptions
                 {
-                    PageSize = 5,
+                    PageSize = 2,
                     PageCount = 1,
                     StartPage = 1
                 };
 
                 var commitStatus = await _commitStatusClient.GetAll(owner, name, reference, options).ToList();
 
-                Assert.Equal(5, commitStatus.Count);
+                Assert.Equal(2, commitStatus.Count);
             }
 
             [IntegrationTest]
@@ -62,7 +62,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var startOptions = new ApiOptions
                 {
-                    PageSize = 5,
+                    PageSize = 2,
                     PageCount = 1
                 };
 
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Integration.Reactive
 
                 var skipStartOptions = new ApiOptions
                 {
-                    PageSize = 5,
+                    PageSize = 2,
                     PageCount = 1,
                     StartPage = 2
                 };
@@ -78,10 +78,7 @@ namespace Octokit.Tests.Integration.Reactive
                 var secondPage = await _commitStatusClient.GetAll(owner, name, reference,skipStartOptions).ToList();             
 
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
-                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
-                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
-                Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
-                Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);                
             }
         }
     }

--- a/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCommitStatusClientTests.cs
@@ -39,7 +39,7 @@ namespace Octokit.Tests.Integration.Reactive
 
                 var commitStatus = await _commitStatusClient.GetAll(owner, name ,reference , options).ToList();
 
-                Assert.Equal(5, commitStatus.Count);
+                Assert.Equal(2, commitStatus.Count);
             }
 
             [IntegrationTest]

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("fake", "repo", "sha", options);
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"),options);
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), Args.ApiOptions);
             }
 
 

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAll("fake", "repo",options, "sha");
+                client.GetAll("fake", "repo", "sha", options);
 
                 connection.Received()
                     .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("fake", "repo", "sha", options);
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"),options);
             }
 
 

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -22,6 +22,25 @@ namespace Octokit.Tests.Clients
                 connection.Received()
                     .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));
             }
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("fake", "repo",options, "sha");
+
+                connection.Received()
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));
+            }
+
 
             [Fact]
             public async Task EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -20,7 +20,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("fake", "repo", "sha");
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"));
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), Arg.Any<ApiOptions>());
             }
             [Fact]
             public void RequestsCorrectUrlWithApiOptions()

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -29,7 +29,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<Release>>(
-                    new Uri("repos/fake/repo/releases", UriKind.Relative), null, null);
+                    new Uri("repos/fake/repo/releases", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -36,7 +36,29 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference));
+            return GetAll(owner,name,ApiOptions.None,reference);            
+        }
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, ApiOptions options, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference),options);
         }
 
         /// <summary>

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return GetAll(owner,name,ApiOptions.None,reference);            
+            return GetAll(owner,name,reference,ApiOptions.None);            
         }
 
         /// <summary>
@@ -47,16 +47,16 @@ namespace Octokit
         /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
+        /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, ApiOptions options, string reference)
+        public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(options, "options");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");            
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference),options);
         }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -32,11 +32,11 @@ namespace Octokit
         /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
+        /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, ApiOptions options, string reference);
+        Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -25,6 +25,20 @@ namespace Octokit
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, ApiOptions options, string reference);
+
+        /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>


### PR DESCRIPTION
This implementation targets the issue [#1150](https://github.com/octokit/octokit.net/issues/1150)

- [x] Add an overload for the GetAll method on ICommitStatusClient with a new parameter ApiOptions
- [x] Implement the the new method on the class which implements ICommitStatusClient
- [x] Add an overload for the GetAll method on IObservableCommitStatusClient with a new parameter ApiOptions
- [x] Implement the new method on the class which implements IObservableCommitStatusClient
- [x] Implement the RequestsCorrectUrlWithApiOptions unit test
- [x] Implement the integration tests

Ps: this is my first contribution to this repo, your remarks are welcome
@shiftkey 