### PR TITLE
ObservableReleasesClient.GetAll should use overloads properly

### DIFF
--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, name, ApiOptions.None);            
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -29,7 +29,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<Release>>(
-                    new Uri("repos/fake/repo/releases", UriKind.Relative), Args.EmptyDictionary, null);
+                    new Uri("repos/fake/repo/releases", UriKind.Relative), Arg.Any<Dictionary<string,string>>(), null);
             }
 
             [Fact]


### PR DESCRIPTION
See comment: https://github.com/octokit/octokit.net/pull/1213#issuecomment-200981143

 - [x] fix impacted tests