### PR TITLE
Fix a broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ flagged as a spammer.
 ### Testing Documentation
 
 If you are making changes to the documentation for Octokit, you can test these
-changes locally using the [guide](https://github.com/shiftkey/octokit.net/blob/rewrite-contributing/docs/contributing.md)
+changes locally using the [guide](https://github.com/shiftkey/octokit.net/blob/master/docs/contributing.md)
 under the `docs` folder.
 
 ### Submitting Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ flagged as a spammer.
 ### Testing Documentation
 
 If you are making changes to the documentation for Octokit, you can test these
-changes locally using the [guide](https://github.com/shiftkey/octokit.net/blob/master/docs/contributing.md)
+changes locally using the [guide](https://github.com/octokit/octokit.net/blob/master/docs/contributing.md)
 under the `docs` folder.
 
 ### Submitting Changes


### PR DESCRIPTION
Fix the Testing Documentation's guide link after merging/deleting the rewrite-contributing branch.