### PR TITLE
Always Be Auditing Your Awaits

### DIFF
--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -66,8 +66,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.CheckAssignee(owner, name, assignee), null, null)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.CheckAssignee(owner, name, assignee), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -320,10 +320,7 @@ namespace Octokit
             {
                 var endpoint = ApiUrls.AuthorizationsForClient(clientId);
 
-                return await ApiConnection.Put<ApplicationAuthorization>(
-                    endpoint,
-                    requestData,
-                    twoFactorAuthenticationCode).ConfigureAwait(false);
+                return await ApiConnection.Put<ApplicationAuthorization>(endpoint, requestData, twoFactorAuthenticationCode).ConfigureAwait(false);
             }
             catch (AuthorizationException e)
             {

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -323,7 +323,7 @@ namespace Octokit
                 return await ApiConnection.Put<ApplicationAuthorization>(
                     endpoint,
                     requestData,
-                    twoFactorAuthenticationCode);
+                    twoFactorAuthenticationCode).ConfigureAwait(false);
             }
             catch (AuthorizationException e)
             {
@@ -341,15 +341,13 @@ namespace Octokit
         /// <param name="clientId">Client ID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to check</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/>.</returns>
-        public async Task<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken)
+        public Task<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(accessToken, "accessToken");
 
             var endpoint = ApiUrls.ApplicationAuthorization(clientId, accessToken);
-            return await ApiConnection.Get<ApplicationAuthorization>(
-                endpoint,
-                null);
+            return ApiConnection.Get<ApplicationAuthorization>(endpoint, null);
         }
 
         /// <summary>
@@ -362,15 +360,14 @@ namespace Octokit
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to reset</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/> with a new OAuth token</returns>
-        public async Task<ApplicationAuthorization> ResetApplicationAuthentication(string clientId, string accessToken)
+        public Task<ApplicationAuthorization> ResetApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, "clientId");
             Ensure.ArgumentNotNullOrEmptyString(accessToken, "accessToken");
 
             var requestData = new { };
 
-            return await ApiConnection.Post<ApplicationAuthorization>(
-                ApiUrls.ApplicationAuthorization(clientId, accessToken), requestData);
+            return ApiConnection.Post<ApplicationAuthorization>(ApiUrls.ApplicationAuthorization(clientId, accessToken), requestData);
         }
 
         /// <summary>

--- a/Octokit/Clients/Enterprise/EnterpriseAdminStatsClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseAdminStatsClient.cs
@@ -21,12 +21,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsIssues"/> statistics.</returns>
-        public async Task<AdminStatsIssues> GetStatisticsIssues()
+        public Task<AdminStatsIssues> GetStatisticsIssues()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsIssues();
 
-            return await ApiConnection.Get<AdminStatsIssues>(endpoint)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsIssues>(endpoint);
         }
 
         /// <summary>
@@ -36,12 +35,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsHooks"/> statistics.</returns>
-        public async Task<AdminStatsHooks> GetStatisticsHooks()
+        public Task<AdminStatsHooks> GetStatisticsHooks()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsHooks();
 
-            return await ApiConnection.Get<AdminStatsHooks>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsHooks>(endpoint);
         }
 
         /// <summary>
@@ -51,12 +49,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsMilestones"/> statistics.</returns>
-        public async Task<AdminStatsMilestones> GetStatisticsMilestones()
+        public Task<AdminStatsMilestones> GetStatisticsMilestones()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsMilestones();
 
-            return await ApiConnection.Get<AdminStatsMilestones>(endpoint)
-                                                        .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsMilestones>(endpoint);
         }
 
         /// <summary>
@@ -66,12 +63,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsOrgs"/> statistics.</returns>
-        public async Task<AdminStatsOrgs> GetStatisticsOrgs()
+        public Task<AdminStatsOrgs> GetStatisticsOrgs()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsOrgs();
 
-            return await ApiConnection.Get<AdminStatsOrgs>(endpoint)
-                                                  .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsOrgs>(endpoint);
         }
 
         /// <summary>
@@ -81,12 +77,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsComments"/> statistics.</returns>
-        public async Task<AdminStatsComments> GetStatisticsComments()
+        public Task<AdminStatsComments> GetStatisticsComments()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsComments();
 
-            return await ApiConnection.Get<AdminStatsComments>(endpoint)
-                                                      .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsComments>(endpoint);
         }
 
         /// <summary>
@@ -96,12 +91,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsPages"/> statistics.</returns>
-        public async Task<AdminStatsPages> GetStatisticsPages()
+        public Task<AdminStatsPages> GetStatisticsPages()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsPages();
 
-            return await ApiConnection.Get<AdminStatsPages>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsPages>(endpoint);
         }
 
         /// <summary>
@@ -111,12 +105,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsUsers"/> statistics.</returns>
-        public async Task<AdminStatsUsers> GetStatisticsUsers()
+        public Task<AdminStatsUsers> GetStatisticsUsers()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsUsers();
 
-            return await ApiConnection.Get<AdminStatsUsers>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsUsers>(endpoint);
         }
 
         /// <summary>
@@ -126,12 +119,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsGists"/> statistics.</returns>
-        public async Task<AdminStatsGists> GetStatisticsGists()
+        public Task<AdminStatsGists> GetStatisticsGists()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsGists();
 
-            return await ApiConnection.Get<AdminStatsGists>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsGists>(endpoint);
         }
 
         /// <summary>
@@ -141,12 +133,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsPulls"/> statistics.</returns>
-        public async Task<AdminStatsPulls> GetStatisticsPulls()
+        public Task<AdminStatsPulls> GetStatisticsPulls()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsPulls();
 
-            return await ApiConnection.Get<AdminStatsPulls>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsPulls>(endpoint);
         }
 
         /// <summary>
@@ -156,12 +147,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsRepos"/> statistics.</returns>
-        public async Task<AdminStatsRepos> GetStatisticsRepos()
+        public Task<AdminStatsRepos> GetStatisticsRepos()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsRepos();
 
-            return await ApiConnection.Get<AdminStatsRepos>(endpoint)
-                                                   .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStatsRepos>(endpoint);
         }
 
         /// <summary>
@@ -171,12 +161,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStats"/> collection of statistics.</returns>
-        public async Task<AdminStats> GetStatisticsAll()
+        public Task<AdminStats> GetStatisticsAll()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsAll();
 
-            return await ApiConnection.Get<AdminStats>(endpoint)
-                                          .ConfigureAwait(false);
+            return ApiConnection.Get<AdminStats>(endpoint);
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.EnterpriseLdapUserSync(userName);
 
-            var response = await Connection.Post<LdapSyncResponse>(endpoint);
+            var response = await Connection.Post<LdapSyncResponse>(endpoint).ConfigureAwait(false);
             if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
             {
                 throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
@@ -90,7 +90,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.EnterpriseLdapTeamSync(teamId);
 
-            var response = await Connection.Post<LdapSyncResponse>(endpoint);
+            var response = await Connection.Post<LdapSyncResponse>(endpoint).ConfigureAwait(false);
             if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
             {
                 throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);

--- a/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
@@ -21,12 +21,11 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/license/#get-license-information
         /// </remarks>
         /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
-        public async Task<LicenseInfo> Get()
+        public Task<LicenseInfo> Get()
         {
             var endpoint = ApiUrls.EnterpriseLicense();
 
-            return await ApiConnection.Get<LicenseInfo>(endpoint)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Get<LicenseInfo>(endpoint);
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
@@ -22,13 +22,13 @@ namespace Octokit
         /// </remarks>
         /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
         /// <returns>The <see cref="Organization"/> created.</returns>
-        public async Task<Organization> Create(NewOrganization newOrganization)
+        public Task<Organization> Create(NewOrganization newOrganization)
         {
             Ensure.ArgumentNotNull(newOrganization, "newOrganization");
 
             var endpoint = ApiUrls.EnterpriseOrganization();
 
-            return await ApiConnection.Post<Organization>(endpoint, newOrganization);
+            return ApiConnection.Post<Organization>(endpoint, newOrganization);
         }
     }
 }

--- a/Octokit/Clients/Enterprise/EnterpriseSearchIndexingClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseSearchIndexingClient.cs
@@ -23,15 +23,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> Queue(string owner)
+        public Task<SearchIndexingResponse> Queue(string owner)
         {
             Ensure.ArgumentNotNull(owner, "owner");
 
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}", owner));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -43,7 +42,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> Queue(string owner, string repository)
+        public Task<SearchIndexingResponse> Queue(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, "owner");
             Ensure.ArgumentNotNull(repository, "repository");
@@ -51,8 +50,7 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/{1}", owner, repository));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -63,15 +61,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> QueueAll(string owner)
+        public Task<SearchIndexingResponse> QueueAll(string owner)
         {
             Ensure.ArgumentNotNull(owner, "owner");
 
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/*", owner));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -83,7 +80,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> QueueAllIssues(string owner, string repository)
+        public Task<SearchIndexingResponse> QueueAllIssues(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, "owner");
             Ensure.ArgumentNotNull(repository, "repository");
@@ -91,8 +88,7 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/{1}/issues", owner, repository));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -103,15 +99,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> QueueAllIssues(string owner)
+        public Task<SearchIndexingResponse> QueueAllIssues(string owner)
         {
             Ensure.ArgumentNotNull(owner, "owner");
 
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/*/issues", owner));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -123,7 +118,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> QueueAllCode(string owner, string repository)
+        public Task<SearchIndexingResponse> QueueAllCode(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, "owner");
             Ensure.ArgumentNotNull(repository, "repository");
@@ -131,8 +126,7 @@ namespace Octokit
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/{1}/code", owner, repository));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
 
         /// <summary>
@@ -143,15 +137,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
-        public async Task<SearchIndexingResponse> QueueAllCode(string owner)
+        public Task<SearchIndexingResponse> QueueAllCode(string owner)
         {
             Ensure.ArgumentNotNull(owner, "owner");
 
             var endpoint = ApiUrls.EnterpriseSearchIndexing();
             var target = new SearchIndexTarget(string.Format(CultureInfo.InvariantCulture, "{0}/*/code", owner));
 
-            return await ApiConnection.Post<SearchIndexingResponse>(endpoint, target)
-                                                    .ConfigureAwait(false);
+            return ApiConnection.Post<SearchIndexingResponse>(endpoint, target);
         }
     }
 }

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -88,8 +88,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.IsFollowing(following), null, null)
-                                                .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.IsFollowing(following), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)
@@ -114,8 +113,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.IsFollowing(login, following), null, null)
-                                                .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.IsFollowing(login, following), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)
@@ -139,8 +137,7 @@ namespace Octokit
             try
             {
                 var requestData = new { };
-                var response = await Connection.Put<object>(ApiUrls.IsFollowing(login), requestData)
-                                                .ConfigureAwait(false);
+                var response = await Connection.Put<object>(ApiUrls.IsFollowing(login), requestData).ConfigureAwait(false);
                 if (response.HttpResponse.StatusCode != HttpStatusCode.NoContent)
                 {
                     throw new ApiException("Invalid Status Code returned. Expected a 204", response.HttpResponse.StatusCode);

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -289,8 +289,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.StarGist(id), null, null)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.StarGist(id), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -38,8 +38,7 @@ namespace Octokit
         public async Task<IReadOnlyList<Emoji>> GetAllEmojis()
         {
             var endpoint = new Uri("emojis", UriKind.Relative);
-            var response = await _connection.Get<Dictionary<string, string>>(endpoint, null, null)
-                .ConfigureAwait(false);
+            var response = await _connection.Get<Dictionary<string, string>>(endpoint, null, null).ConfigureAwait(false);
             return new ReadOnlyCollection<Emoji>(
                 response.Body.Select(kvp => new Emoji(kvp.Key, new Uri(kvp.Value))).ToArray());
         }
@@ -53,8 +52,7 @@ namespace Octokit
         public async Task<string> RenderRawMarkdown(string markdown)
         {
             var endpoint = new Uri("markdown/raw", UriKind.Relative);
-            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain")
-                .ConfigureAwait(false);
+            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain").ConfigureAwait(false);
             return response.Body;
         }
 
@@ -67,8 +65,7 @@ namespace Octokit
         public async Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
         {
             var endpoint = new Uri("markdown", UriKind.Relative);
-            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain")
-                .ConfigureAwait(false);
+            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain").ConfigureAwait(false);
             return response.Body;
         }
 
@@ -80,8 +77,7 @@ namespace Octokit
         {
             var endpoint = new Uri("gitignore/templates", UriKind.Relative);
 
-            var response = await _connection.Get<string[]>(endpoint, null, null)
-                .ConfigureAwait(false);
+            var response = await _connection.Get<string[]>(endpoint, null, null).ConfigureAwait(false);
             return new ReadOnlyCollection<string>(response.Body);
         }
 
@@ -96,8 +92,7 @@ namespace Octokit
 
             var endpoint = new Uri("gitignore/templates/" + Uri.EscapeUriString(templateName), UriKind.Relative);
 
-            var response = await _connection.Get<GitIgnoreTemplate>(endpoint, null, null)
-                .ConfigureAwait(false);
+            var response = await _connection.Get<GitIgnoreTemplate>(endpoint, null, null).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -111,8 +106,7 @@ namespace Octokit
         {
             var endpoint = new Uri("licenses", UriKind.Relative);
 
-            var response = await _connection.Get<LicenseMetadata[]>(endpoint, null, AcceptHeaders.LicensesApiPreview)
-                .ConfigureAwait(false);
+            var response = await _connection.Get<LicenseMetadata[]>(endpoint, null, AcceptHeaders.LicensesApiPreview).ConfigureAwait(false);
             return new ReadOnlyCollection<LicenseMetadata>(response.Body);
         }
 
@@ -125,8 +119,7 @@ namespace Octokit
         {
             var endpoint = new Uri("licenses/" + Uri.EscapeUriString(key), UriKind.Relative);
 
-            var response = await _connection.Get<License>(endpoint, null, AcceptHeaders.LicensesApiPreview)
-                .ConfigureAwait(false);
+            var response = await _connection.Get<License>(endpoint, null, AcceptHeaders.LicensesApiPreview).ConfigureAwait(false);
             return response.Body;
         }
 

--- a/Octokit/Clients/OAuthClient.cs
+++ b/Octokit/Clients/OAuthClient.cs
@@ -62,7 +62,7 @@ namespace Octokit
 
             var body = new FormUrlEncodedContent(request.ToParametersDictionary());
 
-            var response = await connection.Post<OauthToken>(endPoint, body, "application/json", null, hostAddress);
+            var response = await connection.Post<OauthToken>(endPoint, body, "application/json", null, hostAddress).ConfigureAwait(false);
             return response.Body;
         }
     }

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -211,8 +211,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.CheckMember(org, user), null, null)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.CheckMember(org, user), null, null).ConfigureAwait(false);
                 var statusCode = response.HttpResponse.StatusCode;
                 if (statusCode != HttpStatusCode.NotFound
                     && statusCode != HttpStatusCode.NoContent

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -244,8 +244,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.CheckMemberPublic(org, user), null, null)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.CheckMemberPublic(org, user), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)
@@ -293,8 +292,7 @@ namespace Octokit
             try
             {
                 var requestData = new { };
-                var response = await Connection.Put<object>(ApiUrls.OrganizationMembership(org, user), requestData)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Put<object>(ApiUrls.OrganizationMembership(org, user), requestData).ConfigureAwait(false);
                 if (response.HttpResponse.StatusCode != HttpStatusCode.NoContent)
                 {
                     throw new ApiException("Invalid Status Code returned. Expected a 204", response.HttpResponse.StatusCode);

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -93,7 +93,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(comment, "comment");
 
-            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, number), comment, null, null).ConfigureAwait(false);
+            var endpoint = ApiUrls.PullRequestReviewComments(owner, name, number);
+            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(endpoint, comment, null, null).ConfigureAwait(false);
 
             if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
             {
@@ -118,7 +119,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(comment, "comment");
 
-            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, number), comment, null, null).ConfigureAwait(false);
+            var endpoint = ApiUrls.PullRequestReviewComments(owner, name, number);
+            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(endpoint, comment, null, null).ConfigureAwait(false);
 
             if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
             {

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -118,7 +118,8 @@ namespace Octokit
 
             try
             {
-                return await ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest).ConfigureAwait(false);
+                var endpoint = ApiUrls.MergePullRequest(owner, name, number);
+                return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest).ConfigureAwait(false);
             }
             catch (ApiException ex)
             {
@@ -151,8 +152,8 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.MergePullRequest(owner, name, number), null, null)
-                                               .ConfigureAwait(false);
+                var endpoint = ApiUrls.MergePullRequest(owner, name, number);
+                var response = await Connection.Get<object>(endpoint, null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -118,7 +118,7 @@ namespace Octokit
 
             try
             {
-                return await ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest);
+                return await ApiConnection.Put<PullRequestMerge>(ApiUrls.MergePullRequest(owner, name, number), mergePullRequest).ConfigureAwait(false);
             }
             catch (ApiException ex)
             {

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -57,8 +57,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(endpoint, null, null)
-                                               .ConfigureAwait(false);
+                var response = await Connection.Get<object>(endpoint, null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -87,7 +87,7 @@ namespace Octokit
         {
             try
             {
-                return await ApiConnection.Post<Repository>(url, newRepository);
+                return await ApiConnection.Post<Repository>(url, newRepository).ConfigureAwait(false);
             }
             catch (ApiValidationException e)
             {

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -518,9 +518,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            var data = await ApiConnection
-                .Get<Dictionary<string, long>>(ApiUrls.RepositoryLanguages(owner, name))
-                .ConfigureAwait(false);
+            var endpoint = ApiUrls.RepositoryLanguages(owner, name);
+            var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
 
             return new ReadOnlyCollection<RepositoryLanguage>(
                 data.Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -259,7 +259,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.RepositoryArchiveLink(owner, name, archiveFormat, reference);
 
-            var response = await Connection.Get<byte[]>(endpoint, timeout);
+            var response = await Connection.Get<byte[]>(endpoint, timeout).ConfigureAwait(false);
 
             return response.Body;
         }

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -189,9 +189,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.Starred(owner, name), null, null)
-                                               .ConfigureAwait(false);
-
+                var response = await Connection.Get<object>(ApiUrls.Starred(owner, name), null, null).ConfigureAwait(false);
                 return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
@@ -213,9 +211,7 @@ namespace Octokit
 
             try
             {
-                var response = await Connection.Put<object>(ApiUrls.Starred(owner, name), null, null)
-                                               .ConfigureAwait(false);
-
+                var response = await Connection.Put<object>(ApiUrls.Starred(owner, name), null, null).ConfigureAwait(false);
                 return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
@@ -237,9 +233,7 @@ namespace Octokit
 
             try
             {
-                var statusCode = await Connection.Delete(ApiUrls.Starred(owner, name))
-                                                 .ConfigureAwait(false);
-
+                var statusCode = await Connection.Delete(ApiUrls.Starred(owner, name)).ConfigureAwait(false);
                 return statusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -39,13 +39,13 @@ namespace Octokit
         /// <param name="repositoryName">The name of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
         /// <returns>A list of <see cref="Contributor"/></returns>
-        public async Task<IReadOnlyList<Contributor>> GetContributors(string owner, string repositoryName, CancellationToken cancellationToken)
+        public Task<IReadOnlyList<Contributor>> GetContributors(string owner, string repositoryName, CancellationToken cancellationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "repos/{0}/{1}/stats/contributors".FormatUri(owner, repositoryName);
-            return await ApiConnection.GetQueuedOperation<Contributor>(endpoint, cancellationToken);
+            return ApiConnection.GetQueuedOperation<Contributor>(endpoint, cancellationToken);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "repos/{0}/{1}/stats/commit_activity".FormatUri(owner, repositoryName);
-            var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(endpoint, cancellationToken);
+            var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(endpoint, cancellationToken).ConfigureAwait(false);
             return new CommitActivity(activity);
         }
 
@@ -100,7 +100,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "repos/{0}/{1}/stats/code_frequency".FormatUri(owner, repositoryName);
-            var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(endpoint, cancellationToken);
+            var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(endpoint, cancellationToken).ConfigureAwait(false);
             return new CodeFrequency(rawFrequencies);
         }
 
@@ -128,7 +128,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "repos/{0}/{1}/stats/participation".FormatUri(owner, repositoryName);
-            var result = await ApiConnection.GetQueuedOperation<Participation>(endpoint, cancellationToken);
+            var result = await ApiConnection.GetQueuedOperation<Participation>(endpoint, cancellationToken).ConfigureAwait(false);
             return result.FirstOrDefault();
         }
 
@@ -156,7 +156,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
             var endpoint = "repos/{0}/{1}/stats/punch_card".FormatUri(owner, repositoryName);
-            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(endpoint, cancellationToken);
+            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(endpoint, cancellationToken).ConfigureAwait(false);
             return new PunchCard(punchCardData);
         }
     }

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -137,7 +137,7 @@ namespace Octokit
 
             try
             {
-                response = await ApiConnection.Get<Dictionary<string, string>>(endpoint);
+                response = await ApiConnection.Get<Dictionary<string, string>>(endpoint).ConfigureAwait(false);
             }
             catch (NotFoundException)
             {
@@ -208,7 +208,7 @@ namespace Octokit
 
             try
             {
-                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, RequestBody.Empty);
+                response = await ApiConnection.Put<Dictionary<string, string>>(endpoint, RequestBody.Empty).ConfigureAwait(false);
             }
             catch (NotFoundException)
             {
@@ -242,7 +242,7 @@ namespace Octokit
 
             try
             {
-                var httpStatusCode = await ApiConnection.Connection.Delete(endpoint);
+                var httpStatusCode = await ApiConnection.Connection.Delete(endpoint).ConfigureAwait(false);
 
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
@@ -268,7 +268,7 @@ namespace Octokit
 
             try
             {
-                var response = await ApiConnection.Connection.GetResponse<string>(endpoint);
+                var response = await ApiConnection.Connection.GetResponse<string>(endpoint).ConfigureAwait(false);
                 return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
@@ -333,7 +333,7 @@ namespace Octokit
 
             try
             {
-                var httpStatusCode = await ApiConnection.Connection.Put(endpoint);
+                var httpStatusCode = await ApiConnection.Connection.Put(endpoint).ConfigureAwait(false);
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)
@@ -356,7 +356,7 @@ namespace Octokit
 
             try
             {
-                var httpStatusCode = await ApiConnection.Connection.Delete(endpoint);
+                var httpStatusCode = await ApiConnection.Connection.Delete(endpoint).ConfigureAwait(false);
 
                 return httpStatusCode == HttpStatusCode.NoContent;
             }
@@ -385,7 +385,7 @@ namespace Octokit
 
             try
             {
-                var response = await ApiConnection.Connection.GetResponse<string>(endpoint);
+                var response = await ApiConnection.Connection.GetResponse<string>(endpoint).ConfigureAwait(false);
                 return response.HttpResponse.StatusCode == HttpStatusCode.NoContent;
             }
             catch (NotFoundException)

--- a/Octokit/Clients/UserAdministrationClient.cs
+++ b/Octokit/Clients/UserAdministrationClient.cs
@@ -95,7 +95,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.UserAdministrationAuthorization(login);
 
-            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            var response = await Connection.Delete(endpoint).ConfigureAwait(false);
             if (response != HttpStatusCode.NoContent)
             {
                 throw new ApiException("Invalid Status Code returned. Expected a 204", response);
@@ -196,7 +196,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
             var endpoint = ApiUrls.UserAdministration(login);
 
-            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            var response = await Connection.Delete(endpoint).ConfigureAwait(false);
             if (response != HttpStatusCode.NoContent)
             {
                 throw new ApiException("Invalid Status Code returned. Expected a 204", response);
@@ -219,7 +219,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(keyId, "keyId");
             var endpoint = ApiUrls.UserAdministrationPublicKeys(keyId);
 
-            var response = ((HttpStatusCode)await Connection.Delete(endpoint));
+            var response = await Connection.Delete(endpoint).ConfigureAwait(false);
             if (response != HttpStatusCode.NoContent)
             {
                 throw new ApiException("Invalid Status Code returned. Expected a 204", response);

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -77,8 +77,8 @@ namespace Octokit
 
             try
             {
-                var subscription = await ApiConnection.Get<Subscription>(ApiUrls.Watched(owner, name))
-                                                      .ConfigureAwait(false);
+                var endpoint = ApiUrls.Watched(owner, name);
+                var subscription = await ApiConnection.Get<Subscription>(endpoint).ConfigureAwait(false);
 
                 return subscription != null;
             }
@@ -117,8 +117,8 @@ namespace Octokit
 
             try
             {
-                var statusCode = await Connection.Delete(ApiUrls.Watched(owner, name))
-                                                 .ConfigureAwait(false);
+                var endpoint = ApiUrls.Watched(owner, name);
+                var statusCode = await Connection.Delete(endpoint).ConfigureAwait(false);
 
                 return statusCode == HttpStatusCode.NoContent;
             }

--- a/Octokit/Helpers/AuthorizationExtensions.cs
+++ b/Octokit/Helpers/AuthorizationExtensions.cs
@@ -41,8 +41,7 @@ namespace Octokit
             TwoFactorRequiredException twoFactorException = null;
             try
             {
-                return await authorizationsClient.GetOrCreateApplicationAuthentication(clientId, clientSecret, newAuthorization)
-                                                 .ConfigureAwait(false);
+                return await authorizationsClient.GetOrCreateApplicationAuthentication(clientId, clientSecret, newAuthorization).ConfigureAwait(false);
             }
             catch (TwoFactorRequiredException exception)
             {

--- a/Octokit/Helpers/ReferenceExtensions.cs
+++ b/Octokit/Helpers/ReferenceExtensions.cs
@@ -29,7 +29,8 @@ namespace Octokit.Helpers
                 throw new ArgumentException(String.Format(CultureInfo.InvariantCulture, "The specified branch name '{0}' appears to be a ref name and not a branch name because it starts with the string 'refs/heads'. Either specify just the branch name or use the Create method if you need to specify the full ref name", branchName), "branchName");
             }
 
-            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseReference.Object.Sha)).ConfigureAwait(false);
+            var newReference = new NewReference("refs/heads/" + branchName, baseReference.Object.Sha);
+            return await referencesClient.Create(owner, name, newReference).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,7 +52,8 @@ namespace Octokit.Helpers
             }
 
             var baseBranch = await referencesClient.Get(owner, name, "heads/master").ConfigureAwait(false);
-            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseBranch.Object.Sha)).ConfigureAwait(false);
+            var newReference = new NewReference("refs/heads/" + branchName, baseBranch.Object.Sha);
+            return await referencesClient.Create(owner, name, newReference).ConfigureAwait(false);
         }
     }
 }

--- a/Octokit/Helpers/ReferenceExtensions.cs
+++ b/Octokit/Helpers/ReferenceExtensions.cs
@@ -29,7 +29,7 @@ namespace Octokit.Helpers
                 throw new ArgumentException(String.Format(CultureInfo.InvariantCulture, "The specified branch name '{0}' appears to be a ref name and not a branch name because it starts with the string 'refs/heads'. Either specify just the branch name or use the Create method if you need to specify the full ref name", branchName), "branchName");
             }
 
-            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseReference.Object.Sha));
+            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseReference.Object.Sha)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace Octokit.Helpers
                 throw new ArgumentException(String.Format(CultureInfo.InvariantCulture, "The specified branch name '{0}' appears to be a ref name and not a branch name because it starts with the string 'refs/heads'. Either specify just the branch name or use the Create method if you need to specify the full ref name", branchName), "branchName");
             }
 
-            var baseBranch = await referencesClient.Get(owner, name, "heads/master");
-            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseBranch.Object.Sha));
+            var baseBranch = await referencesClient.Get(owner, name, "heads/master").ConfigureAwait(false);
+            return await referencesClient.Create(owner, name, new NewReference("refs/heads/" + branchName, baseBranch.Object.Sha)).ConfigureAwait(false);
         }
     }
 }

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -494,7 +494,7 @@ namespace Octokit
         public async Task<string> GetRedirect(Uri uri)
         {
             Ensure.ArgumentNotNull(uri, "uri");
-            var response = await Connection.GetRedirect<string>(uri);
+            var response = await Connection.GetRedirect<string>(uri).ConfigureAwait(false);
 
             if (response.HttpResponse.StatusCode == HttpStatusCode.Redirect)
             {

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -171,8 +171,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(uri, "uri");
 
-            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts)
-                                                                 .ConfigureAwait(false), uri);
+            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts).ConfigureAwait(false), uri);
         }
 
         public Task<IReadOnlyList<T>> GetAll<T>(Uri uri, IDictionary<string, string> parameters, string accepts, ApiOptions options)

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -181,8 +181,7 @@ namespace Octokit
 
             parameters = Pagination.Setup(parameters, options);
 
-            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts, options)
-                                                                 .ConfigureAwait(false), uri);
+            return _pagination.GetAllPages(async () => await GetPage<T>(uri, parameters, accepts, options).ConfigureAwait(false), uri);
         }
 
         /// <summary>
@@ -258,11 +257,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(uri, "uri");
             Ensure.ArgumentNotNull(data, "data");
 
-            var response = await Connection.Post<T>(
-                uri,
-                data,
-                accepts,
-                contentType).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -283,12 +278,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(data, "data");
             Ensure.ArgumentNotNull(twoFactorAuthenticationCode, "twoFactorAuthenticationCode");
 
-            var response = await Connection.Post<T>(
-                uri,
-                data,
-                accepts,
-                contentType,
-                twoFactorAuthenticationCode).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType, twoFactorAuthenticationCode).ConfigureAwait(false);
             return response.Body;
         }
 
@@ -298,12 +288,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(uri, "uri");
             Ensure.ArgumentNotNull(data, "data");
 
-            var response = await Connection.Post<T>(
-                uri,
-                data,
-                accepts,
-                contentType,
-                timeout).ConfigureAwait(false);
+            var response = await Connection.Post<T>(uri, data, accepts, contentType, timeout).ConfigureAwait(false);
             return response.Body;
         }
 

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -521,7 +521,7 @@ namespace Octokit
             {
                 Ensure.ArgumentNotNull(uri, "uri");
 
-                var response = await Connection.GetResponse<IReadOnlyList<T>>(uri, cancellationToken);
+                var response = await Connection.GetResponse<IReadOnlyList<T>>(uri, cancellationToken).ConfigureAwait(false);
 
                 switch (response.HttpResponse.StatusCode)
                 {

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -451,14 +451,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(uri, "uri");
 
-            var response = await SendData<object>(
-                uri,
-                HttpMethod.Delete,
-                null,
-                null,
-                null,
-                CancellationToken.None,
-                twoFactorAuthenticationCode).ConfigureAwait(false);
+            var response = await SendData<object>(uri, HttpMethod.Delete, null, null, null, CancellationToken.None, twoFactorAuthenticationCode).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -233,7 +233,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(uri, "uri");
 
-            var response = await SendData<object>(uri, HttpMethod.Post, null, null, null, CancellationToken.None);
+            var response = await SendData<object>(uri, HttpMethod.Post, null, null, null, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -399,7 +399,7 @@ namespace Octokit
                 BaseAddress = BaseAddress,
                 Endpoint = uri
             };
-            var response = await Run<object>(request, CancellationToken.None);
+            var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -418,7 +418,7 @@ namespace Octokit
                 BaseAddress = BaseAddress,
                 Endpoint = uri
             };
-            var response = await Run<object>(request, CancellationToken.None);
+            var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -437,7 +437,7 @@ namespace Octokit
                 BaseAddress = BaseAddress,
                 Endpoint = uri
             };
-            var response = await Run<object>(request, CancellationToken.None);
+            var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -458,7 +458,7 @@ namespace Octokit
                 null,
                 null,
                 CancellationToken.None,
-                twoFactorAuthenticationCode);
+                twoFactorAuthenticationCode).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -480,7 +480,7 @@ namespace Octokit
                 BaseAddress = BaseAddress,
                 Endpoint = uri
             };
-            var response = await Run<object>(request, CancellationToken.None);
+            var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -496,7 +496,7 @@ namespace Octokit
             Ensure.ArgumentNotNull(uri, "uri");
             Ensure.ArgumentNotNull(accepts, "accepts");
 
-            var response = await SendData<object>(uri, HttpMethod.Delete, data, accepts, null, CancellationToken.None);
+            var response = await SendData<object>(uri, HttpMethod.Delete, data, accepts, null, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
         }
 
@@ -543,7 +543,7 @@ namespace Octokit
         async Task<IApiResponse<string>> GetHtml(IRequest request)
         {
             request.Headers.Add("Accept", AcceptHeaders.StableVersionHtml);
-            var response = await RunRequest(request, CancellationToken.None);
+            var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
             return new ApiResponse<string>(response, response.Body as string);
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -43,8 +43,7 @@ namespace Octokit.Internal
             using (var requestMessage = BuildRequestMessage(request))
             {
                 // Make the request
-                var responseMessage = await _http.SendAsync(requestMessage, HttpCompletionOption.ResponseContentRead, cancellationTokenForRequest)
-                                                .ConfigureAwait(false);
+                var responseMessage = await _http.SendAsync(requestMessage, HttpCompletionOption.ResponseContentRead, cancellationTokenForRequest).ConfigureAwait(false);
                 return await BuildResponse(responseMessage).ConfigureAwait(false);
             }
         }
@@ -230,7 +229,7 @@ namespace Octokit.Internal
                 {
                     newRequest.Headers.Authorization = null;
                 }
-                response = await SendAsync(newRequest, cancellationToken);
+                response = await SendAsync(newRequest, cancellationToken).ConfigureAwait(false);
             }
 
             return response;

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -178,7 +178,7 @@ namespace Octokit.Internal
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // Can't redirect without somewhere to redirect too.  Throw?
             if (response.Headers.Location == null) return response;

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -213,7 +213,7 @@ namespace Octokit.Internal
                 {
                     if (request.Content != null && request.Content.Headers.ContentLength != 0)
                     {
-                        var stream = await request.Content.ReadAsStreamAsync();
+                        var stream = await request.Content.ReadAsStreamAsync().ConfigureAwait(false);
                         if (stream.CanSeek)
                         {
                             stream.Position = 0;


### PR DESCRIPTION
As discussed in #1111, there are some places where we use `await` but do not specify the context correctly.

This is me scanning the codebase and doing three things with each scenario I find:

 - if possible, drop the `async/await` usage completely
 - if not possible to remove, ensure `ConfigureAwait` is set
 - ensure that the `await` and `ConfigureAwait` are on the same line - to make finding and verifying these usages easier in the future

<img width="1397" src="https://cloud.githubusercontent.com/assets/359239/14336953/23a12f3c-fc37-11e5-864f-774167f93b4f.png">

 - [x] integration tests passing

cc @ryangribble as I found myself refactoring in some of the Enterprise API clients