### PR TITLE
Add ApiOption overloads to methods on IRepoCollaboratorsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -10,8 +10,17 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
         IObservable<User> GetAll(string owner, string repo);
+
+        /// <summary>
+        /// Gets all the available collaborators on this repo.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
+        IObservable<User> GetAll(string owner, string repo, ApiOptions options);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -26,8 +26,8 @@ namespace Octokit.Reactive
         /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
         public IObservable<User> GetAll(string owner, string repo)
         {
-            Ensure.ArgumentNotNull(owner, "owner");
-            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
 
             return GetAll(owner, repo, ApiOptions.None);
         }
@@ -41,8 +41,8 @@ namespace Octokit.Reactive
         /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
         public IObservable<User> GetAll(string owner, string repo, ApiOptions options)
         {
-            Ensure.ArgumentNotNull(owner, "owner");
-            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
             Ensure.ArgumentNotNull(options, "options");
             
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(owner, repo), options);

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -23,14 +23,29 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
         public IObservable<User> GetAll(string owner, string repo)
         {
             Ensure.ArgumentNotNull(owner, "owner");
             Ensure.ArgumentNotNull(repo, "repo");
 
-            var endpoint = ApiUrls.RepoCollaborators(owner, repo);
-            return _connection.GetAndFlattenAllPages<User>(endpoint);
+            return GetAll(owner, repo, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the available collaborators on this repo.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
+        public IObservable<User> GetAll(string owner, string repo, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(owner, "owner");
+            Ensure.ArgumentNotNull(repo, "repo");
+            Ensure.ArgumentNotNull(options, "options");
+            
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(owner, repo), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
@@ -27,6 +24,91 @@ public class RepositoryCollaboratorClientTests
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName);
                 Assert.NotNull(collaborators);
                 Assert.Equal(2, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             }
         }
     }

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Reactive\ObservableUserEmailsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />
     <Compile Include="Reactive\ObservableUserKeysClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryCollaboratorClientTests.cs" />
     <Compile Include="RedirectTests.cs" />
     <Compile Include="Clients\RepositoryCollaboratorClientTests.cs" />
     <Compile Include="SelfTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Octokit;
+using Octokit.Reactive;
+using Octokit.Tests.Integration;
+using Xunit;
+using Octokit.Tests.Integration.Helpers;
+
+public class ObservableRepositoryCollaboratorClientTests
+{
+    public class TheGetAllMethod
+    {
+        [IntegrationTest]
+        public async Task ReturnsAllCollaborators()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = new ObservableRepoCollaboratorsClient(github);
+
+                // add a collaborator
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName).ToList();
+                Assert.NotNull(collaborators);
+                Assert.Equal(2, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = new ObservableRepoCollaboratorsClient(github);
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options).ToList();
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = new ObservableRepoCollaboratorsClient(github);
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options).ToList();
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = new ObservableRepoCollaboratorsClient(github);
+
+                // add some collaborators
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+        }
+    }
+
+    public class TheIsCollaboratorMethod
+    {
+        [IntegrationTest]
+        public async Task ReturnsTrueIfUserIsCollaborator()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = new ObservableRepoCollaboratorsClient(github);
+
+                // add a collaborator
+                fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var isCollab = await fixture.IsCollaborator(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                Assert.True(isCollab);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAll("fake", "repo", options);
+                client.GetAll("owner", "test", options);
 
                 connection.Received()
                     .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepoCollaboratorsClient(connection);
 
                 client.GetAll("owner", "test");
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"));
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);
             }
 
             [Fact]
@@ -51,7 +51,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("owner", "test", options);
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);
+                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -36,6 +36,25 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("fake", "repo", options);
+
+                connection.Received()
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
@@ -44,6 +63,10 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "test"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "test", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "test", null));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepoCollaboratorsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentStatusClientTests.cs" />
     <Compile Include="Reactive\ObservableEventsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Octokit.Tests.Helpers;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepoCollaboratorsClientTests
+    {
+        public class TheGetAllMethod
+        {
+            private readonly IGitHubClient _githubClient;
+            private readonly IObservableRepoCollaboratorsClient _client;
+            private const string owner = "owner";
+            private const string name = "name";
+
+            public TheGetAllMethod()
+            {
+                _githubClient = Substitute.For<IGitHubClient>();
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, name));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, null));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, name, null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                Assert.Throws<ArgumentException>(() => _client.GetAll("", name));
+                Assert.Throws<ArgumentException>(() => _client.GetAll(owner, ""));
+            }
+
+            [Fact]
+            public async Task EnsuresNonWhitespaceArguments()
+            {
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.GetAll(whitespace, name));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.GetAll(owner, whitespace));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var expectedUrl = string.Format("repos/{0}/{1}/collaborators", owner, name);
+
+                _client.GetAll(owner, name);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
+                        Arg.Any<string>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var expectedUrl = string.Format("repos/{0}/{1}/collaborators", owner, name);
+
+                // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                _client.GetAll(owner, name, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                        null);
+
+                // StartPage is setted => only 1 option (StartPage) in dictionary
+                options = new ApiOptions
+                {
+                    StartPage = 1
+                };
+
+                _client.GetAll(owner, name, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                        null);
+
+                // PageCount is setted => none of options in dictionary
+                options = new ApiOptions
+                {
+                    PageCount = 1
+                };
+
+                _client.GetAll(owner, name, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                        null);
+            }
+        }
+
+        public class TheAddMethod
+        {
+            private readonly IGitHubClient _githubClient;
+            private IObservableRepoCollaboratorsClient _client;
+
+            public TheAddMethod()
+            {
+                _githubClient = Substitute.For<IGitHubClient>();
+            }
+
+            private void SetupWithoutNonReactiveClient()
+            {
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            private void SetupWithNonReactiveClient()
+            {
+                var deploymentsClient = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
+                _githubClient.Repository.Collaborator.Returns(deploymentsClient);
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentNullException>(() => _client.Add(null, "repo", "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.Add("owner", null, "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.Add("owner", "repo", null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => _client.Add("", "repo", "user"));
+                Assert.Throws<ArgumentException>(() => _client.Add("owner", "", "user"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonWhitespaceArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Add(whitespace, "repo", "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Add("owner", whitespace, "user"));
+            }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClient()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.Add("owner", "repo", "user");
+
+                _githubClient.Repository.Collaborator.Received(1).Add(Arg.Is("owner"),
+                    Arg.Is("repo"),
+                    Arg.Is("user"));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableRepoCollaboratorsClient(null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -19,9 +19,24 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string repo);
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        Task<IReadOnlyList<User>> GetAll(string owner, string repo, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repo

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -28,6 +28,8 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
         public Task<IReadOnlyList<User>> GetAll(string owner, string repo)
@@ -35,8 +37,27 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
 
-            var endpoint = ApiUrls.RepoCollaborators(owner, repo);
-            return ApiConnection.GetAll<User>(endpoint);
+            return GetAll(owner, repo, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="repo">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        public Task<IReadOnlyList<User>> GetAll(string owner, string repo, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, repo), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Refer #1170

To-do:

- [x] Add overload  Task<IReadOnlyList<User>> GetAll(string owner, string repo, ApiOptions options) on IRepoCollaboratorsClient.
- [x] Add overload IObservable<User> GetAll(string owner, string repo, ApiOptions options) on IObservableRepoCollaboratorsClient.
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods.

Unfortunately, I haven't found the approach to add more than 2 users on integration tests. So, there are only two users in each test case: user configured on local machine ("dampirtest" for my PC) and "m-zuber-octokit-integration-tests". How and where "m-zuber-octokit-integration-tests" was added as repository user I not found.

/cc @shiftkey, @ryangribble 