### PR TITLE
Add pagination support (ApiOptions overloads) to UserKeys client.

### DIFF
--- a/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
@@ -13,12 +13,33 @@ namespace Octokit.Reactive
     public interface IObservableUserKeysClient
     {
         /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
+        IObservable<PublicKey> GetAll(string userName);
+
+        /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
+        IObservable<PublicKey> GetAll(string userName, ApiOptions options);
+
+        /// <summary>
         /// Gets all public keys for the authenticated user.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-your-public-keys
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>Lists the current user's keys.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<PublicKey> GetAllForCurrent();
 
@@ -28,27 +49,10 @@ namespace Octokit.Reactive
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-your-public-keys
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<PublicKey> GetAllForCurrent(ApiOptions options);
-
-        /// <summary>
-        /// Gets all verified public keys for a user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
-        /// </remarks>
-        /// <returns></returns>
-        IObservable<PublicKey> GetAll(string userName);
-
-        /// <summary>
-        /// Gets all verified public keys for a user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
-        /// </remarks>
-        /// <returns></returns>
-        IObservable<PublicKey> GetAll(string userName, ApiOptions options);
 
         /// <summary>
         /// Retrieves the <see cref="PublicKey"/> for the specified id.
@@ -57,7 +61,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/users/keys/#get-a-single-public-key
         /// </remarks>
         /// <param name="id">The ID of the SSH key</param>
-        /// <returns></returns>
+        /// <returns>View extended details for a single public key.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<PublicKey> Get(int id);
 
@@ -68,7 +72,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/users/keys/#create-a-public-key
         /// </remarks>
         /// <param name="newKey">The SSH Key contents</param>
-        /// <returns></returns>
+        /// <returns>Creates a public key.</returns>
         IObservable<PublicKey> Create(NewPublicKey newKey);
 
         /// <summary>
@@ -78,7 +82,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/users/keys/#delete-a-public-key
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
-        /// <returns></returns>
+        /// <returns>Removes a public key.</returns>
         IObservable<Unit> Delete(int id);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUserKeysClient.cs
@@ -23,6 +23,16 @@ namespace Octokit.Reactive
         IObservable<PublicKey> GetAllForCurrent();
 
         /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<PublicKey> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Gets all verified public keys for a user.
         /// </summary>
         /// <remarks>
@@ -30,6 +40,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns></returns>
         IObservable<PublicKey> GetAll(string userName);
+
+        /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <returns></returns>
+        IObservable<PublicKey> GetAll(string userName, ApiOptions options);
 
         /// <summary>
         /// Retrieves the <see cref="PublicKey"/> for the specified id.

--- a/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
@@ -23,38 +23,13 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <returns></returns>
-        public IObservable<PublicKey> GetAllForCurrent()
-        {
-            return GetAllForCurrent(ApiOptions.None);
-        }
-
-        /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <returns></returns>
-        public IObservable<PublicKey> GetAllForCurrent(ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, "options");
-
-            return _client.GetAllForCurrent(options).ToObservable().SelectMany(k => k);
-        }
-
-        /// <summary>
         /// Gets all verified public keys for a user.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
         public IObservable<PublicKey> GetAll(string userName)
         {
             Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
@@ -68,7 +43,9 @@ namespace Octokit.Reactive
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
         public IObservable<PublicKey> GetAll(string userName, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
@@ -78,13 +55,40 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <returns>Lists the current user's keys.</returns>
+        public IObservable<PublicKey> GetAllForCurrent()
+        {
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
+        public IObservable<PublicKey> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _client.GetAllForCurrent(options).ToObservable().SelectMany(k => k);
+        }
+
+        /// <summary>
         /// Retrieves the <see cref="PublicKey"/> for the specified id.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#get-a-single-public-key
         /// </remarks>
         /// <param name="id">The ID of the SSH key</param>
-        /// <returns></returns>
+        /// <returns>View extended details for a single public key.</returns>
         public IObservable<PublicKey> Get(int id)
         {
             return _client.Get(id).ToObservable();
@@ -97,7 +101,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/users/keys/#create-a-public-key
         /// </remarks>
         /// <param name="newKey">The SSH Key contents</param>
-        /// <returns></returns>
+        /// <returns>Creates a public key.</returns>
         public IObservable<PublicKey> Create(NewPublicKey newKey)
         {
             Ensure.ArgumentNotNull(newKey, "newKey");
@@ -112,7 +116,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/users/keys/#delete-a-public-key
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
-        /// <returns></returns>
+        /// <returns>Removes a public key.</returns>
         public IObservable<Unit> Delete(int id)
         {
             return _client.Delete(id).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
@@ -31,7 +31,21 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<PublicKey> GetAllForCurrent()
         {
-            return _client.GetAllForCurrent().ToObservable().SelectMany(k => k);
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <returns></returns>
+        public IObservable<PublicKey> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _client.GetAllForCurrent(options).ToObservable().SelectMany(k => k);
         }
 
         /// <summary>
@@ -43,7 +57,24 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<PublicKey> GetAll(string userName)
         {
-            return _client.GetAll(userName).ToObservable().SelectMany(k => k);
+            Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
+
+            return GetAll(userName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <returns></returns>
+        public IObservable<PublicKey> GetAll(string userName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _client.GetAll(userName, options).ToObservable().SelectMany(k => k);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/UserKeysClientTests.cs
+++ b/Octokit.Tests/Clients/UserKeysClientTests.cs
@@ -19,7 +19,8 @@ namespace Octokit.Tests.Clients
                 client.GetAllForCurrent();
 
                 connection.Received().GetAll<PublicKey>(
-                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri),
+                    Arg.Any<ApiOptions>());
             }
         }
 
@@ -30,6 +31,7 @@ namespace Octokit.Tests.Clients
             {
                 var client = new UserKeysClient(Substitute.For<IApiConnection>());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("fake", null));
             }
 
             [Fact]
@@ -50,7 +52,8 @@ namespace Octokit.Tests.Clients
                 client.GetAll("auser");
 
                 connection.Received().GetAll<PublicKey>(
-                    Arg.Is<Uri>(u => u.ToString() == expectedUri));
+                    Arg.Is<Uri>(u => u.ToString() == expectedUri),
+                    Arg.Any<ApiOptions>());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrent();
 
-                gitHubClient.User.Keys.Received().GetAllForCurrent();
+                gitHubClient.User.Keys.Received().GetAllForCurrent(Arg.Any<ApiOptions>());
             }
         }
 
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("auser");
 
-                gitHubClient.User.Keys.Received().GetAll("auser");
+                gitHubClient.User.Keys.Received().GetAll("auser", Arg.Any<ApiOptions>());
             }
         }
 

--- a/Octokit/Clients/IUserKeysClient.cs
+++ b/Octokit/Clients/IUserKeysClient.cs
@@ -18,9 +18,20 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-your-public-keys
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>Lists the current user's keys.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<PublicKey>> GetAllForCurrent();
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
         /// Gets all verified public keys for a user.
@@ -28,8 +39,20 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
         Task<IReadOnlyList<PublicKey>> GetAll(string userName);
+
+        /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
+        Task<IReadOnlyList<PublicKey>> GetAll(string userName, ApiOptions options);
 
         /// <summary>
         /// Retrieves the <see cref="PublicKey"/> for the specified id.

--- a/Octokit/Clients/IUserKeysClient.cs
+++ b/Octokit/Clients/IUserKeysClient.cs
@@ -13,27 +13,6 @@ namespace Octokit
     public interface IUserKeysClient
     {
         /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <returns>Lists the current user's keys.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        Task<IReadOnlyList<PublicKey>> GetAllForCurrent();
-
-        /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <param name="options">Options to change API's behavior.</param>
-        /// <returns>Lists the current user's keys.</returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options);
-
-        /// <summary>
         /// Gets all verified public keys for a user.
         /// </summary>
         /// <remarks>
@@ -55,13 +34,34 @@ namespace Octokit
         Task<IReadOnlyList<PublicKey>> GetAll(string userName, ApiOptions options);
 
         /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <returns>Lists the current user's keys.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<PublicKey>> GetAllForCurrent();
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Retrieves the <see cref="PublicKey"/> for the specified id.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#get-a-single-public-key
         /// </remarks>
         /// <param name="id">The ID of the SSH key</param>
-        /// <returns></returns>
+        /// <returns>View extended details for a single public key.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<PublicKey> Get(int id);
 
@@ -72,7 +72,7 @@ namespace Octokit
         /// https://developer.github.com/v3/users/keys/#create-a-public-key
         /// </remarks>
         /// <param name="newKey">The SSH Key contents</param>
-        /// <returns></returns>
+        /// <returns>Creates a public key.</returns>
         Task<PublicKey> Create(NewPublicKey newKey);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit
         /// https://developer.github.com/v3/users/keys/#delete-a-public-key
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
-        /// <returns></returns>
+        /// <returns>Removes a public key.</returns>
         Task Delete(int id);
     }
 }

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -22,10 +22,25 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-your-public-keys
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>Lists the current user's keys.</returns>
         public Task<IReadOnlyList<PublicKey>> GetAllForCurrent()
         {
-            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys());
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <param name="options">Options to chagne API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
+        public Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(), options);
         }
 
         /// <summary>
@@ -34,12 +49,30 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
         /// </remarks>
-        /// <returns></returns>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
         public Task<IReadOnlyList<PublicKey>> GetAll(string userName)
         {
             Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
 
-            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(userName));
+            return GetAll(userName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all verified public keys for a user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-public-keys-for-a-user
+        /// </remarks>
+        /// <param name="userName">The @ handle of the user.</param>
+        /// <param name="options">Options to change API's behavior.</param>
+        /// <returns>Lists the verified public keys for a user.</returns>
+        public Task<IReadOnlyList<PublicKey>> GetAll(string userName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(userName, "userName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(userName), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -17,33 +17,6 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <returns>Lists the current user's keys.</returns>
-        public Task<IReadOnlyList<PublicKey>> GetAllForCurrent()
-        {
-            return GetAllForCurrent(ApiOptions.None);
-        }
-
-        /// <summary>
-        /// Gets all public keys for the authenticated user.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
-        /// </remarks>
-        /// <param name="options">Options to chagne API's behavior.</param>
-        /// <returns>Lists the current user's keys.</returns>
-        public Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, "options");
-
-            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(), options);
-        }
-
-        /// <summary>
         /// Gets all verified public keys for a user.
         /// </summary>
         /// <remarks>
@@ -73,6 +46,33 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(userName), options);
+        }
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <returns>Lists the current user's keys.</returns>
+        public Task<IReadOnlyList<PublicKey>> GetAllForCurrent()
+        {
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all public keys for the authenticated user.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/users/keys/#list-your-public-keys
+        /// </remarks>
+        /// <param name="options">Options to chagne API's behavior.</param>
+        /// <returns>Lists the current user's keys.</returns>
+        public Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PublicKey>(ApiUrls.Keys(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1183.

Adds pagination support in the Users->SSH Keys API.

Checklist:

- [x] ApiOptions overloads and tests on IUserKeysClient.
- [x] ApiOptions overloads and tests on IObservableUserKeysClient.
- [x] Add missing docs.

/cc @shiftkey 