### PR TITLE
Fix Ensure methods parameters

### DIFF
--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// <returns>The created <see cref="Authorization"/>.</returns>
         public IObservable<ApplicationAuthorization> Create(NewAuthorization newAuthorization)
         {
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             return _client.Create(newAuthorization).ToObservable();
         }
@@ -105,7 +105,7 @@ namespace Octokit.Reactive
             NewAuthorization newAuthorization,
             string twoFactorAuthenticationCode)
         {
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             return _client.Create(newAuthorization, twoFactorAuthenticationCode).ToObservable();
@@ -137,7 +137,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             return _client.Create(clientId, clientSecret, newAuthorization).ToObservable();
         }
@@ -170,7 +170,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             return _client.Create(clientId, clientSecret, newAuthorization, twoFactorAuthenticationCode).ToObservable();
@@ -200,7 +200,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             return _client.GetOrCreateApplicationAuthentication(clientId, clientSecret, newAuthorization)
                 .ToObservable();
@@ -232,7 +232,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             return _client.GetOrCreateApplicationAuthentication(

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -27,7 +27,8 @@ namespace Octokit.Reactive
         public IObservable<User> GetAll(string owner, string repo)
         {
             Ensure.ArgumentNotNull(owner, "owner");
-            Ensure.ArgumentNotNull(repo, "name");
+            Ensure.ArgumentNotNull(repo, "repo");
+
             var endpoint = ApiUrls.RepoCollaborators(owner, repo);
             return _connection.GetAndFlattenAllPages<User>(endpoint);
         }

--- a/Octokit.Reactive/Helpers/AuthorizationExtensions.cs
+++ b/Octokit.Reactive/Helpers/AuthorizationExtensions.cs
@@ -38,7 +38,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(authorizationsClient, "authorizationsClient");
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             return authorizationsClient.GetOrCreateApplicationAuthentication(clientId, clientSecret, newAuthorization)
                 .Catch<ApplicationAuthorization, TwoFactorRequiredException>(exception => twoFactorChallengeHandler(exception)

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -96,7 +96,7 @@ namespace Octokit
         /// <returns>The created <see cref="Authorization"/>.</returns>
         public Task<ApplicationAuthorization> Create(NewAuthorization newAuthorization)
         {
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             var requestData = new
             {
@@ -132,7 +132,7 @@ namespace Octokit
             NewAuthorization newAuthorization,
             string twoFactorAuthenticationCode)
         {
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             var requestData = new
@@ -173,7 +173,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             var requestData = new
             {
@@ -218,7 +218,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             var requestData = new
@@ -261,7 +261,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
 
             var requestData = new
             {
@@ -304,7 +304,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(clientSecret, "clientSecret");
-            Ensure.ArgumentNotNull(newAuthorization, "authorization");
+            Ensure.ArgumentNotNull(newAuthorization, "newAuthorization");
             Ensure.ArgumentNotNullOrEmptyString(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
             var requestData = new

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -55,7 +55,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(newDeployment, "deployment");
+            Ensure.ArgumentNotNull(newDeployment, "newDeployment");
 
             return ApiConnection.Post<Deployment>(ApiUrls.Deployments(owner, name),
                                                      newDeployment);

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -34,7 +34,7 @@ namespace Octokit
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "repository");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAll(owner, name, ApiOptions.None);
         }
@@ -53,7 +53,7 @@ namespace Octokit
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "repository");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
             var endpoint = ApiUrls.Releases(owner, name);
@@ -113,7 +113,7 @@ namespace Octokit
         public Task<Release> Create(string owner, string name, NewRelease data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "repository");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(data, "data");
 
             var endpoint = ApiUrls.Releases(owner, name);

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -183,8 +183,8 @@ namespace Octokit
         public Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "repositoryName");
-            Ensure.ArgumentNotNullOrEmptyString(branch, "branchName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
 
             return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(owner, name, branch), update, AcceptHeaders.ProtectedBranchesApiPreview);

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -102,7 +102,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(name, "reference");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             var url = ApiUrls.RepositoryContent(owner, name, string.Empty, reference);
 

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -290,7 +290,7 @@ namespace Octokit
         /// <returns></returns>
         public async Task<bool> RemoveRepository(int id, string organization, string repoName)
         {
-            Ensure.ArgumentNotNullOrEmptyString(organization, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
             Ensure.ArgumentNotNullOrEmptyString(repoName, "repoName");
 
             var endpoint = ApiUrls.TeamRepository(id, organization, repoName);

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="sha">The sha.</param>
         public DeleteFileRequest(string message, string sha) : base(message)
         {
-            Ensure.ArgumentNotNullOrEmptyString(sha, "content");
+            Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
             Sha = sha;
         }

--- a/Octokit/Models/Request/NewReference.cs
+++ b/Octokit/Models/Request/NewReference.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="sha">The SHA1 value to set this reference to</param>
         public NewReference(string reference, string sha)
         {
-            Ensure.ArgumentNotNullOrEmptyString(reference, "ref");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
             Ref = GetReference(reference);


### PR DESCRIPTION
I found and fixed some issues when Ensure.ArgumentNotNull and Ensure.ArgumentNotNullOrEmptyString were used.

/cc @shiftkey, @ryangribble 