### PR TITLE
[WIP] Add ApiOption overloads to methods on IDeploymentStatusClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -18,6 +18,20 @@ namespace Octokit.Reactive
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
         /// statuses for a given deployment.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -33,8 +33,30 @@ namespace Octokit.Reactive.Clients
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
+            return GetAll(owner, name, deploymentId, ApiOptions.None);
+        }
+
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<DeploymentStatus>(
-                ApiUrls.DeploymentStatuses(owner, name, deploymentId));
+                ApiUrls.DeploymentStatuses(owner, name, deploymentId), options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -1,113 +1,134 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit;
 using Xunit;
 
-public class DeploymentStatusClientTests
+namespace Octokit.Tests.Clients
 {
-    public class TheGetAllMethod
+    public class DeploymentStatusClientTests
     {
-        [Fact]
-        public async Task EnsuresNonNullArguments()
+        public class TheCtor
         {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+            [Fact]
+            public void EnsuresArgument()
+            {
+                Assert.Throws<ArgumentNullException>(() => new DeploymentStatusClient(null));
+            }
+        }
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
+            }
+
+            [Theory]
+            [InlineData(" ")]
+            [InlineData("\n")]
+            [InlineData("\t")]
+            [InlineData("  ")]
+            [InlineData("\n\r")]
+            public async Task EnsureNonWhitespaceArguments(string whitespace)
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace, 1));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new DeploymentStatusClient(connection);
+                var expectedUrl = "repos/owner/name/deployments/1/statuses";
+
+                client.GetAll("owner", "name", 1);
+                connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new DeploymentStatusClient(connection);
+                var expectedUrl = "repos/owner/name/deployments/1/statuses";
+
+                var options=new ApiOptions()
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+                client.GetAll("owner", "name", 1, options);
+                connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
+            }
         }
 
-        [Fact]
-        public async Task EnsuresNonEmptyArguments()
+        public class TheCreateMethod
         {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+            readonly NewDeploymentStatus newDeploymentStatus = new NewDeploymentStatus(DeploymentState.Success);
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
-        }
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
 
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("\n")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("\n\r")]
-        public async Task EnsureNonWhitespaceArguments(string whitespace)
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, newDeploymentStatus));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, newDeploymentStatus));
+            }
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace, 1));
-        }
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
 
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/name/deployments/1/statuses";
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
+            }
 
-            client.GetAll("owner", "name", 1);
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl));
-        }
-    }
+            [Theory]
+            [InlineData(" ")]
+            [InlineData("\n")]
+            [InlineData("\t")]
+            [InlineData("  ")]
+            [InlineData("\n\r")]
+            public async Task EnsureNonWhitespaceArguments(string whitespace)
+            {
+                var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
 
-    public class TheCreateMethod
-    {
-        readonly NewDeploymentStatus newDeploymentStatus = new NewDeploymentStatus(DeploymentState.Success);
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "repo", 1, newDeploymentStatus));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, 1, newDeploymentStatus));
+            }
 
-        [Fact]
-        public async Task EnsuresNonNullArguments()
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new DeploymentStatusClient(connection);
+                var expectedUrl = "repos/owner/repo/deployments/1/statuses";
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, newDeploymentStatus));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, newDeploymentStatus));
-        }
+                client.Create("owner", "repo", 1, newDeploymentStatus);
 
-        [Fact]
-        public async Task EnsuresNonEmptyArguments()
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
-
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
-        }
-
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("\n")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("\n\r")]
-        public async Task EnsureNonWhitespaceArguments(string whitespace)
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
-
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "repo", 1, newDeploymentStatus));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, 1, newDeploymentStatus));
-        }
-
-        [Fact]
-        public void PostsToCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/repo/deployments/1/statuses";
-
-            client.Create("owner", "repo", 1, newDeploymentStatus);
-
-            connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                                                         Arg.Any<NewDeploymentStatus>());
-        }
-    }
-
-    public class TheCtor
-    {
-        [Fact]
-        public void EnsuresArgument()
-        {
-            Assert.Throws<ArgumentNullException>(() => new DeploymentStatusClient(null));
-        }
+                connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                    Arg.Any<NewDeploymentStatus>());
+            }
+        }      
     }
 }

--- a/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
@@ -27,6 +27,7 @@ namespace Octokit.Tests.Reactive
             {
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo", 1));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null, 1));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", "repo", 1, null));
             }
 
             [Fact]
@@ -34,6 +35,8 @@ namespace Octokit.Tests.Reactive
             {
                 Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1));
                 Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1));
+                Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1, ApiOptions.None));
             }
 
             [Fact]
@@ -54,8 +57,27 @@ namespace Octokit.Tests.Reactive
 
                 _githubClient.Connection.Received(1)
                     .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
+                                                      Args.EmptyDictionary,
+                                                      null);
+            }
+
+            [Fact]
+            public void GetsFromCorrectUrlWithApiOptions()
+            {
+                var expectedUri = ApiUrls.DeploymentStatuses("owner", "repo", 1);
+
+                var options=new ApiOptions()
+                {
+                    StartPage = 1,
+                    PageSize = 1,
+                    PageCount = 1
+                };
+                _client.GetAll("owner", "repo", 1, options);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
                                                       Arg.Any<IDictionary<string, string>>(),
-                                                      Arg.Any<string>());
+                                                      null);
             }
         }
 

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -33,7 +33,28 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId));
+            return GetAll(owner, name, deploymentId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -26,6 +26,20 @@ namespace Octokit
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
         /// statuses for a given deployment.
         /// </summary>


### PR DESCRIPTION
Fixes #1152 

- [x] Add overloads for the `GetAll` method in the `IDeploymentStatusClient` with the the `ApiOptions` parameter.
- [x] Implement the the `GetAll` method in the `DeploymentStatusClient` class.
- [x] Add an overload for the `GetAll` method to the `IObservableDeploymentStatusClient` with the ApiOptions parameter.
- [x] Implement the `GetAll` methods in the `ObservableDeploymentStatusClient` class.
- [x] Implement the needed tests in the `DeploymentStatusClientTests` class.
- [ ] Implement the required integration tests in the `ObservableDeploymentStatusClientTests` class.