### PR TITLE
Add check of client constructor test class name

### DIFF
--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Octokit.Tests.Clients;
 using Xunit;
 
 namespace Octokit.Tests.Conventions
@@ -23,7 +22,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetTestConstructorsClasses()
         {
-            var tests = typeof(EventsClientTests)
+            var tests = typeof(GitHubClientTests)
                 .Assembly
                 .ExportedTypes
                 .Where(type => type.IsClass && type.IsPublic && type.Name.EndsWith("ClientTests"))

--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -27,7 +27,7 @@ namespace Octokit.Tests.Conventions
                 .Assembly
                 .ExportedTypes
                 .Where(type => type.IsClass && type.IsPublic && type.Name.EndsWith("ClientTests"))
-                .Select(type => new[] { type }).ToList();
+                .Select(type => new[] { type });
             return tests;
         }
     }

--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -8,19 +8,32 @@ namespace Octokit.Tests.Conventions
     public class ClientConstructorTests
     {
         [Theory]
-        [MemberData("GetTestConstructorsClasses")]
-        public void CheckTestConstructorsNames(Type type)
+        [MemberData("GetTestConstructorClasses")]
+        public void CheckTestConstructorNames(Type type)
         {
-            const string constructorClassName = "TheCtor";
+            const string constructorTestClassName = "TheCtor";
+            const string constructorTestMethodName = "EnsuresNonNullArguments";
+
             var classes = new HashSet<string>(type.GetNestedTypes().Select(t => t.Name));
             
-            if (!classes.Contains(constructorClassName))
+            if (!classes.Contains(constructorTestClassName))
             {
                 throw new MissingClientConstructorTestClassException(type);
             }
+
+            var ctors = type.GetNestedTypes().Where(t => t.Name == constructorTestClassName)
+                .SelectMany(t => t.GetMethods())
+                .Where(info => info.ReturnType == typeof(void) && info.IsPublic)
+                .Select(info => info.Name);
+
+            var methods = new HashSet<string>(ctors);
+            if (!methods.Contains(constructorTestMethodName))
+            {
+                throw new MissingClientConstructorTestMethodException(type);
+            }
         }
 
-        public static IEnumerable<object[]> GetTestConstructorsClasses()
+        public static IEnumerable<object[]> GetTestConstructorClasses()
         {
             var tests = typeof(GitHubClientTests)
                 .Assembly

--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Conventions
             
             if (!classes.Contains(constructorClassName))
             {
-                throw new MissingConstructorTestClassException(type);
+                throw new MissingClientConstructorTestClassException(type);
             }
         }
 

--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Octokit.Tests.Conventions
 {
-    public class TestConstructorTests
+    public class ClientConstructorTests
     {
         [Theory]
         [MemberData("GetTestConstructorsClasses")]

--- a/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestClassException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestClassException.cs
@@ -2,9 +2,9 @@
 
 namespace Octokit.Tests.Conventions
 {
-    public class MissingConstructorTestClassException : Exception
+    public class MissingClientConstructorTestClassException : Exception
     {
-        public MissingConstructorTestClassException(Type modelType)
+        public MissingClientConstructorTestClassException(Type modelType)
             : base(CreateMessage(modelType))
         { }
 

--- a/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestClassException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestClassException.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Conventions
 
         static string CreateMessage(Type ctorTest)
         {
-            return string.Format("Constructor test method is missing {0}.", ctorTest.FullName);
+            return string.Format("Constructor test class is missing {0}.", ctorTest.FullName);
         }
     }
 }

--- a/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestMethodException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingClientConstructorTestMethodException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MissingClientConstructorTestMethodException : Exception
+    {
+        public MissingClientConstructorTestMethodException(Type modelType)
+            : base(CreateMessage(modelType))
+        { }
+
+        static string CreateMessage(Type ctorTest)
+        {
+            return string.Format("Constructor test method is missing {0}.", ctorTest.FullName);
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/Exception/MissingConstructorTestClassException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingConstructorTestClassException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MissingConstructorTestClassException : Exception
+    {
+        public MissingConstructorTestClassException(Type modelType)
+            : base(CreateMessage(modelType))
+        { }
+
+        static string CreateMessage(Type ctorTest)
+        {
+            return string.Format("Constructor test method is missing {0}.", ctorTest.FullName);
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -82,7 +82,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="SyncObservableClients.cs" />
-    <Compile Include="TestConstructorTests.cs" />
+    <Compile Include="ClientConstructorTests.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Compile Include="Exception\InvalidDebuggerDisplayAttributeValueException.cs" />
     <Compile Include="Exception\InvalidDebuggerDisplayReturnType.cs" />
+    <Compile Include="Exception\MissingConstructorTestClassException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayAttributeException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
     <Compile Include="Exception\MutableModelPropertiesException.cs" />
@@ -81,6 +82,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="SyncObservableClients.cs" />
+    <Compile Include="TestConstructorTests.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Exception\InvalidDebuggerDisplayAttributeValueException.cs" />
     <Compile Include="Exception\InvalidDebuggerDisplayReturnType.cs" />
     <Compile Include="Exception\MissingClientConstructorTestClassException.cs" />
+    <Compile Include="Exception\MissingClientConstructorTestMethodException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayAttributeException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
     <Compile Include="Exception\MutableModelPropertiesException.cs" />

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -64,7 +64,7 @@
   <ItemGroup>
     <Compile Include="Exception\InvalidDebuggerDisplayAttributeValueException.cs" />
     <Compile Include="Exception\InvalidDebuggerDisplayReturnType.cs" />
-    <Compile Include="Exception\MissingConstructorTestClassException.cs" />
+    <Compile Include="Exception\MissingClientConstructorTestClassException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayAttributeException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
     <Compile Include="Exception\MutableModelPropertiesException.cs" />

--- a/Octokit.Tests.Conventions/TestConstructorTests.cs
+++ b/Octokit.Tests.Conventions/TestConstructorTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octokit.Tests.Clients;
+using Xunit;
+
+namespace Octokit.Tests.Conventions
+{
+    public class TestConstructorTests
+    {
+        [Theory]
+        [MemberData("GetTestConstructorsClasses")]
+        public void CheckTestConstructorsNames(Type type)
+        {
+            const string constructorClassName = "TheCtor";
+            var classes = new HashSet<string>(type.GetNestedTypes().Select(t => t.Name));
+            
+            if (!classes.Contains(constructorClassName))
+            {
+                throw new MissingConstructorTestClassException(type);
+            }
+        }
+
+        public static IEnumerable<object[]> GetTestConstructorsClasses()
+        {
+            var tests = typeof(EventsClientTests)
+                .Assembly
+                .ExportedTypes
+                .Where(type => type.IsClass && type.IsPublic && type.Name.EndsWith("ClientTests"))
+                .Select(type => new[] { type }).ToList();
+            return tests;
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -12,6 +12,16 @@ using Xunit;
 
 public class ReleasesClientTests
 {
+    public class TheCtor
+    {
+        [Fact]
+        public void EnsuresNonNullArguments()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new ReleasesClient(null));
+        }
+    }
+
     public class TheGetReleasesMethod : IDisposable
     {
         private readonly IReleasesClient _releaseClient;

--- a/Octokit.Tests/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests/Clients/AssigneesClientTests.cs
@@ -115,7 +115,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new AssigneesClient(null));
             }

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new AuthorizationsClient(null));
             }

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class AuthorizationsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Clients/BlobClientTests.cs
+++ b/Octokit.Tests/Clients/BlobClientTests.cs
@@ -4,13 +4,21 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class BlobClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new BlobsClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -133,7 +133,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 public class CommitsClientTests
@@ -71,7 +70,7 @@ public class CommitsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new CommitsClient(null));
         }

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -105,7 +105,7 @@ public class DeploymentStatusClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new DeploymentStatusClient(null));
         }

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -143,7 +143,7 @@ public class DeploymentsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new DeploymentsClient(null));
         }

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseAdminStatsClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseAdminStatsClientTests.cs
@@ -159,5 +159,15 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<AdminStats>(Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EnterpriseAdminStatsClient(null));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseLdapClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseLdapClientTests.cs
@@ -130,5 +130,15 @@ namespace Octokit.Tests.Clients
                     Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EnterpriseLdapClient(null));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseLicenseClientTests.cs
@@ -19,5 +19,15 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<LicenseInfo>(Arg.Is<Uri>(u => u.ToString() == expectedUri));
             }
         }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EnterpriseLicenseClient(null));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseOrganizationClientTests.cs
@@ -46,5 +46,15 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null));
             }
         }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EnterpriseOrganizationClient(null));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/Enterprise/EnterpriseSearchIndexingClientTests.cs
+++ b/Octokit.Tests/Clients/Enterprise/EnterpriseSearchIndexingClientTests.cs
@@ -7,6 +7,16 @@ namespace Octokit.Tests.Clients
 {
     public class EnterpriseSearchIndexingClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EnterpriseSearchIndexingClient(null));
+            }
+        }
+
         public class TheQueueMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -6,14 +6,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class EventsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new EventsClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/FeedsClientTests.cs
+++ b/Octokit.Tests/Clients/FeedsClientTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -12,7 +10,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class FeedsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -4,10 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests;
-using Octokit.Tests.Helpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Octokit.Tests.Clients
 {
@@ -17,7 +14,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class FollowersClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new GistCommentsClient(null));
             }
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist("24", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist("", ApiOptions.None));
-            
+
             }
         }
 

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -305,7 +305,7 @@ public class GistsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
         }

--- a/Octokit.Tests/Clients/GitDatabaseClientTests.cs
+++ b/Octokit.Tests/Clients/GitDatabaseClientTests.cs
@@ -8,7 +8,7 @@ public class GitDatabaseClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new GitDatabaseClient(null));
         }

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -209,14 +209,14 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheCtor
+    public class TheCtor
+    {
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
-            [Fact]
-            public void EnsuresArgument()
-            {
-                Assert.Throws<ArgumentNullException>(() => new IssueCommentsClient(null));
-            }
+            Assert.Throws<ArgumentNullException>(() => new IssueCommentsClient(null));
         }
+    }
 
         [Fact]
         public void CanDeserializeIssueComment()

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -240,7 +239,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new IssuesClient(null));
             }

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -1,13 +1,22 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class IssuesEventsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new IssuesEventsClient(null));
+            }
+        }
+
         public class TheGetForIssueMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 using System.Collections.Generic;
 
@@ -9,6 +8,16 @@ namespace Octokit.Tests.Clients
 {
     public class IssuesLabelsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new IssuesLabelsClient(null));
+            }
+        }
+
         public class TheGetForIssueMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/MergingClientTests.cs
+++ b/Octokit.Tests/Clients/MergingClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -46,7 +45,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new CommitsClient(null));
             }

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -151,7 +150,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new MilestonesClient(null));
             }

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -175,7 +175,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new MiscellaneousClient(null));
             }

--- a/Octokit.Tests/Clients/NotificationsClientTests.cs
+++ b/Octokit.Tests/Clients/NotificationsClientTests.cs
@@ -6,6 +6,16 @@ namespace Octokit.Tests.Clients
 {
     public class NotificationsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new NotificationsClient(null));
+            }
+        }
+
         public class TheGetAllForCurrentMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/OauthClientTests.cs
+++ b/Octokit.Tests/Clients/OauthClientTests.cs
@@ -12,7 +12,7 @@ public class OauthClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgumentIsNotNull()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() =>
                 new OauthClient(null));

--- a/Octokit.Tests/Clients/OauthClientTests.cs
+++ b/Octokit.Tests/Clients/OauthClientTests.cs
@@ -9,6 +9,16 @@ using Xunit;
 
 public class OauthClientTests
 {
+    public class TheCtor
+    {
+        [Fact]
+        public void EnsuresArgumentIsNotNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new OauthClient(null));
+        }
+    }
+
     public class TheGetGitHubLoginUrlMethod
     {
         [Theory]

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -18,7 +17,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsureNonNullArguments()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new OrganizationMembersClient(null));
             }

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -15,7 +15,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class OrganizationMembersClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsureNonNullArguments()

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -12,7 +11,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class OrganizationsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 public class PullRequestReviewCommentsClientTests
 {
-    public class TheModelConstructors
+    public class TheCtor
     {
         [Fact]
         public void PullRequestReviewCommentCreateEnsuresArgumentsValue()

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -10,6 +10,12 @@ public class PullRequestReviewCommentsClientTests
     public class TheCtor
     {
         [Fact]
+        public void EnsuresNonNullArguments()
+        {
+            Assert.Throws<ArgumentNullException>(() => new PullRequestReviewCommentsClient(null));
+        }
+
+        [Fact]
         public void PullRequestReviewCommentCreateEnsuresArgumentsValue()
         {
             string body = "body";

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -249,7 +249,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new PullRequestsClient(null));
             }

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -11,7 +10,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ReferencesClient(null));
             }

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() =>
                     new ReleasesClient(null));

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -8,6 +8,16 @@ namespace Octokit.Tests.Clients
 {
     public class ReleasesClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgumentIsNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() =>
+                    new ReleasesClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new RepoCollaboratorsClient(null));
             }

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 using System.Net;
 using Octokit.Internal;
@@ -15,7 +14,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class RepoCollaboratorsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -13,7 +13,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class RepositoriesClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 public class RepositoryCommentsClientTests
@@ -177,7 +176,7 @@ public class RepositoryCommentsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new RepositoryCommentsClient(null));
         }

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -9,6 +9,16 @@ namespace Octokit.Tests.Clients
 {
     public class RepositoryContentsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new RepositoryContentsClient(null));
+            }
+        }
+
         public class TheGetReadmeMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new RepositoryDeployKeysClient(null));
             }

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class RepositoryDeployKeysClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -8,6 +8,16 @@ namespace Octokit.Tests.Clients
 {
     public class RepositoryForksClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new RepositoryForksClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -8,6 +8,16 @@ namespace Octokit.Tests.Clients
 {
     public class RepositoryHooksClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new RepositoryHooksClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
@@ -7,6 +7,16 @@ namespace Octokit.Tests.Clients
 {
     public class RepositoryPagesClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new RepositoryPagesClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -1,12 +1,21 @@
 ﻿using NSubstitute;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Octokit.Tests.Clients
 {
     public class RespositoryCommitsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new RepositoryCommitsClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class SearchClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/SshKeysClientTests.cs
+++ b/Octokit.Tests/Clients/SshKeysClientTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new SshKeysClient(null));
             }

--- a/Octokit.Tests/Clients/SshKeysClientTests.cs
+++ b/Octokit.Tests/Clients/SshKeysClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -12,7 +11,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class SshKeysClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -10,6 +10,16 @@ namespace Octokit.Tests.Clients
 {
     public class StarredClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new StarredClient(null));
+            }
+        }
+
         public class TheGetAllForCurrentMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Clients
 {
     public class StatisticsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void DoesThrowOnBadArguments()

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -13,7 +13,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void DoesThrowOnBadArguments()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new StatisticsClient(null));
             }

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -64,7 +64,7 @@ public class TagsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new TagsClient(null));
         }

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class TeamsClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()

--- a/Octokit.Tests/Clients/TreesClientTests.cs
+++ b/Octokit.Tests/Clients/TreesClientTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests
@@ -108,7 +107,7 @@ namespace Octokit.Tests
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new TreesClient(null));
             }

--- a/Octokit.Tests/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests/Clients/UserAdministrationClientTests.cs
@@ -8,6 +8,16 @@ namespace Octokit.Tests.Clients
 {
     public class UserAdministrationClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new UserAdministrationClient(null));
+            }
+        }
+
         public class TheCreateMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/UserEmailsClientTests.cs
+++ b/Octokit.Tests/Clients/UserEmailsClientTests.cs
@@ -113,7 +113,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArguments()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
                     () => new UserEmailsClient(null));

--- a/Octokit.Tests/Clients/UserKeysClientTests.cs
+++ b/Octokit.Tests/Clients/UserKeysClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using NSubstitute;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -129,7 +128,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArguments()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
                     () => new UserEmailsClient(null));

--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 #if NET_45
 using System.Collections.ObjectModel;
 #endif
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -17,7 +15,7 @@ namespace Octokit.Tests.Clients
     /// </summary>
     public class UsersClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Clients/UsersClientTests.cs
+++ b/Octokit.Tests/Clients/UsersClientTests.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Clients
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new UsersClient(null));
             }

--- a/Octokit.Tests/Clients/WatchedClientTests.cs
+++ b/Octokit.Tests/Clients/WatchedClientTests.cs
@@ -10,6 +10,16 @@ namespace Octokit.Tests.Clients
 {
     public class WatchedClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new WatchedClient(null));
+            }
+        }
+
         public class TheGetAllForCurrentMethod
         {
             [Fact]

--- a/Octokit.Tests/Exceptions/TwoFactorRequiredExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/TwoFactorRequiredExceptionTests.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using Octokit.Internal;
 using Xunit;
 
@@ -11,7 +7,7 @@ namespace Octokit.Tests.Exceptions
 {
     public class TwoFactorRequiredExceptionTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void SetsDefaultMessage()

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
 using Xunit;
-using Xunit.Extensions;
 using System.Collections.Generic;
 
 namespace Octokit.Tests
 {
     public class GitHubClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void CreatesAnonymousClientByDefault()

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -17,26 +17,26 @@ namespace Octokit.Tests
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient((IConnection)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient((ProductHeaderValue)null));
 
-                var productHeaderValue = new ProductHeaderValue("UnitTest");
+                var productInformation = new ProductHeaderValue("UnitTest");
                 var baseAddress = new Uri("http://github.com");
                 var credentialStore = Substitute.For<ICredentialStore>();
 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, (ICredentialStore)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, (ICredentialStore)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore));
                 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, (Uri)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, (Uri)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, baseAddress));
 
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (ICredentialStore)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (Uri)null));
 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, null, null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, null, null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, null, baseAddress));
                 
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, baseAddress));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, null, baseAddress));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, credentialStore, null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, null, baseAddress));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productInformation, credentialStore, null));
             }
 
             [Fact]

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -17,22 +17,26 @@ namespace Octokit.Tests
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient((IConnection)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient((ProductHeaderValue)null));
 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), (ICredentialStore)null));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>()));
+                var productHeaderValue = new ProductHeaderValue("UnitTest");
+                var baseAddress = new Uri("http://github.com");
+                var credentialStore = Substitute.For<ICredentialStore>();
+
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, (ICredentialStore)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore));
                 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), (Uri)null));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, new Uri("http://github.com")));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, (Uri)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, baseAddress));
 
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (ICredentialStore)null));
                 Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (Uri)null));
 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), null, null));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>(), null));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, null, new Uri("http://github.com")));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, null, null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, null, baseAddress));
                 
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>(), new Uri("http://github.com")));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), null, new Uri("http://github.com")));
-                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), Substitute.For<ICredentialStore>(), null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, credentialStore, baseAddress));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, null, baseAddress));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(productHeaderValue, credentialStore, null));
             }
 
             [Fact]

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -12,6 +12,30 @@ namespace Octokit.Tests
         public class TheCtor
         {
             [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient((IConnection)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient((ProductHeaderValue)null));
+
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), (ICredentialStore)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>()));
+                
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), (Uri)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, new Uri("http://github.com")));
+
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (ICredentialStore)null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, (Uri)null));
+
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), null, null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>(), null));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, null, new Uri("http://github.com")));
+                
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(null, Substitute.For<ICredentialStore>(), new Uri("http://github.com")));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), null, new Uri("http://github.com")));
+                Assert.Throws<ArgumentNullException>(() => new GitHubClient(new ProductHeaderValue("UnitTest"), Substitute.For<ICredentialStore>(), null));
+            }
+
+            [Fact]
             public void CreatesAnonymousClientByDefault()
             {
                 var client = new GitHubClient(new ProductHeaderValue("OctokitTests", "1.0"));

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
@@ -7,6 +7,16 @@ namespace Octokit.Tests
 {
     public class ObservableEnterpriseLDAPClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableEnterpriseLdapClient(null));
+            }
+        }
+
         public class TheUpdateUserMappingMethod
         {
             readonly string _distinguishedName = "uid=test-user,ou=users,dc=company,dc=com";

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseLicenseClientTests.cs
@@ -7,6 +7,16 @@ namespace Octokit.Tests
 {
     public class ObservableEnterpriseLicenseClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableEnterpriseLicenseClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseOrganizationClientTests.cs
@@ -7,6 +7,16 @@ namespace Octokit.Tests
 {
     public class ObservableEnterpriseOrganizationClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableEnterpriseOrganizationClient(null));
+            }
+        }
+
         public class TheCreateMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute;
+﻿using System;
+using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
 
@@ -6,6 +7,16 @@ namespace Octokit.Tests
 {
     public class ObservableEnterpriseSearchIndexingClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgumentIsNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() =>
+                    new ObservableEnterpriseSearchIndexingClient(null));
+            }
+        }
+
         public class TheQueueMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
+++ b/Octokit.Tests/Reactive/Enterprise/ObservableEnterpriseSearchIndexingClientTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() =>
                     new ObservableEnterpriseSearchIndexingClient(null));

--- a/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -69,7 +67,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableBlobClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -9,7 +9,7 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableCommitsClientTests
     {
-        public class TheCtorMethod
+        public class TheCtor
         {
             [Fact]
             public void EnsuresArgumentIsNotNull()

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableCommitsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
@@ -121,7 +121,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
                     () => new ObservableDeploymentStatusClient(null));

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -174,7 +174,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArguments()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableDeploymentsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -1,17 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservableEventsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableEventsClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableFeedsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableFeedsClientTests.cs
@@ -1,16 +1,22 @@
-﻿using NSubstitute;
+﻿using System;
+using NSubstitute;
 using Octokit.Reactive;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservableFeedsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableFeedsClient(null));
+            }
+        }
+
         public class TheGetFeedsMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -192,7 +190,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableIssueCommentsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -2,7 +2,6 @@
 using Octokit;
 using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
@@ -390,7 +389,7 @@ public class ObservableIssuesClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new IssuesClient(null));
         }

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -236,7 +235,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new MilestonesClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
@@ -136,7 +136,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableMiscellaneousClient((IGitHubClient)null));
             }

--- a/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -1,11 +1,7 @@
 ﻿using NSubstitute;
-using Octokit;
-using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using System;
 using System.Collections.Generic;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Xunit;
@@ -14,6 +10,16 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableOrganizationMembersClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableOrganizationMembersClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -6,13 +6,22 @@ using NSubstitute;
 using Octokit.Internal;
 using Octokit.Reactive;
 using System.Reactive.Threading.Tasks;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservablePullRequestReviewCommentsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservablePullRequestReviewCommentsClient(null));
+            }
+        }
+
         static IResponse CreateResponseWithApiInfo(IDictionary<string, Uri> links)
         {
             var response = Substitute.For<IResponse>();

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -352,10 +351,11 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Files("owner", "", 1));
             }
         }
+
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new PullRequestsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableReleasesClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -9,7 +9,7 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableReleasesClientTests
     {
-        public class TheCtorMethod
+        public class TheCtor
         {
             [Fact]
             public void EnsuresArgumentIsNotNull()

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -11,6 +11,16 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableRepositoriesClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableRepositoriesClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             // This isn't really a test specific to this method. This is just as good a place as any to test

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableRepositoryCommitsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void ThrowsForBadArgs()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableRepositoryDeployKeysClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NSubstitute;
-using NSubstitute.Core;
 using Octokit.Reactive;
 using Xunit;
 
@@ -12,7 +8,7 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableRepositoryDeployKeysClientTests
     {
-        public class TheConstructor
+        public class TheCtor
         {
             [Fact]
             public void ThrowsForBadArgs()

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -1,21 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit;
-using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Reactive.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservableStarredClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgumentIsNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableStarredClient(null));
+            }
+        }
+
         public class TheGetAllStargazersMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -13,7 +13,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableStarredClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStatisticsClientTests.cs
@@ -1,16 +1,23 @@
 using System;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservableStatisticsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableStatisticsClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -38,7 +37,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresNotNullGitHubClient()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableTeamsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableTreesClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTreesClientTests.cs
@@ -1,16 +1,23 @@
 ﻿using System;
-using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests
 {
     public class ObservableTreesClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgumentIsNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableTreesClient(null));
+            }
+        }
+
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserAdministrationClientTests.cs
@@ -180,7 +180,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableUserAdministrationClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -84,7 +83,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtor
         {
             [Fact]
-            public void EnsuresArgument()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableUserKeysClient(null));
             }

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -9,11 +9,12 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="http://developer.github.com/v3/repos/commits/">Repository Commits API documentation</a> for more information.
     /// </remarks>
-    public class RepositoryCommitsClient : IRepositoryCommitsClient
+    public class RepositoryCommitsClient : ApiClient, IRepositoryCommitsClient
     {
         readonly IApiConnection _apiConnection;
 
-        public RepositoryCommitsClient(IApiConnection apiConnection)
+        public RepositoryCommitsClient(IApiConnection apiConnection) 
+            : base(apiConnection)
         {
             _apiConnection = apiConnection;
         }


### PR DESCRIPTION
Refer #1231

In order to provide uniform name for constructors test classes, I've created new convention test checks  
that each client test class must contain a nested TheCtor class.

- [x] Add new convention test.
- [x] Fix all red tests (Rename/Add needed tests classes)
- [x] Remove unused usings in modified classes.
- [x] Find way to detect tests assembly in proper way.
- [x] Each test class TheCtor should have method EnsuresNonNullArguments that test a client constructor against null arguments.
- [x] All unused "using" directives in modified classes were removed in order to get code more robust.

Ready to any discussion about implementation of convention test ClientConstructorTests.cs, especially about GetTestConstructorsClasses method. 

/cc @shiftkey, @ryangribble 