### PR TITLE
Fix common redundancies

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -14,7 +14,7 @@ namespace Octokit.Reactive
         /// <param name="head">The reference to use as the head commit</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
-        IObservable<CompareResult> Compare(string owner, string name, string @base, string @head);
+        IObservable<CompareResult> Compare(string owner, string name, string @base, string head);
 
         /// <summary>
         /// Gets all commits for a given repository

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -297,7 +297,7 @@ public class IssuesClientTests : IDisposable
 
         var newIssue = new NewIssue("A test issue1")
         {
-            Body = "A new unassigned issue",
+            Body = "A new unassigned issue"
         };
         newIssue.Labels.Add("something");
 
@@ -320,7 +320,7 @@ public class IssuesClientTests : IDisposable
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
         {
-            Body = "A new unassigned issue",
+            Body = "A new unassigned issue"
         };
         newIssue.Labels.Add("something");
 
@@ -345,7 +345,7 @@ public class IssuesClientTests : IDisposable
         // setup us the issue
         var newIssue = new NewIssue("A test issue1")
         {
-            Body = "A new unassigned issue",
+            Body = "A new unassigned issue"
         };
         newIssue.Labels.Add("something");
         newIssue.Labels.Add("another thing");

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -249,7 +249,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var data = new PullRequestData
         {
             Sha = createdCommitInBranch.Sha,
-            Number = createdPullRequest.Number,
+            Number = createdPullRequest.Number
         };
 
         return data;
@@ -273,7 +273,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
             Type = TreeType.Blob,
             Mode = FileMode.File,
             Path = treePath,
-            Sha = createdBlob.Sha,
+            Sha = createdBlob.Sha
         });
 
         var createdTree = await _github.Git.Tree.Create(Helper.UserName, repoName, newTree);

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -82,7 +82,7 @@ public class RepositoryCommitsClientTests
             var startOptions = new ApiOptions
             {
                 PageSize = 5,
-                PageCount = 1,
+                PageCount = 1
             };
 
             var skipStartOptions = new ApiOptions

--- a/Octokit.Tests.Integration/Clients/UserAdministrationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserAdministrationClientTests.cs
@@ -91,7 +91,7 @@ namespace Octokit.Tests.Integration.Clients
                 // Create Impersonation token
                 var token = await _github.User.Administration.CreateImpersonationToken(
                     context.UserLogin,
-                    new NewImpersonationToken(new string[] { "public_repo" }));
+                    new NewImpersonationToken(new[] { "public_repo" }));
 
                 Assert.NotNull(token);
                 Assert.True(

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryCommitsClientTests.cs
@@ -51,7 +51,7 @@ namespace Octokit.Tests.Integration.Reactive
                 var startOptions = new ApiOptions
                 {
                     PageSize = 5,
-                    PageCount = 1,
+                    PageCount = 1
                 };
 
                 var skipStartOptions = new ApiOptions

--- a/Octokit.Tests.Integration/Reactive/ObservableUserAdministrationClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserAdministrationClientTests.cs
@@ -94,7 +94,7 @@ namespace Octokit.Tests.Integration.Clients
                 // Create Impersonation token
                 var observable = _github.User.Administration.CreateImpersonationToken(
                     context.UserLogin,
-                    new NewImpersonationToken(new string[] { "public_repo" }));
+                    new NewImpersonationToken(new[] { "public_repo" }));
                 var token = await observable;
 
                 Assert.NotNull(token);

--- a/Octokit.Tests/Clients/GistsClientTests.cs
+++ b/Octokit.Tests/Clients/GistsClientTests.cs
@@ -414,7 +414,7 @@ public class GistsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new GistsClient(connection);
 
-            var options = new ApiOptions()
+            var options = new ApiOptions
             {
                 PageSize = 1,
                 PageCount = 1,

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -100,7 +100,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueCommentsClient(connection);
 
-                var options = new ApiOptions()
+                var options = new ApiOptions
                 {
                     StartPage = 1,
                     PageSize = 1,

--- a/Octokit.Tests/Http/ApiInfoTests.cs
+++ b/Octokit.Tests/Http/ApiInfoTests.cs
@@ -36,7 +36,7 @@ namespace Octokit.Tests.Http
                                 },
                                 new List<string>
                                 {
-                                    "user",
+                                    "user"
                                 },
                                 new List<string>
                                 {


### PR DESCRIPTION
Just continue my war with redundancies in code.

1) redundant @ prefix was removed
2) redundant explicit array type specifications were removed
3) redundant argument list was removed
4) redundant commas in object initializer were removed.

/cc @shiftkey