### PR TITLE
Add ApiOption overloads to methods on I(Observable)RepositoryContentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -81,6 +81,21 @@ namespace Octokit.Reactive
         IObservable<RepositoryContent> GetAllContents(string owner, string name, string path);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContents(string owner, string name, string path, ApiOptions options);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -89,6 +104,17 @@ namespace Octokit.Reactive
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         IObservable<RepositoryContent> GetAllContents(string owner, string name);
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContents(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -106,6 +132,23 @@ namespace Octokit.Reactive
         /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path);
 
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path, ApiOptions options);
+
 
         /// <summary>
         /// Returns the contents of the home directory in a repository.
@@ -117,6 +160,18 @@ namespace Octokit.Reactive
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference);
+
+        /// <summary>
+        /// Returns the contents of the home directory in a repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
         /// Creates a commit that creates a new file in a repository.

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -105,9 +105,32 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
+            return GetAllContents(owner, name, path, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContents(string owner, string name, string path, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _client
                 .Connection
-                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path));
+                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path), options);
         }
 
         /// <summary>
@@ -142,9 +165,27 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
+            return GetAllContents(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContents(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _client
                 .Connection
-                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty));
+                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty), options);
         }
 
         /// <summary>
@@ -168,7 +209,33 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path, reference));
+            return GetAllContentsByRef(owner, name, path, reference, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path, reference), options);
         }
 
         /// <summary>
@@ -186,7 +253,27 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty, reference));
+            return GetAllContentsByRef(owner, name, reference, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns the contents of the home directory in a repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty, reference), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -17,6 +17,8 @@ namespace Octokit.Reactive
         /// <param name="client"></param>
         public ObservableRepositoryContentsClient(IGitHubClient client)
         {
+            Ensure.ArgumentNotNull(client, "client");
+
             _client = client;
         }
 
@@ -209,7 +211,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-            return GetAllContentsByRef(owner, name, path, reference, ApiOptions.None);
+            return GetAllContentsByRef(owner, name, reference, path, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Helpers/ConnectionExtensions.cs
+++ b/Octokit.Reactive/Helpers/ConnectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -38,6 +38,358 @@ namespace Octokit.Tests.Integration.Clients
         public class TheGetContentsMethod
         {
             [IntegrationTest]
+            public async Task ReturnsContents()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 3
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsDistinctContentsBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var firstPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", skipStartOptions);
+
+                Assert.NotEqual(firstPageResults[0].Path, secondPageResults[0].Path);
+                Assert.NotEqual(firstPageResults[1].Path, secondPageResults[1].Path);
+                Assert.NotEqual(firstPageResults[2].Path, secondPageResults[2].Path);
+                Assert.NotEqual(firstPageResults[3].Path, secondPageResults[3].Path);
+                Assert.NotEqual(firstPageResults[4].Path, secondPageResults[4].Path);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsContentsWithPath()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", "Octokit.Reactive");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsWithPathWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", "Octokit.Reactive", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsWithPathWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", "Octokit.Reactive", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsDistinctContentsWithPathBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var firstPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", "Octokit.Reactive", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octokit", "octokit.net", "Octokit.Reactive", skipStartOptions);
+
+                Assert.NotEqual(firstPageResults[0].Path, secondPageResults[0].Path);
+                Assert.NotEqual(firstPageResults[1].Path, secondPageResults[1].Path);
+                Assert.NotEqual(firstPageResults[2].Path, secondPageResults[2].Path);
+                Assert.NotEqual(firstPageResults[3].Path, secondPageResults[3].Path);
+                Assert.NotEqual(firstPageResults[4].Path, secondPageResults[4].Path);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsContentsByRef()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsByRefWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsCorrectCountOfContentsByRefWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsDistinctContentsByRefBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var firstPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", skipStartOptions);
+
+                Assert.NotEqual(firstPageResults[0].Path, secondPageResults[0].Path);
+                Assert.NotEqual(firstPageResults[1].Path, secondPageResults[1].Path);
+                Assert.NotEqual(firstPageResults[2].Path, secondPageResults[2].Path);
+                Assert.NotEqual(firstPageResults[3].Path, secondPageResults[3].Path);
+                Assert.NotEqual(firstPageResults[4].Path, secondPageResults[4].Path);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsContentsByRefWithPath()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsContentsByRefWithPathWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsContentsByRefWithPathWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", options);
+
+                Assert.Equal(2, contents.Count);
+            }
+
+            [IntegrationTest(Skip = "The Contents does not support a pagination at this moment. See https://github.com/octokit/octokit.net/issues/1315")]
+            public async Task ReturnsDistinctContentsByRefWithPathBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                var firstPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPageResults = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive", "26cc074d743612fc1f0c9268dad1e4c2a15c3fc4", skipStartOptions);
+
+                Assert.NotEqual(firstPageResults[0].Path, secondPageResults[0].Path);
+                Assert.NotEqual(firstPageResults[1].Path, secondPageResults[1].Path);
+                Assert.NotEqual(firstPageResults[2].Path, secondPageResults[2].Path);
+                Assert.NotEqual(firstPageResults[3].Path, secondPageResults[3].Path);
+                Assert.NotEqual(firstPageResults[4].Path, secondPageResults[4].Path);
+            }
+
+            [IntegrationTest]
             public async Task GetsFileContent()
             {
                 var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableMilestonesClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Net.Http.Headers;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit.Reactive;

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
                 var result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
-                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(info => Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
                 var contentsClient = new RepositoryContentsClient(connection);
 
                 var contents = await contentsClient.GetAllContents("fake", "repo");

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -222,237 +222,92 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, (string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (string)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (string)null));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
-                
                 
                 // empty string checks
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", ""));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", "", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", ""));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
             }

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -68,34 +68,393 @@ namespace Octokit.Tests.Clients
         public class TheGetContentsMethod
         {
             [Fact]
-            public async Task ReturnsContentsByRef()
+            public async Task ReturnsContents()
             {
-                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
+                var result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
-                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(info => Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
                 var contentsClient = new RepositoryContentsClient(connection);
 
-                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "readme.md", "master");
+                var contents = await contentsClient.GetAllContents("fake", "repo");
 
-                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"));
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), Args.ApiOptions);
                 Assert.Equal(1, contents.Count);
             }
 
+            [Fact]
+            public async Task ReturnsContentsWithApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+                
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, options).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", options);
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), options);
+                Assert.Equal(1, contents.Count);
+            }
 
             [Fact]
-            public async Task ReturnsContents()
+            public async Task ReturnsContentsWithPath()
             {
-                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
+                var result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
-                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
                 var contentsClient = new RepositoryContentsClient(connection);
 
                 var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md");
 
-                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"));
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"), Args.ApiOptions);
                 Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithPathAndApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, options).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md", options);
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"), options);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRef()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"), Args.ApiOptions);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, options).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master", options);
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"), options);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithPath()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, Args.ApiOptions).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "readme.md", "master");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"), Args.ApiOptions);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithPathAndApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri, options).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "readme.md", "master", options);
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"), options);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullarguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (string)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (string)null));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
+                
+                
+                // empty string checks
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", ""));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", ""));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Reactive\ObservableRepositoriesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryContentsClientTest.cs" />
     <Compile Include="Reactive\ObservableRepositoryPagesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
@@ -36,7 +36,9 @@ namespace Octokit.Tests.Reactive
                     "base64");
 
                 var githubClient = Substitute.For<IGitHubClient>();
-                var readmeFake = new Readme(readmeInfo, githubClient.Connection);
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetHtml(new Uri(readmeInfo.Url)).Returns(Task.FromResult("<html>README</html>"));
+                var readmeFake = new Readme(readmeInfo, apiConnection);
                 var contentsClient = new ObservableRepositoryContentsClient(githubClient);
 
                 githubClient.Repository.Content.GetReadme("fake", "repo").Returns(Task.FromResult(readmeFake));
@@ -55,7 +57,7 @@ namespace Octokit.Tests.Reactive
 
                 var htmlReadme = await readme.GetHtmlContent();
                 Assert.Equal("<html>README</html>", htmlReadme);
-                githubClient.Connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
+                apiConnection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
@@ -1,0 +1,692 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Internal;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryContentsClientTest
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableRepositoryContentsClient(null));
+            }
+        }
+        
+        public class TheGetReadmeMethod
+        {
+            [Fact]
+            public async Task ReturnsReadme()
+            {
+                string encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+                var readmeInfo = new ReadmeResponse(
+                    encodedContent,
+                    "README.md",
+                    "https://github.example.com/readme",
+                    "https://github.example.com/readme.md",
+                    "base64");
+
+                var githubClient = Substitute.For<IGitHubClient>();
+                var readmeFake = new Readme(readmeInfo, githubClient.Connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+
+                githubClient.Repository.Content.GetReadme("fake", "repo").Returns(Task.FromResult(readmeFake));
+
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+                githubClient.Connection.GetHtml(Args.Uri, null)
+                    .Returns(Task.FromResult(apiResponse));
+                
+                var readme = await contentsClient.GetReadme("fake", "repo");
+
+                Assert.Equal("README.md", readme.Name);
+
+                githubClient.Repository.Content.Received(1).GetReadme("fake", "repo");
+                githubClient.Connection.DidNotReceive().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme"),
+                    Args.EmptyDictionary);
+
+                var htmlReadme = await readme.GetHtmlContent();
+                Assert.Equal("<html>README</html>", htmlReadme);
+                githubClient.Connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
+            }
+        }
+
+        public class TheGetReadmeHtmlMethod
+        {
+            [Fact]
+            public async Task ReturnsReadmeHtml()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+
+                connection.GetHtml(Args.Uri, null).Returns(Task.FromResult(apiResponse));
+
+                var readme = await contentsClient.GetReadmeHtml("fake", "repo");
+
+                connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/readme"), null);
+                Assert.Equal("<html>README</html>", readme);
+            }
+        }
+
+        public class TheGetContentsMethod
+        {
+            [Fact]
+            public async Task ReturnsContents()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), Args.EmptyDictionary, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null).Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", options).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), 
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithPath()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"), Args.EmptyDictionary, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithPathAndApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null).Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md", options).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRef()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"), Args.EmptyDictionary, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null).Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master", options).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithPath()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master", "readme.md").ToList();
+
+                connection.Received()
+                    .Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"), Args.EmptyDictionary, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithPathAndApiOptions()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(githubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null).Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master", "readme.md", options).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public void EnsuresNonNullarguments()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (string)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (string)null));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
+
+                // empty string checks
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", ""));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", "", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", (ApiOptions)null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
+
+                // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", ""));
+
+                //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", null));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
+            }
+        }
+
+        public class TheCreateFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile(null, "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", null, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", "repo", null, new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", "repo", "path/to/file", null));
+            }
+        }
+
+        public class TheDeleteFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                connection.Received().Delete(
+                    Arg.Any<Uri>(),
+                    Arg.Is<DeleteFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile(null, "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", null, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", "repo", null, new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", "repo", "path/to/file", null));
+            }
+        }
+
+        public class TheUpdateFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile(null, "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", null, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", "repo", null, new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", "repo", "path/to/file", null));
+            }
+        }
+
+        public class TheGetArchiveMethod
+        {
+            [Fact]
+            public void EnsurePassingCorrectParameters()
+            {
+                var connection = Substitute.For<IConnection>();
+                var githubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(githubClient);
+
+                client.GetArchive("org", "repo", ArchiveFormat.Tarball, "dev");
+
+                const string expectedUri = "repos/org/repo/tarball/dev";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTest.cs
@@ -297,236 +297,92 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(githubClient);
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, (string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (string)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, null, "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", (string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, (string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", (string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, (string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (string)null));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, null, "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, null, "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", null, "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, null, "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "master", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
 
                 // empty string checks
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", ""));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", (ApiOptions)null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", "", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", "", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", "readme.md", null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", (ApiOptions)null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", (ApiOptions)null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", (ApiOptions)null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", (ApiOptions)null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", (ApiOptions)null));
 
                 // public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master"));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", ""));
 
                 //public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "", "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "", "readme.md", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "readme.md", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "master", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", null));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "readme.md", "master", null));
             }

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -25,6 +25,21 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -36,6 +51,20 @@ namespace Octokit
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name);
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -53,6 +82,22 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -66,6 +111,22 @@ namespace Octokit
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference);
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
         /// Gets the preferred README for the specified repository.

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -33,10 +33,32 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-            var url = ApiUrls.RepositoryContent(owner, name, path);
+            return GetAllContents(owner, name, path, ApiOptions.None);
+        }
 
-            return ApiConnection.GetAll<RepositoryContent>(url);
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path), options);
         }
 
         /// <summary>
@@ -55,9 +77,28 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            var url = ApiUrls.RepositoryContent(owner, name, string.Empty);
+            return GetAllContents(owner, name, ApiOptions.None);
+        }
 
-            return ApiConnection.GetAll<RepositoryContent>(url);
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty), options);
         }
 
         /// <summary>
@@ -81,9 +122,32 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            var url = ApiUrls.RepositoryContent(owner, name, path, reference);
+            return GetAllContentsByRef(owner, name, path, reference, ApiOptions.None);
+        }
 
-            return ApiConnection.GetAll<RepositoryContent>(url);
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path, reference), options);
         }
 
         /// <summary>
@@ -104,9 +168,31 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            var url = ApiUrls.RepositoryContent(owner, name, string.Empty, reference);
+            return GetAllContentsByRef(owner, name, reference, ApiOptions.None);
+        }
 
-            return ApiConnection.GetAll<RepositoryContent>(url);
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty, reference), options);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/Readme.cs
+++ b/Octokit/Models/Response/Readme.cs
@@ -30,6 +30,22 @@ namespace Octokit
             htmlContent = new Lazy<Task<string>>(async () => await client.GetHtml(Url).ConfigureAwait(false));
         }
 
+        internal Readme(ReadmeResponse response, IConnection client)
+        {
+            Ensure.ArgumentNotNull(response, "response");
+            Ensure.ArgumentNotNull(client, "client");
+
+            Name = response.Name;
+            Url = new Uri(response.Url);
+            HtmlUrl = new Uri(response.HtmlUrl);
+            if (response.Encoding.Equals("base64", StringComparison.OrdinalIgnoreCase))
+            {
+                var contentAsBytes = Convert.FromBase64String(response.Content);
+                Content = Encoding.UTF8.GetString(contentAsBytes, 0, contentAsBytes.Length);
+            }
+            htmlContent = new Lazy<Task<string>>(async () => (await client.GetHtml(Url).ConfigureAwait(false)).Body);
+        }
+
         public Readme(Lazy<Task<string>> htmlContent, string content, string name, Uri htmlUrl, Uri url)
         {
             this.htmlContent = htmlContent;

--- a/Octokit/Models/Response/Readme.cs
+++ b/Octokit/Models/Response/Readme.cs
@@ -30,22 +30,6 @@ namespace Octokit
             htmlContent = new Lazy<Task<string>>(async () => await client.GetHtml(Url).ConfigureAwait(false));
         }
 
-        internal Readme(ReadmeResponse response, IConnection client)
-        {
-            Ensure.ArgumentNotNull(response, "response");
-            Ensure.ArgumentNotNull(client, "client");
-
-            Name = response.Name;
-            Url = new Uri(response.Url);
-            HtmlUrl = new Uri(response.HtmlUrl);
-            if (response.Encoding.Equals("base64", StringComparison.OrdinalIgnoreCase))
-            {
-                var contentAsBytes = Convert.FromBase64String(response.Content);
-                Content = Encoding.UTF8.GetString(contentAsBytes, 0, contentAsBytes.Length);
-            }
-            htmlContent = new Lazy<Task<string>>(async () => (await client.GetHtml(Url).ConfigureAwait(false)).Body);
-        }
-
         public Readme(Lazy<Task<string>> htmlContent, string content, string name, Uri htmlUrl, Uri url)
         {
             this.htmlContent = htmlContent;


### PR DESCRIPTION
Refer #1174

Despite on this #1262, I've do this by myself, because we should finish Pagination milestone in near future in order to start working on repositoryId functionality (#1120).

To-do:

- [x]  Add overloads on IRepositoryContentsClient.
- [x]  Add overloads on IObservableRepositoryContentsClient.
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods. 
    
    I've add whole new integration test class for RepositoryCommentsClient, but I found out that [Contents](https://developer.github.com/v3/repos/contents/) **do not support pagination** (#1315), so I marked tests as skipped.

/cc @shiftkey , @ryangribble