### PR TITLE
Ensure that Commit.Compare(..) sets MergeBaseCommit correctly.

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -21,6 +21,13 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetMergeBaseCommit()
+        {
+            var compareResult = await _fixture.Compare("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            Assert.NotNull(compareResult.MergeBaseCommit);
+        }
+
+        [IntegrationTest]
         public async Task CanGetCommit()
         {
             var commit = await _fixture.Get("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f");

--- a/Octokit/Models/Response/CompareResult.cs
+++ b/Octokit/Models/Response/CompareResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -9,7 +10,7 @@ namespace Octokit
     {
         public CompareResult() { }
 
-        public CompareResult(string url, string htmlUrl, string permalinkUrl, string diffUrl, string patchUrl, GitHubCommit baseCommit, GitHubCommit mergedBaseCommit, string status, int aheadBy, int behindBy, int totalCommits, IReadOnlyList<GitHubCommit> commits, IReadOnlyList<GitHubCommitFile> files)
+        public CompareResult(string url, string htmlUrl, string permalinkUrl, string diffUrl, string patchUrl, GitHubCommit baseCommit, GitHubCommit mergeBaseCommit, string status, int aheadBy, int behindBy, int totalCommits, IReadOnlyList<GitHubCommit> commits, IReadOnlyList<GitHubCommitFile> files)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -17,7 +18,7 @@ namespace Octokit
             DiffUrl = diffUrl;
             PatchUrl = patchUrl;
             BaseCommit = baseCommit;
-            MergedBaseCommit = mergedBaseCommit;
+            MergeBaseCommit = mergeBaseCommit;
             Status = status;
             AheadBy = aheadBy;
             BehindBy = behindBy;
@@ -32,7 +33,9 @@ namespace Octokit
         public string DiffUrl { get; protected set; }
         public string PatchUrl { get; protected set; }
         public GitHubCommit BaseCommit { get; protected set; }
+        [Obsolete("This property is obsolete. Use MergeBaseCommit instead.", false)]
         public GitHubCommit MergedBaseCommit { get; protected set; }
+        public GitHubCommit MergeBaseCommit { get; protected set; }
         public string Status { get; protected set; }
         public int AheadBy { get; protected set; }
         public int BehindBy { get; protected set; }


### PR DESCRIPTION
MergeBaseCommit was spelled incorrectly in CompareResult causing Octokit to pass
"null" no matter what the comparison is. This commit makes MergedBaseCommit (the
previous spelling) obsolete, introduces MergeBaseCommit property and adds a test
to ensure that MergeBaseCommit is set properly in CompareResult.

In the test, I specifically compared a commit with itself since the test only
cares whether the property is filled correctly or not, it is not testing whether
the internal computation is correct or not.

Closes #1258.