### PR TITLE
Add ApiOption overloads to methods on IFollowersClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableFollowersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableFollowersClient.cs
@@ -17,6 +17,17 @@ namespace Octokit.Reactive
         IObservable<User> GetAllForCurrent();
 
         /// <summary>
+        /// List the authenticated user’s followers
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<User> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// List a user’s followers
         /// </summary>
         /// <param name="login">The login name for the user</param>
@@ -25,6 +36,17 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
         IObservable<User> GetAll(string login);
+
+        /// <summary>
+        /// List a user’s followers
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <param name="login">The login name for the user</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        IObservable<User> GetAll(string login, ApiOptions options);
 
         /// <summary>
         /// List who the authenticated user is following
@@ -37,6 +59,16 @@ namespace Octokit.Reactive
         IObservable<User> GetAllFollowingForCurrent();
 
         /// <summary>
+        /// List who the authenticated user is following
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>        
+        IObservable<User> GetAllFollowingForCurrent(ApiOptions options);
+
+        /// <summary>
         /// List who a user is following
         /// </summary>
         /// <param name="login">The login name of the user</param>
@@ -45,6 +77,17 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
         IObservable<User> GetAllFollowing(string login);
+
+        /// <summary>
+        /// List who a user is following
+        /// </summary>
+        /// <param name="login">The login name of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        IObservable<User> GetAllFollowing(string login, ApiOptions options);
 
         /// <summary>
         /// Check if the authenticated user follows another user

--- a/Octokit.Reactive/Clients/ObservableFollowersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableFollowersClient.cs
@@ -31,7 +31,22 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
         public IObservable<User> GetAllForCurrent()
         {
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers());
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s followers
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        public IObservable<User> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers(), options);
         }
 
         /// <summary>
@@ -46,7 +61,24 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers(login));
+            return GetAll(login, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user’s followers
+        /// </summary>
+        /// <param name="login">The login name for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        public IObservable<User> GetAll(string login, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Followers(login), options);
         }
 
         /// <summary>
@@ -58,7 +90,20 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
         public IObservable<User> GetAllFollowingForCurrent()
         {
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following());
+            return GetAllFollowingForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List who the authenticated user is following
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        public IObservable<User> GetAllFollowingForCurrent(ApiOptions options)
+        {
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following(), options);
         }
 
         /// <summary>
@@ -73,7 +118,24 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following(login));
+            return GetAllFollowing(login, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List who a user is following
+        /// </summary>
+        /// <param name="login">The login name of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        public IObservable<User> GetAllFollowing(string login, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following(login), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableFollowersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableFollowersClient.cs
@@ -103,6 +103,8 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
         public IObservable<User> GetAllFollowingForCurrent(ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Following(), options);
         }
 

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
+    <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
     <Compile Include="Reactive\ObservableGistCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
+    <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
+    <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitStatusClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableFollowersClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableFollowersClientTests.cs
@@ -1,0 +1,305 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableFollowersClientTests
+    {
+        public class TheGetAllForCurrentMethod
+        {
+            readonly ObservableFollowersClient _followersClient;            
+
+            public TheGetAllForCurrentMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _followersClient = new ObservableFollowersClient(github);
+            }
+
+            [IntegrationTest]       
+            public async Task ReturnsFollowers()
+            {
+                var followers = await _followersClient.GetAllForCurrent().ToList();
+
+                Assert.NotEmpty(followers);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowersWithoutStart()
+            {
+                var options = new ApiOptions
+                {   
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var followers = await _followersClient.GetAllForCurrent(options).ToList();
+
+                Assert.Equal(1, followers.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowersWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var followers = await _followersClient.GetAllForCurrent(options).ToList();
+
+                Assert.Equal(1, followers.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstFollowersPage = await _followersClient.GetAllForCurrent(startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondFollowersPage = await _followersClient.GetAllForCurrent(skipStartOptions).ToList();
+
+                Assert.NotEqual(firstFollowersPage[0].Id, secondFollowersPage[0].Id);               
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            readonly ObservableFollowersClient _followersClient;
+            const string login = "samthedev";
+
+            public TheGetAllMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _followersClient = new ObservableFollowersClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsFollowers()
+            {
+                var followers = await _followersClient.GetAll(login).ToList();
+
+                Assert.NotEmpty(followers);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowersWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var followers = await _followersClient.GetAll(login, options).ToList();
+
+                Assert.Equal(3, followers.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowersWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var followers = await _followersClient.GetAll(login, options).ToList();
+
+                Assert.Equal(2, followers.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var firstFollowersPage = await _followersClient.GetAll(login, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondFollowersPage = await _followersClient.GetAll(login, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstFollowersPage[0].Id, secondFollowersPage[0].Id);
+                Assert.NotEqual(firstFollowersPage[1].Id, secondFollowersPage[1].Id);
+            }
+        }
+
+        public class TheGetAllFollowingForCurrentMethod
+        {
+            readonly ObservableFollowersClient _followersClient;            
+
+            public TheGetAllFollowingForCurrentMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _followersClient = new ObservableFollowersClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsFollowing()
+            {
+                var following = await _followersClient.GetAllFollowingForCurrent().ToList();
+
+                Assert.NotEmpty(following);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowingWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var following = await _followersClient.GetAllFollowingForCurrent(options).ToList();
+
+                Assert.Equal(1, following.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowingWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var following = await _followersClient.GetAllFollowingForCurrent(options).ToList();
+
+                Assert.Equal(1, following.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstFollowingPage = await _followersClient.GetAllFollowingForCurrent(startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondFollowingPage = await _followersClient.GetAllFollowingForCurrent(skipStartOptions).ToList();
+
+                Assert.NotEqual(firstFollowingPage[0].Id, secondFollowingPage[0].Id);                
+            }
+        }
+
+        public class TheGetAllFollowingMethod
+        {
+            readonly ObservableFollowersClient _followersClient;
+            const string login = "samthedev";
+
+            public TheGetAllFollowingMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _followersClient = new ObservableFollowersClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsFollowing()
+            {
+                var following = await _followersClient.GetAllFollowing(login).ToList();
+
+                Assert.NotEmpty(following);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowingWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var following = await _followersClient.GetAllFollowing(login, options).ToList();
+
+                Assert.Equal(5, following.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfFollowingWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var following = await _followersClient.GetAllFollowing(login, options).ToList();
+
+                Assert.Equal(5, following.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstFollowingPage = await _followersClient.GetAllFollowing(login, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondFollowingPage = await _followersClient.GetAllFollowing(login, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstFollowingPage[0].Id, secondFollowingPage[0].Id);
+                Assert.NotEqual(firstFollowingPage[1].Id, secondFollowingPage[1].Id);
+                Assert.NotEqual(firstFollowingPage[2].Id, secondFollowingPage[2].Id);
+                Assert.NotEqual(firstFollowingPage[3].Id, secondFollowingPage[3].Id);
+                Assert.NotEqual(firstFollowingPage[4].Id, secondFollowingPage[4].Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/FollowersClientTests.cs
+++ b/Octokit.Tests/Clients/FollowersClientTests.cs
@@ -37,7 +37,35 @@ namespace Octokit.Tests.Clients
                 client.GetAllForCurrent();
 
                 connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "user/followers"));
+                    Arg.Is<Uri>(u => u.ToString() == "user/followers"),Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForCurrent(options);
+
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "user/followers"),options);
+            }
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+                                
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));                
             }
         }
 
@@ -52,7 +80,26 @@ namespace Octokit.Tests.Clients
                 client.GetAll("alfhenrik");
 
                 connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/followers"));
+                    Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/followers"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("alfhenrik",options);
+
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/followers"), options);
             }
 
             [Fact]
@@ -63,10 +110,12 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("fake",null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("",ApiOptions.None));
             }
         }
 
-        public class TheGetFollowingForCurrentMethod
+        public class TheGetAllFollowingForCurrentMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -76,11 +125,38 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllFollowingForCurrent();
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "user/following"));
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "user/following"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllFollowingForCurrent(options);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "user/following"), options);
+            }
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllFollowingForCurrent(null));
             }
         }
 
-        public class TheGetFollowingMethod
+        public class TheGetAllFollowingMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -90,7 +166,25 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllFollowing("alfhenrik");
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following"));
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new FollowersClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllFollowing("alfhenrik", options);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "users/alfhenrik/following"), options);
             }
 
             [Fact]
@@ -101,6 +195,8 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllFollowing(null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllFollowing(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllFollowing("fake", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllFollowing("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableFollowersTest.cs
+++ b/Octokit.Tests/Reactive/ObservableFollowersTest.cs
@@ -25,7 +25,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForCurrent();
 
                 githubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("user/followers", UriKind.Relative), null, null);
+                    new Uri("user/followers", UriKind.Relative), Args.EmptyDictionary, null);
             }
         }
 
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("alfhenrik");
 
                 githubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("users/alfhenrik/followers", UriKind.Relative), null, null);
+                    new Uri("users/alfhenrik/followers", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]
@@ -64,7 +64,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllFollowingForCurrent();
 
                 githubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("user/following", UriKind.Relative), null, null);
+                    new Uri("user/following", UriKind.Relative), Args.EmptyDictionary, null);
             }
         }
 
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllFollowing("alfhenrik");
 
                 githubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("users/alfhenrik/following", UriKind.Relative), null, null);
+                    new Uri("users/alfhenrik/following", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -29,7 +29,22 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
         public Task<IReadOnlyList<User>> GetAllForCurrent()
         {
-            return ApiConnection.GetAll<User>(ApiUrls.Followers());
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s followers
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        public Task<IReadOnlyList<User>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Followers(),options);
         }
 
         /// <summary>
@@ -44,7 +59,24 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Followers(login));
+            return GetAll(login, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user’s followers
+        /// </summary>
+        /// <param name="login">The login name for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        public Task<IReadOnlyList<User>> GetAll(string login, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Followers(login), options);
         }
 
         /// <summary>
@@ -56,7 +88,22 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
         public Task<IReadOnlyList<User>> GetAllFollowingForCurrent()
         {
-            return ApiConnection.GetAll<User>(ApiUrls.Following());
+            return GetAllFollowingForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List who the authenticated user is following
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        public Task<IReadOnlyList<User>> GetAllFollowingForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Following(), options);
         }
 
         /// <summary>
@@ -71,7 +118,24 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Following(login));
+            return GetAllFollowing(login, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List who a user is following
+        /// </summary>
+        /// <param name="login">The login name of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        public Task<IReadOnlyList<User>> GetAllFollowing(string login, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Following(login), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IFollowersClient.cs
+++ b/Octokit/Clients/IFollowersClient.cs
@@ -23,6 +23,16 @@ namespace Octokit
         Task<IReadOnlyList<User>> GetAllForCurrent();
 
         /// <summary>
+        /// List the authenticated user’s followers
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>        
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>        
+        Task<IReadOnlyList<User>> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// List a user’s followers
         /// </summary>
         /// <param name="login">The login name for the user</param>
@@ -31,6 +41,17 @@ namespace Octokit
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
         Task<IReadOnlyList<User>> GetAll(string login);
+
+        /// <summary>
+        /// List a user’s followers
+        /// </summary>
+        /// <param name="login">The login name for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        Task<IReadOnlyList<User>> GetAll(string login, ApiOptions options);
 
         /// <summary>
         /// List who the authenticated user is following
@@ -43,6 +64,16 @@ namespace Octokit
         Task<IReadOnlyList<User>> GetAllFollowingForCurrent();
 
         /// <summary>
+        /// List who the authenticated user is following
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>        
+        Task<IReadOnlyList<User>> GetAllFollowingForCurrent(ApiOptions options);
+
+        /// <summary>
         /// List who a user is following
         /// </summary>
         /// <param name="login">The login name of the user</param>
@@ -51,6 +82,17 @@ namespace Octokit
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
         Task<IReadOnlyList<User>> GetAllFollowing(string login);
+
+        /// <summary>
+        /// List who a user is following
+        /// </summary>
+        /// <param name="login">The login name of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        Task<IReadOnlyList<User>> GetAllFollowing(string login, ApiOptions options);
 
         /// <summary>
         /// Check if the authenticated user follows another user


### PR DESCRIPTION
This implementation targets the issue : #1154 

- [x]  Add an overload for the GetAll* methods on IFollowersClient with the ApiOptions parameter.
- [x]  Implement the the GetAll* method in the FollowersClient class.
- [x]  Add an overload for the GetAll* methods to the IObservableFollowersClient with the ApiOptions parameter.
- [x]  Implement the GetAll* methods in the ObservableFollowersClient class.
- [x]  Implement the needed tests in the FollowersClientTests class.
- [x] Implement the required integration tests in the ObservableFollowersClientTests class.