### PR TITLE
Add ApiOption overloads to methods on I(Observable)DeploymentStatusClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -18,6 +18,20 @@ namespace Octokit.Reactive
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
         /// statuses for a given deployment.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -33,8 +33,29 @@ namespace Octokit.Reactive.Clients
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
+            return GetAll(owner, name, deploymentId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<DeploymentStatus>(
-                ApiUrls.DeploymentStatuses(owner, name, deploymentId));
+                ApiUrls.DeploymentStatuses(owner, name, deploymentId), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -83,9 +83,9 @@ public class DeploymentStatusClientTests : IDisposable
             PageCount = 1
         };
 
-        var eventInfos = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, options);
+        var deploymentStatuses = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, options);
 
-        Assert.Equal(3, eventInfos.Count);
+        Assert.Equal(3, deploymentStatuses.Count);
     }
 
     [IntegrationTest]
@@ -105,9 +105,9 @@ public class DeploymentStatusClientTests : IDisposable
             StartPage = 2
         };
 
-        var eventInfos = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, options);
+        var deploymentStatuses = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, options);
 
-        Assert.Equal(1, eventInfos.Count);
+        Assert.Equal(1, deploymentStatuses.Count);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
+using Octokit.Tests;
 using Xunit;
 
 public class DeploymentStatusClientTests
@@ -15,6 +16,10 @@ public class DeploymentStatusClientTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
         }
 
         [Fact]
@@ -24,6 +29,9 @@ public class DeploymentStatusClientTests
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
         }
 
         [Theory]
@@ -38,6 +46,9 @@ public class DeploymentStatusClientTests
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace, 1));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name", 1, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace, 1, ApiOptions.None));
         }
 
         [Fact]
@@ -48,7 +59,25 @@ public class DeploymentStatusClientTests
             var expectedUrl = "repos/owner/name/deployments/1/statuses";
 
             client.GetAll("owner", "name", 1);
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl));
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
+        }
+
+        [Fact]
+        public void RequestsCorrectUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repos/owner/name/deployments/1/statuses";
+
+            var options =new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            client.GetAll("owner", "name", 1, options);
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
         }
     }
 

--- a/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
@@ -27,6 +27,10 @@ namespace Octokit.Tests.Reactive
             {
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo", 1));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null, 1));
+
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo", 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null, 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", "repo", 1, null));
             }
 
             [Fact]
@@ -34,6 +38,9 @@ namespace Octokit.Tests.Reactive
             {
                 Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1));
                 Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1));
+
+                Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1, ApiOptions.None));
             }
 
             [Fact]
@@ -43,10 +50,15 @@ namespace Octokit.Tests.Reactive
                     async whitespace => await _client.GetAll(whitespace, "repo", 1));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
                     async whitespace => await _client.GetAll("owner", whitespace, 1));
+
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.GetAll(whitespace, "repo", 1, ApiOptions.None));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.GetAll("owner", whitespace, 1, ApiOptions.None));
             }
 
             [Fact]
-            public void GetsFromCorrectUrl()
+            public void RequestsCorrectUrl()
             {
                 var expectedUri = ApiUrls.DeploymentStatuses("owner", "repo", 1);
 
@@ -54,8 +66,28 @@ namespace Octokit.Tests.Reactive
 
                 _githubClient.Connection.Received(1)
                     .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
-                                                      Arg.Any<IDictionary<string, string>>(),
-                                                      Arg.Any<string>());
+                                                      Args.EmptyDictionary,
+                                                      null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWitApiOptions()
+            {
+                var expectedUri = ApiUrls.DeploymentStatuses("owner", "repo", 1);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                _client.GetAll("owner", "repo", 1, options);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
+                                                      Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2),
+                                                      null);
             }
         }
 

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -33,7 +33,28 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId));
+            return GetAll(owner, name, deploymentId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -26,6 +26,20 @@ namespace Octokit
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All deployment statuses for the given deployment.</returns>
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
         /// statuses for a given deployment.
         /// </summary>


### PR DESCRIPTION
Fixes #1152 

To-do:

- [x]  Add overloads on IDeploymentStatusClient
- [x]  Add overloads on IObservableDeploymentStatusClient
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods. 

/cc @shiftkey , @ryangribble