### PR TITLE
Add ApiOption overloads to methods on I(Observable)MilestonesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -36,9 +36,34 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
         IObservable<Milestone> GetAllForRepository(string owner, string name, MilestoneRequest request);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -85,8 +85,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
-            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(owner, name),
-                request.ToParametersDictionary());
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -44,7 +44,29 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Milestone> GetAllForRepository(string owner, string name)
         {
-            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(owner, name));
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(owner, name), options);
         }
 
         /// <summary>
@@ -65,6 +87,28 @@ namespace Octokit.Reactive
 
             return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(owner, name),
                 request.ToParametersDictionary());
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(owner, name),
+                request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -110,6 +110,158 @@ public class MilestonesClientTests : IDisposable
         Assert.True(retrieved.Any(i => i.Number == issue2.Number));
     }
 
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithoutStart()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3) };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(3, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithStart()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3) };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(1, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPage()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithoutStartParametrized()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        var milestone4 = new NewMilestone("milestone 4") { DueOn = DateTime.Now.AddDays(4), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone4);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
+
+        Assert.Equal(3, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithStartParametrized()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        var milestone4 = new NewMilestone("milestone 4") { DueOn = DateTime.Now.AddDays(4), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone4);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
+
+        Assert.Equal(1, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageParametrized()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var milestoneRequest = new MilestoneRequest { State = ItemStateFilter.Closed };
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, milestoneRequest, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+        
+        var secondPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, milestoneRequest, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
+    }
+
     public void Dispose()
     {
         _context.Dispose();

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -108,35 +108,30 @@ namespace Octokit.Tests.Clients
             {
                 var client = new MilestonesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -116,30 +116,30 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new ApiOptions()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, new ApiOptions()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), new ApiOptions()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), new ApiOptions()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), new ApiOptions()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), new ApiOptions()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -112,30 +112,30 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new ApiOptions()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new ApiOptions()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, new ApiOptions()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), new ApiOptions()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), new ApiOptions()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new ApiOptions()));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), new ApiOptions()));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), new ApiOptions()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -175,11 +175,11 @@ namespace Octokit.Tests.Reactive
                     }
                );
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<Milestone>>(firstPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Milestone>>(firstPageUrl, Args.EmptyDictionary, null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
-                gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, Args.EmptyDictionary, null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => secondPageResponse));
-                gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, Args.EmptyDictionary, null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
                 var client = new ObservableMilestonesClient(gitHubClient);
 
@@ -221,7 +221,7 @@ namespace Octokit.Tests.Reactive
                 );
                 var lastPageResponse = new ApiResponse<List<Milestone>>
                 (
-                    new Response(),
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit(new Dictionary<string, string>())) },
                     new List<Milestone>
                     {
                         new Milestone(7)
@@ -232,12 +232,19 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["state"] == "open"
-                        && d["sort"] == "due_date"), Arg.Any<string>())
+                        && d["sort"] == "due_date"), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
-                gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["state"] == "open"
+                        && d["sort"] == "due_date"), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => secondPageResponse));
-                gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Milestone>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["state"] == "open"
+                        && d["sort"] == "due_date"), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
+                
                 var client = new ObservableMilestonesClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo", new MilestoneRequest { SortDirection = SortDirection.Descending }).ToArray();

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -104,42 +104,37 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableMilestonesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));
             }
 
             [Fact]
-            public void ReturnsEveryPageOfMilestones()
+            public async Task ReturnsEveryPageOfMilestones()
             {
                 var firstPageUrl = new Uri("repos/fake/repo/milestones", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
@@ -183,7 +178,7 @@ namespace Octokit.Tests.Reactive
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
                 var client = new ObservableMilestonesClient(gitHubClient);
 
-                var results = client.GetAllForRepository("fake", "repo").ToArray().Wait();
+                var results = await client.GetAllForRepository("fake", "repo").ToArray();
 
                 Assert.Equal(7, results.Length);
                 Assert.Equal(firstPageResponse.Body[0].Number, results[0].Number);

--- a/Octokit/Clients/IMilestonesClient.cs
+++ b/Octokit/Clients/IMilestonesClient.cs
@@ -42,9 +42,34 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
         Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -45,7 +45,29 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            
             return GetAllForRepository(owner, name, new MilestoneRequest());
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(owner, name, new MilestoneRequest(), options);
         }
 
         /// <summary>
@@ -64,8 +86,29 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
             return ApiConnection.GetAll<Milestone>(ApiUrls.Milestones(owner, name),
-                request.ToParametersDictionary());
+                request.ToParametersDictionary(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Refer #1161

To-do:

- [x]  Add overloads on IMilestonesClient.
- [x]  Add overloads on IObservableMilestonesClient.
- [x]  Add unit tests for these new methods.
       
       ~~I've added all new units tests, but **_I've one failed test and I need some help in order to fix it._**
       public async Task SendsAppropriateParametersMulti() is failed [here](https://github.com/octokit/octokit.net/blob/43f6cfe28ba4fd67f56e0c127d2ccdf082f787db/Octokit.Reactive/Helpers/ConnectionExtensions.cs#L58) on second pass, because of ApiInfo equal to null. As I found out, ApiInfo is class and NSubstitute cannot substitute ApiInfo automatically. So there is NullReferenceException occur on the second pass i.e. when Observable.Defer(() => getPageFunc(nextPageUrl, null, null)) fires for the first time. 
For better illustration I captured [the video](https://yadi.sk/i/2jNxQ6pvrvMWf) (please select HD quality in right bottom corner). In this video I showed that NullReferenceException occurs only when IConnection.GetAndFlattenAllPages with ApiOptions is used~~.
        I've fixed these tests by myself :smile: 
- [x]  Add integration tests for these new methods. 
      
/cc @shiftkey , @ryangribble
