### PR TITLE
Duplicated code was removed in SearchClientTests.

### DIFF
--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using NSubstitute;
 using Xunit;
 using System.Threading.Tasks;
@@ -1612,21 +1611,6 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+repo:octokit/octokit.net"));
-            }
-
-            [Fact]
-            public void TestingTheRepoQualifier_InConstructor()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something", "octokit", "octokit.net");
-
-                client.SearchCode(request);
-
-                connection.Received().Get<SearchCodeResult>(
-                    Arg.Is<Uri>(u => u.ToString() == "search/code"),
-                    Arg.Is<Dictionary<string, string>>(d =>
-                        d["q"] == "something+repo:octokit/octokit.net"));
             }
 
             [Fact]


### PR DESCRIPTION
I found methods with duplicated piece of code in SearchClientTests.cs (TestingTheRepoQualifier and TestingTheRepoQualifier_InConstructor) and just remove it.