### PR TITLE
Add ApiOptions overloads to methods on I(Observable)RepositoryDeployKeysClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -29,6 +29,17 @@ namespace Octokit.Reactive
         IObservable<DeployKey> GetAll(string owner, string name);
 
         /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Creates a new deploy key for a repository.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -48,7 +48,25 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name));
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name), options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 deployKeysClient.GetAll("user", "repo");
 
-                apiConnection.Received().GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"));
+                apiConnection.Received().GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"), Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -59,14 +59,46 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void GetsAListOfDeployKeysWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryDeployKeysClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("user", "repo", options);
+
+                connection.Received(1)
+                    .GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"),
+                        options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var deployKeysClient = new RepositoryDeployKeysClient(Substitute.For<IApiConnection>());
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo"));
-                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", "repo", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("user", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -57,7 +57,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void GetsCorrectUrlWithApiOption()
+            public void GetsCorrectUrlWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -53,7 +53,7 @@ namespace Octokit.Tests.Reactive
                 deployKeysClient.GetAll("user", "repo");
 
                 githubClient.Connection.Received(1).Get<List<DeployKey>>(
-                    new Uri("repos/user/repo/keys", UriKind.Relative), null, null);
+                    new Uri("repos/user/repo/keys", UriKind.Relative), Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -57,14 +57,72 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void GetsCorrectUrlWithApiOption()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+                var expectedUrl = string.Format("repos/{0}/{1}/keys", "user", "repo");
+
+                // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                deployKeysClient.GetAll("user", "repo", options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                        null);
+
+                // StartPage is setted => only 1 option (StartPage) in dictionary
+                options = new ApiOptions
+                {
+                    StartPage = 1
+                };
+
+                deployKeysClient.GetAll("user", "repo", options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                        null);
+
+                // PageCount is setted => none of options in dictionary
+                options = new ApiOptions
+                {
+                    PageCount = 1
+                };
+
+                deployKeysClient.GetAll("user", "repo", options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                        null);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(Substitute.For<IGitHubClient>());
 
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo"));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null));
+
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, null));
+
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", null));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, null));
+
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", "repo", null));
+
                 Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("user", ""));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
             }
         }
 

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -35,6 +35,17 @@ namespace Octokit
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name);
 
         /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Creates a new deploy key for a repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -53,7 +53,25 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name));
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Refer #1175 .

To-do:

- [x]  Add overload Task> GetAll(ApiOptions options) on IRepositoryDeployKeysClient.
- [x]  Add overload IObservable GetAll(ApiOptions options) on IObservableRepositoryDeployKeysClient.
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods.
       I've implemented the integration tests, but they are skipped now, because we don't have opportunity generate ssh keys in C# code (#1003).
       Also I haven't implemented integration tests for ObservableRepositoryDeployKeysClient because internally ObservableRepositoryDeployKeysClient use RepositoryDeployKeysClient that have integration tests already (just they skipped :smile: ).

/cc @shiftkey , @ryangribble 