### PR TITLE
Add ApiOption overloads to methods on IRepositoryHooksClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -10,8 +10,20 @@ namespace Octokit.Reactive
         /// Gets the list of hooks defined for a repository
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
         /// <returns></returns>
         IObservable<RepositoryHook> GetAll(string owner, string repositoryName);
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<RepositoryHook> GetAll(string owner, string repositoryName, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook defined for a repository by id

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -22,13 +22,32 @@ namespace Octokit.Reactive
         /// Gets the list of hooks defined for a repository
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
         /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName));
+            return GetAll(owner, repositoryName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<RepositoryHook> GetAll(string owner, string repositoryName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
@@ -25,10 +25,69 @@ namespace Octokit.Tests.Integration.Clients
 
                 var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName);
 
-                Assert.Single(hooks);
-                var actualHook = hooks[0];
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
 
+                var actualHook = hooks[0];
                 AssertHook(_fixture.ExpectedHook, actualHook);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options);
+
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 3
+                };
+
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options);
+
+                Assert.Equal(1, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
             }
         }
 

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Helper.cs" />
     <Compile Include="Clients\UsersClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryHooksClientTests.cs" />
     <Compile Include="Reactive\ObservableUserAdministrationClientTests.cs" />
     <Compile Include="Reactive\ObservableUserEmailsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryHooksClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryHooksClientTests.cs
@@ -1,0 +1,115 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit.Reactive;
+using Octokit.Tests.Integration.fixtures;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Reactive
+{
+    public class ObservableRepositoryHooksClientTests
+    {
+        [Collection(RepositoriesHooksCollection.Name)]
+        public class TheGetAllMethod
+        {
+            readonly RepositoriesHooksFixture _fixture;
+
+            public TheGetAllMethod(RepositoriesHooksFixture fixture)
+            {
+                _fixture = fixture;
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsAllHooksFromRepository()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var client = new ObservableRepositoryHooksClient(github);
+
+                var hooks = await client.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName).ToList();
+
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
+
+                var actualHook = hooks[0];
+                AssertHook(_fixture.ExpectedHook, actualHook);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var client = new ObservableRepositoryHooksClient(github);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var hooks = await client.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options).ToList();
+
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var client = new ObservableRepositoryHooksClient(github);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 3
+                };
+
+                var hooks = await client.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options).ToList();
+
+                Assert.Equal(1, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var client = new ObservableRepositoryHooksClient(github);
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var firstPage = await client.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await client.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+            }
+
+            static void AssertHook(RepositoryHook expectedHook, RepositoryHook actualHook)
+            {
+                Assert.Equal(expectedHook.Id, actualHook.Id);
+                Assert.Equal(expectedHook.Active, actualHook.Active);
+                Assert.Equal(expectedHook.Config, actualHook.Config);
+                Assert.Equal(expectedHook.CreatedAt, actualHook.CreatedAt);
+                Assert.Equal(expectedHook.Name, actualHook.Name);
+                Assert.Equal(expectedHook.PingUrl, actualHook.PingUrl);
+                Assert.Equal(expectedHook.TestUrl, actualHook.TestUrl);
+                Assert.Equal(expectedHook.UpdatedAt, actualHook.UpdatedAt);
+                Assert.Equal(expectedHook.Url, actualHook.Url);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
+++ b/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
@@ -8,12 +8,21 @@ namespace Octokit.Tests.Integration.fixtures
         readonly IGitHubClient _github;
         readonly Repository _repository;
         readonly RepositoryHook _hook;
+        readonly IList<RepositoryHook> _hooks;
 
         public RepositoriesHooksFixture()
         {
             _github = Helper.GetAuthenticatedClient();
             _repository = CreateRepository(_github);
-            _hook = CreateHook(_github, _repository);
+            _hooks = new List<RepositoryHook>(5)
+            {
+                CreateHook(_github, _repository, "awscodedeploy", "deployment"),
+                CreateHook(_github, _repository, "awsopsworks", "push"),
+                CreateHook(_github, _repository, "activecollab", "push"),
+                CreateHook(_github, _repository, "acunote", "push"),
+                CreateHook(_github, _repository, "agilebench", "push")
+            };
+            _hook = _hooks[0];
         }
 
         public string RepositoryOwner { get { return _repository.Owner.Login; } }
@@ -21,6 +30,8 @@ namespace Octokit.Tests.Integration.fixtures
         public string RepositoryName { get { return _repository.Name; } }
 
         public RepositoryHook ExpectedHook { get { return _hook; } }
+
+        public IList<RepositoryHook> ExpectedHooks { get { return _hooks; } }
 
         public void Dispose()
         {
@@ -35,12 +46,12 @@ namespace Octokit.Tests.Integration.fixtures
             return repository.Result;
         }
 
-        static RepositoryHook CreateHook(IGitHubClient github, Repository repository)
+        static RepositoryHook CreateHook(IGitHubClient github, Repository repository, string hookName, string eventComment)
         {
             var config = new Dictionary<string, string> { { "content_type", "json" }, { "url", "http://test.com/example" } };
-            var parameters = new NewRepositoryHook("apropos", config)
+            var parameters = new NewRepositoryHook(hookName, config)
             {
-                Events = new[] { "commit_comment" },
+                Events = new[] { eventComment },
                 Active = false
             };
             var createdHook = github.Repository.Hooks.Create(Helper.UserName, repository.Name, parameters);

--- a/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
+++ b/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
@@ -46,12 +46,12 @@ namespace Octokit.Tests.Integration.fixtures
             return repository.Result;
         }
 
-        static RepositoryHook CreateHook(IGitHubClient github, Repository repository, string hookName, string eventComment)
+        static RepositoryHook CreateHook(IGitHubClient github, Repository repository, string hookName, string eventName)
         {
             var config = new Dictionary<string, string> { { "content_type", "json" }, { "url", "http://test.com/example" } };
             var parameters = new NewRepositoryHook(hookName, config)
             {
-                Events = new[] { eventComment },
+                Events = new[] { eventName },
                 Active = false
             };
             var createdHook = github.Repository.Hooks.Create(Helper.UserName, repository.Name, parameters);

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -1,7 +1,7 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -18,7 +18,27 @@ namespace Octokit.Tests.Clients
 
                 client.Hooks.GetAll("fake", "repo");
 
-                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"));
+                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.Hooks.GetAll("fake", "repo", options);
+
+                connection.Received(1)
+                    .GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"),
+                        options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -18,7 +18,8 @@ namespace Octokit.Tests.Clients
 
                 client.Hooks.GetAll("fake", "repo");
 
-                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), Args.ApiOptions);
+                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), 
+                    Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryHooksClientTests.cs" />
     <Compile Include="Reactive\ObservableStarredClientTests.cs" />
     <Compile Include="Reactive\ObservableStatisticsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
@@ -74,15 +74,15 @@ namespace Octokit.Tests.Reactive
                             null);
                 }
             }
+        }
 
-            public class TheCtor
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
-                [Fact]
-                public void EnsuresNonNullArguments()
-                {
-                    Assert.Throws<ArgumentNullException>(
-                        () => new ObservableRepositoryHooksClient(null));
-                }
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableRepositoryHooksClient(null));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryHooksClientTests
+    {
+        public class ObservableAuthorizationsClientTests
+        {
+            const string owner = "owner";
+            const string repositoryName = "name";
+
+            public class TheGetAllMethod
+            {
+                [Fact]
+                public void GetsCorrectUrl()
+                {
+                    var client = Substitute.For<IGitHubClient>();
+                    var authEndpoint = new ObservableRepositoryHooksClient(client);
+                    var expectedUrl = string.Format("repos/{0}/{1}/hooks", owner, repositoryName);
+
+                    authEndpoint.GetAll(owner, repositoryName);
+
+                    client.Connection.Received(1).Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
+                }
+
+                [Fact]
+                public void GetsCorrectUrlWithApiOption()
+                {
+                    var gitHubClient = Substitute.For<IGitHubClient>();
+                    var hooksClient = new ObservableRepositoryHooksClient(gitHubClient);
+                    var expectedUrl = string.Format("repos/{0}/{1}/hooks", owner, repositoryName);
+
+                    // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
+                    var options = new ApiOptions
+                    {
+                        StartPage = 1,
+                        PageCount = 1,
+                        PageSize = 1
+                    };
+
+                    hooksClient.GetAll(owner, repositoryName, options);
+                    gitHubClient.Connection.Received(1)
+                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                            null);
+
+                    // StartPage is setted => only 1 option (StartPage) in dictionary
+                    options = new ApiOptions
+                    {
+                        StartPage = 1
+                    };
+
+                    hooksClient.GetAll(owner, repositoryName, options);
+                    gitHubClient.Connection.Received(1)
+                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                            null);
+
+                    // PageCount is setted => none of options in dictionary
+                    options = new ApiOptions
+                    {
+                        PageCount = 1
+                    };
+
+                    hooksClient.GetAll(owner, repositoryName, options);
+                    gitHubClient.Connection.Received(1)
+                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                            null);
+                }
+            }
+
+            public class TheCtor
+            {
+                [Fact]
+                public void EnsuresNonNullArguments()
+                {
+                    Assert.Throws<ArgumentNullException>(
+                        () => new ObservableRepositoryHooksClient(null));
+                }
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -10,8 +10,20 @@ namespace Octokit
         /// Gets the list of hooks defined for a repository
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
         /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName);
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -18,13 +18,32 @@ namespace Octokit
         /// Gets the list of hooks defined for a repository
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
         /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName));
+            return GetAll(owner, repositoryName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1149 .

To-do:

 - [x]  Add overload <Task> GetAll(ApiOptions options) on IRepositoryHooksClient.
 - [x]  Add overload IObservable GetAll(ApiOptions options) on IObservableRepositoryHooksClient.
 - [x]  Add unit tests for these new methods.
 - [x]  Add integration tests for these new methods.

Please review these changes, especially changes in RepositoriesHooksFixture.cs. I had to change it in order to get additional hooks and properly test methods with ApiOptions parameter.

/cc @shiftkey, @ryangribble 