### PR TITLE
Add ApiOption overloads to methods on I(Observable)RepositoryCommentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
@@ -28,6 +28,16 @@ namespace Octokit.Reactive
         IObservable<CommitComment> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        IObservable<CommitComment> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Commit Comments for a specified Commit.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
@@ -36,6 +46,17 @@ namespace Octokit.Reactive
         /// <param name="sha">The sha of the commit</param>
         /// <returns></returns>
         IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha);
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
@@ -46,7 +46,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public IObservable<CommitComment> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name), options);
         }
 
         /// <summary>
@@ -63,7 +80,26 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
-            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name, sha));
+            return GetAllForCommit(owner, name, sha, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public IObservable<CommitComment> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<CommitComment>(ApiUrls.CommitComments(owner, name, sha), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
@@ -1,0 +1,370 @@
+﻿using System;
+using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
+using Xunit;
+
+public class RepositoryCommentsClientTests
+{
+    public class TheGetMethod
+    {
+        readonly IRepositoryCommentsClient _fixture;
+        const string owner = "octocat";
+        const string name = "Hello-World";
+
+        public TheGetMethod()
+        {
+            var client = Helper.GetAuthenticatedClient();
+
+            _fixture = client.Repository.Comment;
+        }
+
+        [IntegrationTest]
+        public async Task CanGetComment()
+        {
+            var commit = await _fixture.Get(owner, name, 1467023);
+            Assert.NotNull(commit);
+        }
+    }
+
+    public class TheGetAllForRepositoryMethod
+    {
+        readonly IRepositoryCommentsClient _fixture;
+        const string owner = "octocat";
+        const string name = "Hello-World";
+
+        public TheGetAllForRepositoryMethod()
+        {
+            var client = Helper.GetAuthenticatedClient();
+
+            _fixture = client.Repository.Comment;
+        }
+
+        [IntegrationTest]
+        public async Task CanGetListOfCommentsForRepository()
+        {
+            var list = await _fixture.GetAllForRepository(owner, name);
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommentsWithoutStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var commits = await _fixture.GetAllForRepository(owner, name, options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommentsWithStart()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var commits = await _fixture.GetAllForRepository(owner, name, options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStart()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var firstCommit = await _fixture.GetAllForRepository(owner, name, startOptions);
+            var secondCommit = await _fixture.GetAllForRepository(owner, name, skipStartOptions);
+
+            Assert.NotEqual(firstCommit[0].Id, secondCommit[0].Id);
+            Assert.NotEqual(firstCommit[1].Id, secondCommit[1].Id);
+            Assert.NotEqual(firstCommit[2].Id, secondCommit[2].Id);
+            Assert.NotEqual(firstCommit[3].Id, secondCommit[3].Id);
+            Assert.NotEqual(firstCommit[4].Id, secondCommit[4].Id);
+        }
+    }
+
+    public class TheGetAllForCommitMethod
+    {
+        readonly IRepositoryCommentsClient _fixture;
+        const string owner = "octocat";
+        const string name = "Hello-World";
+
+        public TheGetAllForCommitMethod()
+        {
+            var client = Helper.GetAuthenticatedClient();
+
+            _fixture = client.Repository.Comment;
+        }
+
+        [IntegrationTest]
+        public async Task CanGetListOfCommentsForCommit()
+        {
+            var list = await _fixture.GetAllForCommit(owner, name, "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d");
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommentsWithoutStartForCommit()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var commits = await _fixture.GetAllForCommit(owner, name, "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommentsWithStartForCommit()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var commits = await _fixture.GetAllForCommit(owner, name, "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartForCommit()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var firstCommit = await _fixture.GetAllForCommit(owner, name, "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", startOptions);
+            var secondCommit = await _fixture.GetAllForCommit(owner, name, "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", skipStartOptions);
+
+            Assert.NotEqual(firstCommit[0].Id, secondCommit[0].Id);
+            Assert.NotEqual(firstCommit[1].Id, secondCommit[1].Id);
+            Assert.NotEqual(firstCommit[2].Id, secondCommit[2].Id);
+            Assert.NotEqual(firstCommit[3].Id, secondCommit[3].Id);
+            Assert.NotEqual(firstCommit[4].Id, secondCommit[4].Id);
+        }
+    }
+
+    public class TheCreateMethod : IDisposable
+    {
+        private readonly IGitHubClient _github;
+        private readonly RepositoryContext _context;
+
+        public TheCreateMethod()
+        {
+            _github = Helper.GetAuthenticatedClient();
+
+            _context = _github.CreateRepositoryContext("public-repo").Result;
+        }
+
+        private async Task<Commit> SetupCommitForRepository(IGitHubClient client)
+        {
+            var blob = new NewBlob
+            {
+                Content = "Hello World!",
+                Encoding = EncodingType.Utf8
+            };
+            var blobResult = await client.Git.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
+
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
+
+            var treeResult = await client.Git.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree);
+
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
+
+            return await client.Git.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit);
+        }
+
+        [IntegrationTest]
+        public async Task CanCreateComment()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var retrieved = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.NotNull(retrieved);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+
+    public class TheUpdateMethod : IDisposable
+    {
+        private readonly IGitHubClient _github;
+        private readonly RepositoryContext _context;
+
+        public TheUpdateMethod()
+        {
+            _github = Helper.GetAuthenticatedClient();
+
+            _context = _github.CreateRepositoryContext("public-repo").Result;
+        }
+
+        private async Task<Commit> SetupCommitForRepository(IGitHubClient client)
+        {
+            var blob = new NewBlob
+            {
+                Content = "Hello World!",
+                Encoding = EncodingType.Utf8
+            };
+            var blobResult = await client.Git.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
+
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
+
+            var treeResult = await client.Git.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree);
+
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
+
+            return await client.Git.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit);
+        }
+
+        [IntegrationTest]
+        public async Task CanUpdateComment()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var retrievedBefore = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.NotNull(retrievedBefore);
+
+            await _github.Repository.Comment.Update(_context.RepositoryOwner, _context.RepositoryName, result.Id, "new comment");
+
+            var retrievedAfter = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.Equal("new comment", retrievedAfter.Body);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+
+    public class TheDeleteMethod : IDisposable
+    {
+        private readonly IGitHubClient _github;
+        private readonly RepositoryContext _context;
+
+        public TheDeleteMethod()
+        {
+            _github = Helper.GetAuthenticatedClient();
+
+            _context = _github.CreateRepositoryContext("public-repo").Result;
+        }
+
+        private async Task<Commit> SetupCommitForRepository(IGitHubClient client)
+        {
+            var blob = new NewBlob
+            {
+                Content = "Hello World!",
+                Encoding = EncodingType.Utf8
+            };
+            var blobResult = await client.Git.Blob.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
+
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
+
+            var treeResult = await client.Git.Tree.Create(_context.RepositoryOwner, _context.RepositoryName, newTree);
+
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
+
+            return await client.Git.Commit.Create(_context.RepositoryOwner, _context.RepositoryName, newCommit);
+        }
+
+        [IntegrationTest]
+        public async Task CanDeleteComment()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var retrievedBefore = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.NotNull(retrievedBefore);
+
+            await _github.Repository.Comment.Delete(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            var retrievedAfter = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.Null(retrievedAfter);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Clients\PullRequestsClientTests.cs" />
     <Compile Include="Clients\ReferencesClientTests.cs" />
     <Compile Include="Clients\RepositoryCommitsClientTests.cs" />
+    <Compile Include="Clients\RepositoryCommentsClientTests.cs" />
     <Compile Include="Clients\RepositoryContentsClientTests.cs" />
     <Compile Include="Clients\RepositoryDeployKeysClientTests.cs" />
     <Compile Include="Clients\RepositoryForksClientTests.cs" />

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -100,7 +100,7 @@ public class RepositoryCommentsClientTests
             await client.GetAllForCommit("fake", "repo", "sha");
 
             connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), 
-                ApiOptions.None);
+                Args.ApiOptions);
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -134,11 +134,11 @@ public class RepositoryCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, null, null));
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, null));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha1", Args.ApiOptions));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha1", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha1", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha1", ApiOptions.None));
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "", "", null));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "", "", ApiOptions.None));
@@ -147,11 +147,11 @@ public class RepositoryCommentsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "", null));
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", ApiOptions.None));
         }
     }
 

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -89,7 +89,7 @@ public class RepositoryCommentsClientTests
         }
     }
 
-    public class TheGetForCommitMethod
+    public class TheGetAllForCommitMethod
     {
         [Fact]
         public async Task RequestsCorrectUrl()
@@ -99,7 +99,8 @@ public class RepositoryCommentsClientTests
 
             await client.GetAllForCommit("fake", "repo", "sha");
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), ApiOptions.None);
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), 
+                ApiOptions.None);
         }
 
         [Fact]
@@ -147,7 +148,7 @@ public class RepositoryCommentsClientTests
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", null));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
 using Octokit.Internal;
+using Octokit.Tests;
 using Xunit;
 
 public class RepositoryCommentsClientTests
@@ -12,12 +13,12 @@ public class RepositoryCommentsClientTests
     public class TheGetMethod
     {
         [Fact]
-        public void RequestsCorrectUrl()
+        public async Task RequestsCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.Get("fake", "repo", 42);
+            await client.Get("fake", "repo", 42);
 
             connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"));
         }
@@ -37,14 +38,32 @@ public class RepositoryCommentsClientTests
     public class TheGetForRepositoryMethod
     {
         [Fact]
-        public void RequestsCorrectUrl()
+        public async Task RequestsCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.GetAllForRepository("fake", "repo");
+            await client.GetAllForRepository("fake", "repo");
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"));
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new RepositoryCommentsClient(connection);
+
+            var options = new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            await client.GetAllForRepository("fake", "repo", options);
+
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), options);
         }
 
         [Fact]
@@ -53,24 +72,52 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
         }
     }
 
     public class TheGetForCommitMethod
     {
         [Fact]
-        public void RequestsCorrectUrl()
+        public async Task RequestsCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.GetAllForCommit("fake", "repo", "sha");
+            await client.GetAllForCommit("fake", "repo", "sha");
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"));
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), ApiOptions.None);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new RepositoryCommentsClient(connection);
+
+            var options = new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            await client.GetAllForCommit("fake", "repo", "sha", options);
+
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), options);
         }
 
         [Fact]
@@ -79,26 +126,45 @@ public class RepositoryCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha"));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha"));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", ""));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, null, null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, null, null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, null, "sha1", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, null, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha1", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha1", Args.ApiOptions));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "", "", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "", "", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "", "sha1", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "", null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));
         }
     }
 
     public class TheCreateMethod
     {
         [Fact]
-        public void PostsToCorrectUrl()
+        public async Task PostsToCorrectUrl()
         {
             NewCommitComment newComment = new NewCommitComment("body");
 
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.Create("fake", "repo", "sha", newComment);
+            await client.Create("fake", "repo", "sha", newComment);
 
             connection.Received().Post<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), Arg.Any<object>());
         }
@@ -122,13 +188,13 @@ public class RepositoryCommentsClientTests
     public class TheUpdateMethod
     {
         [Fact]
-        public void PostsToCorrectUrl()
+        public async Task PostsToCorrectUrl()
         {
             const string issueCommentUpdate = "updated comment";
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.Update("fake", "repo", 42, issueCommentUpdate);
+            await client.Update("fake", "repo", 42, issueCommentUpdate);
 
             connection.Received().Patch<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"), Arg.Any<object>());
         }
@@ -150,12 +216,12 @@ public class RepositoryCommentsClientTests
     public class TheDeleteMethod
     {
         [Fact]
-        public void DeletesCorrectUrl()
+        public async Task DeletesCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new RepositoryCommentsClient(connection);
 
-            client.Delete("fake", "repo", 42);
+            await client.Delete("fake", "repo", 42);
 
             connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"));
         }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -219,8 +219,9 @@
     <Compile Include="Reactive\ObservableReleasesClientTests.cs" />
     <Compile Include="Reactive\ObservablePullRequestReviewCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
-    <Compile Include="Reactive\ObservableRepositoryPagesClientTests.cs"/>
+    <Compile Include="Reactive\ObservableRepositoryPagesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryHooksClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
@@ -122,8 +122,8 @@ namespace Octokit.Tests.Reactive
 
             private void SetupWithNonReactiveClient()
             {
-                var deploymentsClient = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
-                _githubClient.Repository.Collaborator.Returns(deploymentsClient);
+                var collaboratorsClient = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
+                _githubClient.Repository.Collaborator.Returns(collaboratorsClient);
                 _client = new ObservableRepoCollaboratorsClient(_githubClient);
             }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -71,6 +71,33 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllForCommitMethod
         {
             [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                client.GetAllForCommit("fake", "repo", "sha1");
+                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCommit("fake", "repo", "sha1", options);
+                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", options);
+            }
+
+            [Fact]
             public void EnsuresArgumentsNotNull()
             {
                 var githubClient = Substitute.For<IGitHubClient>();
@@ -101,33 +128,6 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));
-            }
-
-            [Fact]
-            public void RequestsCorrectUrl()
-            {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoryCommentsClient(githubClient);
-
-                client.GetAllForCommit("fake", "repo", "sha1");
-                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
-            {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoryCommentsClient(githubClient);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                client.GetAllForCommit("fake", "repo", "sha1", options);
-                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", options);
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryCommentsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableRepositoryCommentsClient(null));
+            }
+        }
+
+        public class TheGetForRepositoryMethod
+        {
+            [Fact]
+            public void EnsuresArgumentsNotNull()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                client.GetAllForRepository("fake", "repo");
+                githubClient.Received().Repository.Comment.GetAllForRepository("fake", "repo", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("fake", "repo", options);
+                githubClient.Received().Repository.Comment.GetAllForRepository("fake", "repo", options);
+            }
+        }
+
+        public class TheGetForCommitMethod
+        {
+            [Fact]
+            public void EnsuresArgumentsNotNull()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, null, "sha1", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, "name", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", null, null, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", null, Args.ApiOptions));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", null, "sha1", Args.ApiOptions));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit(null, "name", "sha1", Args.ApiOptions));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "", "sha1", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "name", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
+                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                client.GetAllForCommit("fake", "repo", "sha1");
+                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCommit("fake", "repo", "sha1", options);
+                githubClient.Received().Repository.Comment.GetAllForCommit("fake", "repo", "sha1", options);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -16,7 +16,7 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetForRepositoryMethod
+        public class TheGetAllForRepositoryMethod
         {
             [Fact]
             public void EnsuresArgumentsNotNull()
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetForCommitMethod
+        public class TheGetAllForCommitMethod
         {
             [Fact]
             public void EnsuresArgumentsNotNull()
@@ -97,7 +97,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
-                Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCommit("owner", "name", "sha1", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "name", "", Args.ApiOptions));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("owner", "", "sha1", Args.ApiOptions));
                 Assert.Throws<ArgumentException>(() => client.GetAllForCommit("", "name", "sha1", Args.ApiOptions));

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -47,7 +48,8 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryCommentsClient(githubClient);
 
                 client.GetAllForRepository("fake", "repo");
-                githubClient.Received().Repository.Comment.GetAllForRepository("fake", "repo", Args.ApiOptions);
+                githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repos/fake/repo/comments"),
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
 
             [Fact]
@@ -64,7 +66,8 @@ namespace Octokit.Tests.Reactive
                 };
 
                 client.GetAllForRepository("fake", "repo", options);
-                githubClient.Received().Repository.Comment.GetAllForRepository("fake", "repo", options);
+                githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repos/fake/repo/comments"),
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), null);
             }
         }
 

--- a/Octokit/Clients/IRepositoryCommentsClient.cs
+++ b/Octokit/Clients/IRepositoryCommentsClient.cs
@@ -34,6 +34,16 @@ namespace Octokit
         Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Gets Commit Comments for a specified Commit.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
@@ -42,6 +52,17 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <returns></returns>
         Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha);
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -49,7 +48,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name), options);
         }
 
         /// <summary>
@@ -66,7 +82,26 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
-            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name, sha));
+            return GetAllForCommit(owner, name, sha, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Commit Comments for a specified Commit.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="sha">The sha of the commit</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<CommitComment>(ApiUrls.CommitComments(owner, name, sha), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Refer #1172

Despite on this #1262, I've do this by myself, because we should finish Pagination milestone in near future in order to start working on repositoryId functionality (#1120).

To-do:

- [x]  Add overloads on IRepositoryCommentsClient.
- [x]  Add overloads on IObservableRepositoryCommentsClient.
- [x]  Add unit tests for these new methods.
        Also I've added await\async modifiers into unit tests class RepositoryCommentsClientTests.cs , because I suppose these modifiers should be there to get determined results of tests.
- [x]  Add integration tests for these new methods. 
        No integration tests exists for these clients, so I've add whole new integration test for RepositoryCommentsClient,

/cc @shiftkey , @ryangribble
