### PR TITLE
Add ApiOption overloads to methods on IDeploymentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
@@ -17,6 +17,19 @@ namespace Octokit.Reactive
         IObservable<Deployment> GetAll(string owner, string name);
 
         /// <summary>
+        /// Gets all the deployments for the specified repository. Any user with pull access
+        /// to a repository can view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployments
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
+        IObservable<Deployment> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Creates a new deployment for the specified repository.
         /// Users with push access can create a deployment for a given ref.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
@@ -31,11 +31,7 @@ namespace Octokit.Reactive.Clients
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         public IObservable<Deployment> GetAll(string owner, string name)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return _connection.GetAndFlattenAllPages<Deployment>(
-                ApiUrls.Deployments(owner, name));
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
@@ -31,6 +31,9 @@ namespace Octokit.Reactive.Clients
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         public IObservable<Deployment> GetAll(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetAll(owner, name, ApiOptions.None);
         }
 

--- a/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
@@ -39,6 +39,27 @@ namespace Octokit.Reactive.Clients
         }
 
         /// <summary>
+        /// Gets all the deployments for the specified repository. Any user with pull access
+        /// to a repository can view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployments
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
+        public IObservable<Deployment> GetAll(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Deployment>(
+                ApiUrls.Deployments(owner, name), options);
+        }
+
+        /// <summary>
         /// Creates a new deployment for the specified repository.
         /// Users with push access can create a deployment for a given ref.
         /// </summary>

--- a/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentsClientTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -9,7 +11,7 @@ public class DeploymentsClientTests : IDisposable
 {
     private readonly IDeploymentsClient _deploymentsClient;
     private readonly RepositoryContext _context;
-    private readonly Commit _commit;
+    private readonly ICollection<Commit> _commits;
 
     public DeploymentsClientTests()
     {
@@ -17,33 +19,38 @@ public class DeploymentsClientTests : IDisposable
 
         _deploymentsClient = github.Repository.Deployment;
         _context = github.CreateRepositoryContext("public-repo").Result;
+        _commits = new List<Commit>();
 
-        var blob = new NewBlob
+        for (int i = 0; i < 6; i++)
         {
-            Content = "Hello World!",
-            Encoding = EncodingType.Utf8
-        };
+            var blob = new NewBlob
+            {
+                Content = string.Format("Hello World {0}!", i),
+                Encoding = EncodingType.Utf8
+            };
 
-        var blobResult = github.Git.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob).Result;
+            var blobResult = github.Git.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob).Result;
 
-        var newTree = new NewTree();
-        newTree.Tree.Add(new NewTreeItem
-        {
-            Type = TreeType.Blob,
-            Mode = FileMode.File,
-            Path = "README.md",
-            Sha = blobResult.Sha
-        });
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
 
-        var treeResult = github.Git.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree).Result;
-        var newCommit = new NewCommit("test-commit", treeResult.Sha);
-        _commit = github.Git.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit).Result;
+            var treeResult = github.Git.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree).Result;
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
+            var commit = github.Git.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit).Result;
+            _commits.Add(commit);
+        }
     }
 
     [IntegrationTest]
     public async Task CanCreateDeployment()
     {
-        var newDeployment = new NewDeployment(_commit.Sha) { AutoMerge = false };
+        var newDeployment = new NewDeployment(_commits.First().Sha) { AutoMerge = false };
 
         var deployment = await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
 
@@ -51,14 +58,86 @@ public class DeploymentsClientTests : IDisposable
     }
 
     [IntegrationTest]
-    public async Task CanGetDeployments()
+    public async Task ReturnsDeployments()
     {
-        var newDeployment = new NewDeployment(_commit.Sha) { AutoMerge = false };
+        var newDeployment = new NewDeployment(_commits.First().Sha) { AutoMerge = false };
         await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
 
         var deployments = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.NotEmpty(deployments);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfDeploymentsWithoutStart()
+    {
+        foreach (var commit in _commits)
+        {
+            var newDeployment = new NewDeployment(commit.Sha) { AutoMerge = false };
+            await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
+        }
+
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var releases = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(5, releases.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfDeploymentsWithStart()
+    {
+        foreach (var commit in _commits)
+        {
+            var newDeployment = new NewDeployment(commit.Sha) { AutoMerge = false };
+            await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
+        }
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var releases = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(3, releases.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPage()
+    {
+        foreach (var commit in _commits)
+        {
+            var newDeployment = new NewDeployment(commit.Sha) { AutoMerge = false };
+            await _deploymentsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newDeployment);
+        }
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var firstPage = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _deploymentsClient.GetAll(_context.RepositoryOwner, _context.RepositoryName, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+        Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+        Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
     }
 
     public void Dispose()

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -53,7 +53,8 @@ public class DeploymentsClientTests
             var expectedUrl = ApiUrls.Deployments(owner, name);
 
             client.GetAll(owner, name);
-            connection.Received(1).GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), Args.ApiOptions);
+            connection.Received(1)
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), Args.ApiOptions);
         }
 
         [Fact]
@@ -70,8 +71,9 @@ public class DeploymentsClientTests
                 StartPage = 1
             };
 
-            client.GetAll(owner, name);
-            connection.Received(1).GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), options);
+            client.GetAll(owner, name, options);
+            connection.Received(1)
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), options);
         }
     }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -50,11 +50,11 @@ public class DeploymentsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
-            var expectedUrl = ApiUrls.Deployments(owner, name);
+            var expectedUrl = string.Format("repos/{0}/{1}/deployments", owner, name);
 
             client.GetAll(owner, name);
             connection.Received(1)
-                .GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), Args.ApiOptions);
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ public class DeploymentsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
-            var expectedUrl = ApiUrls.Deployments(owner, name);
+            var expectedUrl = string.Format("repos/{0}/{1}/deployments", owner, name);
 
             var options = new ApiOptions
             {
@@ -73,21 +73,21 @@ public class DeploymentsClientTests
 
             client.GetAll(owner, name, options);
             connection.Received(1)
-                .GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), options);
+                .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
         }
     }
 
     public class TheCreateMethod
     {
-        private readonly NewDeployment _newDeployment = new NewDeployment("aRef");
+        private readonly NewDeployment newDeployment = new NewDeployment("aRef");
 
         [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", _newDeployment));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, _newDeployment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newDeployment));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
         }
 
@@ -96,8 +96,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", _newDeployment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", _newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newDeployment));
         }
 
         [Theory]
@@ -110,8 +110,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "name", _newDeployment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, _newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "name", newDeployment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, newDeployment));
         }
 
         [Fact]
@@ -121,7 +121,7 @@ public class DeploymentsClientTests
             var client = new DeploymentsClient(connection);
             var expectedUrl = "repos/owner/name/deployments";
 
-            client.Create("owner", "name", _newDeployment);
+            client.Create("owner", "name", newDeployment);
 
             connection.Received(1).Post<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                                                     Arg.Any<NewDeployment>());
@@ -133,10 +133,10 @@ public class DeploymentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
 
-            client.Create("owner", "name", _newDeployment);
+            client.Create("owner", "name", newDeployment);
 
             connection.Received(1).Post<Deployment>(Arg.Any<Uri>(),
-                                                    _newDeployment);
+                                                    newDeployment);
         }
     }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -119,11 +119,11 @@ public class DeploymentsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
-            var expectedUrl = ApiUrls.Deployments("owner", "name");
+            var expectedUrl = "repos/owner/name/deployments";
 
             client.Create("owner", "name", _newDeployment);
 
-            connection.Received(1).Post<Deployment>(Arg.Is<Uri>(u => u == expectedUrl),
+            connection.Received(1).Post<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                                                     Arg.Any<NewDeployment>());
         }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -9,14 +9,17 @@ public class DeploymentsClientTests
 {
     public class TheGetAllMethod
     {
+        private const string name = "name";
+        private const string owner = "name";
+
         [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, name));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(owner, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(owner, name, null));
         }
 
         [Fact]
@@ -24,8 +27,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", name));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(owner, ""));
         }
 
         [Theory]
@@ -38,8 +41,8 @@ public class DeploymentsClientTests
         {
             var client = new DeploymentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, name));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(owner, whitespace));
         }
 
         [Fact]
@@ -47,9 +50,9 @@ public class DeploymentsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
-            var expectedUrl = ApiUrls.Deployments("owner", "name");
+            var expectedUrl = ApiUrls.Deployments(owner, name);
 
-            client.GetAll("owner", "name");
+            client.GetAll(owner, name);
             connection.Received(1).GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), Args.ApiOptions);
         }
 
@@ -58,7 +61,7 @@ public class DeploymentsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new DeploymentsClient(connection);
-            var expectedUrl = ApiUrls.Deployments("owner", "name");
+            var expectedUrl = ApiUrls.Deployments(owner, name);
 
             var options = new ApiOptions
             {
@@ -67,7 +70,7 @@ public class DeploymentsClientTests
                 StartPage = 1
             };
 
-            client.GetAll("owner", "name");
+            client.GetAll(owner, name);
             connection.Received(1).GetAll<Deployment>(Arg.Is<Uri>(u => u == expectedUrl), options);
         }
     }

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -10,7 +10,7 @@ public class DeploymentsClientTests
     public class TheGetAllMethod
     {
         private const string name = "name";
-        private const string owner = "name";
+        private const string owner = "owner";
 
         [Fact]
         public async Task EnsuresNonNullArguments()

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -15,6 +15,8 @@ namespace Octokit.Tests.Reactive
         {
             private readonly IGitHubClient _githubClient;
             private readonly ObservableDeploymentsClient _client;
+            private const string owner = "owner";
+            private const string name = "name";
 
             public TheGetAllMethod()
             {
@@ -25,33 +27,33 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo"));
-                Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null));
-                Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, name));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, null));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, name, null));
             }
 
             [Fact]
             public void EnsuresNonEmptyArguments()
             {
-                Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo"));
-                Assert.Throws<ArgumentException>(() => _client.GetAll("owner", ""));
+                Assert.Throws<ArgumentException>(() => _client.GetAll("", name));
+                Assert.Throws<ArgumentException>(() => _client.GetAll(owner, ""));
             }
 
             [Fact]
             public async Task EnsuresNonWhitespaceArguments()
             {
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.GetAll(whitespace, "repo"));
+                    async whitespace => await _client.GetAll(whitespace, name));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
-                    async whitespace => await _client.GetAll("owner", whitespace));
+                    async whitespace => await _client.GetAll(owner, whitespace));
             }
 
             [Fact]
             public void RequestsCorrectUrl()
             {
-                var expectedUri = ApiUrls.Deployments("owner", "repo");
+                var expectedUri = ApiUrls.Deployments(owner, name);
 
-                _client.GetAll("owner", "repo");
+                _client.GetAll(owner, name);
                 _githubClient.Connection
                              .Received(1)
                              .Get<List<Deployment>>(Arg.Is(expectedUri),
@@ -61,7 +63,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
-                var expectedUri = ApiUrls.Deployments("owner", "repo");
+                var expectedUri = ApiUrls.Deployments(owner, name);
                 
                 var options = new ApiOptions
                 {
@@ -70,7 +72,7 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                _client.GetAll("owner", "repo", options);
+                _client.GetAll(owner, name, options);
                 _githubClient.Connection
                              .Received(1)
                              .Get<List<Deployment>>(Arg.Is(expectedUri),

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -51,21 +51,21 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void RequestsCorrectUrl()
             {
-                var expectedUri = ApiUrls.Deployments(owner, name);
+                var expectedUrl = string.Format("repos/{0}/{1}/deployments", owner, name);
 
                 _client.GetAll(owner, name);
-                _githubClient.Connection
-                             .Received(1)
-                             .Get<List<Deployment>>(Arg.Is(expectedUri),
-                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), Arg.Any<string>());
+                _githubClient.Connection.Received(1)
+                    .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
+                        Arg.Any<string>());
             }
 
             [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
-                var expectedUri = ApiUrls.Deployments(owner, name);
-                
-                // all properties are setted => only 2 options (StartPage, PageSize) in Dictionary
+                var expectedUrl = string.Format("repos/{0}/{1}/deployments", owner, name);
+
+                // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -74,34 +74,34 @@ namespace Octokit.Tests.Reactive
                 };
 
                 _client.GetAll(owner, name, options);
-                _githubClient.Connection
-                             .Received(1)
-                             .Get<List<Deployment>>(Arg.Is(expectedUri),
-                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2), null);
+                _githubClient.Connection.Received(1)
+                    .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                        null);
 
-                // StartPage is setted => only 1 option (StartPage) in Dictionary
+                // StartPage is setted => only 1 option (StartPage) in dictionary
                 options = new ApiOptions
                 {
                     StartPage = 1
                 };
 
                 _client.GetAll(owner, name, options);
-                _githubClient.Connection
-                             .Received(1)
-                             .Get<List<Deployment>>(Arg.Is(expectedUri),
-                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1), null);
+                _githubClient.Connection.Received(1)
+                    .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                        null);
 
-                // PageCount is setted => none of options in Dictionary
+                // PageCount is setted => none of options in dictionary
                 options = new ApiOptions
                 {
                     PageCount = 1
                 };
 
                 _client.GetAll(owner, name, options);
-                _githubClient.Connection
-                             .Received(1)
-                             .Get<List<Deployment>>(Arg.Is(expectedUri),
-                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+                _githubClient.Connection.Received(1)
+                    .Get<List<Deployment>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                        null);
             }
         }
 
@@ -164,9 +164,10 @@ namespace Octokit.Tests.Reactive
 
                 var newDeployment = new NewDeployment("ref");
                 _client.Create("owner", "repo", newDeployment);
+
                 _githubClient.Repository.Deployment.Received(1).Create(Arg.Is("owner"),
-                                                            Arg.Is("repo"),
-                                                            Arg.Is(newDeployment));
+                    Arg.Is("repo"),
+                    Arg.Is(newDeployment));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -65,6 +65,7 @@ namespace Octokit.Tests.Reactive
             {
                 var expectedUri = ApiUrls.Deployments(owner, name);
                 
+                // all properties are setted => only 2 options (StartPage, PageSize) in Dictionary
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -76,7 +77,31 @@ namespace Octokit.Tests.Reactive
                 _githubClient.Connection
                              .Received(1)
                              .Get<List<Deployment>>(Arg.Is(expectedUri),
-                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 3), Arg.Any<string>());
+                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2), null);
+
+                // StartPage is setted => only 1 option (StartPage) in Dictionary
+                options = new ApiOptions
+                {
+                    StartPage = 1
+                };
+
+                _client.GetAll(owner, name, options);
+                _githubClient.Connection
+                             .Received(1)
+                             .Get<List<Deployment>>(Arg.Is(expectedUri),
+                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1), null);
+
+                // PageCount is setted => none of options in Dictionary
+                options = new ApiOptions
+                {
+                    PageCount = 1
+                };
+
+                _client.GetAll(owner, name, options);
+                _githubClient.Connection
+                             .Received(1)
+                             .Get<List<Deployment>>(Arg.Is(expectedUri),
+                                                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
         }
 

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -34,6 +34,9 @@ namespace Octokit
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetAll(owner, name, ApiOptions.None);
         }
 
@@ -50,7 +53,7 @@ namespace Octokit
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "login");
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -34,10 +34,27 @@ namespace Octokit
         /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name)
         {
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the deployments for the specified repository. Any user with pull access
+        /// to a repository can view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployments
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "login");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Deployment>(ApiUrls.Deployments(owner, name));
+            return ApiConnection.GetAll<Deployment>(ApiUrls.Deployments(owner, name), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IDeploymentsClient.cs
+++ b/Octokit/Clients/IDeploymentsClient.cs
@@ -25,6 +25,19 @@ namespace Octokit
         Task<IReadOnlyList<Deployment>> GetAll(string owner, string name);
 
         /// <summary>
+        /// Gets all the deployments for the specified repository. Any user with pull access
+        /// to a repository can view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployments
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Deployment"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Creates a new deployment for the specified repository.
         /// Users with push access can create a deployment for a given ref.
         /// </summary>


### PR DESCRIPTION
Refer #1151 .

To-do:

- [x] Add overload Task> GetAll(ApiOptions options) on IDeploymentsClient.
- [x]  Add overload IObservable GetAll(ApiOptions options) on IObservableDeploymentsClient.
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods.

Some additional checks for count of received parameters were added in ObservableDeploymentsClientTests. If these are ambiguous checks, pls, let me know :+1: 