### PR TITLE
Add ApiOption overloads to methods on IIssueCommentsClient 

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -28,6 +28,16 @@ namespace Octokit.Reactive
         IObservable<IssueComment> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="IssueComment"/>s for the specified Repository.</returns>
+        IObservable<IssueComment> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
@@ -36,6 +46,17 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>The list of <see cref="IssueComment"/>s for the specified Issue.</returns>
         IObservable<IssueComment> GetAllForIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="IssueComment"/>s for the specified Issue.</returns>
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -46,7 +46,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="IssueComment"/>s for the specified Repository.</returns>
+        public IObservable<IssueComment> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), options);
         }
 
         /// <summary>
@@ -62,7 +79,25 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number));
+            return GetAllForIssue(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="IssueComment"/>s for the specified Issue.</returns>
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\ObservableFollowersClientTests.cs" />
+    <Compile Include="Reactive\ObservableIssueCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableIssueCommentsClientTests
+    {
+        public class TheGetAllForRepositoryMethod
+        {
+            readonly ObservableIssueCommentsClient _issueCommentsClient;
+            const string owner = "octokit";
+            const string name = "octokit.net";
+
+            public TheGetAllForRepositoryMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _issueCommentsClient = new ObservableIssueCommentsClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsIssueComments()
+            {
+                var issueComments = await _issueCommentsClient.GetAllForRepository(owner, name).ToList();
+
+                Assert.NotEmpty(issueComments);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfIssueCommentsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var issueComments = await _issueCommentsClient.GetAllForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, issueComments.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfIssueCommentsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var issueComments = await _issueCommentsClient.GetAllForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, issueComments.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstPageIssueComments = await _issueCommentsClient.GetAllForRepository(owner, name, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPageIssueComments = await _issueCommentsClient.GetAllForRepository(owner, name, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPageIssueComments[0].Id, secondPageIssueComments[0].Id);
+                Assert.NotEqual(firstPageIssueComments[1].Id, secondPageIssueComments[1].Id);
+                Assert.NotEqual(firstPageIssueComments[2].Id, secondPageIssueComments[2].Id);
+                Assert.NotEqual(firstPageIssueComments[3].Id, secondPageIssueComments[3].Id);
+                Assert.NotEqual(firstPageIssueComments[4].Id, secondPageIssueComments[4].Id);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
 using Octokit.Internal;
+using Octokit.Tests;
 using Octokit.Tests.Helpers;
 using Xunit;
 
@@ -45,7 +46,7 @@ public class IssueCommentsClientTests
 
             client.GetAllForRepository("fake", "repo");
 
-            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"));
+            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), Args.ApiOptions);
         }
 
         [Fact]
@@ -71,7 +72,7 @@ public class IssueCommentsClientTests
 
             client.GetAllForIssue("fake", "repo", 3);
 
-            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"));
+            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), Args.ApiOptions);
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -3,212 +3,252 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit;
 using Octokit.Internal;
-using Octokit.Tests;
-using Octokit.Tests.Helpers;
 using Xunit;
 
-public class IssueCommentsClientTests
+namespace Octokit.Tests.Clients
 {
-    public class TheGetMethod
+    public class IssueCommentsClientTests
     {
-        [Fact]
-        public void RequestsCorrectUrl()
+        public class TheGetMethod
         {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
 
-            client.Get("fake", "repo", 42);
+                client.Get("fake", "repo", 42);
 
-            connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
+                connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new IssueCommentsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
+            }
+        }
+
+        public class TheGetForRepositoryMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                client.GetAllForRepository("fake", "repo");
+
+                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                var options = new ApiOptions()
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+                client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+            }
+        }
+
+        public class TheGetForIssueMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                client.GetAllForIssue("fake", "repo", 3);
+
+                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                var options = new ApiOptions()
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+                client.GetAllForIssue("fake", "repo", 3, options);
+
+                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                const string newComment = "some title";
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                client.Create("fake", "repo", 1, newComment);
+
+                connection.Received().Post<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/comments"), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, "title"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, "x"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, "x"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, "x"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+            }
+        }
+
+        public class TheUpdateMethod
+        {
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                const string issueCommentUpdate = "Worthwhile update";
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                client.Update("fake", "repo", 42, issueCommentUpdate);
+
+                connection.Received().Patch<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 42, "title"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 42, "x"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 42, "x"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 42, "x"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void DeletesCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                client.Delete("fake", "repo", 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNullOrEmpty()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 42));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresArgument()
+            {
+                Assert.Throws<ArgumentNullException>(() => new IssueCommentsClient(null));
+            }
         }
 
         [Fact]
-        public async Task EnsuresNonNullArguments()
+        public void CanDeserializeIssueComment()
         {
-            var client = new IssueCommentsClient(Substitute.For<IApiConnection>());
+            const string issueResponseJson =
+                "{\"id\": 1," +
+                "\"url\": \"https://api.github.com/repos/octocat/Hello-World/issues/comments/1\"," +
+                "\"html_url\": \"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1\"," +
+                "\"body\": \"Me too\"," +
+                "\"user\": {" +
+                "\"login\": \"octocat\"," +
+                "\"id\": 1," +
+                "\"avatar_url\": \"https://github.com/images/error/octocat_happy.gif\"," +
+                "\"gravatar_id\": \"somehexcode\"," +
+                "\"url\": \"https://api.github.com/users/octocat\"" +
+                "}," +
+                "\"created_at\": \"2011-04-14T16:00:49Z\"," +
+                "\"updated_at\": \"2011-04-14T16:00:49Z\"" +
+                "}";
+            var httpResponse = new Response(
+                HttpStatusCode.OK,
+                issueResponseJson,
+                new Dictionary<string, string>(),
+                "application/json");
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
+            var jsonPipeline = new JsonHttpPipeline();
+
+            var response = jsonPipeline.DeserializeResponse<IssueComment>(httpResponse);
+
+            Assert.NotNull(response.Body);
+            Assert.Equal(issueResponseJson, response.HttpResponse.Body);
+            Assert.Equal(1, response.Body.Id);
         }
-    }
-
-    public class TheGetForRepositoryMethod
-    {
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            client.GetAllForRepository("fake", "repo");
-
-            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNull()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
-        }
-    }
-
-    public class TheGetForIssueMethod
-    {
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            client.GetAllForIssue("fake", "repo", 3);
-
-            connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), Args.ApiOptions);
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNull()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
-        }
-    }
-
-    public class TheCreateMethod
-    {
-        [Fact]
-        public void PostsToCorrectUrl()
-        {
-            const string newComment = "some title";
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            client.Create("fake", "repo", 1, newComment);
-
-            connection.Received().Post<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/comments"), Arg.Any<object>());
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNull()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, "title"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, "x"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, "x"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, "x"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
-        }
-    }
-
-    public class TheUpdateMethod
-    {
-        [Fact]
-        public void PostsToCorrectUrl()
-        {
-            const string issueCommentUpdate = "Worthwhile update";
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            client.Update("fake", "repo", 42, issueCommentUpdate);
-
-            connection.Received().Patch<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"), Arg.Any<object>());
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNull()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 42, "title"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 42, "x"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 42, "x"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 42, "x"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
-        }
-    }
-
-    public class TheDeleteMethod
-    {
-        [Fact]
-        public void DeletesCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            client.Delete("fake", "repo", 42);
-
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
-        }
-
-        [Fact]
-        public async Task EnsuresArgumentsNotNullOrEmpty()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new IssueCommentsClient(connection);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 42));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 42));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 42));
-        }
-    }
-
-    public class TheCtor
-    {
-        [Fact]
-        public void EnsuresArgument()
-        {
-            Assert.Throws<ArgumentNullException>(() => new IssueCommentsClient(null));
-        }
-    }
-
-    [Fact]
-    public void CanDeserializeIssueComment()
-    {
-        const string issueResponseJson =
-            "{\"id\": 1," +
-            "\"url\": \"https://api.github.com/repos/octocat/Hello-World/issues/comments/1\"," +
-            "\"html_url\": \"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1\"," +
-            "\"body\": \"Me too\"," +
-            "\"user\": {" +
-            "\"login\": \"octocat\"," +
-            "\"id\": 1," +
-            "\"avatar_url\": \"https://github.com/images/error/octocat_happy.gif\"," +
-            "\"gravatar_id\": \"somehexcode\"," +
-            "\"url\": \"https://api.github.com/users/octocat\"" +
-            "}," +
-            "\"created_at\": \"2011-04-14T16:00:49Z\"," +
-            "\"updated_at\": \"2011-04-14T16:00:49Z\"" +
-            "}";
-        var httpResponse = new Response(
-            HttpStatusCode.OK,
-            issueResponseJson,
-            new Dictionary<string, string>(),
-            "application/json");
-
-        var jsonPipeline = new JsonHttpPipeline();
-
-        var response = jsonPipeline.DeserializeResponse<IssueComment>(httpResponse);
-
-        Assert.NotNull(response.Body);
-        Assert.Equal(issueResponseJson, response.HttpResponse.Body);
-        Assert.Equal(1, response.Body.Id);
     }
 }

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -52,6 +52,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueCommentsClient(gitHubClient);
+
+                var options=new ApiOptions()
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+                client.GetAllForRepository("fake", "repo", options);
+
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), Arg.Any<Dictionary<string, string>>(), null);
+            }
+
+            [Fact]
             public async Task EnsuresArgumentsNotNull()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -61,6 +79,9 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None).ToTask());
             }
         }
 
@@ -79,6 +100,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueCommentsClient(gitHubClient);
+
+                var options=new ApiOptions()
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+                client.GetAllForIssue("fake", "repo", 3, options);
+
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), Arg.Any<Dictionary<string, string>>(), null);
+            }
+
+            [Fact]
             public async Task EnsuresArgumentsNotNull()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -88,6 +127,9 @@ namespace Octokit.Tests.Reactive
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), null, null);
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]
@@ -75,7 +75,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), null, null);
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -34,6 +34,16 @@ namespace Octokit
         Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
@@ -42,6 +52,17 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <returns></returns>
         Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -47,7 +47,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), options);
         }
 
         /// <summary>
@@ -63,7 +80,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number));
+            return GetAllForIssue(owner, name, number, ApiOptions.None);
+        }
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1157 

- [x] Add overloads for the `GetAllForRepository` and `GetAllForIssue` methods in the `IIssueCommentsClient` with the the `ApiOptions` parameter.
- [x]  Implement the the `GetAllForRepository` and `GetAllForIssue` methods in the `IssueCommentsClient` class.
- [x]  Add an overload for the `GetAllForRepository` and `GetAllForIssue` methods to the `IObservableIssueCommentsClient` with the `ApiOptions` parameter.
- [x]  Implement the `GetAllForRepository` and `GetAllForIssue` methods in the `ObservableIssueCommentsClient` class.
- [x] Implement the needed tests in the `IssueCommentsClientTests` class.
- [x] Implement the required integration tests in the `ObservableIssueCommentsClientTests` class.