### PR TITLE
Some ArgumentNotNullOrEmptyString cheсks were added in ObservableAssigneesClient

### DIFF
--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -25,6 +25,9 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<User> GetAllForRepository(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetAllForRepository(owner, name, ApiOptions.None);
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
+    <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableAssigneesClientTests
+    {
+        private const string owner = "owner";
+        private const string name = "name";
+        private const string assignee = "assignee";
+        
+        public class TheGetAllMethod
+        {
+            private readonly Uri _expectedUri;
+            
+            public TheGetAllMethod()
+            {
+                var uri = string.Format("repos/{0}/{1}/assignees", owner, name);
+                _expectedUri = new Uri(uri, UriKind.Relative);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(github);
+
+                client.GetAllForRepository(owner, name);
+
+                github.Connection.Received(1).Get<List<User>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOption()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(github);
+
+                client.GetAllForRepository(owner, name, new ApiOptions {PageSize = 1, StartPage = 1});
+
+                github.Connection.Received(1).Get<List<User>>(_expectedUri,
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(github);
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(null, name));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(null, string.Empty));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(owner, null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(string.Empty, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(owner, name, null));
+            }
+        }
+
+        private static ObservableAssigneesClient CreateFixtureWithNonReactiveClient()
+        {
+            var nonreactiveClient = new AssigneesClient(Substitute.For<IApiConnection>());
+            var github = Substitute.For<IGitHubClient>();
+            github.Issue.Assignee.Returns(nonreactiveClient);
+            return new ObservableAssigneesClient(github);
+        }
+
+        public class TheCheckAssigneeMethod
+        {
+            [Fact]
+            public void CallsCheckAssigneeOnClient()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableAssigneesClient(github);
+
+                client.CheckAssignee(owner, name, assignee);
+
+                github.Issue.Assignee.Received(1).CheckAssignee(Arg.Is(owner), Arg.Is(name), Arg.Is(assignee));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = CreateFixtureWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(null, name, assignee));
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, null, assignee));
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, name, null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                var client = CreateFixtureWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(string.Empty, name, assignee));
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, string.Empty, assignee));
+                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, name, string.Empty));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableAssigneesClient(null));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
@@ -57,6 +57,15 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(owner, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(owner, name, null));
             }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                var client = CreateFixtureWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(string.Empty, name));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(owner, string.Empty));
+            }
         }
 
         private static ObservableAssigneesClient CreateFixtureWithNonReactiveClient()

--- a/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
@@ -53,10 +53,8 @@ namespace Octokit.Tests.Reactive
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableAssigneesClient(github);
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(null, name));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(null, string.Empty));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(owner, null));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository(string.Empty, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, name));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(owner, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(owner, name, null));
             }
         }
@@ -87,9 +85,9 @@ namespace Octokit.Tests.Reactive
             {
                 var client = CreateFixtureWithNonReactiveClient();
 
-                Assert.Throws<ArgumentException>(() => client.CheckAssignee(null, name, assignee));
-                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, null, assignee));
-                Assert.Throws<ArgumentException>(() => client.CheckAssignee(owner, name, null));
+                Assert.Throws<ArgumentNullException>(() => client.CheckAssignee(null, name, assignee));
+                Assert.Throws<ArgumentNullException>(() => client.CheckAssignee(owner, null, assignee));
+                Assert.Throws<ArgumentNullException>(() => client.CheckAssignee(owner, name, null));
             }
 
             [Fact]


### PR DESCRIPTION
After the discussion https://github.com/octokit/octokit.net/pull/1218/commits/42c3a2b728a30def1e8e4385804eeb77b8162c32,  I checked usage of ApiOptions and add necessary null checking.

/cc @shiftkey 