### PR TITLE
Add ApiOption overloads to methods on IGistCommentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableGistCommentsClient.cs
@@ -26,6 +26,15 @@ namespace Octokit.Reactive
         IObservable<GistComment> GetAllForGist(string gistId);
 
         /// <summary>
+        /// Gets all comments for the gist with the specified id.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
+        /// <param name="gistId">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>IObservable{GistComment}.</returns>
+        IObservable<GistComment> GetAllForGist(string gistId, ApiOptions options);
+
+        /// <summary>
         /// Creates a comment for the gist with the specified id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/gists/comments/#create-a-comment</remarks>

--- a/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
@@ -38,7 +38,21 @@ namespace Octokit.Reactive
         /// <returns>IObservable{GistComment}.</returns>
         public IObservable<GistComment> GetAllForGist(string gistId)
         {
-            return _connection.GetAndFlattenAllPages<GistComment>(ApiUrls.GistComments(gistId));
+            return GetAllForGist(gistId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all comments for the gist with the specified id.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
+        /// <param name="gistId">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>IObservable{GistComment}.</returns>
+        public IObservable<GistComment> GetAllForGist(string gistId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<GistComment>(ApiUrls.GistComments(gistId), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistCommentsClient.cs
@@ -38,6 +38,8 @@ namespace Octokit.Reactive
         /// <returns>IObservable{GistComment}.</returns>
         public IObservable<GistComment> GetAllForGist(string gistId)
         {
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");             
+
             return GetAllForGist(gistId, ApiOptions.None);
         }
 
@@ -50,6 +52,7 @@ namespace Octokit.Reactive
         /// <returns>IObservable{GistComment}.</returns>
         public IObservable<GistComment> GetAllForGist(string gistId, ApiOptions options)
         {
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<GistComment>(ApiUrls.GistComments(gistId), options);

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
+    <Compile Include="Reactive\ObservableGistCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesClientTests.cs" />
     <Compile Include="Reactive\ObservableMilestonesClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitStatusClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Text;
+﻿using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit.Reactive;
 using Xunit;

--- a/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistCommentsClientTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableGistCommentsClientTests
+    {   
+        public class TheGetAllForGistMethod
+        {
+            readonly ObservableGistCommentsClient _gistCommentsClient;
+            const string gistId = "7783a2c14a15a2e3c93b";
+
+            public TheGetAllForGistMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistCommentsClient = new ObservableGistCommentsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsGistComments()
+            {
+                var comments = await _gistCommentsClient.GetAllForGist(gistId).ToList();
+
+                Assert.NotEmpty(comments);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistCommentsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var comments = await _gistCommentsClient.GetAllForGist(gistId, options).ToList();
+
+                Assert.Equal(5, comments.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistCommentsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var comments = await _gistCommentsClient.GetAllForGist(gistId, options).ToList();
+
+                Assert.Equal(4, comments.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1
+                };
+
+                var firstCommentsPage = await _gistCommentsClient.GetAllForGist(gistId, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondCommentsPage = await _gistCommentsClient.GetAllForGist(gistId, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstCommentsPage[0].Id, secondCommentsPage[0].Id);
+                Assert.NotEqual(firstCommentsPage[1].Id, secondCommentsPage[1].Id);
+                Assert.NotEqual(firstCommentsPage[2].Id, secondCommentsPage[2].Id);
+                Assert.NotEqual(firstCommentsPage[3].Id, secondCommentsPage[3].Id);                
+            }
+        }
+    }    
+}

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -31,7 +31,7 @@ public class GistCommentsClientTests
         }
     }
 
-    public class TheGetForGistMethod
+    public class TheGetAllForGistMethod
     {
         [Fact]
         public async Task RequestsCorrectUrl()

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
+using Octokit.Tests;
 using Octokit.Tests.Helpers;
 using Xunit;
 
@@ -40,7 +41,25 @@ public class GistCommentsClientTests
 
             await client.GetAllForGist("24");
 
-            connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"));
+            connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistCommentsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+
+            await client.GetAllForGist("24", options);
+
+            connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), options);
         }
     }
 

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -61,6 +61,19 @@ public class GistCommentsClientTests
 
             connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), options);
         }
+
+        [Fact]
+        public async Task EnsuresNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistCommentsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist("24", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist("", ApiOptions.None));
+            
+        }
     }
 
     public class TheCreateMethod

--- a/Octokit.Tests/Clients/GistCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/GistCommentsClientTests.cs
@@ -1,140 +1,140 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit;
-using Octokit.Tests;
-using Octokit.Tests.Helpers;
 using Xunit;
 
-public class GistCommentsClientTests
+namespace Octokit.Tests.Clients
 {
-    public class TheCtor
+    public class GistCommentsClientTests
     {
-        [Fact]
-        public void EnsuresArgument()
+        public class TheCtor
         {
-            Assert.Throws<ArgumentNullException>(() => new GistCommentsClient(null));
-        }
-    }
-
-    public class TheGetMethod
-    {
-        [Fact]
-        public async Task RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
-
-            await client.Get("24", 1337);
-
-            connection.Received().Get<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
-        }
-    }
-
-    public class TheGetAllForGistMethod
-    {
-        [Fact]
-        public async Task RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
-
-            await client.GetAllForGist("24");
-
-            connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public async Task RequestsCorrectUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void EnsuresArgument()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-
-            await client.GetAllForGist("24", options);
-
-            connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), options);
+                Assert.Throws<ArgumentNullException>(() => new GistCommentsClient(null));
+            }
         }
 
-        [Fact]
-        public async Task EnsuresNonNullArguments()
+        public class TheGetMethod
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist(null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist(""));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist("24", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist("", ApiOptions.None));
+                await client.Get("24", 1337);
+
+                connection.Received().Get<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
+            }
+        }
+
+        public class TheGetAllForGistMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
+
+                await client.GetAllForGist("24");
+
+                connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAllForGist("24", options);
+
+                connection.Received().GetAll<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForGist("24", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForGist("", ApiOptions.None));
             
-        }
-    }
-
-    public class TheCreateMethod
-    {
-        [Fact]
-        public async Task EnsuresNonNullArguments()
-        {
-            var client = new GistCommentsClient(Substitute.For<IApiConnection>());
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("24", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("24", ""));
+            }
         }
 
-        [Fact]
-        public async Task PostsToCorrectUrl()
+        public class TheCreateMethod
         {
-            var comment = "This is a comment.";
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await client.Create("24", comment);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("24", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("24", ""));
+            }
 
-            connection.Received().Post<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Arg.Is<BodyWrapper>(x => x.Body == comment));
+            [Fact]
+            public async Task PostsToCorrectUrl()
+            {
+                var comment = "This is a comment.";
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
+
+                await client.Create("24", comment);
+
+                connection.Received().Post<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments"), Arg.Is<BodyWrapper>(x => x.Body == comment));
+            }
         }
-    }
 
-    public class TheUpdateMethod
-    {
-        [Fact]
-        public async Task EnsuresNonNullArguments()
+        public class TheUpdateMethod
         {
-            var client = new GistCommentsClient(Substitute.For<IApiConnection>());
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new GistCommentsClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("24", 1337, null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("24", 1337, ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("24", 1337, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("24", 1337, ""));
+            }
+
+            [Fact]
+            public async Task PostsToCorrectUrl()
+            {
+                var comment = "This is a comment.";
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
+
+                await client.Update("24", 1337, comment);
+
+                connection.Received().Patch<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"), Arg.Is<BodyWrapper>(x => x.Body == comment));
+            }
         }
 
-        [Fact]
-        public async Task PostsToCorrectUrl()
+        public class TheDeleteMethod
         {
-            var comment = "This is a comment.";
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
+            [Fact]
+            public async Task PostsToCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistCommentsClient(connection);
 
-            await client.Update("24", 1337, comment);
+                await client.Delete("24", 1337);
 
-            connection.Received().Patch<GistComment>(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"), Arg.Is<BodyWrapper>(x => x.Body == comment));
-        }
-    }
-
-    public class TheDeleteMethod
-    {
-        [Fact]
-        public async Task PostsToCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistCommentsClient(connection);
-
-            await client.Delete("24", 1337);
-
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/24/comments/1337"));
+            }
         }
     }
 }

--- a/Octokit/Clients/GistCommentsClient.cs
+++ b/Octokit/Clients/GistCommentsClient.cs
@@ -39,7 +39,21 @@ namespace Octokit
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId)
         {
-            return ApiConnection.GetAll<GistComment>(ApiUrls.GistComments(gistId));
+            return GetAllForGist(gistId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all comments for the gist with the specified id.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
+        /// <param name="gistId">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
+        public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<GistComment>(ApiUrls.GistComments(gistId), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/GistCommentsClient.cs
+++ b/Octokit/Clients/GistCommentsClient.cs
@@ -39,6 +39,8 @@ namespace Octokit
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId)
         {
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");
+
             return GetAllForGist(gistId, ApiOptions.None);
         }
 
@@ -51,6 +53,7 @@ namespace Octokit
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId, ApiOptions options)
         {
+            Ensure.ArgumentNotNullOrEmptyString(gistId, "gistId");            
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<GistComment>(ApiUrls.GistComments(gistId), options);

--- a/Octokit/Clients/IGistCommentsClient.cs
+++ b/Octokit/Clients/IGistCommentsClient.cs
@@ -32,6 +32,15 @@ namespace Octokit
         Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId);
 
         /// <summary>
+        /// Gets all comments for the gist with the specified id.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
+        /// <param name="gistId">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
+        Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId, ApiOptions options);
+
+        /// <summary>
         /// Creates a comment for the gist with the specified id.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/gists/comments/#create-a-comment</remarks>


### PR DESCRIPTION
This implementation targets the issue : #1155 

- [x]  Add an overload for the GetAllForGist methods to IGistCommentsClient with the ApiOptions parameter.
- [x]  Implement the the GetAllForGist  method to the GistCommentsClient class.
- [x]  Add an overload for the GetAllForGist  methods to the IObservableGistCommentsClient with the ApiOptions parameter.
- [x]  Implement the GetAllForGist methods in the ObservableGistCommentsClient class.
- [x]  Implement the needed tests in the GistCommentsClientTests class.
- [x]  Implement the required integration tests in the ObservableGistCommentsClientTests class.