### PR TITLE
Fix some misspellings in code, comments and xml docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
   - osx
   - linux
 install:
-  - curl -sS http://storage.bos.xamarin.com/bot-provisioning/PortableReferenceAssemblies-2014-04-14.zip > /tmp/pcl-assemblies.zip
-  - unzip /tmp/pcl-assemblies.zip -d /tmp/pcl-assemblies && mv /tmp/pcl-assemblies/PortableReferenceAssemblies-2014-04-14 /tmp/pcl-assemblies/.NETPortable
-  - export XBUILD_FRAMEWORK_FOLDERS_PATH=/tmp/pcl-assemblies/
   - nuget restore Octokit-Mono.sln 
 script: 
   - mono tools/nuget/NuGet.exe restore Octokit-Mono.sln

--- a/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAuthorizationsClient.cs
@@ -190,7 +190,7 @@ namespace Octokit.Reactive
         IObservable<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken);
 
         /// <summary>
-        /// Resets a valid OAuth token for an OAuth application without end user involvment.
+        /// Resets a valid OAuth token for an OAuth application without end user involvement.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.

--- a/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         IObservable<LicenseMetadata> GetAllLicenses();
 
         /// <summary>
-        /// Retrieves a license based on the licence key such as "mit"
+        /// Retrieves a license based on the license key such as "mit"
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -16,7 +16,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Creates a new repository in the specified organization.
         /// </summary>
-        /// <param name="organizationLogin">The login of the organization in which to create the repostiory</param>
+        /// <param name="organizationLogin">The login of the organization in which to create the repository</param>
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <returns>An <see cref="IObservable{Repository}"/> instance for the created repository</returns>
         IObservable<Repository> Create(string organizationLogin, NewRepository newRepository);
@@ -256,7 +256,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All of the repositorys tags.</returns>
+        /// <returns>All of the repositories tags.</returns>
         IObservable<RepositoryTag> GetAllTags(string owner, string name);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAuthorizationsClient.cs
@@ -264,7 +264,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Resets a valid OAuth token for an OAuth application without end user involvment.
+        /// Resets a valid OAuth token for an OAuth application without end user involvement.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Retrieves a license based on the licence key such as "mit"
+        /// Retrieves a license based on the license key such as "mit"
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Creates a new repository in the specified organization.
         /// </summary>
-        /// <param name="organizationLogin">The login of the organization in which to create the repostiory</param>
+        /// <param name="organizationLogin">The login of the organization in which to create the repository</param>
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <returns>An <see cref="IObservable{Repository}"/> instance for the created repository</returns>
         public IObservable<Repository> Create(string organizationLogin, NewRepository newRepository)
@@ -374,7 +374,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All of the repositorys tags.</returns>
+        /// <returns>All of the repositories tags.</returns>
         public IObservable<RepositoryTag> GetAllTags(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 using Octokit.Tests.Integration.Helpers;
@@ -37,7 +36,7 @@ public class ReferencesClientTests : IDisposable
     }
 
     [IntegrationTest]
-    public async Task WhenReferenceDoesNotExistAnExeptionIsThrown()
+    public async Task WhenReferenceDoesNotExistAnExceptionIsThrown()
     {
         await Assert.ThrowsAsync<NotFoundException>(
             () => _fixture.Get("octokit", "octokit.net", "heads/foofooblahblah"));

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -319,9 +319,9 @@ public class ReleasesClientTests
             using (var zipstream = new MemoryStream((byte[])response.Body))
             using (var archive = new ZipArchive(zipstream))
             {
-                var enttry = archive.Entries[0];
-                var data = new byte[enttry.Length];
-                await enttry.Open().ReadAsync(data, 0, data.Length);
+                var entry = archive.Entries[0];
+                var data = new byte[entry.Length];
+                await entry.Open().ReadAsync(data, 0, data.Length);
                 textContent = Encoding.ASCII.GetString(data);
             }
 

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Integration.Clients
             [IntegrationTest]
             public async Task ForkCreatedForUserLoggedIn()
             {
-                // The fork is created asynchronically by github and therefore it cannot 
+                // The fork is created asynchronously by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts instead of after.
                 Helper.DeleteRepo(Helper.Credentials.Login, "octokit.net");
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Integration.Clients
             [OrganizationTest]
             public async Task ForkCreatedForOrganization()
             {
-                // The fork is created asynchronically by github and therefore it cannot 
+                // The fork is created asynchronously by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts.
                 Helper.DeleteRepo(Helper.Organization, "octokit.net");

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -41,7 +40,7 @@ namespace Octokit.Tests.Integration.Clients
             [IntegrationTest]
             public async Task ForkCreatedForUserLoggedIn()
             {
-                // The fork is created asynchronially by github and therefore it cannot 
+                // The fork is created asynchronically by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts instead of after.
                 Helper.DeleteRepo(Helper.Credentials.Login, "octokit.net");
@@ -58,7 +57,7 @@ namespace Octokit.Tests.Integration.Clients
             [OrganizationTest]
             public async Task ForkCreatedForOrganization()
             {
-                // The fork is created asynchronially by github and therefore it cannot 
+                // The fork is created asynchronically by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts.
                 Helper.DeleteRepo(Helper.Organization, "octokit.net");

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -148,7 +148,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="Clients\UsersClientTests.cs" />
-    <Compile Include="Reactive\ObservableRespositoryDeployKeysClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableUserAdministrationClientTests.cs" />
     <Compile Include="Reactive\ObservableUserEmailsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -6,7 +6,7 @@ using Octokit.Reactive;
 using Octokit.Tests.Integration;
 using Xunit;
 
-public class ObservableRespositoryDeployKeysClientTests : IDisposable
+public class ObservableRepositoryDeployKeysClientTests : IDisposable
 {
     const string _key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDB8IE5+RppLpeW+6lqo0fpfvMunKg6W4bhYCfVJIOYbpKoHP95nTUMZPBT++9NLeB4/YsuNTCrrpnpjc4f2IVpGvloRiVXjAzoJk9QIL6uzn1zRFdvaxSJ3Urhe9LcLHcIgccgZgSdWGzaZI3xtMvGC4diwWNsPjvVc/RyDM/MPqAim0X5XVOQwEFsSsUSraezJ+VgYMYzLYBcKWW0B86HVVhL4ZtmcY/RN2544bljnzw2M3aQvXNPTvkuiUoqLOI+5/qzZ8PfkruO55YtweEd0lkY6oZvrBPMD6dLODEqMHb4tD6htx60wSipNqjPwpOMpzp0Bk3G909unVXi6Fw5";
     const string _keyTitle = "octokit@github";
@@ -14,7 +14,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
     Repository _repository;
     string _owner;
 
-    public ObservableRespositoryDeployKeysClientTests()
+    public ObservableRepositoryDeployKeysClientTests()
     {
         var github = Helper.GetAuthenticatedClient();
 

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -335,7 +335,7 @@ namespace Octokit.Tests.Clients
         public class TheRevokeApplicationAuthenticationMethod
         {
             [Fact]
-            public async Task RevokesApplicatonAuthenticationAtCorrectUrl()
+            public async Task RevokesApplicationAuthenticationAtCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var authEndpoint = new AuthorizationsClient(client);

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -82,7 +82,7 @@ namespace Octokit.Tests.Clients
         public class TheGetResourceRateLimitsMethod
         {
             [Fact]
-            public async Task RequestsTheRecourceRateLimitEndpoint()
+            public async Task RequestsTheResourceRateLimitEndpoint()
             {
                 IApiResponse<MiscellaneousRateLimit> response = new ApiResponse<MiscellaneousRateLimit>
                 (

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -119,7 +118,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task UsesTheOrganizatinosReposUrl()
+            public async Task UsesTheOrganizationsReposUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -377,7 +377,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                //get repos whos stargazers are greater than 500
+                //get repos who's stargazers are greater than 500
                 var request = new SearchRepositoriesRequest("github");
                 request.Stars = Range.GreaterThan(500);
                 client.SearchRepo(request);
@@ -391,7 +391,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                //get repos whos stargazers are less than 500
+                //get repos who's stargazers are less than 500
                 var request = new SearchRepositoriesRequest("github");
                 request.Stars = Range.LessThan(500);
                 client.SearchRepo(request);
@@ -405,7 +405,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                //get repos whos stargazers are less than 500 or equal to
+                //get repos who's stargazers are less than 500 or equal to
                 var request = new SearchRepositoriesRequest("github");
                 request.Stars = Range.LessThanOrEquals(500);
                 client.SearchRepo(request);
@@ -445,7 +445,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                //get repos whos language is Ruby
+                //get repos who's language is Ruby
                 var request = new SearchRepositoriesRequest("github");
                 request.Language = Language.Ruby;
                 client.SearchRepo(request);

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -25,7 +24,7 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsTheCorrectlUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -7,9 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
-using NSubstitute.Core.Arguments;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Http
@@ -44,7 +42,7 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
-            public async Task CanMakeMutipleRequestsWithSameConnection()
+            public async Task CanMakeMultipleRequestsWithSameConnection()
             {
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response();

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -353,7 +353,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Resets a valid OAuth token for an OAuth application without end user involvment.
+        /// Resets a valid OAuth token for an OAuth application without end user involvement.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="options">The options to chagne API's response.</param>
+        /// <param name="options">The options to change API's response.</param>
         /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name, ApiOptions options);
 

--- a/Octokit/Clients/IAuthorizationsClient.cs
+++ b/Octokit/Clients/IAuthorizationsClient.cs
@@ -215,7 +215,7 @@ namespace Octokit
         Task<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken);
 
         /// <summary>
-        /// Resets a valid OAuth token for an OAuth application without end user involvment.
+        /// Resets a valid OAuth token for an OAuth application without end user involvement.
         /// </summary>
         /// <remarks>
         /// This method requires authentication.

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -62,7 +62,7 @@ namespace Octokit
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
 
         /// <summary>
-        /// Retrieves a license based on the licence key such as "mit"
+        /// Retrieves a license based on the license key such as "mit"
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -73,7 +73,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#create">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="organizationLogin">Login of the organization in which to create the repostiory</param>
+        /// <param name="organizationLogin">Login of the organization in which to create the repository</param>
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository</returns>
@@ -351,7 +351,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All of the repositorys tags.</returns>
+        /// <returns>All of the repositories tags.</returns>
         Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -80,7 +80,7 @@ namespace Octokit
         Task<Readme> GetReadme(string owner, string name);
 
         /// <summary>
-        /// Gets the perferred README's HTML for the specified repository.
+        /// Gets the preferred README's HTML for the specified repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -117,7 +117,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Retrieves a license based on the licence key such as "mit"
+        /// Retrieves a license based on the license key such as "mit"
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -69,7 +69,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#create">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="organizationLogin">Login of the organization in which to create the repostiory</param>
+        /// <param name="organizationLogin">Login of the organization in which to create the repository</param>
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository</returns>
@@ -551,7 +551,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All of the repositorys tags.</returns>
+        /// <returns>All of the repositories tags.</returns>
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -131,7 +131,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets the perferred README's HTML for the specified repository.
+        /// Gets the preferred README's HTML for the specified repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -17,7 +17,7 @@ namespace Octokit
         static readonly Uri _currentUserAllIssues = new Uri("issues", UriKind.Relative);
         static readonly Uri _currentUserOwnedAndMemberIssues = new Uri("user/issues", UriKind.Relative);
         static readonly Uri _oauthAuthorize = new Uri("login/oauth/authorize", UriKind.Relative);
-        static readonly Uri _oauthAccesToken = new Uri("login/oauth/access_token", UriKind.Relative);
+        static readonly Uri _oauthAccessToken = new Uri("login/oauth/access_token", UriKind.Relative);
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all public repositories in
@@ -1135,7 +1135,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> for a specifc blob.
+        /// Returns the <see cref="Uri"/> for a specific blob.
         /// </summary>
         /// <param name="owner">The owner of the blob</param>
         /// <param name="name">The name of the organization</param>
@@ -1146,7 +1146,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> for a specifc blob.
+        /// Returns the <see cref="Uri"/> for a specific blob.
         /// </summary>
         /// <param name="owner">The owner of the blob</param>
         /// <param name="name">The name of the organization</param>
@@ -1560,7 +1560,7 @@ namespace Octokit
         /// <returns></returns>
         public static Uri OauthAccessToken()
         {
-            return _oauthAccesToken;
+            return _oauthAccessToken;
         }
 
         /// <summary>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -142,7 +142,7 @@ namespace Octokit
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>
         public ApiInfo GetLastApiInfo()
         {
-            // We've choosen to not wrap the _lastApiInfo in a lock.  Originally the code was returning a reference - so there was a danger of
+            // We've chosen to not wrap the _lastApiInfo in a lock.  Originally the code was returning a reference - so there was a danger of
             // on thread writing to the object while another was reading.  Now we are cloning the ApiInfo on request - thus removing the need (or overhead)
             // of putting locks in place.
             // See https://github.com/octokit/octokit.net/pull/855#discussion_r36774884

--- a/Octokit/Http/IApiInfoProvider.cs
+++ b/Octokit/Http/IApiInfoProvider.cs
@@ -1,7 +1,7 @@
 ﻿namespace Octokit
 {
     /// <summary>
-    /// Provides a property for the Last recorded API infomation
+    /// Provides a property for the Last recorded API information
     /// </summary>
     public interface IApiInfoProvider
     {

--- a/Octokit/Models/Request/RepositoryIssueRequest.cs
+++ b/Octokit/Models/Request/RepositoryIssueRequest.cs
@@ -3,7 +3,7 @@
 namespace Octokit
 {
     /// <summary>
-    /// Used to requent and filter a list of repository issues.
+    /// Used to request and filter a list of repository issues.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryIssueRequest : IssueRequest

--- a/Octokit/Models/Request/RepositoryRequest.cs
+++ b/Octokit/Models/Request/RepositoryRequest.cs
@@ -90,7 +90,7 @@ namespace Octokit
         Owner,
 
         /// <summary>
-        /// Returns public repositoires.
+        /// Returns public repositories.
         /// </summary>
         Public,
 

--- a/Octokit/Models/Request/SearchQualifierOperator.cs
+++ b/Octokit/Models/Request/SearchQualifierOperator.cs
@@ -1,7 +1,7 @@
 ﻿namespace Octokit
 {
     /// <summary>
-    /// Used to qualify a serch term.
+    /// Used to qualify a search term.
     /// </summary>
     public enum SearchQualifierOperator
     {

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -321,10 +321,10 @@ namespace Octokit
         }
 
         /// <summary>
-        /// helper method to create a LessThan Date Comparision
+        /// helper method to create a LessThan Date Comparison
         /// e.g. &lt; 2011
         /// </summary>
-        /// <param name="date">date to be used for comparision (times are ignored)</param>
+        /// <param name="date">date to be used for comparison (times are ignored)</param>
         /// <returns><see cref="DateRange"/></returns>
         public static DateRange LessThan(DateTime date)
         {
@@ -332,10 +332,10 @@ namespace Octokit
         }
 
         /// <summary>
-        /// helper method to create a LessThanOrEqualTo Date Comparision
+        /// helper method to create a LessThanOrEqualTo Date Comparison
         /// e.g. &lt;= 2011
         /// </summary>
-        /// <param name="date">date to be used for comparision (times are ignored)</param>
+        /// <param name="date">date to be used for comparison (times are ignored)</param>
         /// <returns><see cref="DateRange"/></returns>
         public static DateRange LessThanOrEquals(DateTime date)
         {
@@ -343,10 +343,10 @@ namespace Octokit
         }
 
         /// <summary>
-        /// helper method to create a GreaterThan Date Comparision
+        /// helper method to create a GreaterThan Date Comparison
         /// e.g. > 2011
         /// </summary>
-        /// <param name="date">date to be used for comparision (times are ignored)</param>
+        /// <param name="date">date to be used for comparison (times are ignored)</param>
         /// <returns><see cref="DateRange"/></returns>
         public static DateRange GreaterThan(DateTime date)
         {
@@ -354,10 +354,10 @@ namespace Octokit
         }
 
         /// <summary>
-        /// helper method to create a GreaterThanOrEqualTo Date Comparision
+        /// helper method to create a GreaterThanOrEqualTo Date Comparison
         /// e.g. >= 2011
         /// </summary>
-        /// <param name="date">date to be used for comparision (times are ignored)</param>
+        /// <param name="date">date to be used for comparison (times are ignored)</param>
         /// <returns><see cref="DateRange"/></returns>
         public static DateRange GreaterThanOrEquals(DateTime date)
         {
@@ -479,9 +479,9 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Edn")]
         Edn,
         Eiffel,
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
-        Elixer,
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
+        Elixir,
         Elm,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
@@ -709,9 +709,9 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "TypeScript")]
         [Parameter(Value = "TypeScript")]
         TypeScript,
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Paralel")]
-        [Parameter(Value = "Unified Paralel C")]
-        UnifiedParalelC,
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Parallel")]
+        [Parameter(Value = "Unified Parallel C")]
+        UnifiedParallelC,
         Unknown,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Vala")]
         Vala,

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -482,6 +482,10 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
         Elixir,
+        [Obsolete("This item is incorrect and will be removed in a future update. Use Elixir instead.")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
+        Elixer,
         Elm,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
@@ -712,6 +716,10 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Parallel")]
         [Parameter(Value = "Unified Parallel C")]
         UnifiedParallelC,
+        [Obsolete("This item is incorrect and will be removed in a future update. Use UnifiedParallelC instead.")]
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Paralel")]
+        [Parameter(Value = "Unified Paralel C")]
+        UnifiedParalelC,
         Unknown,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Vala")]
         Vala,

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -82,7 +82,7 @@ namespace Octokit
         Off,
 
         /// <summary>
-        /// Required status checks will be enforeced for non-admins.
+        /// Required status checks will be enforced for non-admins.
         /// </summary>
         NonAdmins,
 

--- a/Octokit/Models/Response/License.cs
+++ b/Octokit/Models/Response/License.cs
@@ -79,7 +79,7 @@ namespace Octokit
         public IReadOnlyList<string> Required { get; protected set; }
 
         /// <summary>
-        /// Set of codes for what is permitted under the terms of the license. For example, "commerical-use"
+        /// Set of codes for what is permitted under the terms of the license. For example, "commercial-use"
         /// </summary>
         public IReadOnlyList<string> Permitted { get; protected set; }
 

--- a/Octokit/Models/Response/Readme.cs
+++ b/Octokit/Models/Response/Readme.cs
@@ -45,7 +45,7 @@ namespace Octokit
         public Uri Url { get; private set; }
 
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
-            Justification = "Makse a network request")]
+            Justification = "Makes a network request")]
         public Task<string> GetHtmlContent()
         {
             return htmlContent.Value;

--- a/Octokit/Models/Response/TagObject.cs
+++ b/Octokit/Models/Response/TagObject.cs
@@ -15,7 +15,7 @@ namespace Octokit
         }
 
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
-            Justification = "Name defined by web api and required for deserialisation")]
+            Justification = "Name defined by web api and required for deserialization")]
         public TaggedType Type { get; protected set; }
     }
 


### PR DESCRIPTION
I've found and fixed some misspellings inside Octokit solution. There are a lot of changes, but they all very simple, one or two letter have been changed only. Hope this PR would be useful.

/cc @ryangribble, @shiftkey 