### PR TITLE
Fixed inconsistency in ApiUrls.cs

### DIFF
--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -557,11 +557,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="milestoneNumber">The milestone number</param>
+        /// <param name="labelName">The name of label</param>
         /// <returns></returns>
-        public static Uri Label(string owner, string name, string milestoneNumber)
+        public static Uri Label(string owner, string name, string labelName)
         {
-            return "repos/{0}/{1}/labels/{2}".FormatUri(owner, name, milestoneNumber);
+            return "repos/{0}/{1}/labels/{2}".FormatUri(owner, name, labelName);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -605,11 +605,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The milestone number</param>
+        /// <param name="labelName">The label name</param>
         /// <returns></returns>
-        public static Uri MilestoneLabels(string owner, string name, int number)
+        public static Uri MilestoneLabels(string owner, string name, int labelName)
         {
-            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, number);
+            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, labelName);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -556,60 +556,60 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that returns the specified label.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The milestone number</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="milestoneNumber">The milestone number</param>
         /// <returns></returns>
-        public static Uri Label(string owner, string repo, string name)
+        public static Uri Label(string owner, string name, string milestoneNumber)
         {
-            return "repos/{0}/{1}/labels/{2}".FormatUri(owner, repo, name);
+            return "repos/{0}/{1}/labels/{2}".FormatUri(owner, name, milestoneNumber);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the labels for the specified repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        public static Uri Labels(string owner, string repo)
+        public static Uri Labels(string owner, string name)
         {
-            return "repos/{0}/{1}/labels".FormatUri(owner, repo);
+            return "repos/{0}/{1}/labels".FormatUri(owner, name);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns the named label for the specified issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <param name="name">The name of the label</param>
+        /// <param name="labelName">The name of the label</param>
         /// <returns></returns>
-        public static Uri IssueLabel(string owner, string repo, int number, string name)
+        public static Uri IssueLabel(string owner, string name, int number, string labelName)
         {
-            return "repos/{0}/{1}/issues/{2}/labels/{3}".FormatUri(owner, repo, number, name);
+            return "repos/{0}/{1}/issues/{2}/labels/{3}".FormatUri(owner, name, number, labelName);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the labels for the specified issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLabels(string owner, string repo, int number)
+        public static Uri IssueLabels(string owner, string name, int number)
         {
-            return "repos/{0}/{1}/issues/{2}/labels".FormatUri(owner, repo, number);
+            return "repos/{0}/{1}/issues/{2}/labels".FormatUri(owner, name, number);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the labels for all issues in the specified milestone.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        public static Uri MilestoneLabels(string owner, string repo, int number)
+        public static Uri MilestoneLabels(string owner, string name, int number)
         {
-            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, repo, number);
+            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, number);
         }
 
         /// <summary>
@@ -628,47 +628,47 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that lists the repository hooks for the specified reference.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        public static Uri RepositoryHooks(string owner, string repositoryName)
+        public static Uri RepositoryHooks(string owner, string name)
         {
-            return "repos/{0}/{1}/hooks".FormatUri(owner, repositoryName);
+            return "repos/{0}/{1}/hooks".FormatUri(owner, name);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that gets the repository hook for the specified reference.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns></returns>
-        public static Uri RepositoryHookById(string owner, string repositoryName, int hookId)
+        public static Uri RepositoryHookById(string owner, string name, int hookId)
         {
-            return "repos/{0}/{1}/hooks/{2}".FormatUri(owner, repositoryName, hookId);
+            return "repos/{0}/{1}/hooks/{2}".FormatUri(owner, name, hookId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that can tests a specified repository hook
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns></returns>
-        public static Uri RepositoryHookTest(string owner, string repositoryName, int hookId)
+        public static Uri RepositoryHookTest(string owner, string name, int hookId)
         {
-            return "repos/{0}/{1}/hooks/{2}/tests".FormatUri(owner, repositoryName, hookId);
+            return "repos/{0}/{1}/hooks/{2}/tests".FormatUri(owner, name, hookId);
         }
 
         /// <summary>
         /// Returns the <see cref="Uri"/> that can ping a specified repository hook
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns></returns>
-        public static Uri RepositoryHookPing(string owner, string repositoryName, int hookId)
+        public static Uri RepositoryHookPing(string owner, string name, int hookId)
         {
-            return "repos/{0}/{1}/hooks/{2}/pings".FormatUri(owner, repositoryName, hookId);
+            return "repos/{0}/{1}/hooks/{2}/pings".FormatUri(owner, name, hookId);
         }
 
         /// <summary>
@@ -699,11 +699,11 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> that lists the repository forks for the specified reference.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        public static Uri RepositoryForks(string owner, string repositoryName)
+        public static Uri RepositoryForks(string owner, string name)
         {
-            return "repos/{0}/{1}/forks".FormatUri(owner, repositoryName);
+            return "repos/{0}/{1}/forks".FormatUri(owner, name);
         }
 
         /// <summary>
@@ -945,7 +945,7 @@ namespace Octokit
         {
             return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, number);
         }
-
+        
         public static Uri PullRequestFiles(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/files".FormatUri(owner, name, number);
@@ -1273,22 +1273,22 @@ namespace Octokit
         /// use for update or deleting a team
         /// </summary>
         /// <param name="owner">owner of repo</param>
-        /// <param name="repo">name of repo</param>
+        /// <param name="name">name of repo</param>
         /// <returns></returns>
-        public static Uri RepoCollaborators(string owner, string repo)
+        public static Uri RepoCollaborators(string owner, string name)
         {
-            return "repos/{0}/{1}/collaborators".FormatUri(owner, repo);
+            return "repos/{0}/{1}/collaborators".FormatUri(owner, name);
         }
 
         /// <summary>
         /// returns the <see cref="Uri"/> for branches
         /// </summary>
         /// <param name="owner">owner of repo</param>
-        /// <param name="repo">name of repo</param>
+        /// <param name="name">name of repo</param>
         /// <returns></returns>
-        public static Uri RepoBranches(string owner, string repo)
+        public static Uri RepoBranches(string owner, string name)
         {
-            return "repos/{0}/{1}/branches".FormatUri(owner, repo);
+            return "repos/{0}/{1}/branches".FormatUri(owner, name);
         }
 
         /// <summary>
@@ -1418,12 +1418,12 @@ namespace Octokit
         /// Returns the <see cref="Uri"/> for a repository branch.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns></returns>
-        public static Uri RepoBranch(string owner, string repositoryName, string branchName)
+        public static Uri RepoBranch(string owner, string name, string branchName)
         {
-            return "repos/{0}/{1}/branches/{2}".FormatUri(owner, repositoryName, branchName);
+            return "repos/{0}/{1}/branches/{2}".FormatUri(owner, name, branchName);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -605,11 +605,11 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="labelName">The label name</param>
+        /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        public static Uri MilestoneLabels(string owner, string name, int labelName)
+        public static Uri MilestoneLabels(string owner, string name, int number)
         {
-            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, labelName);
+            return "repos/{0}/{1}/milestones/{2}/labels".FormatUri(owner, name, number);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -945,7 +945,13 @@ namespace Octokit
         {
             return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, number);
         }
-        
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns the files on a pull request.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The pull request number</param>
         public static Uri PullRequestFiles(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/files".FormatUri(owner, name, number);

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1603,6 +1603,14 @@ namespace Octokit
             return "repos/{0}/{1}/contents/{2}".FormatUri(owner, name, path);
         }
 
+        /// <summary>
+        /// Creates the relative <see cref="Uri"/> for getting an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <returns>The <see cref="Uri"/> for getting an archive of a given repository's contents, in a specific format</returns>
         public static Uri RepositoryArchiveLink(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             return "repos/{0}/{1}/{2}/{3}".FormatUri(owner, name, archiveFormat.ToParameter(), reference);
@@ -1621,16 +1629,34 @@ namespace Octokit
             return "repos/{0}/{1}/contents/{2}?ref={3}".FormatUri(owner, name, path, reference);
         }
 
+        /// <summary>
+        /// Creates the relative <see cref="Uri"/> for getting the page metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> for getting the page metadata for a given repository</returns>
         public static Uri RepositoryPage(string owner, string name)
         {
             return "repos/{0}/{1}/pages".FormatUri(owner, name);
         }
 
+        /// <summary>
+        /// Creates the relative <see cref="Uri"/> for getting all build metadata for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> for getting all build metadata for a given repository</returns>
         public static Uri RepositoryPageBuilds(string owner, string name)
         {
             return "repos/{0}/{1}/pages/builds".FormatUri(owner, name);
         }
 
+        /// <summary>
+        /// Creates the relative <see cref="Uri"/> for getting the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> for getting the build metadata for the last build for a given repository</returns>
         public static Uri RepositoryPageBuildsLatest(string owner, string name)
         {
             return "repos/{0}/{1}/pages/builds/latest".FormatUri(owner, name);

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -711,6 +711,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> that lists the watched repositories for the authenticated user.</returns>
         public static Uri Watchers(string owner, string name)
         {
             return "repos/{0}/{1}/subscribers".FormatUri(owner, name);
@@ -749,6 +750,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> that lists the starred repositories for the authenticated user.</returns>
         public static Uri Stargazers(string owner, string name)
         {
             return "repos/{0}/{1}/stargazers".FormatUri(owner, name);
@@ -930,6 +932,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        /// <returns>The <see cref="Uri"/> that returns the pull request merge state.</returns>
         public static Uri MergePullRequest(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/merge".FormatUri(owner, name, number);
@@ -941,6 +944,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        /// <returns>The <see cref="Uri"/> that returns the commits on a pull request.</returns>
         public static Uri PullRequestCommits(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/commits".FormatUri(owner, name, number);
@@ -952,6 +956,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        /// <returns>The <see cref="Uri"/> that returns the files on a pull request.</returns>
         public static Uri PullRequestFiles(string owner, string name, int number)
         {
             return "repos/{0}/{1}/pulls/{2}/files".FormatUri(owner, name, number);
@@ -1027,6 +1032,9 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> for the network of repositories.
         /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>The <see cref="Uri"/> for the network of repositories.</returns>
         public static Uri NetworkEvents(string owner, string name)
         {
             return "networks/{0}/{1}/events".FormatUri(owner, name);


### PR DESCRIPTION
As part of my work on #1120 I've done some improvements in ApiUrls.cs class. 

I've found that in order to support work with repo by their ID we should add 83 new methods in ApiUrls.cs that would duplicate methods that allow to work with repo by their owner and name identificators.

E.g.

We have the next method in ApiUrls.cs:

```cs
public static Uri RepoBranch(string owner, string name, string branchName)
{
      return "repos/{0}/{1}/branches/{2}".FormatUri(owner, name, branchName);
}
```

So we should add the new one:

```cs
public static Uri RepoBranch(int repositoryId, string branchName)
{
      return "repositories/{0}/branches/{1}".FormatUri(repositoryId, branchName);
}
```

Because of the fact that we should add 83 new methods, I've decided to generate them programmatically. And in order to get appropriate result of code generation, I've done some useful changes in ApiUrls.cs.

- [x]  Added XML documentation for needed methods.
- [x] Rename some method's parameters on order to eliminate conflicts of parameter's names.
- [x] Most of ApiUrls methods use "owner" and "name" as name of parameters that identify repository. But some of them use "repositoryName" or "repo" as parameter name. Now all of such methods use consistent parameter names: "owner" and "name".

BTW, I've implemented program that generate new 83 methods. Here is the [repo](https://github.com/dampir/OctokitUrlMethodsGenerator) and here is the [file](https://github.com/dampir/OctokitUrlMethodsGenerator/blob/master/new_methods.txt) with new generated methods. All methods contains appropriate XML documentation in many cases better than their original prototypes. I'm going to pull these methods in next PR after this one would be merged.

Now I'm thinking about how to validate them against their prototypes, how to check that each pair of methods returns equal results (e.g. RepoBranch(string owner, string name, string branchName) and RepoBranch(int repositoryId, string branchName) should return an equal JSONs if repositoryId is according to owner and name of repository).

/cc @shiftkey , @ryangribble 