### PR TITLE
Implement additional `SearchIssuesRequest` options

### DIFF
--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -153,12 +153,12 @@ public class SearchClientTests
         labelRequest.Repos.Add("octokit", "octokit.net");
         labelRequest.Labels = new List<string> { "up-for-grabs" };
 
-        var notLabelRequest = new SearchIssuesRequest();
-        notLabelRequest.Repos.Add("octokit", "octokit.net");
-        notLabelRequest.NotLabels = new List<string> { "up-for-grabs" };
+        var excludeLabelRequest = new SearchIssuesRequest();
+        excludeLabelRequest.Repos.Add("octokit", "octokit.net");
+        excludeLabelRequest.ExcludeLabels = new List<string> { "up-for-grabs" };
 
         var upForGrabs = await _gitHubClient.Search.SearchIssues(labelRequest);
-        var notUpForGrabs = await _gitHubClient.Search.SearchIssues(notLabelRequest);
+        var notUpForGrabs = await _gitHubClient.Search.SearchIssues(excludeLabelRequest);
 
         Assert.NotEmpty(upForGrabs.Items);
         Assert.NotEmpty(notUpForGrabs.Items);

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -132,7 +132,7 @@ public class SearchClientTests
     {
         var allRequest = new SearchIssuesRequest();
         allRequest.Repos.Add("octokit", "octokit.net");
-        allRequest.Type = IssueTypeQualifier.PR;
+        allRequest.Type = IssueTypeQualifier.PullRequest;
 
         var mergedRequest = new SearchIssuesRequest();
         mergedRequest.Repos.Add("octokit", "octokit.net");

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -15,7 +15,7 @@ public class SearchClientTests
         _gitHubClient = Helper.GetAuthenticatedClient();
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForCSharpRepositories()
     {
         var request = new SearchRepositoriesRequest("csharp");
@@ -24,7 +24,7 @@ public class SearchClientTests
         Assert.NotEmpty(repos.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForGitHub()
     {
         var request = new SearchUsersRequest("github");
@@ -33,7 +33,7 @@ public class SearchClientTests
         Assert.NotEmpty(repos.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForFunctionInCode()
     {
         var request = new SearchCodeRequest("addClass", "jquery", "jquery");
@@ -43,7 +43,7 @@ public class SearchClientTests
         Assert.NotEmpty(repos.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForFileNameInCode()
     {
         var request = new SearchCodeRequest("GitHub")
@@ -57,7 +57,7 @@ public class SearchClientTests
         Assert.NotEmpty(repos.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForWordInCode()
     {
         var request = new SearchIssuesRequest("windows");
@@ -74,7 +74,7 @@ public class SearchClientTests
         Assert.NotEmpty(repos.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForOpenIssues()
     {
         var request = new SearchIssuesRequest("phone");
@@ -86,7 +86,7 @@ public class SearchClientTests
         Assert.NotEmpty(issues.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForAllIssues()
     {
         var request = new SearchIssuesRequest("phone");
@@ -97,7 +97,7 @@ public class SearchClientTests
         Assert.NotEmpty(issues.Items);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForAllIssuesWithoutUsingTerm()
     {
         var request = new SearchIssuesRequest();
@@ -112,7 +112,7 @@ public class SearchClientTests
         Assert.NotEmpty(openedIssues);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForAllIssuesUsingTerm()
     {
         var request = new SearchIssuesRequest("phone");
@@ -127,7 +127,7 @@ public class SearchClientTests
         Assert.NotEmpty(openedIssues);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForMergedPullRequests()
     {
         var allRequest = new SearchIssuesRequest();
@@ -146,7 +146,7 @@ public class SearchClientTests
         Assert.NotEqual(allPullRequests.TotalCount, mergedPullRequests.TotalCount);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForMissingMetadata()
     {
         var allRequest = new SearchIssuesRequest();
@@ -164,7 +164,7 @@ public class SearchClientTests
         Assert.NotEqual(allIssues.TotalCount, noAssigneeIssues.TotalCount);
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedAuthor()
     {
         var author = "shiftkey";
@@ -196,7 +196,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedAssignee()
     {
         var assignee = "shiftkey";
@@ -228,7 +228,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedMentions()
     {
         var mentioned = "shiftkey";
@@ -260,7 +260,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedCommenter()
     {
         var commenter = "shiftkey";
@@ -292,7 +292,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedInvolves()
     {
         var involves = "shiftkey";
@@ -324,7 +324,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedState()
     {
         var state = ItemState.Open;
@@ -356,7 +356,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedLabels()
     {
         var label1 = "up-for-grabs";
@@ -389,7 +389,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedLanguage()
     {
         var language = Language.CSharp;
@@ -419,7 +419,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedStatus()
     {
         var status = CommitState.Success;
@@ -451,7 +451,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedHead()
     {
         var branch = "search-issues";
@@ -483,7 +483,7 @@ public class SearchClientTests
         Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 
-    [Fact]
+    [IntegrationTest]
     public async Task SearchForExcludedBase()
     {
         var branch = "master";

--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -147,27 +147,6 @@ public class SearchClientTests
     }
 
     [Fact]
-    public async Task SearchForLabelsAndExcludedLabels()
-    {
-        var labelRequest = new SearchIssuesRequest();
-        labelRequest.Repos.Add("octokit", "octokit.net");
-        labelRequest.Labels = new List<string> { "up-for-grabs" };
-
-        var excludeLabelRequest = new SearchIssuesRequest();
-        excludeLabelRequest.Repos.Add("octokit", "octokit.net");
-        excludeLabelRequest.ExcludeLabels = new List<string> { "up-for-grabs" };
-
-        var upForGrabs = await _gitHubClient.Search.SearchIssues(labelRequest);
-        var notUpForGrabs = await _gitHubClient.Search.SearchIssues(excludeLabelRequest);
-
-        Assert.NotEmpty(upForGrabs.Items);
-        Assert.NotEmpty(notUpForGrabs.Items);
-        Assert.NotEqual(upForGrabs.TotalCount, notUpForGrabs.TotalCount);
-
-        Assert.False(upForGrabs.Items.Any(x1 => notUpForGrabs.Items.Any(x2 => x2.Number == x1.Number)));
-    }
-
-    [Fact]
     public async Task SearchForMissingMetadata()
     {
         var allRequest = new SearchIssuesRequest();
@@ -183,5 +162,356 @@ public class SearchClientTests
         Assert.NotEmpty(allIssues.Items);
         Assert.NotEmpty(noAssigneeIssues.Items);
         Assert.NotEqual(allIssues.TotalCount, noAssigneeIssues.TotalCount);
+    }
+
+    [Fact]
+    public async Task SearchForExcludedAuthor()
+    {
+        var author = "shiftkey";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Author = author;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Author = author
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedAssignee()
+    {
+        var assignee = "shiftkey";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Assignee = assignee;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Assignee = assignee
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedMentions()
+    {
+        var mentioned = "shiftkey";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Mentions = mentioned;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Mentions = mentioned
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedCommenter()
+    {
+        var commenter = "shiftkey";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Commenter = commenter;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Commenter = commenter
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedInvolves()
+    {
+        var involves = "shiftkey";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Involves = involves;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Involves = involves
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedState()
+    {
+        var state = ItemState.Open;
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.State = state;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            State = state
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedLabels()
+    {
+        var label1 = "up-for-grabs";
+        var label2 = "feature";
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Labels = new[] { label1, label2 };
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Labels = new[] { label1, label2 }
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedLanguage()
+    {
+        var language = Language.CSharp;
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest("octokit");
+        request.Language = language;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest("octokit");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Language = language
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedStatus()
+    {
+        var status = CommitState.Success;
+
+        // Search for issues by include filter
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Status = status;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues by exclude filter
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Status = status
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedHead()
+    {
+        var branch = "search-issues";
+
+        // Search for issues by source branch
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Head = branch;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues excluding source branch
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Head = branch
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
+    }
+
+    [Fact]
+    public async Task SearchForExcludedBase()
+    {
+        var branch = "master";
+
+        // Search for issues by target branch
+        var request = new SearchIssuesRequest();
+        request.Repos.Add("octokit", "octokit.net");
+        request.Base = branch;
+
+        var issues = await _gitHubClient.Search.SearchIssues(request);
+
+        // Ensure we found issues
+        Assert.NotEmpty(issues.Items);
+
+        // Search for issues excluding target branch
+        var excludeRequest = new SearchIssuesRequest();
+        excludeRequest.Repos.Add("octokit", "octokit.net");
+        excludeRequest.Exclusions = new SearchIssuesRequestExclusions
+        {
+            Base = branch
+        };
+
+        var otherIssues = await _gitHubClient.Search.SearchIssues(excludeRequest);
+
+        // Ensure we found issues
+        Assert.NotEmpty(otherIssues.Items);
+
+        // Ensure no items from the first search are in the results for the second
+        Assert.DoesNotContain(issues.Items, x1 => otherIssues.Items.Any(x2 => x2.Id == x1.Id));
     }
 }

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -806,12 +806,12 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void TestingTheTypeQualifier_PR()
+            public void TestingTheTypeQualifier_PullRequest()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchIssuesRequest("something");
-                request.Type = IssueTypeQualifier.PR;
+                request.Type = IssueTypeQualifier.PullRequest;
 
                 client.SearchIssues(request);
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -967,7 +967,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+language:CSharp"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+language:C#"));
             }
 
             [Fact]

--- a/Octokit.Tests/Models/SearchIssuesRequestExclusionsTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestExclusionsTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octokit;
+using Octokit.Tests.Helpers;
+using Xunit;
+
+public class SearchIssuesRequestExclusionsTests
+{
+    public class TheExclusionsMergedQualifiersMethod
+    {
+        [Fact]
+        public void HandlesStringAttributesCorrectly()
+        {
+            var stringProperties = new List<Tuple<string, Action<SearchIssuesRequestExclusions, string>>>()
+            {
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("author:", (x,value) => x.Author = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("assignee:", (x,value) => x.Assignee = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("mentions:", (x,value) => x.Mentions = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("commenter:", (x,value) => x.Commenter = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("involves:", (x,value) => x.Involves = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("head:", (x,value) => x.Head = value),
+                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("base:", (x,value) => x.Base = value)
+            };
+
+            foreach (var property in stringProperties)
+            {
+                var request = new SearchIssuesRequestExclusions();
+
+                // Ensure the specified parameter does not exist when not set
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+
+                // Set the parameter
+                property.Item2(request, "blah");
+
+                // Ensure the specified parameter now exists
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+            }
+        }
+
+        [Fact]
+        public void HandlesStateAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequestExclusions();
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-state:")));
+
+            request.State = ItemState.Closed;
+            Assert.True(request.MergedQualifiers().Contains("-state:closed"));
+        }
+
+        [Fact]
+        public void HandlesExcludeLabelsAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequestExclusions();
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-label:")));
+
+            request.Labels = new[] { "label1", "label2" };
+
+            Assert.True(request.MergedQualifiers().Contains("-label:label1"));
+            Assert.True(request.MergedQualifiers().Contains("-label:label2"));
+        }
+
+        [Fact]
+        public void HandlesLanguageAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequestExclusions();
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-language:")));
+
+            request.Language = Language.CSharp;
+
+            Assert.True(request.MergedQualifiers().Contains("-language:C#"));
+        }
+
+        [Fact]
+        public void HandlesStatusAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequestExclusions();
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-status:")));
+
+            request.Status = CommitState.Error;
+
+            Assert.True(request.MergedQualifiers().Contains("-status:error"));
+        }
+    }
+}

--- a/Octokit.Tests/Models/SearchIssuesRequestExclusionsTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestExclusionsTests.cs
@@ -12,15 +12,15 @@ public class SearchIssuesRequestExclusionsTests
         [Fact]
         public void HandlesStringAttributesCorrectly()
         {
-            var stringProperties = new List<Tuple<string, Action<SearchIssuesRequestExclusions, string>>>()
+            var stringProperties = new Dictionary<string, Action<SearchIssuesRequestExclusions, string>>()
             {
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("author:", (x,value) => x.Author = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("assignee:", (x,value) => x.Assignee = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("mentions:", (x,value) => x.Mentions = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("commenter:", (x,value) => x.Commenter = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("involves:", (x,value) => x.Involves = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("head:", (x,value) => x.Head = value),
-                new Tuple<string, Action<SearchIssuesRequestExclusions, string>>("base:", (x,value) => x.Base = value)
+                { "author:", (x,value) => x.Author = value },
+                { "assignee:", (x,value) => x.Assignee = value },
+                { "mentions:", (x,value) => x.Mentions = value },
+                { "commenter:", (x,value) => x.Commenter = value },
+                { "involves:", (x,value) => x.Involves = value },
+                { "head:", (x,value) => x.Head = value },
+                { "base:", (x,value) => x.Base = value }
             };
 
             foreach (var property in stringProperties)
@@ -28,13 +28,13 @@ public class SearchIssuesRequestExclusionsTests
                 var request = new SearchIssuesRequestExclusions();
 
                 // Ensure the specified parameter does not exist when not set
-                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Key)));
 
                 // Set the parameter
-                property.Item2(request, "blah");
+                property.Value(request, "blah");
 
                 // Ensure the specified parameter now exists
-                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Key)) == 1);
             }
         }
 

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -31,17 +31,17 @@ public class SearchIssuesRequestTests
         [Fact]
         public void HandlesStringAttributesCorrectly()
         {
-            var stringProperties = new List<Tuple<string, Action<SearchIssuesRequest, string>>>()
+            var stringProperties = new Dictionary<string, Action<SearchIssuesRequest, string>>
             {
-                new Tuple<string, Action<SearchIssuesRequest, string>>("author:", (x,value) => x.Author = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("assignee:", (x,value) => x.Assignee = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("mentions:", (x,value) => x.Mentions = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("commenter:", (x,value) => x.Commenter = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("involves:", (x,value) => x.Involves = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("team:", (x,value) => x.Team = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("head:", (x,value) => x.Head = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("base:", (x,value) => x.Base = value),
-                new Tuple<string, Action<SearchIssuesRequest, string>>("user:", (x,value) => x.User = value)
+                { "author:", (x,value) => x.Author = value },
+                { "assignee:", (x,value) => x.Assignee = value },
+                { "mentions:", (x,value) => x.Mentions = value },
+                { "commenter:", (x,value) => x.Commenter = value },
+                { "involves:", (x,value) => x.Involves = value },
+                { "team:", (x,value) => x.Team = value },
+                { "head:", (x,value) => x.Head = value },
+                { "base:", (x,value) => x.Base = value },
+                { "user:", (x,value) => x.User = value }
             };
 
             foreach (var property in stringProperties)
@@ -49,25 +49,25 @@ public class SearchIssuesRequestTests
                 var request = new SearchIssuesRequest("query");
 
                 // Ensure the specified parameter does not exist when not set
-                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Key)));
 
                 // Set the parameter
-                property.Item2(request, "blah");
+                property.Value(request, "blah");
 
                 // Ensure the specified parameter now exists
-                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Key)) == 1);
             }
         }
 
         [Fact]
         public void HandlesDateRangeAttributesCorrectly()
         {
-            var dateProperties = new List<Tuple<string, Action<SearchIssuesRequest, DateRange>>>()
+            var dateProperties = new Dictionary<string, Action<SearchIssuesRequest, DateRange>>
             {
-                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("created:", (x,value) => x.Created = value),
-                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("updated:", (x,value) => x.Updated = value),
-                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("merged:", (x,value) => x.Merged = value),
-                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("closed:", (x,value) => x.Closed = value)
+                { "created:", (x,value) => x.Created = value },
+                { "updated:", (x,value) => x.Updated = value },
+                { "merged:", (x,value) => x.Merged = value },
+                { "closed:", (x,value) => x.Closed = value }
             };
 
             foreach (var property in dateProperties)
@@ -75,13 +75,13 @@ public class SearchIssuesRequestTests
                 var request = new SearchIssuesRequest("query");
 
                 // Ensure the specified parameter does not exist when not set
-                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Key)));
 
                 // Set the parameter
-                property.Item2(request, DateRange.GreaterThan(DateTime.Today.AddDays(-7)));
+                property.Value(request, DateRange.GreaterThan(DateTime.Today.AddDays(-7)));
 
                 // Ensure the specified parameter now exists
-                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Key)) == 1);
             }
         }
 

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -144,7 +144,7 @@ public class SearchIssuesRequestTests
             Assert.False(request.MergedQualifiers().Any(x => x.Contains("language:")));
 
             request.Language = Language.CSharp;
-            Assert.True(request.MergedQualifiers().Contains("language:CSharp"));
+            Assert.True(request.MergedQualifiers().Contains("language:C#"));
         }
 
         [Fact]

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Octokit;
 using Octokit.Tests.Helpers;
 using Xunit;
 
-internal class SearchIssuesRequestTests
+public class SearchIssuesRequestTests
 {
     public class TheMergedQualifiersMethod
     {
@@ -24,6 +26,168 @@ internal class SearchIssuesRequestTests
             var request = new SearchIssuesRequest("test");
             Assert.True(string.IsNullOrWhiteSpace(request.Sort));
             Assert.False(request.Parameters.ContainsKey("sort"));
+        }
+
+        [Fact]
+        public void HandlesStringAttributesCorrectly()
+        {
+            var stringProperties = new List<Tuple<string, Action<SearchIssuesRequest, string>>>()
+            {
+                new Tuple<string, Action<SearchIssuesRequest, string>>("author:", (x,value) => x.Author = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("assignee:", (x,value) => x.Assignee = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("mentions:", (x,value) => x.Mentions = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("commenter:", (x,value) => x.Commenter = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("involves:", (x,value) => x.Involves = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("team:", (x,value) => x.Team = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("head:", (x,value) => x.Head = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("base:", (x,value) => x.Base = value),
+                new Tuple<string, Action<SearchIssuesRequest, string>>("user:", (x,value) => x.User = value)
+            };
+
+            foreach (var property in stringProperties)
+            {
+                var request = new SearchIssuesRequest("query");
+
+                // Ensure the specified parameter does not exist when not set
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+
+                // Set the parameter
+                property.Item2(request, "blah");
+
+                // Ensure the specified parameter now exists
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+            }
+        }
+
+        [Fact]
+        public void HandlesDateRangeAttributesCorrectly()
+        {
+            var dateProperties = new List<Tuple<string, Action<SearchIssuesRequest, DateRange>>>()
+            {
+                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("created:", (x,value) => x.Created = value),
+                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("updated:", (x,value) => x.Updated = value),
+                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("merged:", (x,value) => x.Merged = value),
+                new Tuple<string, Action<SearchIssuesRequest, DateRange>>("closed:", (x,value) => x.Closed = value)
+            };
+
+            foreach (var property in dateProperties)
+            {
+                var request = new SearchIssuesRequest("query");
+
+                // Ensure the specified parameter does not exist when not set
+                Assert.False(request.MergedQualifiers().Any(x => x.Contains(property.Item1)));
+
+                // Set the parameter
+                property.Item2(request, DateRange.GreaterThan(DateTime.Today.AddDays(-7)));
+
+                // Ensure the specified parameter now exists
+                Assert.True(request.MergedQualifiers().Count(x => x.Contains(property.Item1)) == 1);
+            }
+        }
+
+        [Fact]
+        public void HandlesInAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("in:")));
+
+            request.In = new List<IssueInQualifier> { IssueInQualifier.Body, IssueInQualifier.Comment };
+            Assert.True(request.MergedQualifiers().Contains("in:body,comment"));
+        }
+
+        [Fact]
+        public void HandlesStateAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("state:")));
+
+            request.State = ItemState.Closed;
+            Assert.True(request.MergedQualifiers().Contains("state:closed"));
+        }
+
+        [Fact]
+        public void HandlesLabelsAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("label:")));
+
+            request.Labels = new List<string> { "label1", "label2" };
+            Assert.True(request.MergedQualifiers().Contains("label:label1"));
+            Assert.True(request.MergedQualifiers().Contains("label:label2"));
+        }
+
+        [Fact]
+        public void HandlesNotLabelsAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-label:")));
+
+            request.NotLabels = new List<string> { "label1", "label2" };
+            Assert.True(request.MergedQualifiers().Contains("-label:label1"));
+            Assert.True(request.MergedQualifiers().Contains("-label:label2"));
+        }
+
+        [Fact]
+        public void HandlesNoMetadataAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("no:")));
+
+            request.No = IssueNoMetadataQualifier.Milestone;
+            Assert.True(request.MergedQualifiers().Contains("no:milestone"));
+        }
+
+        [Fact]
+        public void HandlesLanguageAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("language:")));
+
+            request.Language = Language.CSharp;
+            Assert.True(request.MergedQualifiers().Contains("language:CSharp"));
+        }
+
+        [Fact]
+        public void HandlesIsAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("is:")));
+
+            request.Is = new List<IssueIsQualifier> { IssueIsQualifier.Merged, IssueIsQualifier.PullRequest };
+            Assert.True(request.MergedQualifiers().Contains("is:merged"));
+            Assert.True(request.MergedQualifiers().Contains("is:pr"));
+        }
+
+        [Fact]
+        public void HandlesStatusAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("status:")));
+
+            request.Status = CommitState.Error;
+            Assert.True(request.MergedQualifiers().Contains("status:error"));
+        }
+
+        [Fact]
+        public void HandlesCommentsAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("comments:")));
+
+            request.Comments = Range.GreaterThan(5);
+            Assert.True(request.MergedQualifiers().Contains("comments:>5"));
+        }
+
+        [Fact]
+        public void HandlesRepoAttributeCorrectly()
+        {
+            var request = new SearchIssuesRequest("test");
+            Assert.False(request.MergedQualifiers().Any(x => x.Contains("repo:")));
+
+            request.Repos.Add("myorg", "repo1");
+            request.Repos.Add("myorg", "repo2");
+            Assert.True(request.MergedQualifiers().Contains("repo:myorg/repo1"));
+            Assert.True(request.MergedQualifiers().Contains("repo:myorg/repo2"));
         }
     }
 }

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -117,12 +117,12 @@ public class SearchIssuesRequestTests
         }
 
         [Fact]
-        public void HandlesNotLabelsAttributeCorrectly()
+        public void HandlesExcludeLabelsAttributeCorrectly()
         {
             var request = new SearchIssuesRequest("test");
             Assert.False(request.MergedQualifiers().Any(x => x.Contains("-label:")));
 
-            request.NotLabels = new List<string> { "label1", "label2" };
+            request.ExcludeLabels = new List<string> { "label1", "label2" };
             Assert.True(request.MergedQualifiers().Contains("-label:label1"));
             Assert.True(request.MergedQualifiers().Contains("-label:label2"));
         }

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -111,20 +111,9 @@ public class SearchIssuesRequestTests
             var request = new SearchIssuesRequest("test");
             Assert.False(request.MergedQualifiers().Any(x => x.Contains("label:")));
 
-            request.Labels = new List<string> { "label1", "label2" };
+            request.Labels = new[] { "label1", "label2" };
             Assert.True(request.MergedQualifiers().Contains("label:label1"));
             Assert.True(request.MergedQualifiers().Contains("label:label2"));
-        }
-
-        [Fact]
-        public void HandlesExcludeLabelsAttributeCorrectly()
-        {
-            var request = new SearchIssuesRequest("test");
-            Assert.False(request.MergedQualifiers().Any(x => x.Contains("-label:")));
-
-            request.ExcludeLabels = new List<string> { "label1", "label2" };
-            Assert.True(request.MergedQualifiers().Contains("-label:label1"));
-            Assert.True(request.MergedQualifiers().Contains("-label:label2"));
         }
 
         [Fact]

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Models\RepositoryUpdateTests.cs" />
     <Compile Include="Models\RequestParametersTests.cs" />
     <Compile Include="Models\SearchCodeRequestTests.cs" />
+    <Compile Include="Models\SearchIssuesRequestExclusionsTests.cs" />
     <Compile Include="Models\SearchRepositoryRequestTests.cs" />
     <Compile Include="Models\SearchRepositoryResultTests.cs" />
     <Compile Include="Models\SearchUsersRequestTests.cs" />

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -161,27 +161,8 @@ namespace Octokit
             }
         }
 
-        private IEnumerable<string> _excludeLabels;
         /// <summary>
-        /// Filters issues based on the labels NOT assigned.
-        /// </summary>
-        /// <remarks>
-        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
-        /// </remarks>
-        public IEnumerable<string> ExcludeLabels
-        {
-            get { return _excludeLabels; }
-            set
-            {
-                if (value != null && value.Any())
-                {
-                    _excludeLabels = value.Distinct().ToList();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Searches for issues based on missing metadata
+        /// Searches for issues based on missing metadata.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-by-missing-metadata-on-an-issue-or-pull-request
@@ -189,7 +170,7 @@ namespace Octokit
         public IssueNoMetadataQualifier? No { get; set; }
 
         /// <summary>
-        /// Searches for issues within repositories that match a certain language.
+        /// Searches for issues in repositories that match a certain language.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-by-the-main-language-of-a-repository
@@ -232,7 +213,7 @@ namespace Octokit
         public DateRange Updated { get; set; }
 
         /// <summary>
-        /// Filters pull requests based on times when they were last merged
+        /// Filters pull requests based on times when they were last merged.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-when-a-pull-request-was-merged
@@ -240,7 +221,7 @@ namespace Octokit
         public DateRange Merged { get; set; }
 
         /// <summary>
-        /// Filters pull requests based on the status of the commits
+        /// Filters pull requests based on the status of the commits.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-commit-status
@@ -248,7 +229,7 @@ namespace Octokit
         public CommitState? Status { get; set; }
 
         /// <summary>
-        /// Filters pull requests based on the branch they came from
+        /// Filters pull requests based on the branch they came from.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
@@ -256,7 +237,7 @@ namespace Octokit
         public string Head { get; set; }
 
         /// <summary>
-        /// Filters pull requests based on the branch they are merging into
+        /// Filters pull requests based on the branch they are merging into.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
@@ -264,7 +245,7 @@ namespace Octokit
         public string Base { get; set; }
 
         /// <summary>
-        /// Filters issues based on times when they were last closed
+        /// Filters issues based on times when they were last closed.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-closed
@@ -280,15 +261,17 @@ namespace Octokit
         public Range Comments { get; set; }
 
         /// <summary>
-        /// Limits searches to a specific user.
+        /// Limits searches to repositories owned by a certain user or organization.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#users-organizations-and-repositories
+        /// https://help.github.com/articles/searching-issues/#search-within-a-users-or-organizations-repositories
         /// </remarks>
         public string User { get; set; }
 
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public RepositoryCollection Repos { get; set; }
+
+        public SearchIssuesRequestExclusions Exclusions { get; set; }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public override IReadOnlyList<string> MergedQualifiers()
@@ -345,11 +328,6 @@ namespace Octokit
             if (Labels != null)
             {
                 parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "label:{0}", label)));
-            }
-
-            if (ExcludeLabels != null)
-            {
-                parameters.AddRange(ExcludeLabels.Select(label => string.Format(CultureInfo.InvariantCulture, "-label:{0}", label)));
             }
 
             if (No.HasValue)
@@ -423,6 +401,12 @@ namespace Octokit
                 parameters.AddRange(Repos.Select(x => string.Format(CultureInfo.InvariantCulture, "repo:{0}", x)));
             }
 
+            // Add any exclusion parameters
+            if (Exclusions != null)
+            {
+                parameters.AddRange(Exclusions.MergedQualifiers());
+            }
+
             return new ReadOnlyCollection<string>(parameters);
         }
 
@@ -430,7 +414,7 @@ namespace Octokit
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "Term: {0}", Term);
+                return string.Format(CultureInfo.InvariantCulture, "Search: {0} {1}", Term, string.Join(" ", MergedQualifiers()));
             }
         }
     }

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -461,8 +461,11 @@ namespace Octokit
 
     public enum IssueTypeQualifier
     {
+        [Obsolete("Use IssueTypeQualifier.PullRequest instead")]
         [Parameter(Value = "pr")]
         PR,
+        [Parameter(Value = "pr")]
+        PullRequest,
         [Parameter(Value = "issue")]
         Issue
     }

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -32,6 +32,16 @@ namespace Octokit
             Repos = new RepositoryCollection();
         }
 
+        [Obsolete("this will be deprecated in a future version")]
+        public SearchIssuesRequest(string term, string owner, string name)
+            : this(term)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            Repos.Add(owner, name);
+        }
+
         /// <summary>
         /// Optional Sort field. One of comments, created, updated or merged 
         /// If not provided, results are sorted by best match.
@@ -182,13 +192,13 @@ namespace Octokit
         /// Searches for issues within repositories that match a certain language.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
+        /// https://help.github.com/articles/searching-issues/#search-by-the-main-language-of-a-repository
         /// </remarks>
         public Language? Language { get; set; }
 
         private IEnumerable<IssueIsQualifier> _is;
         /// <summary>
-        /// Searches for issues using a more human syntax covering options like state, type and merged status
+        /// Searches for issues using a more human syntax covering options like state, type, merged status, private/public repository
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-the-state-of-an-issue-or-pull-request
@@ -349,7 +359,7 @@ namespace Octokit
 
             if (Language != null)
             {
-                parameters.Add(string.Format(CultureInfo.InvariantCulture, "language:{0}", Language));
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "language:{0}", Language.ToParameter()));
             }
 
             if (Is != null)

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -32,22 +32,12 @@ namespace Octokit
             Repos = new RepositoryCollection();
         }
 
-        [Obsolete("this will be deprecated in a future version")]
-        public SearchIssuesRequest(string term, string owner, string name)
-            : this(term)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            Repos.Add(owner, name);
-        }
-
         /// <summary>
         /// Optional Sort field. One of comments, created, updated or merged 
         /// If not provided, results are sorted by best match.
         /// </summary>
         /// <remarks>
-        /// http://developer.github.com/v3/search/#search-issues
+        /// https://help.github.com/articles/searching-issues/#sort-the-results
         /// </remarks>
         public IssueSearchSort? SortField { get; set; }
 
@@ -57,11 +47,20 @@ namespace Octokit
         }
 
         /// <summary>
+        /// With this qualifier you can restrict the search to issues or pull request only.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-issues-or-pull-requests
+        /// </remarks>
+        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
+        public IssueTypeQualifier? Type { get; set; }
+
+        /// <summary>
         /// Qualifies which fields are searched. With this qualifier you can restrict 
         /// the search to just the title, body, comments, or any combination of these.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#search-in
+        /// https://help.github.com/articles/searching-issues/#scope-the-search-fields
         /// </remarks>
         private IEnumerable<IssueInQualifier> _inQualifier;
         public IEnumerable<IssueInQualifier> In
@@ -77,19 +76,10 @@ namespace Octokit
         }
 
         /// <summary>
-        /// With this qualifier you can restrict the search to issues or pull request only.
-        /// </summary>
-        /// <remarks>
-        /// https://help.github.com/articles/searching-issues#type
-        /// </remarks>
-        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
-        public IssueTypeQualifier? Type { get; set; }
-
-        /// <summary>
         /// Finds issues created by a certain user.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#author
+        /// https://help.github.com/articles/searching-issues/#search-by-the-author-of-an-issue-or-pull-request
         /// </remarks>
         public string Author { get; set; }
 
@@ -97,7 +87,7 @@ namespace Octokit
         /// Finds issues that are assigned to a certain user.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#assignee
+        /// https://help.github.com/articles/searching-issues/#search-by-the-assignee-of-an-issue-or-pull-request
         /// </remarks>
         public string Assignee { get; set; }
 
@@ -105,7 +95,7 @@ namespace Octokit
         /// Finds issues that mention a certain user.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#mentions
+        /// https://help.github.com/articles/searching-issues/#search-by-a-mentioned-user-within-an-issue-or-pull-request
         /// </remarks>
         public string Mentions { get; set; }
 
@@ -113,7 +103,7 @@ namespace Octokit
         /// Finds issues that a certain user commented on.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#commenter
+        /// https://help.github.com/articles/searching-issues/#search-by-a-commenter-within-an-issue-or-pull-request
         /// </remarks>
         public string Commenter { get; set; }
 
@@ -122,24 +112,32 @@ namespace Octokit
         /// mention that user, or were commented on by that user.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#involves
+        /// https://help.github.com/articles/searching-issues/#search-by-a-user-thats-involved-within-an-issue-or-pull-request
         /// </remarks>
         public string Involves { get; set; }
+
+        /// <summary>
+        /// Finds issues that @mention a team within the organization
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request
+        /// </remarks>
+        public string Team { get; set; }
 
         /// <summary>
         /// Filter issues based on whether they’re open or closed.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#state
+        /// https://help.github.com/articles/searching-issues/#search-based-on-whether-an-issue-or-pull-request-is-open
         /// </remarks>
         public ItemState? State { get; set; }
 
         private IEnumerable<string> _labels;
         /// <summary>
-        /// Filters issues based on their labels.
+        /// Filters issues based on the labels assigned.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#labels
+        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
         /// </remarks>
         public IEnumerable<string> Labels
         {
@@ -153,19 +151,65 @@ namespace Octokit
             }
         }
 
+        private IEnumerable<string> _notLabels;
+        /// <summary>
+        /// Filters issues based on the labels NOT assigned.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
+        /// </remarks>
+        public IEnumerable<string> NotLabels
+        {
+            get { return _notLabels; }
+            set
+            {
+                if (value != null && value.Any())
+                {
+                    _notLabels = value.Distinct().ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Searches for issues based on missing metadata
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-missing-metadata-on-an-issue-or-pull-request
+        /// </remarks>
+        public IssueNoMetadataQualifier? No { get; set; }
+
         /// <summary>
         /// Searches for issues within repositories that match a certain language.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#language
+        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
         /// </remarks>
         public Language? Language { get; set; }
+
+        private IEnumerable<IssueIsQualifier> _is;
+        /// <summary>
+        /// Searches for issues using a more human syntax covering options like state, type and merged status
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-the-state-of-an-issue-or-pull-request
+        /// </remarks>
+        public IEnumerable<IssueIsQualifier> Is
+        {
+            get { return _is; }
+            set
+            {
+                if (value != null && value.Any())
+                {
+                    _is = value.Distinct().ToList();
+                }
+            }
+        }
 
         /// <summary>
         /// Filters issues based on times of creation.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#created-and-last-updated
+        /// https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated
         /// </remarks>
         public DateRange Created { get; set; }
 
@@ -173,17 +217,50 @@ namespace Octokit
         /// Filters issues based on times when they were last updated.
         /// </summary>
         /// <remarks>
-        /// https://help.github.com/articles/searching-issues#created-and-last-updated
+        /// https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-created-or-last-updated
         /// </remarks>
         public DateRange Updated { get; set; }
 
         /// <summary>
-        /// Filters issues based on times when they were last merged
+        /// Filters pull requests based on times when they were last merged
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-based-on-when-a-pull-request-was-merged
         /// </remarks>
         public DateRange Merged { get; set; }
+
+        /// <summary>
+        /// Filters pull requests based on the status of the commits
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-commit-status
+        /// </remarks>
+        public CommitState? Status { get; set; }
+
+        /// <summary>
+        /// Filters pull requests based on the branch they came from
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
+        /// </remarks>
+        public string Head { get; set; }
+
+        /// <summary>
+        /// Filters pull requests based on the branch they are merging into
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
+        /// </remarks>
+        public string Base { get; set; }
+
+        /// <summary>
+        /// Filters issues based on times when they were last closed
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-closed
+        /// </remarks>
+        public DateRange Closed { get; set; }
+
         /// <summary>
         /// Filters issues based on the quantity of comments.
         /// </summary>
@@ -208,16 +285,16 @@ namespace Octokit
         {
             var parameters = new List<string>();
 
-            if (In != null)
-            {
-                parameters.Add(string.Format(CultureInfo.InvariantCulture, "in:{0}",
-                    string.Join(",", In.Select(i => i.ToParameter()))));
-            }
-
             if (Type != null)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "type:{0}",
                     Type.ToParameter()));
+            }
+
+            if (In != null)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "in:{0}",
+                    string.Join(",", In.Select(i => i.ToParameter()))));
             }
 
             if (Author.IsNotBlank())
@@ -245,6 +322,11 @@ namespace Octokit
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "involves:{0}", Involves));
             }
 
+            if (Team.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "team:{0}", Team));
+            }
+
             if (State.HasValue)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "state:{0}", State.Value.ToParameter()));
@@ -255,9 +337,24 @@ namespace Octokit
                 parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "label:{0}", label)));
             }
 
+            if (NotLabels != null)
+            {
+                parameters.AddRange(NotLabels.Select(label => string.Format(CultureInfo.InvariantCulture, "-label:{0}", label)));
+            }
+
+            if (No.HasValue)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "no:{0}", No.Value.ToParameter()));
+            }
+
             if (Language != null)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "language:{0}", Language));
+            }
+
+            if (Is != null)
+            {
+                parameters.AddRange(Is.Select(@is => string.Format(CultureInfo.InvariantCulture, "is:{0}", @is)));
             }
 
             if (Created != null)
@@ -269,10 +366,32 @@ namespace Octokit
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "updated:{0}", Updated));
             }
+
             if (Merged != null)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "merged:{0}", Merged));
             }
+
+            if (Status.HasValue)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "status:{0}", Status.Value.ToParameter()));
+            }
+
+            if (Head.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "head:{0}", Head));
+            }
+
+            if (Base.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "base:{0}", Base));
+            }
+
+            if (Closed != null)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "closed:{0}", Closed));
+            }
+
             if (Comments != null)
             {
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "comments:{0}", Comments));
@@ -331,6 +450,14 @@ namespace Octokit
         Merged
     }
 
+    public enum IssueTypeQualifier
+    {
+        [Parameter(Value = "pr")]
+        PR,
+        [Parameter(Value = "issue")]
+        Issue
+    }
+
     public enum IssueInQualifier
     {
         [Parameter(Value = "title")]
@@ -341,12 +468,30 @@ namespace Octokit
         Comment
     }
 
-    public enum IssueTypeQualifier
+    public enum IssueIsQualifier
     {
+        [Parameter(Value = "open")]
+        Open,
+        [Parameter(Value = "closed")]
+        Closed,
+        [Parameter(Value = "merged")]
+        Merged,
+        [Parameter(Value = "unmerged")]
+        Unmerged,
         [Parameter(Value = "pr")]
-        PR,
+        PullRequest,
         [Parameter(Value = "issue")]
         Issue
+    }
+
+    public enum IssueNoMetadataQualifier
+    {
+        [Parameter(Value = "label")]
+        Label,
+        [Parameter(Value = "milestone")]
+        Milestone,
+        [Parameter(Value = "assignee")]
+        Assignee
     }
 
     [DebuggerDisplay("{DebuggerDisplay,nq}")]

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -354,7 +354,7 @@ namespace Octokit
 
             if (Is != null)
             {
-                parameters.AddRange(Is.Select(@is => string.Format(CultureInfo.InvariantCulture, "is:{0}", @is)));
+                parameters.AddRange(Is.Select(x => string.Format(CultureInfo.InvariantCulture, "is:{0}", x.ToParameter())));
             }
 
             if (Created != null)
@@ -410,8 +410,7 @@ namespace Octokit
                     throw new RepositoryFormatException(invalidFormatRepos);
                 }
 
-                parameters.Add(
-                    string.Join("+", Repos.Select(x => "repo:" + x)));
+                parameters.AddRange(Repos.Select(x => string.Format(CultureInfo.InvariantCulture, "repo:{0}", x)));
             }
 
             return new ReadOnlyCollection<string>(parameters);
@@ -481,7 +480,11 @@ namespace Octokit
         [Parameter(Value = "pr")]
         PullRequest,
         [Parameter(Value = "issue")]
-        Issue
+        Issue,
+        [Parameter(Value = "private")]
+        Private,
+        [Parameter(Value = "public")]
+        Public
     }
 
     public enum IssueNoMetadataQualifier

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -161,21 +161,21 @@ namespace Octokit
             }
         }
 
-        private IEnumerable<string> _notLabels;
+        private IEnumerable<string> _excludeLabels;
         /// <summary>
         /// Filters issues based on the labels NOT assigned.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
         /// </remarks>
-        public IEnumerable<string> NotLabels
+        public IEnumerable<string> ExcludeLabels
         {
-            get { return _notLabels; }
+            get { return _excludeLabels; }
             set
             {
                 if (value != null && value.Any())
                 {
-                    _notLabels = value.Distinct().ToList();
+                    _excludeLabels = value.Distinct().ToList();
                 }
             }
         }
@@ -347,9 +347,9 @@ namespace Octokit
                 parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "label:{0}", label)));
             }
 
-            if (NotLabels != null)
+            if (ExcludeLabels != null)
             {
-                parameters.AddRange(NotLabels.Select(label => string.Format(CultureInfo.InvariantCulture, "-label:{0}", label)));
+                parameters.AddRange(ExcludeLabels.Select(label => string.Format(CultureInfo.InvariantCulture, "-label:{0}", label)));
             }
 
             if (No.HasValue)

--- a/Octokit/Models/Request/SearchIssuesRequestExclusions.cs
+++ b/Octokit/Models/Request/SearchIssuesRequestExclusions.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Searching Issues
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class SearchIssuesRequestExclusions
+    {
+        /// <summary>
+        /// Exclusions for Issue Search
+        /// </summary>
+        public SearchIssuesRequestExclusions()
+        {
+        }
+
+        /// <summary>
+        /// Excludes issues created by a certain user.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-the-author-of-an-issue-or-pull-request
+        /// </remarks>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Excludes issues that are assigned to a certain user.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-the-assignee-of-an-issue-or-pull-request
+        /// </remarks>
+        public string Assignee { get; set; }
+
+        /// <summary>
+        /// Excludes issues that mention a certain user.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-a-mentioned-user-within-an-issue-or-pull-request
+        /// </remarks>
+        public string Mentions { get; set; }
+
+        /// <summary>
+        /// Excludes issues that a certain user commented on.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-a-commenter-within-an-issue-or-pull-request
+        /// </remarks>
+        public string Commenter { get; set; }
+
+        /// <summary>
+        /// Excludes issues that were either created by a certain user, assigned to that user, 
+        /// mention that user, or were commented on by that user.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-a-user-thats-involved-within-an-issue-or-pull-request
+        /// </remarks>
+        public string Involves { get; set; }
+
+        /// <summary>
+        /// Excludes issues based on open/closed state.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-whether-an-issue-or-pull-request-is-open
+        /// </remarks>
+        public ItemState? State { get; set; }
+
+        private IEnumerable<string> _labels;
+        /// <summary>
+        /// Excludes issues based on the labels assigned.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue
+        /// </remarks>
+        public IEnumerable<string> Labels
+        {
+            get { return _labels; }
+            set
+            {
+                if (value != null && value.Any())
+                {
+                    _labels = value.Distinct().ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Excludes issues in repositories that match a certain language.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-by-the-main-language-of-a-repository
+        /// </remarks>
+        public Language? Language { get; set; }
+
+        /// <summary>
+        /// Excludes pull requests based on the status of the commits.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-commit-status
+        /// </remarks>
+        public CommitState? Status { get; set; }
+
+        /// Excludes pull requests based on the branch they came from.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
+        /// </remarks>
+        public string Head { get; set; }
+
+        /// <summary>
+        /// Excludes pull requests based on the branch they are merging into.
+        /// </summary>
+        /// <remarks>
+        /// https://help.github.com/articles/searching-issues/#search-based-on-branch-names
+        /// </remarks>
+        public string Base { get; set; }
+
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
+        public IReadOnlyList<string> MergedQualifiers()
+        {
+            var parameters = new List<string>();
+
+            if (Author.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-author:{0}", Author));
+            }
+
+            if (Assignee.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-assignee:{0}", Assignee));
+            }
+
+            if (Mentions.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-mentions:{0}", Mentions));
+            }
+
+            if (Commenter.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-commenter:{0}", Commenter));
+            }
+
+            if (Involves.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-involves:{0}", Involves));
+            }
+
+            if (State.HasValue)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-state:{0}", State.Value.ToParameter()));
+            }
+
+            if (Labels != null)
+            {
+                parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "-label:{0}", label)));
+            }
+
+            if (Language != null)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-language:{0}", Language.ToParameter()));
+            }
+
+            if (Status.HasValue)
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-status:{0}", Status.Value.ToParameter()));
+            }
+
+            if (Head.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-head:{0}", Head));
+            }
+
+            if (Base.IsNotBlank())
+            {
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "-base:{0}", Base));
+            }
+
+            return new ReadOnlyCollection<string>(parameters);
+        }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Exclusions: {0}", string.Join(" ", MergedQualifiers()));
+            }
+        }
+    }
+}

--- a/Octokit/Models/Request/SearchIssuesRequestExclusions.cs
+++ b/Octokit/Models/Request/SearchIssuesRequestExclusions.cs
@@ -106,6 +106,7 @@ namespace Octokit
         /// </remarks>
         public CommitState? Status { get; set; }
 
+        /// <summary>
         /// Excludes pull requests based on the branch they came from.
         /// </summary>
         /// <remarks>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -458,6 +458,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Models\Request\RepositoryForksListRequest.cs" />
     <Compile Include="Models\Request\RepositoryRequest.cs" />
     <Compile Include="Models\Request\Enterprise\SearchIndexingTarget.cs" />
+    <Compile Include="Models\Request\SearchIssuesRequestExclusions.cs" />
     <Compile Include="Models\Request\Signature.cs" />
     <Compile Include="Models\Request\CreateFileRequest.cs" />
     <Compile Include="Http\Response.cs" />


### PR DESCRIPTION
## Status
- [x] Implemented new options
- [x] Unit tests for the request parameters for all new (and existing types)
- [x] Flesh out some integration tests to use some of the new options
- [x] Get feedback on naming of `No` property and `IssueNoMetadataQualifier` enum
- [x] Get feedback on implementation of exclusion parameters
- [x] Guidance from @Haacked +/- @shiftkey on whether to include additional fields other than `label` in the exclusion support

## Details
Fixes #1227 
https://developer.github.com/v3/search/#search-issues
https://help.github.com/articles/searching-issues

Added new options to `SearchIssuesRequest`

- Searching by [`team`](https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request)
- Searching by "not" label syntax [`-label`](https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue)
- Searching on missing metadata [`no`](https://help.github.com/articles/searching-issues/#search-by-missing-metadata-on-an-issue-or-pull-request)
- The "human" styled [`is`](https://help.github.com/articles/searching-issues/#search-based-on-the-state-of-an-issue-or-pull-request) query 
 - (although `state` and `type` cover most of the `is` options, the `merged`/`unmerged` have no alternative)
- Searching by commit [`status`](https://help.github.com/articles/searching-issues/#search-based-on-commit-status)
- Searching by branch names [`base`](https://help.github.com/articles/searching-issues/#search-based-on-branch-names) or [`head`](https://help.github.com/articles/searching-issues/#search-based-on-branch-names)
- Searching on [`closed`](https://help.github.com/articles/searching-issues/#search-based-on-when-an-issue-or-pull-request-was-closed) date range

## Testing
Added unit tests for each parameter on this class to verify that when not set, the parameter is not in the query string, and when set the parameter is set as expected

Added some integration tests that excercise some of the new options

## Discussion

~~I'd appreciate feedback on the implementation for ["excluding" labels](https://help.github.com/articles/searching-issues/#search-by-the-labels-on-an-issue).  In the API docs, this is done by using notation `-label:labelname` as opposed to `label:labelname` to include a label.  At first I thought we could just implement this by having any label prepended with a hyphen be deemed to be an "exclusion" label, however it turns out that it's actually valid to have labels that start with a hyphen.  So I implemented this as a separate list property `SearchIssuesRequest.NotLabels`~~

~~It feels a bit ugly so if someone has a better way, let me know~~

~~**Update**: Now renamed to `SearchIssuesRequest.ExcludeLabels`~~
See https://github.com/octokit/octokit.net/pull/1228#issuecomment-203965890 for how the "exclusion" field implementation is shaping up...

Similarly, the ["missing metadata"](https://help.github.com/articles/searching-issues/#search-by-missing-metadata-on-an-issue-or-pull-request) search option, ive called the class property `No` to match the query property in API docs `no`, and gone with `IssueNoMetadataQualifier` as the enum name.  Open to better suggestions...