### PR TITLE
Modifiers declaration order was adjusted

### DIFF
--- a/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
@@ -6,7 +6,7 @@ namespace Octokit.Tests.Integration.Helpers
 {
     internal static class ObservableGithubClientExtensions
     {
-        internal async static Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, string repositoryName)
+        internal static async Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, string repositoryName)
         {
             var repoName = Helper.MakeNameWithTimestamp(repositoryName);
             var repo = await client.Repository.Create(new NewRepository(repoName) { AutoInit = true });
@@ -14,35 +14,35 @@ namespace Octokit.Tests.Integration.Helpers
             return new RepositoryContext(repo);
         }
 
-        internal async static Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, string organizationLogin, NewRepository newRepository)
+        internal static async Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, string organizationLogin, NewRepository newRepository)
         {
             var repo = await client.Repository.Create(organizationLogin, newRepository);
 
             return new RepositoryContext(repo);
         }
 
-        internal async static Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, NewRepository newRepository)
+        internal static async Task<RepositoryContext> CreateRepositoryContext(this IObservableGitHubClient client, NewRepository newRepository)
         {
             var repo = await client.Repository.Create(newRepository);
 
             return new RepositoryContext(repo);
         }
 
-        internal async static Task<EnterpriseTeamContext> CreateEnterpriseTeamContext(this IObservableGitHubClient client, string organization, NewTeam newTeam)
+        internal static async Task<EnterpriseTeamContext> CreateEnterpriseTeamContext(this IObservableGitHubClient client, string organization, NewTeam newTeam)
         {
             var team = await client.Organization.Team.Create(organization, newTeam);
 
             return new EnterpriseTeamContext(team);
         }
 
-        internal async static Task<EnterpriseUserContext> CreateEnterpriseUserContext(this IObservableGitHubClient client, NewUser newUser)
+        internal static async Task<EnterpriseUserContext> CreateEnterpriseUserContext(this IObservableGitHubClient client, NewUser newUser)
         {
             var user = await client.User.Administration.Create(newUser);
 
             return new EnterpriseUserContext(user);
         }
 
-        internal async static Task<PublicKeyContext> CreatePublicKeyContext(this IObservableGitHubClient client)
+        internal static async Task<PublicKeyContext> CreatePublicKeyContext(this IObservableGitHubClient client)
         {
             // Create a key
             string keyTitle = "title";


### PR DESCRIPTION
Modifiers declaration order was adjusted a little as part of whole check of Octokit by Resharper.
The order `internal async static` was changed to 'internal static async'

Citation from [Resharper documentation](https://www.jetbrains.com/help/resharper/10.0/Modifiers_Style.html?origin=old_help)

> C# modifiers of types and type members can be written in any order. However, arranging them in a similar way throughout your code is a good practice, which improves code readability. 

/cc @shiftkey 