### PR TITLE
Add ApiOption overloads to methods on I(Observable)ReleasesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -111,6 +111,20 @@ namespace Octokit.Reactive
         IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id);
 
         /// <summary>
+        /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-assets-for-a-release">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="id">The id of the <see cref="Release"/>.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="ReleaseAsset"/> for the specified release of the specified repository.</returns>
+        IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id, ApiOptions options);
+
+        /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -168,7 +168,28 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<ReleaseAsset>(ApiUrls.ReleaseAssets(owner, name, id));
+            return GetAllAssets(owner, name, id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-assets-for-a-release">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="id">The id of the <see cref="Release"/>.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="ReleaseAsset"/> for the specified release of the specified repository.</returns>
+        public IObservable<ReleaseAsset> GetAllAssets(string owner, string name, int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<ReleaseAsset>(ApiUrls.ReleaseAssets(owner, name, id), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -226,6 +226,9 @@ public class ReleasesClientTests
         readonly IGitHubClient _github;
         readonly RepositoryContext _context;
         readonly IReleasesClient _releaseClient;
+        const string owner = "octokit";
+        const string name = "octokit.net";
+        const int releaseId = 2248679;
 
         public TheUploadAssetMethod()
         {
@@ -301,6 +304,7 @@ public class ReleasesClientTests
 
             Assert.Contains("This is a plain text file.", Encoding.ASCII.GetString((byte[])response.Body));
         }
+
         [IntegrationTest]
         public async Task CanDownloadBinaryAsset()
         {
@@ -338,6 +342,57 @@ public class ReleasesClientTests
             Assert.Contains("This is a plain text file.", textContent);
         }
 
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfReleasesWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 2,
+                PageCount = 1
+            };
+
+            var releases = await _releaseClient.GetAllAssets(owner, name, releaseId, options);
+
+            Assert.Equal(2, releases.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfReleasesWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var assets = await _releaseClient.GetAllAssets(owner, name, releaseId, options);
+
+            Assert.Equal(1, assets.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPage()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await _releaseClient.GetAllAssets(owner, name, releaseId, startOptions);
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondPage = await _releaseClient.GetAllAssets(owner, name, releaseId, skipStartOptions);
+
+            Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+        }
 
         public void Dispose()
         {

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -249,7 +248,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, Args.ApiOptions));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, null));
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -232,7 +232,8 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllAssets("fake", "repo", 1, options);
 
-                connection.Received().GetAll<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
+                connection.Received().GetAll<ReleaseAsset>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
                     null,
                     "application/vnd.github.v3", options);
             }

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -235,7 +236,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<ReleaseAsset>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
                     null,
-                    "application/vnd.github.v3", Args.ApiOptions);
+                    "application/vnd.github.v3", options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -235,7 +235,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<ReleaseAsset>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
                     null,
-                    "application/vnd.github.v3", options);
+                    "application/vnd.github.v3", Args.ApiOptions);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Octokit.Tests.Clients
 {
-    public class ReleasesClientTests
+    public class    ReleasesClientTests
     {
         public class TheCtor
         {
@@ -243,14 +243,12 @@ namespace Octokit.Tests.Clients
             {
                 var client = new ReleasesClient(Substitute.For<IApiConnection>());
                 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", "name", 1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllAssets("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllAssets("owner", "", 1));

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -259,7 +259,7 @@ namespace Octokit.Tests.Clients
         public class TheUploadReleaseAssetMethod
         {
             [Fact]
-            public async void UploadsToCorrectUrl()
+            public async Task UploadsToCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -21,7 +21,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public async void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
         public class TheGetReleaseMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -98,7 +98,7 @@ namespace Octokit.Tests.Clients
         public class TheGetLatestReleaseMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -122,7 +122,7 @@ namespace Octokit.Tests.Clients
         public class TheCreateReleaseMethod
         {
             [Fact]
-            public async void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
@@ -151,7 +151,7 @@ namespace Octokit.Tests.Clients
         public class TheEditReleaseMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(connection);
@@ -179,7 +179,7 @@ namespace Octokit.Tests.Clients
         public class TheDeleteReleaseMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -204,7 +204,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAssetsMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -218,7 +218,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async void RequestsTheCorrectUrlWithApiOptions()
+            public async Task RequestsTheCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -308,7 +308,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAssetMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -333,7 +333,7 @@ namespace Octokit.Tests.Clients
         public class TheEditAssetMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
@@ -361,7 +361,7 @@ namespace Octokit.Tests.Clients
         public class TheDeleteAssetMethod
         {
             [Fact]
-            public async void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -21,12 +21,12 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async void RequestsCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
 
-                releasesClient.GetAll("fake", "repo");
+                await releasesClient.GetAll("fake", "repo");
 
                 client.Received().GetAll<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
                     null,
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async void RequestsCorrectUrlWithApiOptions()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                releasesClient.GetAll("fake", "repo", options);
+                await releasesClient.GetAll("fake", "repo", options);
 
                 client.Received().GetAll<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
                     null,
@@ -73,12 +73,12 @@ namespace Octokit.Tests.Clients
         public class TheGetReleaseMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.Get("fake", "repo", 1);
+                await client.Get("fake", "repo", 1);
 
                 connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1"));
             }
@@ -98,12 +98,12 @@ namespace Octokit.Tests.Clients
         public class TheGetLatestReleaseMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.GetLatest("fake", "repo");
+                await client.GetLatest("fake", "repo");
 
                 connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/latest"));
             }
@@ -122,13 +122,13 @@ namespace Octokit.Tests.Clients
         public class TheCreateReleaseMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async void RequestsCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
                 var data = new NewRelease("fake-tag");
 
-                releasesClient.Create("fake", "repo", data);
+                await releasesClient.Create("fake", "repo", data);
 
                 client.Received().Post<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases"),
                     data,
@@ -151,13 +151,13 @@ namespace Octokit.Tests.Clients
         public class TheEditReleaseMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(connection);
                 var data = new ReleaseUpdate { TagName = "fake-tag" };
 
-                releasesClient.Edit("fake", "repo", 1, data);
+                await releasesClient.Edit("fake", "repo", 1, data);
 
                 connection.Received().Patch<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1"), data);
             }
@@ -179,12 +179,12 @@ namespace Octokit.Tests.Clients
         public class TheDeleteReleaseMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.Delete("fake", "repo", 1);
+                await client.Delete("fake", "repo", 1);
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1"));
             }
@@ -204,26 +204,54 @@ namespace Octokit.Tests.Clients
         public class TheGetAssetsMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.GetAllAssets("fake", "repo", 1);
+                await client.GetAllAssets("fake", "repo", 1);
 
                 connection.Received().GetAll<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
                     null,
-                    "application/vnd.github.v3");
+                    "application/vnd.github.v3",
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReleasesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllAssets("fake", "repo", 1, options);
+
+                connection.Received().GetAll<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/1/assets"),
+                    null,
+                    "application/vnd.github.v3", options);
             }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ReleasesClient(Substitute.For<IApiConnection>());
-
+                
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllAssets("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, Args.ApiOptions));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllAssets("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllAssets("owner", "", 1));
             }
         }
@@ -231,7 +259,7 @@ namespace Octokit.Tests.Clients
         public class TheUploadReleaseAssetMethod
         {
             [Fact]
-            public void UploadsToCorrectUrl()
+            public async void UploadsToCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var releasesClient = new ReleasesClient(client);
@@ -239,7 +267,7 @@ namespace Octokit.Tests.Clients
                 var rawData = Substitute.For<Stream>();
                 var upload = new ReleaseAssetUpload("example.zip", "application/zip", rawData, null);
 
-                releasesClient.UploadAsset(release, upload);
+                await releasesClient.UploadAsset(release, upload);
 
                 client.Received().Post<ReleaseAsset>(
                     Arg.Is<Uri>(u => u.ToString() == "https://uploads.test.dev/does/not/matter/releases/1/assets?name=example.zip"),
@@ -280,12 +308,12 @@ namespace Octokit.Tests.Clients
         public class TheGetAssetMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.GetAsset("fake", "repo", 1);
+                await client.GetAsset("fake", "repo", 1);
 
                 connection.Received().Get<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"));
             }
@@ -305,13 +333,13 @@ namespace Octokit.Tests.Clients
         public class TheEditAssetMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
                 var data = new ReleaseAssetUpdate("asset");
 
-                client.EditAsset("fake", "repo", 1, data);
+                await client.EditAsset("fake", "repo", 1, data);
 
                 connection.Received().Patch<ReleaseAsset>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"),
                     data);
@@ -333,12 +361,12 @@ namespace Octokit.Tests.Clients
         public class TheDeleteAssetMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReleasesClient(connection);
 
-                client.DeleteAsset("fake", "repo", 1);
+                await client.DeleteAsset("fake", "repo", 1);
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/assets/1"));
             }

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -212,14 +212,12 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableReleasesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", "name", 1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllAssets("", "name", 1));
                 Assert.Throws<ArgumentException>(() => client.GetAllAssets("owner", "", 1));

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -188,6 +188,8 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void RequestsTheCorrectUrlWithApiOptions()
             {
+                var expectedUrl = string.Format("repos/{0}/{1}/releases/1/assets", "fake", "repo");
+
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableReleasesClient(gitHubClient);
 
@@ -199,9 +201,11 @@ namespace Octokit.Tests.Reactive
                 };
 
                 client.GetAllAssets("fake", "repo", 1, options);
-
+                
                 gitHubClient.Connection.Received(1).Get<List<ReleaseAsset>>(
-                    new Uri("repos/fake/repo/releases/1/assets", UriKind.Relative), Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2), null);
+                    Arg.Is<Uri>(u => u.ToString() == expectedUrl), 
+                    Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2), 
+                    null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reactive.Linq;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -218,7 +217,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, Args.ApiOptions));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllAssets(null, "name", 1, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllAssets("owner", null, 1, null));
 

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -119,6 +119,20 @@ namespace Octokit
         Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id);
 
         /// <summary>
+        /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-assets-for-a-release">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="id">The id of the <see cref="Release"/>.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="ReleaseAsset"/> for the specified release of the specified repository.</returns>
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id, ApiOptions options);
+
+        /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -178,8 +178,29 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
+            return GetAllAssets(owner, name, id, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#list-assets-for-a-release">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="id">The id of the <see cref="Release"/>.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The list of <see cref="ReleaseAsset"/> for the specified release of the specified repository.</returns>
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             var endpoint = ApiUrls.ReleaseAssets(owner, name, id);
-            return ApiConnection.GetAll<ReleaseAsset>(endpoint, null, AcceptHeaders.StableVersion);
+            return ApiConnection.GetAll<ReleaseAsset>(endpoint, null, AcceptHeaders.StableVersion, options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1169

To-do:

- [x]  Add overloads on IReleasesClient.
- [x]  Add overloads on IObservableReleasesClient.
- [x]  Add unit tests for these new methods.
        Also I've added await\async modifiers into unit tests class ReleasesClientTests.cs , because I suppose these modifiers should be there to get determined results of tests, shouldn't be?
- [x]  Add integration tests for these new methods.

/cc @shiftkey , @ryangribble all is done, but there are some strange failures in test cases.
