### PR TITLE
Add custom exception for the HTTP 451 response

### DIFF
--- a/Octokit.Tests/Exceptions/LegalRestrictionExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/LegalRestrictionExceptionTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Exceptions
         [Fact]
         public void HasDefaultMessage()
         {
-            var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
+            var response = new Response((HttpStatusCode)451, null, new Dictionary<string, string>(), "application/json");
             var legalRestrictionException = new LegalRestrictionException(response);
 
             Assert.Equal("Resource taken down due to a DMCA notice.", legalRestrictionException.Message);

--- a/Octokit.Tests/Exceptions/LegalRestrictionExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/LegalRestrictionExceptionTests.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Exceptions
+{
+    public class LegalRestrictionExceptionTests
+    {
+        [Fact]
+        public void HasDefaultMessage()
+        {
+            var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
+            var legalRestrictionException = new LegalRestrictionException(response);
+
+            Assert.Equal("Resource taken down due to a DMCA notice.", legalRestrictionException.Message);
+        }
+    }
+}

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Exceptions\ApiErrorTests.cs" />
     <Compile Include="Exceptions\ApiExceptionTests.cs" />
     <Compile Include="Exceptions\ApiValidationExceptionTests.cs" />
+    <Compile Include="Exceptions\LegalRestrictionExceptionTests.cs" />
     <Compile Include="Exceptions\RepositoryExistsExceptionTests.cs" />
     <Compile Include="Exceptions\TwoFactorChallengeFailedException.cs" />
     <Compile Include="Exceptions\ForbiddenExceptionTests.cs" />

--- a/Octokit/Exceptions/LegalRestrictionException.cs
+++ b/Octokit/Exceptions/LegalRestrictionException.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Represents a HTTP 451 - Unavailable For Legal Reasons response returned from the API.
+    /// This will returned if GitHub has been asked to takedown the requested resource due to
+    /// a DMCA takedown.
+    /// </summary>
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class LegalRestrictionException : ApiException
+    {
+        /// <summary>
+        /// Constructs an instance of LegalRestrictionException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        public LegalRestrictionException(IResponse response) : this(response, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of LegalRestrictionException
+        /// </summary>
+        /// <param name="message">The exception message</param>
+        /// <param name="statusCode">The http status code returned by the response</param>
+        public LegalRestrictionException(string message, HttpStatusCode statusCode) : base(message, statusCode)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of LegalRestrictionException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        /// <param name="innerException">The inner exception</param>
+        public LegalRestrictionException(IResponse response, Exception innerException)
+            : base(response, innerException)
+        {
+            Debug.Assert(response != null && response.StatusCode == 451,
+                "LegalRestrictionException created with wrong status code");
+        }
+
+#if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of LegalRestrictionException
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected LegalRestrictionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/Octokit/Exceptions/LegalRestrictionException.cs
+++ b/Octokit/Exceptions/LegalRestrictionException.cs
@@ -18,6 +18,11 @@ namespace Octokit
         Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
     public class LegalRestrictionException : ApiException
     {
+        public override string Message
+        {
+            get { return ApiErrorMessageSafe ?? "Resource taken down due to a DMCA notice."; }
+        }
+
         /// <summary>
         /// Constructs an instance of LegalRestrictionException
         /// </summary>

--- a/Octokit/Exceptions/LegalRestrictionException.cs
+++ b/Octokit/Exceptions/LegalRestrictionException.cs
@@ -43,7 +43,7 @@ namespace Octokit
         public LegalRestrictionException(IResponse response, Exception innerException)
             : base(response, innerException)
         {
-            Debug.Assert(response != null && response.StatusCode == 451,
+            Debug.Assert(response != null && response.StatusCode == (HttpStatusCode)451,
                 "LegalRestrictionException created with wrong status code");
         }
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -559,7 +559,8 @@ namespace Octokit
                 { HttpStatusCode.Unauthorized, GetExceptionForUnauthorized },
                 { HttpStatusCode.Forbidden, GetExceptionForForbidden },
                 { HttpStatusCode.NotFound, response => new NotFoundException(response) },
-                { (HttpStatusCode)422, response => new ApiValidationException(response) }
+                { (HttpStatusCode)422, response => new ApiValidationException(response) },
+                { (HttpStatusCode)451, response => new LegalRestrictionException(response) }
             };
 
         static void HandleErrors(IResponse response)

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -458,6 +458,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -455,6 +455,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -462,6 +462,7 @@
     <Compile Include="Models\Request\UserRename.cs" />
     <Compile Include="Models\Response\UserRenameResponse.cs" />
     <Compile Include="Models\Request\NewPublicKey.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Clients\UserKeysClient.cs" />
     <Compile Include="Clients\RepositoryContentsClient.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
+    <Compile Include="Exceptions\LegalRestrictionException.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />
     <Compile Include="Exceptions\PullRequestMismatchException.cs" />
     <Compile Include="Exceptions\PullRequestNotMergeableException.cs" />

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -6,10 +6,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersionAttribute("0.19.0")]
 [assembly: AssemblyFileVersionAttribute("0.19.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System
-{
-    internal static class AssemblyVersionInformation
-    {
+namespace System {
+    internal static class AssemblyVersionInformation {
         internal const string Version = "0.19.0";
     }
 }


### PR DESCRIPTION
Implements #1237.

As per this [blog](https://developer.github.com/changes/#--the-451-status-code-is-now-supported) post.

GitHub API will now return a HTTP 451 response (rather than a 403) when a repository or gist cannot be accessed due to a DMCA notice.

Checklist:

- [x] Add new exception.
- [x] Add it to `HandleErrors`.
- [x] `.\build FixProjects`
- [x] Unit tests.
- [x] Integration tests.

/cc @ryangribble 