### PR TITLE
Add ApiOption overloads to methods on IGistsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableGistsClient.cs
@@ -35,8 +35,29 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAll(ApiOptions options);
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         IObservable<Gist> GetAll(DateTimeOffset since);
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAll(DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// Lists all public gists
@@ -52,8 +73,27 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllPublic(ApiOptions options);
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         IObservable<Gist> GetAllPublic(DateTimeOffset since);
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllPublic(DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// List the authenticated user’s starred gists
@@ -69,8 +109,27 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllStarred(ApiOptions options);
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         IObservable<Gist> GetAllStarred(DateTimeOffset since);
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllStarred(DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// List a user's gists
@@ -88,8 +147,29 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="user">The user</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllForUser(string user, ApiOptions options);
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         IObservable<Gist> GetAllForUser(string user, DateTimeOffset since);
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<Gist> GetAllForUser(string user, DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// List gist commits
@@ -101,6 +181,16 @@ namespace Octokit.Reactive
         IObservable<GistHistory> GetAllCommits(string id);
 
         /// <summary>
+        /// List gist commits
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-commits
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<GistHistory> GetAllCommits(string id, ApiOptions options);
+
+        /// <summary>
         /// List gist forks
         /// </summary>
         /// <remarks>
@@ -108,6 +198,16 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The id of the gist</param>
         IObservable<GistFork> GetAllForks(string id);
+
+        /// <summary>
+        /// List gist forks
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-forks
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<GistFork> GetAllForks(string id, ApiOptions options);
 
         /// <summary>
         /// Creates a new gist

--- a/Octokit.Reactive/Clients/ObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistsClient.cs
@@ -129,7 +129,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.Gist(), request.ToParametersDictionary());
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.Gist(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options"); 
 
             var request = new GistRequest(since);
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary());
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -232,10 +232,10 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Gist> GetAllStarred(DateTimeOffset since, ApiOptions options)
         {
-            
+            Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.StarredGists(), request.ToParametersDictionary());
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.StarredGists(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user), request.ToParametersDictionary());
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistsClient.cs
@@ -247,7 +247,7 @@ namespace Octokit.Reactive
         /// <param name="user">The user</param>
         public IObservable<Gist> GetAllForUser(string user)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
             return GetAllForUser(user, ApiOptions.None);
         }
@@ -262,7 +262,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Gist> GetAllForUser(string user, ApiOptions options)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user), options);
@@ -278,7 +278,7 @@ namespace Octokit.Reactive
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public IObservable<Gist> GetAllForUser(string user, DateTimeOffset since)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
             return GetAllForUser(user, since, ApiOptions.None);
         }
@@ -294,7 +294,7 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Gist> GetAllForUser(string user, DateTimeOffset since, ApiOptions options)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);

--- a/Octokit.Reactive/Clients/ObservableGistsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGistsClient.cs
@@ -84,7 +84,22 @@ namespace Octokit.Reactive
         /// </remarks>
         public IObservable<Gist> GetAll()
         {
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.Gist());
+            return GetAll(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.Gist(), options);
         }
 
         /// <summary>
@@ -96,7 +111,23 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public IObservable<Gist> GetAll(DateTimeOffset since)
+        {            
+            return GetAll(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAll(DateTimeOffset since, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             var request = new GistRequest(since);
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.Gist(), request.ToParametersDictionary());
         }
@@ -109,7 +140,21 @@ namespace Octokit.Reactive
         /// </remarks>
         public IObservable<Gist> GetAllPublic()
         {
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists());
+            return GetAllPublic(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllPublic(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists(), options);
         }
 
         /// <summary>
@@ -121,6 +166,21 @@ namespace Octokit.Reactive
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public IObservable<Gist> GetAllPublic(DateTimeOffset since)
         {
+            return GetAllPublic(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllPublic(DateTimeOffset since, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options"); 
+
             var request = new GistRequest(since);
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary());
         }
@@ -133,7 +193,21 @@ namespace Octokit.Reactive
         /// </remarks>
         public IObservable<Gist> GetAllStarred()
         {
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.StarredGists());
+            return GetAllStarred(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllStarred(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.StarredGists(), options);
         }
 
         /// <summary>
@@ -145,6 +219,21 @@ namespace Octokit.Reactive
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public IObservable<Gist> GetAllStarred(DateTimeOffset since)
         {
+            return GetAllStarred(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllStarred(DateTimeOffset since, ApiOptions options)
+        {
+            
+
             var request = new GistRequest(since);
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.StarredGists(), request.ToParametersDictionary());
         }
@@ -160,7 +249,23 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(user, "user");
 
-            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user));
+            return GetAllForUser(user, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllForUser(string user, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user), options);
         }
 
         /// <summary>
@@ -174,6 +279,23 @@ namespace Octokit.Reactive
         public IObservable<Gist> GetAllForUser(string user, DateTimeOffset since)
         {
             Ensure.ArgumentNotNull(user, "user");
+
+            return GetAllForUser(user, since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<Gist> GetAllForUser(string user, DateTimeOffset since, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
             return _connection.GetAndFlattenAllPages<Gist>(ApiUrls.UsersGists(user), request.ToParametersDictionary());
@@ -190,7 +312,23 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(id, "id");
 
-            return _connection.GetAndFlattenAllPages<GistHistory>(ApiUrls.GistCommits(id));
+            return GetAllCommits(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List gist commits
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-commits
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<GistHistory> GetAllCommits(string id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<GistHistory>(ApiUrls.GistCommits(id), options);
         }
 
         /// <summary>
@@ -204,7 +342,23 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(id, "id");
 
-            return _connection.GetAndFlattenAllPages<GistFork>(ApiUrls.ForkGist(id));
+            return GetAllForks(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List gist forks
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-forks
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<GistFork> GetAllForks(string id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<GistFork>(ApiUrls.ForkGist(id), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
+    <Compile Include="Reactive\ObservableGistClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
+    <Compile Include="Reactive\ObservableGistClientTests.cs" />
     <Compile Include="Reactive\ObservableIssueCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -285,5 +285,146 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
             }
         }
+
+        public class TheGetAllStarredMethod
+        {
+            readonly ObservableGistsClient _gistsClient;
+
+            public TheGetAllStarredMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsStartedGists()
+            {
+                var gists = await _gistsClient.GetAllStarred().ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfStartedGistsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var gists = await _gistsClient.GetAllStarred(options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfStartedGistsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gists = await _gistsClient.GetAllStarred(options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstStartedGistsPage = await _gistsClient.GetAllStarred(startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondStartedGistsPage = await _gistsClient.GetAllStarred(skipStartOptions).ToList();
+
+                Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
+                Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
+                Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
+                Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
+                Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsStartedGistsSince()
+            {
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllStarred(since).ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfStartedGistsSinceWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllStarred(since, options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfStartedGistsSinceWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllStarred(since, options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctStartedGistsSinceBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var firstStartedGistsPage = await _gistsClient.GetAllStarred(since, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondStartedGistsPage = await _gistsClient.GetAllStarred(since, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
+                Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
+                Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
+                Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
+                Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -426,5 +426,143 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
             }
         }
+
+        public class TheGetAllForUserMethod
+        {
+            readonly ObservableGistsClient _gistsClient;
+            const string user = "shiftkey";
+
+            public TheGetAllForUserMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsUserGists()
+            {
+                var gists = await _gistsClient.GetAllForUser(user).ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfUserGistsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var gists = await _gistsClient.GetAllForUser(user, options).ToList();
+
+                Assert.Equal(3, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfUserGistsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gists = await _gistsClient.GetAllForUser(user, options).ToList();
+
+                Assert.Equal(3, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var firstUsersGistsPage = await _gistsClient.GetAllForUser(user, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondUsersGistsPage = await _gistsClient.GetAllForUser(user, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstUsersGistsPage[0].Id, secondUsersGistsPage[0].Id);
+                Assert.NotEqual(firstUsersGistsPage[1].Id, secondUsersGistsPage[1].Id);
+                Assert.NotEqual(firstUsersGistsPage[2].Id, secondUsersGistsPage[2].Id);                
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsUserGistsSince()
+            {
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllForUser(user, since).ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfUserGistsSinceWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
+
+                Assert.Equal(3, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfUserGistsSinceWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
+
+                Assert.Equal(3, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctUserGistsSinceBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var firstUserGistsPage = await _gistsClient.GetAllForUser(user, since, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondUserGistsPage = await _gistsClient.GetAllForUser(user, since, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstUserGistsPage[0].Id, secondUserGistsPage[0].Id);
+                Assert.NotEqual(firstUserGistsPage[1].Id, secondUserGistsPage[1].Id);
+                Assert.NotEqual(firstUserGistsPage[2].Id, secondUserGistsPage[2].Id);          
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -639,5 +639,82 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstGistCommitsPage[2].Url, secondGistCommitsPage[2].Url);
             }          
         }
+
+        public class TheGetAllForksMethod
+        {
+            readonly ObservableGistsClient _gistsClient;
+            const string gistId = "670c22f3966e662d2f83";
+
+            public TheGetAllForksMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsGistCommits()
+            {
+                var gistForks = await _gistsClient.GetAllForks(gistId).ToList();
+
+                Assert.NotEmpty(gistForks);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistForksWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
+
+                Assert.Equal(5, gistForks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountGistForksWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
+
+                Assert.Equal(5, gistForks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstGistForksPage = await _gistsClient.GetAllForks(gistId, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondGistForksPage = await _gistsClient.GetAllForks(gistId, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstGistForksPage[0].Url, secondGistForksPage[0].Url);
+                Assert.NotEqual(firstGistForksPage[1].Url, secondGistForksPage[1].Url);
+                Assert.NotEqual(firstGistForksPage[2].Url, secondGistForksPage[2].Url);
+                Assert.NotEqual(firstGistForksPage[3].Url, secondGistForksPage[3].Url);
+                Assert.NotEqual(firstGistForksPage[4].Url, secondGistForksPage[4].Url);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -564,5 +564,80 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstUserGistsPage[2].Id, secondUserGistsPage[2].Id);          
             }
         }
+
+        public class TheGetAllCommitsMethod
+        {
+            readonly ObservableGistsClient _gistsClient;
+            const string gistId = "670c22f3966e662d2f83";
+
+            public TheGetAllCommitsMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();   
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsGistCommits()
+            {
+                var gistCommits = await _gistsClient.GetAllCommits(gistId).ToList();
+
+                Assert.NotEmpty(gistCommits);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistCommisWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
+
+                Assert.Equal(3, gistCommits.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountGistCommitsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
+
+                Assert.Equal(3, gistCommits.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var firstGistCommitsPage = await _gistsClient.GetAllCommits(gistId, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondGistCommitsPage = await _gistsClient.GetAllCommits(gistId, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstGistCommitsPage[0].Url, secondGistCommitsPage[0].Url);
+                Assert.NotEqual(firstGistCommitsPage[1].Url, secondGistCommitsPage[1].Url);
+                Assert.NotEqual(firstGistCommitsPage[2].Url, secondGistCommitsPage[2].Url);
+            }          
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -146,6 +146,144 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);
             }
         }
-        
+
+        public class TheGetAllPublicMethod
+        {
+            readonly ObservableGistsClient _gistsClient;
+
+            public TheGetAllPublicMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsPublicGists()
+            {
+                var gists = await _gistsClient.GetAllPublic().ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfPublicGistsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var gists = await _gistsClient.GetAllPublic(options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfPublicGistsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gists = await _gistsClient.GetAllPublic(options).ToList();
+
+                Assert.Equal(4, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1
+                };
+
+                var firstPublicGistsPage = await _gistsClient.GetAllPublic(startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPublicGistsPage = await _gistsClient.GetAllPublic(skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
+                Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
+                Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
+                Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsPublicGistsSince()
+            {
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllPublic(since).ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfPublicGistsSinceWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllPublic(since, options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfPublicGistsSinceWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var gists = await _gistsClient.GetAllPublic(since, options).ToList();
+
+                Assert.Equal(4, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctPublicGistsSinceBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1
+                };
+                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+                var firstPublicGistsPage = await _gistsClient.GetAllPublic(since, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPublicGistsPage = await _gistsClient.GetAllPublic(since, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
+                Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
+                Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
+                Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -1,720 +1,720 @@
 ﻿using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Octokit;
 using Octokit.Reactive;
+using Octokit.Tests.Integration;
 using Xunit;
 
-namespace Octokit.Tests.Integration.Reactive
+public class ObservableGistClientTests
 {
-    public class ObservableGistClientTests
+    public class TheGetAllMethod
     {
-        public class TheGetAllMethod
+        readonly ObservableGistsClient _gistsClient;
+
+        public TheGetAllMethod()
         {
-            readonly ObservableGistsClient _gistsClient;             
+            var github = Helper.GetAuthenticatedClient();
 
-            public TheGetAllMethod()
-            {
-                var github = Helper.GetAuthenticatedClient();
-
-                _gistsClient = new ObservableGistsClient(github);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsGists()
-            {
-                var gists = await _gistsClient.GetAll().ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistsWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-
-                var gists = await _gistsClient.GetAll(options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistsWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var gists = await _gistsClient.GetAll(options).ToList();
-
-                Assert.Equal(4, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1
-                };
-
-                var firstGistsPage = await _gistsClient.GetAll(startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondGistsPage = await _gistsClient.GetAll(skipStartOptions).ToList();
-
-                Assert.NotEqual(firstGistsPage[0].Id, secondGistsPage[0].Id);
-                Assert.NotEqual(firstGistsPage[1].Id, secondGistsPage[1].Id);
-                Assert.NotEqual(firstGistsPage[2].Id, secondGistsPage[2].Id);
-                Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);                
-            }            
-
-            [IntegrationTest]
-            public async Task ReturnsGistsSince()
-            {
-                var since=new DateTimeOffset(new DateTime(2016,1,1));
-                var gists = await _gistsClient.GetAll(since).ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistsSinceWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAll(since, options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistsSinceWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAll(since, options).ToList();
-
-                Assert.Equal(4, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctGistsSinceBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var firstGistsPage = await _gistsClient.GetAll(since, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondGistsPage = await _gistsClient.GetAll(since, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstGistsPage[0].Id, secondGistsPage[0].Id);
-                Assert.NotEqual(firstGistsPage[1].Id, secondGistsPage[1].Id);
-                Assert.NotEqual(firstGistsPage[2].Id, secondGistsPage[2].Id);
-                Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);
-            }
+            _gistsClient = new ObservableGistsClient(github);
         }
 
-        public class TheGetAllPublicMethod
+        [IntegrationTest]
+        public async Task ReturnsGists()
         {
-            readonly ObservableGistsClient _gistsClient;
+            var gists = await _gistsClient.GetAll().ToList();
 
-            public TheGetAllPublicMethod()
-            {
-                var github = Helper.GetAuthenticatedClient();
-
-                _gistsClient = new ObservableGistsClient(github);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsPublicGists()
-            {
-                var gists = await _gistsClient.GetAllPublic().ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfPublicGistsWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-
-                var gists = await _gistsClient.GetAllPublic(options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfPublicGistsWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var gists = await _gistsClient.GetAllPublic(options).ToList();
-
-                Assert.Equal(4, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1
-                };
-
-                var firstPublicGistsPage = await _gistsClient.GetAllPublic(startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondPublicGistsPage = await _gistsClient.GetAllPublic(skipStartOptions).ToList();
-
-                Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
-                Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
-                Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
-                Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsPublicGistsSince()
-            {
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllPublic(since).ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfPublicGistsSinceWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllPublic(since, options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfPublicGistsSinceWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllPublic(since, options).ToList();
-
-                Assert.Equal(4, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctPublicGistsSinceBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var firstPublicGistsPage = await _gistsClient.GetAllPublic(since, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 4,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondPublicGistsPage = await _gistsClient.GetAllPublic(since, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
-                Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
-                Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
-                Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
-            }
+            Assert.NotEmpty(gists);
         }
 
-        public class TheGetAllStarredMethod
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistsWithoutStart()
         {
-            readonly ObservableGistsClient _gistsClient;
-
-            public TheGetAllStarredMethod()
+            var options = new ApiOptions
             {
-                var github = Helper.GetAuthenticatedClient();
+                PageSize = 5,
+                PageCount = 1
+            };
 
-                _gistsClient = new ObservableGistsClient(github);
-            }
+            var gists = await _gistsClient.GetAll(options).ToList();
 
-            [IntegrationTest]
-            public async Task ReturnsStartedGists()
-            {
-                var gists = await _gistsClient.GetAllStarred().ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfStartedGistsWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-
-                var gists = await _gistsClient.GetAllStarred(options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfStartedGistsWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var gists = await _gistsClient.GetAllStarred(options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-
-                var firstStartedGistsPage = await _gistsClient.GetAllStarred(startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondStartedGistsPage = await _gistsClient.GetAllStarred(skipStartOptions).ToList();
-
-                Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
-                Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
-                Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
-                Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
-                Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsStartedGistsSince()
-            {
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllStarred(since).ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfStartedGistsSinceWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllStarred(since, options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfStartedGistsSinceWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllStarred(since, options).ToList();
-
-                Assert.Equal(5, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctStartedGistsSinceBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var firstStartedGistsPage = await _gistsClient.GetAllStarred(since, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondStartedGistsPage = await _gistsClient.GetAllStarred(since, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
-                Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
-                Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
-                Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
-                Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
-            }
+            Assert.Equal(5, gists.Count);
         }
 
-        public class TheGetAllForUserMethod
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistsWithStart()
         {
-            readonly ObservableGistsClient _gistsClient;
-            const string user = "shiftkey";
-
-            public TheGetAllForUserMethod()
+            var options = new ApiOptions
             {
-                var github = Helper.GetAuthenticatedClient();
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
 
-                _gistsClient = new ObservableGistsClient(github);
-            }
+            var gists = await _gistsClient.GetAll(options).ToList();
 
-            [IntegrationTest]
-            public async Task ReturnsUserGists()
-            {
-                var gists = await _gistsClient.GetAllForUser(user).ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfUserGistsWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-
-                var gists = await _gistsClient.GetAllForUser(user, options).ToList();
-
-                Assert.Equal(3, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfUserGistsWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var gists = await _gistsClient.GetAllForUser(user, options).ToList();
-
-                Assert.Equal(3, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-
-                var firstUsersGistsPage = await _gistsClient.GetAllForUser(user, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondUsersGistsPage = await _gistsClient.GetAllForUser(user, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstUsersGistsPage[0].Id, secondUsersGistsPage[0].Id);
-                Assert.NotEqual(firstUsersGistsPage[1].Id, secondUsersGistsPage[1].Id);
-                Assert.NotEqual(firstUsersGistsPage[2].Id, secondUsersGistsPage[2].Id);                
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsUserGistsSince()
-            {
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllForUser(user, since).ToList();
-
-                Assert.NotEmpty(gists);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfUserGistsSinceWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
-
-                Assert.Equal(3, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfUserGistsSinceWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
-
-                Assert.Equal(3, gists.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctUserGistsSinceBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-                var since = new DateTimeOffset(new DateTime(2016, 1, 1));
-                var firstUserGistsPage = await _gistsClient.GetAllForUser(user, since, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondUserGistsPage = await _gistsClient.GetAllForUser(user, since, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstUserGistsPage[0].Id, secondUserGistsPage[0].Id);
-                Assert.NotEqual(firstUserGistsPage[1].Id, secondUserGistsPage[1].Id);
-                Assert.NotEqual(firstUserGistsPage[2].Id, secondUserGistsPage[2].Id);          
-            }
+            Assert.Equal(4, gists.Count);
         }
 
-        public class TheGetAllCommitsMethod
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
         {
-            readonly ObservableGistsClient _gistsClient;
-            const string gistId = "670c22f3966e662d2f83";
-
-            public TheGetAllCommitsMethod()
+            var startOptions = new ApiOptions
             {
-                var github = Helper.GetAuthenticatedClient();   
+                PageSize = 4,
+                PageCount = 1
+            };
 
-                _gistsClient = new ObservableGistsClient(github);
-            }
+            var firstGistsPage = await _gistsClient.GetAll(startOptions).ToList();
 
-            [IntegrationTest]
-            public async Task ReturnsGistCommits()
+            var skipStartOptions = new ApiOptions
             {
-                var gistCommits = await _gistsClient.GetAllCommits(gistId).ToList();
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
 
-                Assert.NotEmpty(gistCommits);
-            }
+            var secondGistsPage = await _gistsClient.GetAll(skipStartOptions).ToList();
 
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistCommisWithoutStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-
-                var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
-
-                Assert.Equal(3, gistCommits.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountGistCommitsWithStart()
-            {
-                var options = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
-
-                Assert.Equal(3, gistCommits.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
-            {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1
-                };
-
-                var firstGistCommitsPage = await _gistsClient.GetAllCommits(gistId, startOptions).ToList();
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 3,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondGistCommitsPage = await _gistsClient.GetAllCommits(gistId, skipStartOptions).ToList();
-
-                Assert.NotEqual(firstGistCommitsPage[0].Url, secondGistCommitsPage[0].Url);
-                Assert.NotEqual(firstGistCommitsPage[1].Url, secondGistCommitsPage[1].Url);
-                Assert.NotEqual(firstGistCommitsPage[2].Url, secondGistCommitsPage[2].Url);
-            }          
+            Assert.NotEqual(firstGistsPage[0].Id, secondGistsPage[0].Id);
+            Assert.NotEqual(firstGistsPage[1].Id, secondGistsPage[1].Id);
+            Assert.NotEqual(firstGistsPage[2].Id, secondGistsPage[2].Id);
+            Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);
         }
 
-        public class TheGetAllForksMethod
+        [IntegrationTest]
+        public async Task ReturnsGistsSince()
         {
-            readonly ObservableGistsClient _gistsClient;
-            const string gistId = "670c22f3966e662d2f83";
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAll(since).ToList();
 
-            public TheGetAllForksMethod()
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistsSinceWithoutStart()
+        {
+            var options = new ApiOptions
             {
-                var github = Helper.GetAuthenticatedClient();
+                PageSize = 5,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAll(since, options).ToList();
 
-                _gistsClient = new ObservableGistsClient(github);
-            }
+            Assert.Equal(5, gists.Count);
+        }
 
-            [IntegrationTest]
-            public async Task ReturnsGistCommits()
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistsSinceWithStart()
+        {
+            var options = new ApiOptions
             {
-                var gistForks = await _gistsClient.GetAllForks(gistId).ToList();
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAll(since, options).ToList();
 
-                Assert.NotEmpty(gistForks);
-            }
+            Assert.Equal(4, gists.Count);
+        }
 
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountOfGistForksWithoutStart()
+        [IntegrationTest]
+        public async Task ReturnsDistinctGistsSinceBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
             {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
+                PageSize = 4,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var firstGistsPage = await _gistsClient.GetAll(since, startOptions).ToList();
 
-                var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
-
-                Assert.Equal(5, gistForks.Count);
-            }
-
-            [IntegrationTest]
-            public async Task ReturnsCorrectCountGistForksWithStart()
+            var skipStartOptions = new ApiOptions
             {
-                var options = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
 
-                var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
+            var secondGistsPage = await _gistsClient.GetAll(since, skipStartOptions).ToList();
 
-                Assert.Equal(5, gistForks.Count);
-            }
+            Assert.NotEqual(firstGistsPage[0].Id, secondGistsPage[0].Id);
+            Assert.NotEqual(firstGistsPage[1].Id, secondGistsPage[1].Id);
+            Assert.NotEqual(firstGistsPage[2].Id, secondGistsPage[2].Id);
+            Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);
+        }
+    }
 
-            [IntegrationTest]
-            public async Task ReturnsDistinctResultsBasedOnStartPage()
+    public class TheGetAllPublicMethod
+    {
+        readonly ObservableGistsClient _gistsClient;
+
+        public TheGetAllPublicMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _gistsClient = new ObservableGistsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsPublicGists()
+        {
+            var gists = await _gistsClient.GetAllPublic().ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfPublicGistsWithoutStart()
+        {
+            var options = new ApiOptions
             {
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1
-                };
+                PageSize = 5,
+                PageCount = 1
+            };
 
-                var firstGistForksPage = await _gistsClient.GetAllForks(gistId, startOptions).ToList();
+            var gists = await _gistsClient.GetAllPublic(options).ToList();
 
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 5,
-                    PageCount = 1,
-                    StartPage = 2
-                };
+            Assert.Equal(5, gists.Count);
+        }
 
-                var secondGistForksPage = await _gistsClient.GetAllForks(gistId, skipStartOptions).ToList();
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfPublicGistsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
 
-                Assert.NotEqual(firstGistForksPage[0].Url, secondGistForksPage[0].Url);
-                Assert.NotEqual(firstGistForksPage[1].Url, secondGistForksPage[1].Url);
-                Assert.NotEqual(firstGistForksPage[2].Url, secondGistForksPage[2].Url);
-                Assert.NotEqual(firstGistForksPage[3].Url, secondGistForksPage[3].Url);
-                Assert.NotEqual(firstGistForksPage[4].Url, secondGistForksPage[4].Url);
-            }
+            var gists = await _gistsClient.GetAllPublic(options).ToList();
+
+            Assert.Equal(4, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1
+            };
+
+            var firstPublicGistsPage = await _gistsClient.GetAllPublic(startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondPublicGistsPage = await _gistsClient.GetAllPublic(skipStartOptions).ToList();
+
+            Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
+            Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
+            Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
+            Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsPublicGistsSince()
+        {
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllPublic(since).ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfPublicGistsSinceWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllPublic(since, options).ToList();
+
+            Assert.Equal(5, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfPublicGistsSinceWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllPublic(since, options).ToList();
+
+            Assert.Equal(4, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctPublicGistsSinceBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var firstPublicGistsPage = await _gistsClient.GetAllPublic(since, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 4,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondPublicGistsPage = await _gistsClient.GetAllPublic(since, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstPublicGistsPage[0].Id, secondPublicGistsPage[0].Id);
+            Assert.NotEqual(firstPublicGistsPage[1].Id, secondPublicGistsPage[1].Id);
+            Assert.NotEqual(firstPublicGistsPage[2].Id, secondPublicGistsPage[2].Id);
+            Assert.NotEqual(firstPublicGistsPage[3].Id, secondPublicGistsPage[3].Id);
+        }
+    }
+
+    public class TheGetAllStarredMethod
+    {
+        readonly ObservableGistsClient _gistsClient;
+
+        public TheGetAllStarredMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _gistsClient = new ObservableGistsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsStartedGists()
+        {
+            var gists = await _gistsClient.GetAllStarred().ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStartedGistsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var gists = await _gistsClient.GetAllStarred(options).ToList();
+
+            Assert.Equal(5, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStartedGistsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var gists = await _gistsClient.GetAllStarred(options).ToList();
+
+            Assert.Equal(5, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var firstStartedGistsPage = await _gistsClient.GetAllStarred(startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondStartedGistsPage = await _gistsClient.GetAllStarred(skipStartOptions).ToList();
+
+            Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
+            Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
+            Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
+            Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
+            Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsStartedGistsSince()
+        {
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllStarred(since).ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStartedGistsSinceWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllStarred(since, options).ToList();
+
+            Assert.Equal(5, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStartedGistsSinceWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllStarred(since, options).ToList();
+
+            Assert.Equal(5, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctStartedGistsSinceBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var firstStartedGistsPage = await _gistsClient.GetAllStarred(since, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondStartedGistsPage = await _gistsClient.GetAllStarred(since, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstStartedGistsPage[0].Id, secondStartedGistsPage[0].Id);
+            Assert.NotEqual(firstStartedGistsPage[1].Id, secondStartedGistsPage[1].Id);
+            Assert.NotEqual(firstStartedGistsPage[2].Id, secondStartedGistsPage[2].Id);
+            Assert.NotEqual(firstStartedGistsPage[3].Id, secondStartedGistsPage[3].Id);
+            Assert.NotEqual(firstStartedGistsPage[4].Id, secondStartedGistsPage[4].Id);
+        }
+    }
+
+    public class TheGetAllForUserMethod
+    {
+        readonly ObservableGistsClient _gistsClient;
+        const string user = "shiftkey";
+
+        public TheGetAllForUserMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _gistsClient = new ObservableGistsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsUserGists()
+        {
+            var gists = await _gistsClient.GetAllForUser(user).ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfUserGistsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+
+            var gists = await _gistsClient.GetAllForUser(user, options).ToList();
+
+            Assert.Equal(3, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfUserGistsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var gists = await _gistsClient.GetAllForUser(user, options).ToList();
+
+            Assert.Equal(3, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+
+            var firstUsersGistsPage = await _gistsClient.GetAllForUser(user, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondUsersGistsPage = await _gistsClient.GetAllForUser(user, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstUsersGistsPage[0].Id, secondUsersGistsPage[0].Id);
+            Assert.NotEqual(firstUsersGistsPage[1].Id, secondUsersGistsPage[1].Id);
+            Assert.NotEqual(firstUsersGistsPage[2].Id, secondUsersGistsPage[2].Id);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsUserGistsSince()
+        {
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllForUser(user, since).ToList();
+
+            Assert.NotEmpty(gists);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfUserGistsSinceWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
+
+            Assert.Equal(3, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfUserGistsSinceWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var gists = await _gistsClient.GetAllForUser(user, since, options).ToList();
+
+            Assert.Equal(3, gists.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctUserGistsSinceBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+            var since = new DateTimeOffset(new DateTime(2016, 1, 1));
+            var firstUserGistsPage = await _gistsClient.GetAllForUser(user, since, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondUserGistsPage = await _gistsClient.GetAllForUser(user, since, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstUserGistsPage[0].Id, secondUserGistsPage[0].Id);
+            Assert.NotEqual(firstUserGistsPage[1].Id, secondUserGistsPage[1].Id);
+            Assert.NotEqual(firstUserGistsPage[2].Id, secondUserGistsPage[2].Id);
+        }
+    }
+
+    public class TheGetAllCommitsMethod
+    {
+        readonly ObservableGistsClient _gistsClient;
+        const string gistId = "670c22f3966e662d2f83";
+
+        public TheGetAllCommitsMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _gistsClient = new ObservableGistsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsGistCommits()
+        {
+            var gistCommits = await _gistsClient.GetAllCommits(gistId).ToList();
+
+            Assert.NotEmpty(gistCommits);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistCommisWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+
+            var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
+
+            Assert.Equal(3, gistCommits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountGistCommitsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var gistCommits = await _gistsClient.GetAllCommits(gistId, options).ToList();
+
+            Assert.Equal(3, gistCommits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1
+            };
+
+            var firstGistCommitsPage = await _gistsClient.GetAllCommits(gistId, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 3,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondGistCommitsPage = await _gistsClient.GetAllCommits(gistId, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstGistCommitsPage[0].Url, secondGistCommitsPage[0].Url);
+            Assert.NotEqual(firstGistCommitsPage[1].Url, secondGistCommitsPage[1].Url);
+            Assert.NotEqual(firstGistCommitsPage[2].Url, secondGistCommitsPage[2].Url);
+        }
+    }
+
+    public class TheGetAllForksMethod
+    {
+        readonly ObservableGistsClient _gistsClient;
+        const string gistId = "670c22f3966e662d2f83";
+
+        public TheGetAllForksMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _gistsClient = new ObservableGistsClient(github);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsGistCommits()
+        {
+            var gistForks = await _gistsClient.GetAllForks(gistId).ToList();
+
+            Assert.NotEmpty(gistForks);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfGistForksWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
+
+            Assert.Equal(5, gistForks.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountGistForksWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var gistForks = await _gistsClient.GetAllForks(gistId, options).ToList();
+
+            Assert.Equal(5, gistForks.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var firstGistForksPage = await _gistsClient.GetAllForks(gistId, startOptions).ToList();
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondGistForksPage = await _gistsClient.GetAllForks(gistId, skipStartOptions).ToList();
+
+            Assert.NotEqual(firstGistForksPage[0].Url, secondGistForksPage[0].Url);
+            Assert.NotEqual(firstGistForksPage[1].Url, secondGistForksPage[1].Url);
+            Assert.NotEqual(firstGistForksPage[2].Url, secondGistForksPage[2].Url);
+            Assert.NotEqual(firstGistForksPage[3].Url, secondGistForksPage[3].Url);
+            Assert.NotEqual(firstGistForksPage[4].Url, secondGistForksPage[4].Url);
         }
     }
 }
+

--- a/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableGistClientTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableGistClientTests
+    {
+        public class TheGetAllMethod
+        {
+            readonly ObservableGistsClient _gistsClient;          
+
+            public TheGetAllMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _gistsClient = new ObservableGistsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsGists()
+            {
+                var gists = await _gistsClient.GetAll().ToList();
+
+                Assert.NotEmpty(gists);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var gists = await _gistsClient.GetAll(options).ToList();
+
+                Assert.Equal(5, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfGistsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var gists = await _gistsClient.GetAll(options).ToList();
+
+                Assert.Equal(4, gists.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1
+                };
+
+                var firstGistsPage = await _gistsClient.GetAll(startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 4,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondGistsPage = await _gistsClient.GetAll(skipStartOptions).ToList();
+
+                Assert.NotEqual(firstGistsPage[0].Id, secondGistsPage[0].Id);
+                Assert.NotEqual(firstGistsPage[1].Id, secondGistsPage[1].Id);
+                Assert.NotEqual(firstGistsPage[2].Id, secondGistsPage[2].Id);
+                Assert.NotEqual(firstGistsPage[3].Id, secondGistsPage[3].Id);                
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -1,14 +1,37 @@
 ﻿using NSubstitute;
-using Octokit;
 using Octokit.Internal;
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests;
 using Xunit;
 
 public class GistsClientTests
 {
+    public static Dictionary<string, string> DictionaryWithSince
+    {
+        get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("since")); }
+    }
+
+    public class TheCtor
+    {
+        [Fact]
+        public void EnsuresArgument()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
+        }
+
+        [Fact]
+        public void SetCommentsClient()
+        {
+            var apiConnection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(apiConnection);
+            Assert.NotNull(client.Comment);
+        }
+    }
+
     public class TheGetMethod
     {
         [Fact]
@@ -32,8 +55,26 @@ public class GistsClientTests
             var client = new GistsClient(connection);
 
             client.GetAll();
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
+        }
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"));
+        [Fact]
+        public void RequestsCorrectGetAllUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+
+            client.GetAll(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
+
         }
 
         [Fact]
@@ -46,9 +87,42 @@ public class GistsClientTests
             client.GetAll(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+        DictionaryWithSince, Args.ApiOptions);
         }
 
+        [Fact]
+        public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAll(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                DictionaryWithSince, options);
+
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(DateTimeOffset.Now, null));
+        }
+    }
+
+    public class TheGetAllPublicMethod
+    {
         [Fact]
         public void RequestsCorrectGetAllPublicUrl()
         {
@@ -57,7 +131,25 @@ public class GistsClientTests
 
             client.GetAllPublic();
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllPublicUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllPublic(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
+
         }
 
         [Fact]
@@ -70,9 +162,43 @@ public class GistsClientTests
             client.GetAllPublic(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+        DictionaryWithSince, Args.ApiOptions);
         }
 
+        [Fact]
+        public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllPublic(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                DictionaryWithSince, options);
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(DateTimeOffset.Now, null));
+
+        }
+
+    }
+
+    public class TheGetAllStarredMethod
+    {
         [Fact]
         public void RequestsCorrectGetAllStarredUrl()
         {
@@ -81,7 +207,25 @@ public class GistsClientTests
 
             client.GetAllStarred();
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllStarredUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllStarred(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
+
         }
 
         [Fact]
@@ -94,9 +238,41 @@ public class GistsClientTests
             client.GetAllStarred(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+        DictionaryWithSince, Args.ApiOptions);
         }
 
+        [Fact]
+        public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllStarred(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                DictionaryWithSince, options);
+        }
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(DateTimeOffset.Now, null));
+
+        }
+    }
+
+    public class TheGetAllForUserMethod
+    {
         [Fact]
         public void RequestsCorrectGetGistsForAUserUrl()
         {
@@ -105,7 +281,25 @@ public class GistsClientTests
 
             client.GetAllForUser("octokit");
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllForUser("octokit", options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
+
         }
 
         [Fact]
@@ -118,25 +312,47 @@ public class GistsClientTests
             client.GetAllForUser("octokit", since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
-        }
-    }
+        DictionaryWithSince, Args.ApiOptions);
 
-    public class TheGetChildrenMethods
-    {
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllForUser("octokit", since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                DictionaryWithSince, options);
+        }
+
+
         [Fact]
         public async Task EnsureNonNullArguments()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new GistsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("user", DateTimeOffset.Now, null));
         }
 
+    }
+
+    public class TheGetAllCommitsMethod
+    {
         [Fact]
         public void RequestsCorrectGetCommitsUrl()
         {
@@ -145,9 +361,42 @@ public class GistsClientTests
 
             client.GetAllCommits("9257657");
 
-            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"));
+            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
         }
 
+        [Fact]
+        public void RequestsCorrectGetCommitsUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions()
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllCommits("9257657", options);
+
+            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), options);
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits("id", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("", ApiOptions.None));
+        }
+
+    }
+
+    public class TheGetAllForksMethod
+    {
         [Fact]
         public void RequestsCorrectGetForksUrl()
         {
@@ -156,7 +405,36 @@ public class GistsClientTests
 
             client.GetAllForks("9257657");
 
-            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"));
+            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetForksUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions()
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllForks("9257657", options);
+
+            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), options);
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks("id", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("", ApiOptions.None));
         }
     }
 
@@ -274,7 +552,8 @@ public class GistsClientTests
             client.Fork("1");
 
             connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
-                                             Arg.Any<object>());
+    Arg.Any<object>());
+
         }
     }
 
@@ -299,23 +578,6 @@ public class GistsClientTests
             client.Edit("1", updateGist);
 
             connection.Received().Patch<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), Arg.Any<object>());
-        }
-    }
-
-    public class TheCtor
-    {
-        [Fact]
-        public void EnsuresNonNullArguments()
-        {
-            Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
-        }
-
-        [Fact]
-        public void SetCommentsClient()
-        {
-            var apiConnection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(apiConnection);
-            Assert.NotNull(client.Comment);
         }
     }
 }

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -10,6 +10,10 @@ using Xunit;
 
 public class GistsClientTests
 {
+    public static Dictionary<string, string> DictionaryWithSince
+    {
+        get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("since")); }
+    }
     public class TheCtor
     {
         [Fact]
@@ -82,7 +86,7 @@ public class GistsClientTests
             client.GetAll(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Args.DictionaryWithSince, Args.ApiOptions);
+                DictionaryWithSince, Args.ApiOptions);
         }
 
         [Fact]
@@ -101,7 +105,7 @@ public class GistsClientTests
             client.GetAll(since, options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Args.DictionaryWithSince, options);
+                DictionaryWithSince, options);
         }
 
         [Fact]
@@ -155,7 +159,7 @@ public class GistsClientTests
             client.GetAllPublic(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Args.DictionaryWithSince, Args.ApiOptions);
+                DictionaryWithSince, Args.ApiOptions);
         }
 
         [Fact]
@@ -174,7 +178,7 @@ public class GistsClientTests
             client.GetAllPublic(since, options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Args.DictionaryWithSince, options);
+                DictionaryWithSince, options);
         }
 
         [Fact]
@@ -229,7 +233,7 @@ public class GistsClientTests
             client.GetAllStarred(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Args.DictionaryWithSince, Args.ApiOptions);
+                DictionaryWithSince, Args.ApiOptions);
         }
 
         [Fact]
@@ -248,7 +252,7 @@ public class GistsClientTests
             client.GetAllStarred(since, options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Args.DictionaryWithSince, options);
+                DictionaryWithSince, options);
         }
         [Fact]
         public async Task EnsureNonNullArguments()
@@ -301,7 +305,7 @@ public class GistsClientTests
             client.GetAllForUser("octokit", since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Args.DictionaryWithSince, Args.ApiOptions);
+                DictionaryWithSince, Args.ApiOptions);
         }
 
         [Fact]
@@ -320,7 +324,7 @@ public class GistsClientTests
             client.GetAllForUser("octokit", since, options);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Args.DictionaryWithSince, options);
+                DictionaryWithSince, options);
         }
 
 

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -1,11 +1,9 @@
 ﻿using NSubstitute;
-using Octokit;
 using Octokit.Internal;
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using Octokit.Tests;
 using Xunit;
 
 namespace Octokit.Tests.Clients

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -290,7 +290,7 @@ public class GistsClientTests
 
             client.GetAllCommits("9257657");
 
-            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"));
+            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
         }
 
         [Fact]
@@ -301,7 +301,7 @@ public class GistsClientTests
 
             client.GetAllForks("9257657");
 
-            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"));
+            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
         }
     }
 

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -8,459 +8,568 @@ using System.Threading.Tasks;
 using Octokit.Tests;
 using Xunit;
 
-public class GistsClientTests
+namespace Octokit.Tests.Clients
 {
-    public class TheGetMethod
+    public class GistsClientTests
     {
-        [Fact]
-        public void RequestsCorrectUrl()
+        public class TheCtor
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.Get("1");
-
-            connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
-        }
-    }
-
-    public class TheGetAllMethod
-    {
-        [Fact]
-        public void RequestsCorrectGetAllUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.GetAll();
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
-        }
-        [Fact]
-        public void RequestsCorrectGetAllUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void EnsuresArgument()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
+                Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
+            }
 
-            client.GetAll(options);
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllWithSinceUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAll(since);
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void SetCommentsClient()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAll(since, options);
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
+                var apiConnection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(apiConnection);
+                Assert.NotNull(client.Comment);
+            }
         }
 
-        [Fact]
-        public void RequestsCorrectGetAllPublicUrl()
+        public class TheGetMethod
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.GetAllPublic();
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllPublicUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void RequestsCorrectUrl()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            client.GetAllPublic(options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
+                client.Get("1");
+
+                connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
+            }
         }
 
-        [Fact]
-        public void RequestsCorrectGetAllPublicWithSinceUrl()
+        public class TheGetAllMethod
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllPublic(since);
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void RequestsCorrectGetAllUrl()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllPublic(since, options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
-        }
+                client.GetAll();
 
-        [Fact]
-        public void RequestsCorrectGetAllStarredUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
+            }
 
-            client.GetAllStarred();
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllStarredUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void RequestsCorrectGetAllUrlWithApiOptions()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            client.GetAllStarred(options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
-        }
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
 
-        [Fact]
-        public void RequestsCorrectGetAllStarredWithSinceUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
+                client.GetAll(options);
 
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllStarred(since);
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
+            }
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void RequestsCorrectGetAllWithSinceUrl()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllStarred(since, options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
-        }
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAll(since);
 
-        [Fact]
-        public void RequestsCorrectGetGistsForAUserUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                    Args.DictionaryWithSince, Args.ApiOptions);
+            }
 
-            client.GetAllForUser("octokit");
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            client.GetAllForUser("octokit", options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
-        }
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAll(since, options);
 
-        [Fact]
-        public void RequestsCorrectGetGistsForAUserWithSinceUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                    Args.DictionaryWithSince, options);
+            }
 
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllForUser("octokit", since);
-
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var options = new ApiOptions
+            [Fact]
+            public async Task EnsureNonNullArguments()
             {
-                PageSize = 1,
-                PageCount = 1,
-                StartPage = 1
-            };
-            DateTimeOffset since = DateTimeOffset.Now;
-            client.GetAllForUser("octokit", since, options);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
-        }
-    }
-
-    public class TheGetChildrenMethods
-    {
-        [Fact]
-        public async Task EnsureNonNullArguments()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(DateTimeOffset.Now, null));
+            }
         }
 
-        [Fact]
-        public void RequestsCorrectGetCommitsUrl()
+        public class TheGetAllPublicMethod
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.GetAllCommits("9257657");
-
-            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectGetForksUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.GetAllForks("9257657");
-
-            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
-        }
-    }
-
-    public class TheCreateMethod
-    {
-        [Fact]
-        public void PostsToTheCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var newGist = new NewGist();
-            newGist.Description = "my new gist";
-            newGist.Public = true;
-
-            newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
-
-            client.Create(newGist);
-
-            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Arg.Any<object>());
-        }
-    }
-
-    public class TheDeleteMethod
-    {
-        [Fact]
-        public void PostsToTheCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.Delete("1");
-
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNull()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null));
-        }
-    }
-
-    public class TheStarMethods
-    {
-        [Fact]
-        public void RequestsCorrectStarUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.Star("1");
-
-            connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
-        }
-
-        [Fact]
-        public void RequestsCorrectUnstarUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.Unstar("1");
-
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
-        }
-
-        [Theory]
-        [InlineData(HttpStatusCode.NoContent, true)]
-        [InlineData(HttpStatusCode.NotFound, false)]
-        public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
-        {
-            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
-            var connection = Substitute.For<IConnection>();
-            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                null, null).Returns(response);
-            var apiConnection = Substitute.For<IApiConnection>();
-            apiConnection.Connection.Returns(connection);
-            var client = new GistsClient(apiConnection);
-
-            var result = await client.IsStarred("1");
-
-            Assert.Equal(expected, result);
-        }
-
-        [Fact]
-        public async Task ThrowsExceptionForInvalidStatusCode()
-        {
-            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
-            var connection = Substitute.For<IConnection>();
-            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                null, null).Returns(response);
-            var apiConnection = Substitute.For<IApiConnection>();
-            apiConnection.Connection.Returns(connection);
-
-            var client = new GistsClient(apiConnection);
-
-            await Assert.ThrowsAsync<ApiException>(() => client.IsStarred("1"));
-        }
-    }
-
-    public class TheForkMethod
-    {
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            client.Fork("1");
-
-            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
-                                             Arg.Any<object>());
-        }
-    }
-
-    public class TheEditMethod
-    {
-        [Fact]
-        public void PostsToTheCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(connection);
-
-            var updateGist = new GistUpdate();
-            updateGist.Description = "my newly updated gist";
-            var gistFileUpdate = new GistFileUpdate
+            [Fact]
+            public void RequestsCorrectGetAllPublicUrl()
             {
-                NewFileName = "myNewGistTestFile.cs",
-                Content = "new GistsClient(connection).Edit();"
-            };
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
 
-            updateGist.Files.Add("myGistTestFile.cs", gistFileUpdate);
+                client.GetAllPublic();
 
-            client.Edit("1", updateGist);
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
+            }
 
-            connection.Received().Patch<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), Arg.Any<object>());
+            [Fact]
+            public void RequestsCorrectGetAllPublicUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllPublic(options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetAllPublicWithSinceUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllPublic(since);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                    Args.DictionaryWithSince, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllPublic(since, options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                    Args.DictionaryWithSince, options);
+            }
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(DateTimeOffset.Now, null));
+            }
+
         }
-    }
 
-    public class TheCtor
-    {
-        [Fact]
-        public void EnsuresArgument()
+        public class TheGetAllStarredMethod
         {
-            Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
+            [Fact]
+            public void RequestsCorrectGetAllStarredUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.GetAllStarred();
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetAllStarredUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllStarred(options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetAllStarredWithSinceUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllStarred(since);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                    Args.DictionaryWithSince, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllStarred(since, options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                    Args.DictionaryWithSince, options);
+            }
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(DateTimeOffset.Now, null));
+            }
         }
 
-        [Fact]
-        public void SetCommentsClient()
+        public class TheGetAllForUserMethod
         {
-            var apiConnection = Substitute.For<IApiConnection>();
-            var client = new GistsClient(apiConnection);
-            Assert.NotNull(client.Comment);
+            [Fact]
+            public void RequestsCorrectGetGistsForAUserUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.GetAllForUser("octokit");
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllForUser("octokit", options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetGistsForAUserWithSinceUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllForUser("octokit", since);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                    Args.DictionaryWithSince, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                DateTimeOffset since = DateTimeOffset.Now;
+                client.GetAllForUser("octokit", since, options);
+
+                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                    Args.DictionaryWithSince, options);
+            }
+
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("user", DateTimeOffset.Now, null));
+            }
+
         }
+
+        public class TheGetAllCommitsMethod
+        {
+            [Fact]
+            public void RequestsCorrectGetCommitsUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.GetAllCommits("9257657");
+
+                connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetCommitsUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions()
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllCommits("9257657", options);
+
+                connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), options);
+            }
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits("id", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("", ApiOptions.None));
+            }
+
+        }
+
+        public class TheGetAllForksMethod
+        {
+            [Fact]
+            public void RequestsCorrectGetForksUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.GetAllForks("9257657");
+
+                connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectGetForksUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var options = new ApiOptions()
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllForks("9257657", options);
+
+                connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), options);
+            }
+
+            [Fact]
+            public async Task EnsureNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks("id", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("", ApiOptions.None));
+            }
+
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void PostsToTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var newGist = new NewGist();
+                newGist.Description = "my new gist";
+                newGist.Public = true;
+
+                newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
+
+                client.Create(newGist);
+
+                connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Arg.Any<object>());
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void PostsToTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.Delete("1");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null));
+            }
+        }
+
+        public class TheStarMethods
+        {
+            [Fact]
+            public void RequestsCorrectStarUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.Star("1");
+
+                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
+            }
+
+            [Fact]
+            public void RequestsCorrectUnstarUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.Unstar("1");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
+            }
+
+            [Theory]
+            [InlineData(HttpStatusCode.NoContent, true)]
+            [InlineData(HttpStatusCode.NotFound, false)]
+            public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
+            {
+                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var connection = Substitute.For<IConnection>();
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
+                    null, null).Returns(response);
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Connection.Returns(connection);
+                var client = new GistsClient(apiConnection);
+
+                var result = await client.IsStarred("1");
+
+                Assert.Equal(expected, result);
+            }
+
+            [Fact]
+            public async Task ThrowsExceptionForInvalidStatusCode()
+            {
+                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var connection = Substitute.For<IConnection>();
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
+                    null, null).Returns(response);
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Connection.Returns(connection);
+
+                var client = new GistsClient(apiConnection);
+
+                await Assert.ThrowsAsync<ApiException>(() => client.IsStarred("1"));
+            }
+        }
+
+        public class TheForkMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                client.Fork("1");
+
+                connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
+                    Arg.Any<object>());
+            }
+        }
+
+        public class TheEditMethod
+        {
+            [Fact]
+            public void PostsToTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GistsClient(connection);
+
+                var updateGist = new GistUpdate();
+                updateGist.Description = "my newly updated gist";
+                var gistFileUpdate = new GistFileUpdate
+                {
+                    NewFileName = "myNewGistTestFile.cs",
+                    Content = "new GistsClient(connection).Edit();"
+                };
+
+                updateGist.Files.Add("myGistTestFile.cs", gistFileUpdate);
+
+                client.Edit("1", updateGist);
+
+                connection.Received().Patch<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), Arg.Any<object>());
+            }
+        }
+
     }
 }

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -18,7 +18,7 @@ public class GistsClientTests
     public class TheCtor
     {
         [Fact]
-        public void EnsuresArgument()
+        public void EnsuresNonNullArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
         }

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -4,570 +4,568 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests;
 using Xunit;
 
-namespace Octokit.Tests.Clients
+public class GistsClientTests
 {
-    public class GistsClientTests
+    public class TheCtor
     {
-        public class TheCtor
+        [Fact]
+        public void EnsuresArgument()
         {
-            [Fact]
-            public void EnsuresArgument()
-            {
-                Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
-            }
-
-            [Fact]
-            public void SetCommentsClient()
-            {
-                var apiConnection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(apiConnection);
-                Assert.NotNull(client.Comment);
-            }
+            Assert.Throws<ArgumentNullException>(() => new GistsClient(null));
         }
 
-        public class TheGetMethod
+        [Fact]
+        public void SetCommentsClient()
         {
-            [Fact]
-            public void RequestsCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var apiConnection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(apiConnection);
+            Assert.NotNull(client.Comment);
+        }
+    }
 
-                client.Get("1");
+    public class TheGetMethod
+    {
+        [Fact]
+        public void RequestsCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
-            }
+            client.Get("1");
+
+            connection.Received().Get<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
+        }
+    }
+
+    public class TheGetAllMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetAllUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.GetAll();
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
         }
 
-        public class TheGetAllMethod
+        [Fact]
+        public void RequestsCorrectGetAllUrlWithApiOptions()
         {
-            [Fact]
-            public void RequestsCorrectGetAllUrl()
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
 
-                client.GetAll();
+            client.GetAll(options);
 
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-
-                client.GetAll(options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllWithSinceUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAll(since);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                    Args.DictionaryWithSince, Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAll(since, options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                    Args.DictionaryWithSince, options);
-            }
-
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(DateTimeOffset.Now, null));
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
         }
 
-        public class TheGetAllPublicMethod
+        [Fact]
+        public void RequestsCorrectGetAllWithSinceUrl()
         {
-            [Fact]
-            public void RequestsCorrectGetAllPublicUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                client.GetAllPublic();
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAll(since);
 
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllPublicUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                client.GetAllPublic(options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllPublicWithSinceUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllPublic(since);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                    Args.DictionaryWithSince, Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllPublic(since, options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                    Args.DictionaryWithSince, options);
-            }
-
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(DateTimeOffset.Now, null));
-            }
-
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                Args.DictionaryWithSince, Args.ApiOptions);
         }
 
-        public class TheGetAllStarredMethod
+        [Fact]
+        public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
         {
-            [Fact]
-            public void RequestsCorrectGetAllStarredUrl()
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAll(since, options);
 
-                client.GetAllStarred();
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllStarredUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                client.GetAllStarred(options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllStarredWithSinceUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllStarred(since);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                    Args.DictionaryWithSince, Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllStarred(since, options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                    Args.DictionaryWithSince, options);
-            }
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(DateTimeOffset.Now, null));
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                Args.DictionaryWithSince, options);
         }
 
-        public class TheGetAllForUserMethod
+        [Fact]
+        public async Task EnsureNonNullArguments()
         {
-            [Fact]
-            public void RequestsCorrectGetGistsForAUserUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                client.GetAllForUser("octokit");
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(DateTimeOffset.Now, null));
+        }
+    }
 
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
-            }
+    public class TheGetAllPublicMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetAllPublicUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-            [Fact]
-            public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            client.GetAllPublic();
 
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                client.GetAllForUser("octokit", options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetGistsForAUserWithSinceUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllForUser("octokit", since);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                    Args.DictionaryWithSince, Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                DateTimeOffset since = DateTimeOffset.Now;
-                client.GetAllForUser("octokit", since, options);
-
-                connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                    Args.DictionaryWithSince, options);
-            }
-
-
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("user", DateTimeOffset.Now, null));
-            }
-
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
         }
 
-        public class TheGetAllCommitsMethod
+        [Fact]
+        public void RequestsCorrectGetAllPublicUrlWithApiOptions()
         {
-            [Fact]
-            public void RequestsCorrectGetCommitsUrl()
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllPublic(options);
 
-                client.GetAllCommits("9257657");
-
-                connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetCommitsUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions()
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                client.GetAllCommits("9257657", options);
-
-                connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), options);
-            }
-
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits("id", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("", ApiOptions.None));
-            }
-
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
         }
 
-        public class TheGetAllForksMethod
+        [Fact]
+        public void RequestsCorrectGetAllPublicWithSinceUrl()
         {
-            [Fact]
-            public void RequestsCorrectGetForksUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                client.GetAllForks("9257657");
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllPublic(since);
 
-                connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectGetForksUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                var options = new ApiOptions()
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 1
-                };
-                client.GetAllForks("9257657", options);
-
-                connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), options);
-            }
-
-            [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks("id", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("", ApiOptions.None));
-            }
-
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                Args.DictionaryWithSince, Args.ApiOptions);
         }
 
-        public class TheCreateMethod
+        [Fact]
+        public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
         {
-            [Fact]
-            public void PostsToTheCorrectUrl()
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllPublic(since, options);
 
-                var newGist = new NewGist();
-                newGist.Description = "my new gist";
-                newGist.Public = true;
-
-                newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
-
-                client.Create(newGist);
-
-                connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Arg.Any<object>());
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                Args.DictionaryWithSince, options);
         }
 
-        public class TheDeleteMethod
+        [Fact]
+        public async Task EnsureNonNullArguments()
         {
-            [Fact]
-            public void PostsToTheCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                client.Delete("1");
-
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
-            }
-
-            [Fact]
-            public async Task EnsuresArgumentsNotNull()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null));
-            }
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(DateTimeOffset.Now, null));
         }
 
-        public class TheStarMethods
+    }
+
+    public class TheGetAllStarredMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetAllStarredUrl()
         {
-            [Fact]
-            public void RequestsCorrectStarUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                client.Star("1");
+            client.GetAllStarred();
 
-                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
-            }
-
-            [Fact]
-            public void RequestsCorrectUnstarUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
-
-                client.Unstar("1");
-
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
-            }
-
-            [Theory]
-            [InlineData(HttpStatusCode.NoContent, true)]
-            [InlineData(HttpStatusCode.NotFound, false)]
-            public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
-            {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
-                var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                    null, null).Returns(response);
-                var apiConnection = Substitute.For<IApiConnection>();
-                apiConnection.Connection.Returns(connection);
-                var client = new GistsClient(apiConnection);
-
-                var result = await client.IsStarred("1");
-
-                Assert.Equal(expected, result);
-            }
-
-            [Fact]
-            public async Task ThrowsExceptionForInvalidStatusCode()
-            {
-                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
-                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
-                var connection = Substitute.For<IConnection>();
-                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
-                    null, null).Returns(response);
-                var apiConnection = Substitute.For<IApiConnection>();
-                apiConnection.Connection.Returns(connection);
-
-                var client = new GistsClient(apiConnection);
-
-                await Assert.ThrowsAsync<ApiException>(() => client.IsStarred("1"));
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
         }
 
-        public class TheForkMethod
+        [Fact]
+        public void RequestsCorrectGetAllStarredUrlWithApiOptions()
         {
-            [Fact]
-            public void RequestsCorrectUrl()
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllStarred(options);
 
-                client.Fork("1");
-
-                connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
-                    Arg.Any<object>());
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
         }
 
-        public class TheEditMethod
+        [Fact]
+        public void RequestsCorrectGetAllStarredWithSinceUrl()
         {
-            [Fact]
-            public void PostsToTheCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new GistsClient(connection);
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
 
-                var updateGist = new GistUpdate();
-                updateGist.Description = "my newly updated gist";
-                var gistFileUpdate = new GistFileUpdate
-                {
-                    NewFileName = "myNewGistTestFile.cs",
-                    Content = "new GistsClient(connection).Edit();"
-                };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllStarred(since);
 
-                updateGist.Files.Add("myGistTestFile.cs", gistFileUpdate);
-
-                client.Edit("1", updateGist);
-
-                connection.Received().Patch<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), Arg.Any<object>());
-            }
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                Args.DictionaryWithSince, Args.ApiOptions);
         }
 
+        [Fact]
+        public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllStarred(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                Args.DictionaryWithSince, options);
+        }
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStarred(DateTimeOffset.Now, null));
+        }
+    }
+
+    public class TheGetAllForUserMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.GetAllForUser("octokit");
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllForUser("octokit", options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserWithSinceUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllForUser("octokit", since);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                Args.DictionaryWithSince, Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllForUser("octokit", since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                Args.DictionaryWithSince, options);
+        }
+
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", DateTimeOffset.Now, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("user", DateTimeOffset.Now, null));
+        }
+
+    }
+
+    public class TheGetAllCommitsMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetCommitsUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.GetAllCommits("9257657");
+
+            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetCommitsUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions()
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllCommits("9257657", options);
+
+            connection.Received().GetAll<GistHistory>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/commits"), options);
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits("id", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("", ApiOptions.None));
+        }
+
+    }
+
+    public class TheGetAllForksMethod
+    {
+        [Fact]
+        public void RequestsCorrectGetForksUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.GetAllForks("9257657");
+
+            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetForksUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions()
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllForks("9257657", options);
+
+            connection.Received().GetAll<GistFork>(Arg.Is<Uri>(u => u.ToString() == "gists/9257657/forks"), options);
+        }
+
+        [Fact]
+        public async Task EnsureNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks(""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks("id", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("", ApiOptions.None));
+        }
+
+    }
+
+    public class TheCreateMethod
+    {
+        [Fact]
+        public void PostsToTheCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var newGist = new NewGist();
+            newGist.Description = "my new gist";
+            newGist.Public = true;
+
+            newGist.Files.Add("myGistTestFile.cs", "new GistsClient(connection).Create();");
+
+            client.Create(newGist);
+
+            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Arg.Any<object>());
+        }
+    }
+
+    public class TheDeleteMethod
+    {
+        [Fact]
+        public void PostsToTheCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.Delete("1");
+
+            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1"));
+        }
+
+        [Fact]
+        public async Task EnsuresArgumentsNotNull()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null));
+        }
+    }
+
+    public class TheStarMethods
+    {
+        [Fact]
+        public void RequestsCorrectStarUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.Star("1");
+
+            connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
+        }
+
+        [Fact]
+        public void RequestsCorrectUnstarUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.Unstar("1");
+
+            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"));
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.NoContent, true)]
+        [InlineData(HttpStatusCode.NotFound, false)]
+        public async Task RequestsCorrectValueForStatusCode(HttpStatusCode status, bool expected)
+        {
+            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+            var connection = Substitute.For<IConnection>();
+            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
+                null, null).Returns(response);
+            var apiConnection = Substitute.For<IApiConnection>();
+            apiConnection.Connection.Returns(connection);
+            var client = new GistsClient(apiConnection);
+
+            var result = await client.IsStarred("1");
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task ThrowsExceptionForInvalidStatusCode()
+        {
+            var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+            var connection = Substitute.For<IConnection>();
+            connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "gists/1/star"),
+                null, null).Returns(response);
+            var apiConnection = Substitute.For<IApiConnection>();
+            apiConnection.Connection.Returns(connection);
+
+            var client = new GistsClient(apiConnection);
+
+            await Assert.ThrowsAsync<ApiException>(() => client.IsStarred("1"));
+        }
+    }
+
+    public class TheForkMethod
+    {
+        [Fact]
+        public void RequestsCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            client.Fork("1");
+
+            connection.Received().Post<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1/forks"),
+                Arg.Any<object>());
+        }
+    }
+
+    public class TheEditMethod
+    {
+        [Fact]
+        public void PostsToTheCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var updateGist = new GistUpdate();
+            updateGist.Description = "my newly updated gist";
+            var gistFileUpdate = new GistFileUpdate
+            {
+                NewFileName = "myNewGistTestFile.cs",
+                Content = "new GistsClient(connection).Edit();"
+            };
+
+            updateGist.Files.Add("myGistTestFile.cs", gistFileUpdate);
+
+            client.Edit("1", updateGist);
+
+            connection.Received().Patch<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/1"), Arg.Any<object>());
+        }
     }
 }

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Octokit.Tests;
 using Xunit;
 
 public class GistsClientTests
@@ -33,7 +34,24 @@ public class GistsClientTests
 
             client.GetAll();
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.ApiOptions);
+        }
+        [Fact]
+        public void RequestsCorrectGetAllUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+
+            client.GetAll(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"), options);
         }
 
         [Fact]
@@ -46,7 +64,26 @@ public class GistsClientTests
             client.GetAll(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAll(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
         }
 
         [Fact]
@@ -57,7 +94,24 @@ public class GistsClientTests
 
             client.GetAllPublic();
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllPublicUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllPublic(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), options);
         }
 
         [Fact]
@@ -70,7 +124,26 @@ public class GistsClientTests
             client.GetAllPublic(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllPublicWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllPublic(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
         }
 
         [Fact]
@@ -81,7 +154,24 @@ public class GistsClientTests
 
             client.GetAllStarred();
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllStarredUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllStarred(options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), options);
         }
 
         [Fact]
@@ -94,7 +184,26 @@ public class GistsClientTests
             client.GetAllStarred(since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetAllStarredWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllStarred(since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
         }
 
         [Fact]
@@ -105,7 +214,24 @@ public class GistsClientTests
 
             client.GetAllForUser("octokit");
 
-            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"));
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            client.GetAllForUser("octokit", options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"), options);
         }
 
         [Fact]
@@ -118,7 +244,26 @@ public class GistsClientTests
             client.GetAllForUser("octokit", since);
 
             connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
-                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")));
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectGetGistsForAUserWithSinceUrlAndApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new GistsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 1
+            };
+            DateTimeOffset since = DateTimeOffset.Now;
+            client.GetAllForUser("octokit", since, options);
+
+            connection.Received().GetAll<Gist>(Arg.Is<Uri>(u => u.ToString() == "users/octokit/gists"),
+                Arg.Is<IDictionary<string, string>>(x => x.ContainsKey("since")), options);
         }
     }
 

--- a/Octokit.Tests/Helpers/Arg.cs
+++ b/Octokit.Tests/Helpers/Arg.cs
@@ -51,22 +51,7 @@ namespace Octokit.Tests
         public static Dictionary<string, string> EmptyDictionary
         {
             get { return Arg.Is<Dictionary<string, string>>(d => d.Count == 0); }
-        }
-
-        public static Dictionary<string, string> DictionaryWithSince
-        {
-            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("since")); }
-        }
-
-        public static Dictionary<string, string> DictionaryWithApiOptions
-        {
-            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page")); }
-        }
-
-        public static Dictionary<string, string> DictionaryWithApiOptionsAndSince
-        {
-            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page") && d.ContainsKey("since")); }
-        }
+        }               
 
         public static OrganizationUpdate OrganizationUpdate
         {

--- a/Octokit.Tests/Helpers/Arg.cs
+++ b/Octokit.Tests/Helpers/Arg.cs
@@ -53,6 +53,21 @@ namespace Octokit.Tests
             get { return Arg.Is<Dictionary<string, string>>(d => d.Count == 0); }
         }
 
+        public static Dictionary<string, string> DictionaryWithSince
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("since")); }
+        }
+
+        public static Dictionary<string, string> DictionaryWithApiOptions
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page")); }
+        }
+
+        public static Dictionary<string, string> DictionaryWithApiOptionsAndSince
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page") && d.ContainsKey("since")); }
+        }
+
         public static OrganizationUpdate OrganizationUpdate
         {
             get { return Arg.Any<OrganizationUpdate>(); }

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -96,48 +96,317 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(DateTimeOffset.Now, null));                
             }
         }
-        
-        public class TheGetChildrenMethods
+
+        public class TheGetAllPublicMethod
         {
             [Fact]
-            public async Task EnsureNonNullArguments()
+            public void RequestsTheCorrectUrl()
             {
-                var client = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null).ToTask());
+                client.GetAllPublic();
 
-
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("").ToTask());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForks(null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForks("").ToTask());
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.EmptyDictionary, null);
             }
 
             [Fact]
-            public void RequestsCorrectGetCommitsUrl()
+            public void RequestsTheCorrectUrlWithApiOptions()
             {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableGistsClient(github);
-                var expected = new Uri("gists/9257657/commits", UriKind.Relative);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
 
-                client.GetAllCommits("9257657");
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllPublic(options);
 
-                github.Connection.Received(1).Get<List<GistHistory>>(expected, Arg.Any<IDictionary<string, string>>(), null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                                  Args.DictionaryWithApiOptions, null);
             }
 
             [Fact]
-            public void RequestsCorrectGetForksUrl()
+            public void RequestsTheCorrectUrlWithSince()
             {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableGistsClient(github);
-                var expected = new Uri("gists/9257657/forks", UriKind.Relative);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
 
-                client.GetAllForks("9257657");
+                var since = DateTimeOffset.Now;
+                client.GetAllPublic(since);
 
-                github.Connection.Received(1).Get<List<GistFork>>(expected, Arg.Any<IDictionary<string, string>>(), null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.DictionaryWithSince, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSinceAndApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions()
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+                var since = DateTimeOffset.Now;
+                client.GetAllPublic(since, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
+                     Args.DictionaryWithApiOptionsAndSince, null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllPublic(null));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllPublic(DateTimeOffset.Now, null));
             }
         }
+
+        public class TheGetAllStarredMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                client.GetAllStarred();
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllStarred(options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                                  Args.DictionaryWithApiOptions, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSince()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var since = DateTimeOffset.Now;
+                client.GetAllStarred(since);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.DictionaryWithSince, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSinceAndApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions()
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+                var since = DateTimeOffset.Now;
+                client.GetAllStarred(since, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
+                     Args.DictionaryWithApiOptionsAndSince, null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllStarred(null));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllStarred(DateTimeOffset.Now, null));
+            }
+        }
+
+        public class TheGetAllForUserMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                client.GetAllForUser("samthedev");
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllForUser("samthedev", options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"),
+                                  Args.DictionaryWithApiOptions, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSince()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var since = DateTimeOffset.Now;
+                var user = "samthedev";
+                client.GetAllForUser(user, since);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"), Args.DictionaryWithSince, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSinceAndApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions()
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+                var since = DateTimeOffset.Now;
+                var user = "samthedev";
+                client.GetAllForUser(user, since, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"),
+                     Args.DictionaryWithApiOptionsAndSince, null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser(null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser(""));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser(null, DateTimeOffset.Now));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser("", DateTimeOffset.Now));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForUser("samthedev",DateTimeOffset.Now, null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForUser("",DateTimeOffset.Now, ApiOptions.None));
+            }
+        }
+
+        public class TheGetAllCommitsMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                client.GetAllCommits("id");
+
+                gitHubClient.Connection.Received(1).Get<List<GistHistory>>(Arg.Is<Uri>(u => u.ToString() == "gists/id/commits"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllCommits("id", options);
+
+                gitHubClient.Connection.Received(1).Get<List<GistHistory>>(Arg.Is<Uri>(u => u.ToString() == "gists/id/commits"),
+                                  Args.DictionaryWithApiOptions, null);
+            }            
+
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllCommits(null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllCommits(""));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllCommits("id", null));                
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllCommits("", ApiOptions.None));                
+                
+            }
+        }
+
+        public class TheGetAllForksMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                client.GetAllForks("id");
+
+                gitHubClient.Connection.Received(1).Get<List<GistFork>>(new Uri("gists/id/forks", UriKind.Relative), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAllForks("id", options);
+
+                gitHubClient.Connection.Received(1).Get<List<GistFork>>(new Uri("gists/id/forks", UriKind.Relative),
+                                  Args.DictionaryWithApiOptions, null);
+            }
+
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForks(null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForks(""));
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAllForks("id", null));
+                Assert.Throws<ArgumentException>(() => gitsClient.GetAllForks("", ApiOptions.None));
+
+            }
+        }        
     }
 }

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -16,12 +16,97 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableGistsTests
     {
+        public class TheCtorMethod
+        {
+            [Fact]
+            public void EnsuresArgumentIsNotNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableGistsClient(null));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                client.GetAll();
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+                client.GetAll(options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), 
+                                  Args.DictionaryWithApiOptions, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSince()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var since = DateTimeOffset.Now;
+                client.GetAll(since);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.DictionaryWithSince, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithSinceAndApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableGistsClient(gitHubClient);
+
+                var options = new ApiOptions()
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+                var since = DateTimeOffset.Now;
+                client.GetAll(since, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"),
+                     Args.DictionaryWithApiOptionsAndSince, null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitsClient = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(null));                
+                Assert.Throws<ArgumentNullException>(() => gitsClient.GetAll(DateTimeOffset.Now, null));                
+            }
+        }
+        
         public class TheGetChildrenMethods
         {
             [Fact]
             public async Task EnsureNonNullArguments()
             {
                 var client = new ObservableGistsClient(Substitute.For<IGitHubClient>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null).ToTask());
+
+
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllCommits(null).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllCommits("").ToTask());

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -9,6 +9,20 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableGistsTests
     {
+        public static Dictionary<string, string> DictionaryWithSince
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("since")); }
+        }
+        public static Dictionary<string, string> DictionaryWithApiOptions
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page")); }
+        }
+
+        public static Dictionary<string, string> DictionaryWithApiOptionsAndSince
+        {
+            get { return Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("per_page") && d.ContainsKey("page") && d.ContainsKey("since")); }
+        }
+
         public class TheCtorMethod
         {
             [Fact]
@@ -46,7 +60,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll(options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), 
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }
 
             [Fact]
@@ -58,7 +72,7 @@ namespace Octokit.Tests.Reactive
                 var since = DateTimeOffset.Now;
                 client.GetAll(since);
 
-                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), Args.DictionaryWithSince, null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"), DictionaryWithSince, null);
             }
 
             [Fact]
@@ -77,7 +91,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll(since, options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists"),
-                     Args.DictionaryWithApiOptionsAndSince, null);
+                     DictionaryWithApiOptionsAndSince, null);
             }
 
             [Fact]
@@ -118,7 +132,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllPublic(options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }
 
             [Fact]
@@ -130,7 +144,7 @@ namespace Octokit.Tests.Reactive
                 var since = DateTimeOffset.Now;
                 client.GetAllPublic(since);
 
-                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), Args.DictionaryWithSince, null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"), DictionaryWithSince, null);
             }
 
             [Fact]
@@ -149,7 +163,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllPublic(since, options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/public"),
-                     Args.DictionaryWithApiOptionsAndSince, null);
+                     DictionaryWithApiOptionsAndSince, null);
             }
 
             [Fact]
@@ -190,7 +204,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllStarred(options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }
 
             [Fact]
@@ -202,7 +216,7 @@ namespace Octokit.Tests.Reactive
                 var since = DateTimeOffset.Now;
                 client.GetAllStarred(since);
 
-                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), Args.DictionaryWithSince, null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"), DictionaryWithSince, null);
             }
 
             [Fact]
@@ -221,7 +235,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllStarred(since, options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "gists/starred"),
-                     Args.DictionaryWithApiOptionsAndSince, null);
+                     DictionaryWithApiOptionsAndSince, null);
             }
 
             [Fact]
@@ -262,7 +276,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForUser("samthedev", options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"),
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }
 
             [Fact]
@@ -275,7 +289,7 @@ namespace Octokit.Tests.Reactive
                 var user = "samthedev";
                 client.GetAllForUser(user, since);
 
-                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"), Args.DictionaryWithSince, null);
+                gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"), DictionaryWithSince, null);
             }
 
             [Fact]
@@ -295,7 +309,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForUser(user, since, options);
 
                 gitHubClient.Connection.Received(1).Get<List<Gist>>(Arg.Is<Uri>(u => u.ToString() == "users/samthedev/gists"),
-                     Args.DictionaryWithApiOptionsAndSince, null);
+                     DictionaryWithApiOptionsAndSince, null);
             }
 
             [Fact]
@@ -340,7 +354,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllCommits("id", options);
 
                 gitHubClient.Connection.Received(1).Get<List<GistHistory>>(Arg.Is<Uri>(u => u.ToString() == "gists/id/commits"),
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }            
 
 
@@ -385,7 +399,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForks("id", options);
 
                 gitHubClient.Connection.Received(1).Get<List<GistFork>>(new Uri("gists/id/forks", UriKind.Relative),
-                                  Args.DictionaryWithApiOptions, null);
+                                  DictionaryWithApiOptions, null);
             }
 
 
@@ -400,6 +414,6 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => gitsClient.GetAllForks("", ApiOptions.None));
 
             }
-        }        
+        }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Reactive
         public class TheCtorMethod
         {
             [Fact]
-            public void EnsuresArgumentIsNotNull()
+            public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => new ObservableGistsClient(null));
             }

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -1,16 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
-using System.Threading.Tasks;
 using NSubstitute;
-using Octokit;
-using Octokit.Internal;
 using Octokit.Reactive;
-using Octokit.Reactive.Internal;
-using Octokit.Tests.Helpers;
 using Xunit;
-using Xunit.Extensions;
+
 
 namespace Octokit.Tests.Reactive
 {

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -87,7 +87,7 @@ namespace Octokit
         /// <param name="id">The id of the gist</param>
         public Task Delete(string id)
         {
-            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
 
             return ApiConnection.Delete(ApiUrls.Gist(id));
         }
@@ -101,7 +101,22 @@ namespace Octokit
         /// </remarks>
         public Task<IReadOnlyList<Gist>> GetAll()
         {
-            return ApiConnection.GetAll<Gist>(ApiUrls.Gist());
+            return GetAll(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAll(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Gist>(ApiUrls.Gist(), options);
         }
 
         /// <summary>
@@ -114,8 +129,25 @@ namespace Octokit
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since)
         {
+                        
+            return GetAll(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             var request = new GistRequest(since);
-            return ApiConnection.GetAll<Gist>(ApiUrls.Gist(), request.ToParametersDictionary());
+            return ApiConnection.GetAll<Gist>(ApiUrls.Gist(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -126,7 +158,21 @@ namespace Octokit
         /// </remarks>
         public Task<IReadOnlyList<Gist>> GetAllPublic()
         {
-            return ApiConnection.GetAll<Gist>(ApiUrls.PublicGists());
+            return GetAllPublic(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllPublic(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Gist>(ApiUrls.PublicGists(), options);
         }
 
         /// <summary>
@@ -137,9 +183,25 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since)
+        {            
+
+            return GetAllPublic(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             var request = new GistRequest(since);
-            return ApiConnection.GetAll<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary());
+            return ApiConnection.GetAll<Gist>(ApiUrls.PublicGists(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -150,7 +212,22 @@ namespace Octokit
         /// </remarks>
         public Task<IReadOnlyList<Gist>> GetAllStarred()
         {
-            return ApiConnection.GetAll<Gist>(ApiUrls.StarredGists());
+
+            return GetAllStarred(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllStarred(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Gist>(ApiUrls.StarredGists(), options);
         }
 
         /// <summary>
@@ -161,9 +238,25 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since)
+        {            
+
+            return GetAllStarred(since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             var request = new GistRequest(since);
-            return ApiConnection.GetAll<Gist>(ApiUrls.StarredGists(), request.ToParametersDictionary());
+            return ApiConnection.GetAll<Gist>(ApiUrls.StarredGists(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -175,9 +268,25 @@ namespace Octokit
         /// <param name="user">The user</param>
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-            return ApiConnection.GetAll<Gist>(ApiUrls.UsersGists(user));
+            return GetAllForUser(user, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllForUser(string user, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Gist>(ApiUrls.UsersGists(user), options);
         }
 
         /// <summary>
@@ -190,10 +299,27 @@ namespace Octokit
         /// <param name="since">Only gists updated at or after this time are returned</param>
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since)
         {
-            Ensure.ArgumentNotNull(user, "user");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            
+            return GetAllForUser(user, since, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
 
             var request = new GistRequest(since);
-            return ApiConnection.GetAll<Gist>(ApiUrls.UsersGists(user), request.ToParametersDictionary());
+            return ApiConnection.GetAll<Gist>(ApiUrls.UsersGists(user), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -207,7 +333,23 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(id, "id");
 
-            return ApiConnection.GetAll<GistHistory>(ApiUrls.GistCommits(id));
+            return GetAllCommits(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List gist commits
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-commits
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<GistHistory>> GetAllCommits(string id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<GistHistory>(ApiUrls.GistCommits(id), options);
         }
 
         /// <summary>
@@ -221,7 +363,23 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(id, "id");
 
-            return ApiConnection.GetAll<GistFork>(ApiUrls.ForkGist(id));
+            return GetAllForks(id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List gist forks
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-forks
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<GistFork>> GetAllForks(string id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<GistFork>(ApiUrls.ForkGist(id), options);
         }
 
         /// <summary>
@@ -234,7 +392,7 @@ namespace Octokit
         /// <param name="gistUpdate">The update to the gist</param>
         public Task<Gist> Edit(string id, GistUpdate gistUpdate)
         {
-            Ensure.ArgumentNotNull(id, "id");
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
             Ensure.ArgumentNotNull(gistUpdate, "gistUpdate");
 
             var filesAsJsonObject = new JsonObject();
@@ -261,6 +419,8 @@ namespace Octokit
         /// <param name="id">The id of the gist</param>
         public Task Star(string id)
         {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+
             return ApiConnection.Put(ApiUrls.StarGist(id));
         }
 
@@ -273,6 +433,8 @@ namespace Octokit
         /// <param name="id">The id of the gist</param>
         public Task Unstar(string id)
         {
+            Ensure.ArgumentNotNullOrEmptyString(id, "id");
+
             return ApiConnection.Delete(ApiUrls.StarGist(id));
         }
 

--- a/Octokit/Clients/IGistsClient.cs
+++ b/Octokit/Clients/IGistsClient.cs
@@ -38,12 +38,33 @@ namespace Octokit
         /// <summary>
         /// List the authenticated user’s gists or if called anonymously, 
         /// this will return all public gists
+        /// </summary>        
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAll(ApiOptions options);
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
         /// </summary>
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since);
+
+        /// <summary>
+        /// List the authenticated user’s gists or if called anonymously, 
+        /// this will return all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// Lists all public gists
@@ -59,8 +80,29 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllPublic(ApiOptions options);
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since);
+
+        /// <summary>
+        /// Lists all public gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since, ApiOptions options);
+        
+
 
         /// <summary>
         /// List the authenticated user’s starred gists
@@ -76,8 +118,27 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllStarred(ApiOptions options);
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since);
+
+        /// <summary>
+        /// List the authenticated user’s starred gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// List a user's gists
@@ -95,8 +156,29 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="user">The user</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllForUser(string user, ApiOptions options);
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since);
+
+        /// <summary>
+        /// List a user's gists
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists
+        /// </remarks>
+        /// <param name="user">The user</param>
+        /// <param name="since">Only gists updated at or after this time are returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since, ApiOptions options);
 
         /// <summary>
         /// List gist commits
@@ -108,6 +190,16 @@ namespace Octokit
         Task<IReadOnlyList<GistHistory>> GetAllCommits(string id);
 
         /// <summary>
+        /// List gist commits
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-commits
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<GistHistory>> GetAllCommits(string id, ApiOptions options);
+
+        /// <summary>
         /// List gist forks
         /// </summary>
         /// <remarks>
@@ -115,6 +207,16 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the gist</param>
         Task<IReadOnlyList<GistFork>> GetAllForks(string id);
+
+        /// <summary>
+        /// List gist forks
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/gists/#list-gists-forks
+        /// </remarks>
+        /// <param name="id">The id of the gist</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<GistFork>> GetAllForks(string id, ApiOptions options);
 
         /// <summary>
         /// Creates a new gist


### PR DESCRIPTION
Fixes #1156 

- [x]  Add overloads for the GetAll* methods in the IGistsClient with the the ApiOptions parameter.
- [x] Implement the the GetAll* methods in the GistsClient class.
- [x] Add an overload for the GetAll* methods to the IObservableGistsClient  with the ApiOptions parameter.
- [x] Implement the GetAll* methods in the ObservableGistsClient  class.
- [x] Implement the needed tests in the GistsClientTests class.
- [x] Implement the required integration tests in the ObservableGistsClientTests class.