### PR TITLE
Add "importers" field to MiscellaneousClient.Meta response

### DIFF
--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -9,7 +9,7 @@ namespace Octokit.Reactive
     {
         readonly IMiscellaneousClient _client;
 
-        [Obsolete("Please use another constructor")]
+        [Obsolete("Please use the IGitHubClient overload constructor")]
         public ObservableMiscellaneousClient(IMiscellaneousClient client)
         {
             Ensure.ArgumentNotNull(client, "client");

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -9,11 +9,19 @@ namespace Octokit.Reactive
     {
         readonly IMiscellaneousClient _client;
 
+        [Obsolete("Please use another constructor")]
         public ObservableMiscellaneousClient(IMiscellaneousClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
 
             _client = client;
+        }
+
+        public ObservableMiscellaneousClient(IGitHubClient client)
+        {
+            Ensure.ArgumentNotNull(client, "client");
+
+            _client = client.Miscellaneous;
         }
 
         /// <summary>

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
             Authorization = new ObservableAuthorizationsClient(gitHubClient);
             Activity = new ObservableActivitiesClient(gitHubClient);
             Issue = new ObservableIssuesClient(gitHubClient);
-            Miscellaneous = new ObservableMiscellaneousClient(gitHubClient.Miscellaneous);
+            Miscellaneous = new ObservableMiscellaneousClient(gitHubClient);
             Notification = new ObservableNotificationsClient(gitHubClient);
             Oauth = new ObservableOauthClient(gitHubClient);
             Organization = new ObservableOrganizationsClient(gitHubClient);

--- a/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
@@ -113,6 +113,11 @@ public class MiscellaneousClientTests
             var result = await github.Miscellaneous.GetMetadata();
 
             Assert.True(result.VerifiablePasswordAuthentication);
+            Assert.NotEmpty(result.GitHubServicesSha);
+            Assert.True(result.Hooks.Count > 0);
+            Assert.True(result.Git.Count > 0);
+            Assert.True(result.Pages.Count > 0);
+            Assert.True(result.Importer.Count > 0);
         }
     }
 }

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -136,6 +136,42 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetMetadataMethod
+        {
+            [Fact]
+            public async Task RequestsTheMetadataEndpoint()
+            {
+                IApiResponse<Meta> response = new ApiResponse<Meta>
+                (
+                    new Response(),
+                    new Meta(
+                        false,
+                        "12345ABCDE",
+                        new[] { "1.1.1.1/24", "1.1.1.2/24" },
+                        new[] { "1.1.2.1/24", "1.1.2.2/24" },
+                        new[] { "1.1.3.1/24", "1.1.3.2/24" },
+                        new[] { "1.1.4.1", "1.1.4.2" }
+                    )
+                );
+                var connection = Substitute.For<IConnection>();
+                connection.Get<Meta>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+                var client = new MiscellaneousClient(connection);
+
+                var result = await client.GetMetadata();
+
+                Assert.Equal(result.VerifiablePasswordAuthentication, false);
+                Assert.Equal(result.GitHubServicesSha, "12345ABCDE");
+                Assert.Equal(result.Hooks, new[] { "1.1.1.1/24", "1.1.1.2/24" });
+                Assert.Equal(result.Git, new[] { "1.1.2.1/24", "1.1.2.2/24" });
+                Assert.Equal(result.Pages, new[] { "1.1.3.1/24", "1.1.3.2/24" });
+                Assert.Equal(result.Importer, new[] { "1.1.4.1", "1.1.4.2" });
+
+                connection.Received()
+                    .Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta"), null, null);
+            }
+        }
+
         public class TheCtor
         {
             [Fact]

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Reactive\ObservableIssueCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
+    <Compile Include="Reactive\ObservableMiscellaneousClientTests.cs" />
     <Compile Include="Reactive\ObservableOrganizationMembersClientTests.cs" />
     <Compile Include="Reactive\ObservablePullRequestsClientTests.cs" />
     <Compile Include="Reactive\ObservableReleasesClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableMiscellaneousClientTests
+    {
+        public class TheGetAllEmojisMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetAllEmojis();
+
+                gitHubClient.Miscellaneous.Received(1).GetAllEmojis();
+            }
+        }
+
+        public class TheRenderArbitraryMarkdownMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.RenderArbitraryMarkdown(new NewArbitraryMarkdown("# test"));
+
+                gitHubClient.Miscellaneous.Received(1).RenderArbitraryMarkdown(Arg.Is<NewArbitraryMarkdown>(a => a.Text == "# test"));
+            }
+        }
+
+        public class TheRenderRawMarkdownMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.RenderRawMarkdown("# test");
+
+                gitHubClient.Miscellaneous.Received(1).RenderRawMarkdown("# test");
+            }
+        }
+
+        public class TheGetAllGitIgnoreTemplatesMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetAllGitIgnoreTemplates();
+
+                gitHubClient.Miscellaneous.Received(1).GetAllGitIgnoreTemplates();
+            }
+        }
+
+        public class TheGetGitIgnoreTemplate
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetGitIgnoreTemplate("template");
+
+                gitHubClient.Miscellaneous.Received(1).GetGitIgnoreTemplate("template");
+            }
+        }
+
+        public class TheGetAllLicensesMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetAllLicenses();
+
+                gitHubClient.Miscellaneous.Received(1).GetAllLicenses();
+            }
+        }
+
+        public class TheGetLicenseMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetLicense("key");
+
+                gitHubClient.Miscellaneous.Received(1).GetLicense("key");
+            }
+        }
+
+        public class TheGetRateLimitsMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetRateLimits();
+
+                gitHubClient.Miscellaneous.Received(1).GetRateLimits();
+            }
+        }
+
+        public class TheGetMetadataMethod
+        {
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMiscellaneousClient(gitHubClient);
+
+                client.GetMetadata();
+
+                gitHubClient.Miscellaneous.Received(1).GetMetadata();
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgument()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableMiscellaneousClient((IGitHubClient)null));
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/Meta.cs
+++ b/Octokit/Models/Response/Meta.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="hooks">An array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from on GitHub.com.</param>
         /// <param name="git">An array of IP addresses in CIDR format specifying the Git servers for the GitHub server</param>
         /// <param name="pages">An array of IP addresses in CIDR format specifying the A records for GitHub Pages.</param>
+        /// <param name="importer">An Array of IP addresses specifying the addresses that source imports will originate from on GitHub.com.</param>
         public Meta(
             bool verifiablePasswordAuthentication,
             string gitHubServicesSha,

--- a/Octokit/Models/Response/Meta.cs
+++ b/Octokit/Models/Response/Meta.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -30,13 +31,15 @@ namespace Octokit
             string gitHubServicesSha,
             IReadOnlyList<string> hooks,
             IReadOnlyList<string> git,
-            IReadOnlyList<string> pages)
+            IReadOnlyList<string> pages,
+            IReadOnlyList<string> importer)
         {
             VerifiablePasswordAuthentication = verifiablePasswordAuthentication;
             GitHubServicesSha = gitHubServicesSha;
             Hooks = hooks;
             Git = git;
             Pages = pages;
+            Importer = importer;
         }
 
         /// <summary>
@@ -49,6 +52,7 @@ namespace Octokit
         /// <summary>
         /// The currently-deployed SHA of github-services.
         /// </summary>
+        [Parameter(Key = "github_services_sha")]
         public string GitHubServicesSha { get; private set; }
 
         /// <summary>
@@ -67,6 +71,11 @@ namespace Octokit
         /// An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.
         /// </summary>
         public IReadOnlyList<string> Pages { get; private set; }
+
+        /// <summary>
+        /// An Array of IP addresses specifying the addresses that source imports will originate from on GitHub.com.
+        /// </summary>
+        public IReadOnlyList<string> Importer { get; private set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
Adds new field "Importers" to the Metadata request of MiscellaneousClient

API docs: https://developer.github.com/v3/meta/

Fixes #1234 

- [x] Added `Importers` field to `Meta` response model and updated `ctor`

- [x] Added unit test for `GetMetadata` method

- [x] Enhanced integration tests for `GetMetadata` method
 - Revealed a bug with an existing field `GitHubServicesSha` not being deserialised properly, added a fix to this PR

- [x] Added unit tests for `ObservableMiscellaneousClient` for all methods
No tests for this observable client existed, so all methods were implemented

- [x] Fixed `ObservableMiscellaneousClient` constructor to be inline with all other obersvable API clients
(Marked old constructor as `[Obsolete]` so it can be removed in a later release)