### PR TITLE
Add actual "GetAllForRepository" Activity Feed

### DIFF
--- a/Octokit.Reactive/Clients/IObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEventsClient.cs
@@ -48,6 +48,29 @@ namespace Octokit.Reactive
         IObservable<Activity> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllIssuesForRepository(string owner, string name);
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets all the events for a given repository network
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -74,6 +74,42 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
+            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.Events(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllIssuesForRepository(string owner, string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.IssuesEvents(owner, name), options);
         }
 

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAllForRepository(owner, name, ApiOptions.None);
+            return GetAllIssuesForRepository(owner, name, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableEventsClientTests.cs
@@ -159,6 +159,82 @@ namespace Octokit.Tests.Integration.Reactive
 
         }
 
+        public class TheGetAllIssuesForRepositoryMethod
+        {
+            readonly ObservableEventsClient _eventsClient;
+            const string owner = "octokit";
+            const string name = "octokit.net";
+
+            public TheGetAllIssuesForRepositoryMethod()
+            {
+                _eventsClient = new ObservableEventsClient(Helper.GetAuthenticatedClient());
+            }
+            [IntegrationTest]
+            public async Task ReturnsRepositoryEvents()
+            {
+                var repositoryEvents = await _eventsClient.GetAllIssuesForRepository(owner, name).ToList();
+
+                Assert.NotEmpty(repositoryEvents);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfRepositoryEventsWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var repositoryEvents = await _eventsClient.GetAllIssuesForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, repositoryEvents.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfRepositoryEventsWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var repositoryEvents = await _eventsClient.GetAllIssuesForRepository(owner, name, options).ToList();
+
+                Assert.Equal(5, repositoryEvents.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctRepositoryEventsBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var firstRepositoryEventsPage = await _eventsClient.GetAllIssuesForRepository(owner, name, startOptions).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondRepositoryEventsPage = await _eventsClient.GetAllIssuesForRepository(owner, name, skipStartOptions).ToList();
+
+                Assert.NotEqual(firstRepositoryEventsPage[0].Id, secondRepositoryEventsPage[0].Id);
+                Assert.NotEqual(firstRepositoryEventsPage[1].Id, secondRepositoryEventsPage[1].Id);
+                Assert.NotEqual(firstRepositoryEventsPage[2].Id, secondRepositoryEventsPage[2].Id);
+                Assert.NotEqual(firstRepositoryEventsPage[3].Id, secondRepositoryEventsPage[3].Id);
+                Assert.NotEqual(firstRepositoryEventsPage[4].Id, secondRepositoryEventsPage[4].Id);
+            }
+
+        }
+
         public class TheGetAllForRepositoryNetworkMethod
         {
             readonly ObservableEventsClient _eventsClient;

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -72,6 +72,53 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("fake", "repo");
 
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/events"), Args.ApiOptions);
+            }
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+
+                client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/events"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name",null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "",ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+            }
+        }
+
+        public class TheGetAllIssuesForRepositoryMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                client.GetAllForRepository("fake", "repo");
+
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
             }
             [Fact]
@@ -103,8 +150,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name",null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "",ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
             }
         }

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -117,7 +117,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllForRepository("fake", "repo");
+                client.GetAllIssuesForRepository("fake", "repo");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
             }
@@ -135,7 +135,7 @@ namespace Octokit.Tests.Clients
                 };
 
 
-                client.GetAllForRepository("fake", "repo", options);
+                client.GetAllIssuesForRepository("fake", "repo", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), options);
             }
@@ -146,13 +146,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                client.GetAllForRepository("fake", "repo");
+                client.GetAllIssuesForRepository("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
             }
@@ -79,10 +79,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", "").ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]
@@ -96,7 +96,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepositoryNetwork("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("networks/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("networks/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -44,7 +44,33 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public async Task EnsuresArgumentsNotNull()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
+            }
+        }
+
+        public class TheGetAllIssuesForRepositoryMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                client.GetAllForRepository("fake", "repo");
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -96,7 +96,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepositoryNetwork("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("networks/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("networks/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -51,7 +51,7 @@ namespace Octokit
         /// Gets all the events for a given repository
         /// </summary>
         /// <remarks>
-        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// https://developer.github.com/v3/activity/events/#list-repository-events
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -68,7 +68,7 @@ namespace Octokit
         /// Gets all the events for a given repository
         /// </summary>
         /// <remarks>
-        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// https://developer.github.com/v3/activity/events/#list-repository-events
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -80,7 +80,44 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(owner, name),options);
+            return ApiConnection.GetAll<Activity>(ApiUrls.Events(owner, name), options);
+        }
+
+
+        /// <summary>
+        /// Gets all the event issues for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllIssuesForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the event issues for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(owner, name), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -54,7 +54,28 @@ namespace Octokit
         /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options);
 
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name);
 
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -495,6 +495,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        public static Uri Events(string owner, string name)
+        {
+            return "repos/{0}/{1}/events".FormatUri(owner, name);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
Currently in EventsClient, "GetAllForRepository" actually gets the Issues activity feed, rather than the actual repository activity feed. This commit fixes that by adding "GetAllIssuesForRepository" and changing "GetAllForRepository" to correctly use the right endpoint.