### PR TITLE
Fixed incorrect names of tests in RepositoryDeployKeysClientTests

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
@@ -58,7 +58,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
     }
 
     [IntegrationTest(Skip = "See https://github.com/octokit/octokit.net/issues/1003 for investigating this failing test")]
-    public async Task ReturnsCorrectCountOfHooksWithoutStart()
+    public async Task ReturnsCorrectCountOfDeployKeysWithoutStart()
     {
         var deployKeys = await _fixture.GetAll(_context.RepositoryOwner, _context.RepositoryName);
         Assert.Equal(0, deployKeys.Count);
@@ -92,7 +92,7 @@ public class RepositoryDeployKeysClientTests : IDisposable
     }
 
     [IntegrationTest(Skip = "See https://github.com/octokit/octokit.net/issues/1003 for investigating this failing test")]
-    public async Task ReturnsCorrectCountOfHooksWithStart()
+    public async Task ReturnsCorrectCountOfDeployKeysWithStart()
     {
         var deployKeys = await _fixture.GetAll(_context.RepositoryOwner, _context.RepositoryName);
         Assert.Equal(0, deployKeys.Count);

--- a/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryDeployKeysClientTests.cs
@@ -64,8 +64,8 @@ public class RepositoryDeployKeysClientTests : IDisposable
         Assert.Equal(0, deployKeys.Count);
 
         var list = new List<NewDeployKey>();
-        var hooksCount = 5;
-        for (int i = 0; i < hooksCount; i++)
+        var deployKeysCount = 5;
+        for (int i = 0; i < deployKeysCount; i++)
         {
             var item = new NewDeployKey
             {
@@ -82,13 +82,13 @@ public class RepositoryDeployKeysClientTests : IDisposable
 
         var options = new ApiOptions
         {
-            PageSize = hooksCount,
+            PageSize = deployKeysCount,
             PageCount = 1
         };
 
         deployKeys = await _fixture.GetAll(_context.RepositoryOwner, _context.RepositoryName, options);
 
-        Assert.Equal(hooksCount, deployKeys.Count);
+        Assert.Equal(deployKeysCount, deployKeys.Count);
     }
 
     [IntegrationTest(Skip = "See https://github.com/octokit/octokit.net/issues/1003 for investigating this failing test")]
@@ -98,8 +98,8 @@ public class RepositoryDeployKeysClientTests : IDisposable
         Assert.Equal(0, deployKeys.Count);
 
         var list = new List<NewDeployKey>();
-        var hooksCount = 5;
-        for (int i = 0; i < hooksCount; i++)
+        var deployKeysCount = 5;
+        for (int i = 0; i < deployKeysCount; i++)
         {
             var item = new NewDeployKey
             {
@@ -130,8 +130,8 @@ public class RepositoryDeployKeysClientTests : IDisposable
     public async Task ReturnsDistinctResultsBasedOnStartPage()
     {
         var list = new List<NewDeployKey>();
-        var hooksCount = 5;
-        for (int i = 0; i < hooksCount; i++)
+        var deployKeysCount = 5;
+        for (int i = 0; i < deployKeysCount; i++)
         {
             var item = new NewDeployKey
             {


### PR DESCRIPTION
I've fixed incorrect names of tests in RepositoryDeployKeysClientTests.

/cc @shiftkey, @ryangribble 