### PR TITLE
Redundant braces of argument list were removed

### DIFF
--- a/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BranchesClientTests.cs
@@ -40,7 +40,7 @@ public class BranchesClientTests
         public async Task CreateTheWorld()
         {
             // Set master branch to be protected, with some status checks
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1", "check2" });
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string> { "check1", "check2" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
@@ -52,7 +52,7 @@ public class BranchesClientTests
         public async Task ProtectsBranch()
         {
             // Set master branch to be protected, with some status checks
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1", "check2", "check3" });
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string> { "check1", "check2", "check3" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
@@ -77,7 +77,7 @@ public class BranchesClientTests
             await CreateTheWorld();
 
             // Remove status check enforcement
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Off, new List<string>() { "check1" });
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Off, new List<string> { "check1" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(true, requiredStatusChecks);
@@ -103,7 +103,7 @@ public class BranchesClientTests
 
             // Unprotect branch
             // Deliberately set Enforcement and Contexts to some values (these should be ignored)
-            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string>() { "check1" });
+            var requiredStatusChecks = new RequiredStatusChecks(EnforcementLevel.Everyone, new List<string> { "check1" });
 
             var update = new BranchUpdate();
             update.Protection = new BranchProtection(false, requiredStatusChecks);

--- a/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
@@ -24,7 +24,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for investigating this failing test")]
     public async Task CanCreateADeployKey()
     {
-        var deployKey = new NewDeployKey()
+        var deployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -42,7 +42,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
         var deployKeys = await _fixture.GetAll(_context.RepositoryOwner, _context.RepositoryName);
         Assert.Equal(0, deployKeys.Count);
 
-        var deployKey = new NewDeployKey()
+        var deployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -59,7 +59,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for the resolution to this failing test")]
     public async Task CanRetrieveADeployKey()
     {
-        var newDeployKey = new NewDeployKey()
+        var newDeployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -76,7 +76,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for the resolution to this failing test")]
     public async Task CanRemoveADeployKey()
     {
-        var newDeployKey = new NewDeployKey()
+        var newDeployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -28,7 +28,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for investigating this failing test")]
     public async Task CanCreateADeployKey()
     {
-        var deployKey = new NewDeployKey()
+        var deployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -48,7 +48,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
         var deployKeys = await _client.GetAll(_owner, _repository.Name).ToList();
         Assert.Empty(deployKeys);
 
-        var deployKey = new NewDeployKey()
+        var deployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -64,7 +64,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for investigating this failing test")]
     public async Task CanRetrieveADeployKey()
     {
-        var newDeployKey = new NewDeployKey()
+        var newDeployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle
@@ -82,7 +82,7 @@ public class ObservableRespositoryDeployKeysClientTests : IDisposable
     [IntegrationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for investigating this failing test")]
     public async Task CanRemoveADeployKey()
     {
-        var newDeployKey = new NewDeployKey()
+        var newDeployKey = new NewDeployKey
         {
             Key = _key,
             Title = _keyTitle

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -370,7 +370,7 @@ public class GistsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistsClient(connection);
 
-            var options = new ApiOptions()
+            var options = new ApiOptions
             {
                 PageSize = 1,
                 PageCount = 1,

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueCommentsClient(connection);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     PageCount = 1,
                     PageSize = 1,

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -152,7 +152,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var editRepositoryHook = new EditRepositoryHook() { Active = false };
+                var editRepositoryHook = new EditRepositoryHook { Active = false };
 
                 client.Hooks.Edit("owner", "repo", 12345678, editRepositoryHook);
 

--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -165,7 +165,7 @@ namespace Octokit.Tests.Http
 
         static HttpMessageInvoker CreateInvoker(HttpResponseMessage httpResponseMessage1, HttpResponseMessage httpResponseMessage2 = null)
         {
-            var redirectHandler = new RedirectHandler()
+            var redirectHandler = new RedirectHandler
             {
                 InnerHandler = new MockRedirectHandler(httpResponseMessage1, httpResponseMessage2)
             };

--- a/Octokit.Tests/Models/RequestParametersTests.cs
+++ b/Octokit.Tests/Models/RequestParametersTests.cs
@@ -116,7 +116,7 @@ namespace Octokit.Tests.Models
             [Fact]
             public void UsesParameterAttributeForKey()
             {
-                var model = new WithPropertyNameDifferentFromKey() { LongPropertyName = "verbose" };
+                var model = new WithPropertyNameDifferentFromKey { LongPropertyName = "verbose" };
 
                 var result = model.ToParametersDictionary();
 

--- a/Octokit.Tests/Reactive/ObservableGistsTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGistsTests.cs
@@ -81,7 +81,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableGistsClient(gitHubClient);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     PageCount = 1,
                     PageSize = 1,
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableGistsClient(gitHubClient);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     PageCount = 1,
                     PageSize = 1,
@@ -225,7 +225,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableGistsClient(gitHubClient);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     PageCount = 1,
                     PageSize = 1,
@@ -298,7 +298,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableGistsClient(gitHubClient);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     PageCount = 1,
                     PageSize = 1,

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                var options=new ApiOptions()
+                var options=new ApiOptions
                 {
                     StartPage = 1,
                     PageSize = 1,
@@ -103,7 +103,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                var options=new ApiOptions()
+                var options=new ApiOptions
                 {
                     StartPage = 1,
                     PageSize = 1,


### PR DESCRIPTION
Redundant braces of argument list were removed as part of whole check of Octokit by Resharper.

/cc @shiftkey 