### PR TITLE
#1285 Updated the ReadTheDocs link to .io

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Xamarin Studio you can find this option under the project's context menu: **A
 
 ## Documentation
 
-Documentation is available at http://octokitnet.readthedocs.org/en/latest/.
+Documentation is available at http://octokitnet.readthedocs.io/en/latest/.
 
 ## Build
 


### PR DESCRIPTION
Fixes #1285 
I looked to the rest of the documentation, but couldn't find another reference to Read The Docs, besides the one in the readme file.