### PR TITLE
[WIP] Add ApiOption overloads to methods on IRepositoryCommentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
@@ -28,6 +28,16 @@ namespace Octokit.Reactive
         IObservable<CommitComment> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        IObservable<CommitComment> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Commit Comments for a specified Commit.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
@@ -36,6 +46,17 @@ namespace Octokit.Reactive
         /// <param name="sha">The sha of the commit</param>
         /// <returns></returns>
         IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha);
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
@@ -90,6 +90,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
         /// <returns></returns>
         public IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
         {

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
@@ -46,7 +46,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public IObservable<CommitComment> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name), options);
         }
 
         /// <summary>
@@ -63,7 +80,25 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
-            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name, sha));
+            return GetAllForCommit(owner, name, sha, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <returns></returns>
+        public IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name, sha), options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -35,7 +35,7 @@ public class RepositoryCommentsClientTests
         }
     }
 
-    public class TheGetForRepositoryMethod
+    public class TheGetAllForRepositoryMethod
     {
         [Fact]
         public void RequestsCorrectUrl()
@@ -58,7 +58,7 @@ public class RepositoryCommentsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
         }
     }
 
@@ -87,7 +87,7 @@ public class RepositoryCommentsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha", new ApiOptions()));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, new ApiOptions()));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", new ApiOptions()));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha", null));
         }
     }
 

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -43,9 +43,9 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.GetAllForRepository("fake", "repo");
+            client.GetAllForRepository("fake", "repo", new ApiOptions());
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"));
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Arg.Any<ApiOptions>());
         }
 
         [Fact]
@@ -54,10 +54,11 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "name", null));
         }
     }
 
@@ -69,9 +70,9 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.GetAllForCommit("fake", "repo", "sha");
+            client.GetAllForCommit("fake", "repo", "sha", new ApiOptions());
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"));
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), Arg.Any<ApiOptions>());
         }
 
         [Fact]
@@ -80,12 +81,13 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", new ApiOptions()));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha", null));
         }
     }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Reactive\ObservableReleasesClientTests.cs" />
     <Compile Include="Reactive\ObservablePullRequestReviewCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -8,7 +8,7 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableRepositoryCommentsClientTests
     {
-        public class TheGetForRepositoryMethod
+        public class TheGetAllForRepositoryMethod
         {
             [Fact]
             public void RequestsCorrectUrl()
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
             }
         }
 
@@ -60,7 +60,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha", new ApiOptions()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, new ApiOptions()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", new ApiOptions()));
-                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha", null));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -1,0 +1,67 @@
+﻿using NSubstitute;
+using Octokit.Reactive;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryCommentsClientTests
+    {
+        public class TheGetForRepositoryMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+                var options = new ApiOptions();
+
+                client.GetAllForRepository("fake", "repo", options);
+                githubClient.Received().Repository.Comment.GetAllForRepository("fake", "repo", options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "name", null));
+            }
+        }
+
+        public class TheGetForCommitMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+                var options = new ApiOptions();
+
+                client.GetAllForCommit("fake", "repo", "sha", options);
+                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha", options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "name", "sha", new ApiOptions()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha", new ApiOptions()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha", null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepositoryCommentsClient.cs
+++ b/Octokit/Clients/IRepositoryCommentsClient.cs
@@ -34,6 +34,16 @@ namespace Octokit
         Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Commit Comments for a specified Commit.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
@@ -42,6 +52,17 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <returns></returns>
         Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha);
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -49,7 +49,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name), options);
         }
 
         /// <summary>
@@ -66,7 +83,26 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
-            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name, sha));
+            return GetAllForCommit(owner, name, sha, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name, sha), options);
         }
 
         /// <summary>

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -6,10 +6,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersionAttribute("0.19.0")]
 [assembly: AssemblyFileVersionAttribute("0.19.0")]
 [assembly: ComVisibleAttribute(false)]
-namespace System
-{
-    internal static class AssemblyVersionInformation
-    {
+namespace System {
+    internal static class AssemblyVersionInformation {
         internal const string Version = "0.19.0";
     }
 }


### PR DESCRIPTION
Fixes #1172

To Do

- [x] Add overload to `IRepositoryCommentsClient` and `IObservableRespositoryCommentsClient`
- [x] Implement the above methods in the respective classes
- [x] Add unit tests for `IRepositoryCommentsClient`
- [x] Add unit tests for `IObservableRespositoryCommentsClient`
- [ ] Add integration tests for `IRepositoryCommentsClient`
- [ ] Add integration tests for `IObservableRepositoryCommentsClient`

