### PR TITLE
Method of assembly determination was changed in order to use types of top level

### DIFF
--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -97,7 +97,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetClientInterfaces()
         {
-            return typeof(GitHubClientTests)
+            return typeof(IGitHubClient)
                 .Assembly
                 .ExportedTypes
                 .Where(TypeExtensions.IsClientInterface)

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -119,7 +119,7 @@ namespace Octokit.Tests.Conventions
         {
             var allModelTypes = new HashSet<Type>();
 
-            var clientInterfaces = typeof(GitHubClientTests).Assembly.ExportedTypes
+            var clientInterfaces = typeof(IGitHubClient).Assembly.ExportedTypes
                 .Where(type => type.IsClientInterface());
 
             foreach (var exportedType in clientInterfaces)

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -97,7 +97,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetClientInterfaces()
         {
-            return typeof(IEventsClient)
+            return typeof(GitHubClientTests)
                 .Assembly
                 .ExportedTypes
                 .Where(TypeExtensions.IsClientInterface)
@@ -119,7 +119,7 @@ namespace Octokit.Tests.Conventions
         {
             var allModelTypes = new HashSet<Type>();
 
-            var clientInterfaces = typeof(IEventsClient).Assembly.ExportedTypes
+            var clientInterfaces = typeof(GitHubClientTests).Assembly.ExportedTypes
                 .Where(type => type.IsClientInterface());
 
             foreach (var exportedType in clientInterfaces)

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -89,7 +89,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetClientInterfaces()
         {
-            return typeof(GitHubClientTests).Assembly.ExportedTypes
+            return typeof(IGitHubClient).Assembly.ExportedTypes
                 .Where(TypeExtensions.IsClientInterface)
                 .Where(type => type != typeof(IStatisticsClient))
                 .Select(type => new[] { type });

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -89,7 +89,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetClientInterfaces()
         {
-            return typeof(IEventsClient).Assembly.ExportedTypes
+            return typeof(GitHubClientTests).Assembly.ExportedTypes
                 .Where(TypeExtensions.IsClientInterface)
                 .Where(type => type != typeof(IStatisticsClient))
                 .Select(type => new[] { type });

--- a/Octokit.Tests.Conventions/SyncObservableClients.cs
+++ b/Octokit.Tests.Conventions/SyncObservableClients.cs
@@ -120,7 +120,7 @@ namespace Octokit.Tests.Conventions
 
         public static IEnumerable<object[]> GetClientInterfaces()
         {
-            return typeof(IEventsClient)
+            return typeof(IGitHubClient)
                 .Assembly
                 .ExportedTypes
                 .Where(TypeExtensions.IsClientInterface)

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Conventions
 
         public static bool IsClientInterface(this Type type)
         {
-            return type.IsInterface && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(IEventsClient).Namespace;
+            return type.IsInterface && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(GitHubClient).Namespace;
         }
 
         public static Type GetObservableClientInterface(this Type type)

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Conventions
 
         public static bool IsClientInterface(this Type type)
         {
-            return type.IsInterface && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(GitHubClient).Namespace;
+            return type.IsInterface && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(IGitHubClient).Namespace;
         }
 
         public static Type GetObservableClientInterface(this Type type)


### PR DESCRIPTION
Refers #1246 

As was discussed in #1246 top level types should be used to determine assembly name in conventions tests. I've changed type from IEventsClient to IGitHubClient and GitHubClientTests types.

/cc @shiftkey @ryangribble 