### PR TITLE
Add ApiOption overloads to methods on I(Observable)PullRequestsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -33,6 +33,18 @@ namespace Octokit.Reactive
         IObservable<PullRequest> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Query pull requests for the repository based on criteria
         /// </summary>
         /// <remarks>
@@ -43,6 +55,19 @@ namespace Octokit.Reactive
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <returns>A collection of <see cref="PullRequest"/> results</returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a pull request for the specified repository.

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -49,7 +49,29 @@ namespace Octokit.Reactive
         /// <returns>A collection of <see cref="PullRequest"/> results</returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name)
         {
-            return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(owner, name));
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(owner, name), options);
         }
 
         /// <summary>
@@ -68,8 +90,29 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(owner, name),
-                request.ToParametersDictionary());
+                request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -201,7 +201,6 @@ public class PullRequestsClientTests : IDisposable
             PageSize = 1,
             PageCount = 1
         };
-
         
         var firstPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, openPullRequests, startOptions);
 

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
-using Octokit.Tests.Helpers;
 using Octokit.Tests.Integration;
 using Xunit;
 using Octokit.Tests.Integration.Helpers;
@@ -53,6 +52,79 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithoutStart()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithStart()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctPullRequestsBasedOnStartPage()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Title, secondPage[0].Title);
+    }
+
+    [IntegrationTest]
     public async Task CanGetOpenPullRequest()
     {
         await CreateTheWorld();
@@ -65,6 +137,84 @@ public class PullRequestsClientTests : IDisposable
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithoutStartParameterized()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithStartParameterized()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+        var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctPullRequestsBasedOnStartPageParameterized()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        
+        var firstPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, openPullRequests, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, openPullRequests, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Title, secondPage[0].Title);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -44,16 +44,35 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
-                    Arg.Any<Dictionary<string, string>>());
+                    Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
             }
 
             [Fact]
-            public void SendsAppropriateParameters()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" });
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
+                    Arg.Any<Dictionary<string, string>>(), options);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParameters()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" });
 
                 connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 5
@@ -61,20 +80,78 @@ namespace Octokit.Tests.Clients
                         && d["state"] == "open"
                         && d["base"] == "fake_base_branch"
                         && d["sort"] == "created"
-                        && d["direction"] == "desc"));
+                        && d["direction"] == "desc"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParametersWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" }, options);
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
+                        && d["head"] == "user:ref-head"
+                        && d["state"] == "open"
+                        && d["base"] == "fake_base_branch"
+                        && d["sort"] == "created"
+                        && d["direction"] == "desc"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new PullRequestsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new PullRequestRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new PullRequestRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (PullRequestRequest)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new PullRequestRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new PullRequestRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new PullRequestRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new PullRequestRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new PullRequestRequest()));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new PullRequestRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new PullRequestRequest(), ApiOptions.None));
             }
         }
 
         public class TheCreateMethod
         {
             [Fact]
-            public void PostsToCorrectUrl()
+            public async Task PostsToCorrectUrl()
             {
                 var newPullRequest = new NewPullRequest("some title", "branch:name", "branch:name");
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.Create("fake", "repo", newPullRequest);
+                await client.Create("fake", "repo", newPullRequest);
 
                 connection.Received().Post<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
                     newPullRequest);
@@ -102,13 +179,13 @@ namespace Octokit.Tests.Clients
         public class TheUpdateMethod
         {
             [Fact]
-            public void PostsToCorrectUrl()
+            public async Task PostsToCorrectUrl()
             {
                 var pullRequestUpdate = new PullRequestUpdate();
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.Update("fake", "repo", 42, pullRequestUpdate);
+                await client.Update("fake", "repo", 42, pullRequestUpdate);
 
                 connection.Received().Patch<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42"),
                     pullRequestUpdate);
@@ -136,13 +213,13 @@ namespace Octokit.Tests.Clients
         public class TheMergeMethod
         {
             [Fact]
-            public void PutsToCorrectUrl()
+            public async Task PutsToCorrectUrl()
             {
                 var mergePullRequest = new MergePullRequest { CommitMessage = "fake commit message" };
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.Merge("fake", "repo", 42, mergePullRequest);
+                await client.Merge("fake", "repo", 42, mergePullRequest);
 
                 connection.Received().Put<PullRequestMerge>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/merge"),
                     mergePullRequest,null, "application/vnd.github.polaris-preview+json");
@@ -166,7 +243,7 @@ namespace Octokit.Tests.Clients
         public class TheMergedMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var conn = Substitute.For<IConnection>();
                 var connection = Substitute.For<IApiConnection>();
@@ -174,7 +251,7 @@ namespace Octokit.Tests.Clients
 
                 var client = new PullRequestsClient(connection);
 
-                client.Merged("fake", "repo", 42);
+                await client.Merged("fake", "repo", 42);
 
                 conn.Received().Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/merge"), null, null);
             }

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -213,13 +213,13 @@ namespace Octokit.Tests.Clients
         public class TheMergeMethod
         {
             [Fact]
-            public async Task PutsToCorrectUrl()
+            public void PutsToCorrectUrl()
             {
                 var mergePullRequest = new MergePullRequest { CommitMessage = "fake commit message" };
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await client.Merge("fake", "repo", 42, mergePullRequest);
+                client.Merge("fake", "repo", 42, mergePullRequest);
 
                 connection.Received().Put<PullRequestMerge>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/merge"),
                     mergePullRequest,null, "application/vnd.github.polaris-preview+json");
@@ -243,7 +243,7 @@ namespace Octokit.Tests.Clients
         public class TheMergedMethod
         {
             [Fact]
-            public async Task RequestsCorrectUrl()
+            public void RequestsCorrectUrl()
             {
                 var conn = Substitute.For<IConnection>();
                 var connection = Substitute.For<IApiConnection>();
@@ -251,7 +251,7 @@ namespace Octokit.Tests.Clients
 
                 var client = new PullRequestsClient(connection);
 
-                await client.Merged("fake", "repo", 42);
+                client.Merged("fake", "repo", 42);
 
                 conn.Received().Get<object>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/merge"), null, null);
             }

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -41,6 +41,66 @@ namespace Octokit.Tests.Reactive
         public class TheGetForRepositoryMethod
         {
             [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestsClient(gitHubClient);
+
+                client.GetAllForRepository("fake", "repo");
+
+                gitHubClient.Received().PullRequest.GetAllForRepository("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository("fake", "repo", options);
+
+                gitHubClient.Received().PullRequest.GetAllForRepository("fake", "repo", options);
+            }
+
+            [Fact]
+            public void SendsAppropriateParameters()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestsClient(gitHubClient);
+
+                var pullRequestRequest = new PullRequestRequest { SortDirection = SortDirection.Descending };
+                client.GetAllForRepository("fake", "repo", pullRequestRequest);
+
+                gitHubClient.Received().PullRequest.GetAllForRepository("fake", "repo", pullRequestRequest, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void SendsAppropriateParametersWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var pullRequestRequest = new PullRequestRequest { SortDirection = SortDirection.Descending };
+                client.GetAllForRepository("fake", "repo", pullRequestRequest, options);
+
+                gitHubClient.Received().PullRequest.GetAllForRepository("fake", "repo", pullRequestRequest, options);
+            }
+
+            [Fact]
             public async Task ReturnsEveryPageOfPullRequests()
             {
                 var firstPageUrl = new Uri("repos/fake/repo/pulls", UriKind.Relative);
@@ -94,74 +154,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task ReturnsEveryPageOfPullRequestsWithApiOptions()
-            {
-                var firstPageUrl = new Uri("repos/fake/repo/pulls", UriKind.Relative);
-                var secondPageUrl = new Uri("https://example.com/page/2");
-                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
-                var firstPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    CreateResponseWithApiInfo(firstPageLinks),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(1),
-                        new PullRequest(2),
-                        new PullRequest(3)
-                    }
-                );
-                var thirdPageUrl = new Uri("https://example.com/page/3");
-                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
-                var secondPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    CreateResponseWithApiInfo(secondPageLinks),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(4),
-                        new PullRequest(5),
-                        new PullRequest(6)
-                    }
-                );
-                var lastPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    new Response(),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(7)
-                    }
-                );
-                
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<PullRequest>>(firstPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
-                        && d["page"] == "1"
-                        && d["per_page"] == "2"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
-                gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
-                        && d["page"] == "1"
-                        && d["per_page"] == "2"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
-                gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
-                        && d["page"] == "1"
-                        && d["per_page"] == "2"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
-                var client = new ObservablePullRequestsClient(gitHubClient);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageSize = 2,
-                    PageCount = 1
-                };
-
-                var results = await client.GetAllForRepository("fake", "repo", options).ToArray();
-
-                Assert.Equal(7, results.Length);
-                Assert.Equal(firstPageResponse.Body[0].Number, results[0].Number);
-                Assert.Equal(secondPageResponse.Body[1].Number, results[4].Number);
-                Assert.Equal(lastPageResponse.Body[0].Number, results[6].Number);
-            }
-
-            [Fact]
-            public async Task SendsAppropriateParameters()
+            public async Task SendsAppropriateParametersMulti()
             {
                 var firstPageUrl = new Uri("repos/fake/repo/pulls", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
@@ -222,87 +215,6 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestsClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-name", Base = "fake_base_branch" }).ToArray();
-
-                Assert.Equal(7, results.Length);
-                Assert.Equal(firstPageResponse.Body[0].Number, results[0].Number);
-                Assert.Equal(secondPageResponse.Body[1].Number, results[4].Number);
-                Assert.Equal(lastPageResponse.Body[0].Number, results[6].Number);
-            }
-
-            [Fact]
-            public async Task SendsAppropriateParametersWitApiOptions()
-            {
-                var firstPageUrl = new Uri("repos/fake/repo/pulls", UriKind.Relative);
-                var secondPageUrl = new Uri("https://example.com/page/2");
-                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
-                var firstPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    CreateResponseWithApiInfo(firstPageLinks),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(1),
-                        new PullRequest(2),
-                        new PullRequest(3)
-                    }
-                );
-                var thirdPageUrl = new Uri("https://example.com/page/3");
-                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
-                var secondPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    CreateResponseWithApiInfo(secondPageLinks),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(4),
-                        new PullRequest(5),
-                        new PullRequest(6)
-                    }
-                );
-                var lastPageResponse = new ApiResponse<List<PullRequest>>
-                (
-                    new Response(),
-                    new List<PullRequest>
-                    {
-                        new PullRequest(7)
-                    }
-                );
-                
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<PullRequest>>(Arg.Is(firstPageUrl),
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 7
-                        && d["head"] == "user:ref-name"
-                        && d["state"] == "open"
-                        && d["base"] == "fake_base_branch"
-                        && d["sort"] == "created"
-                        && d["direction"] == "desc"
-                        && d["page"] == "1"
-                        && d["per_page"] == "2"), Arg.Any<string>())
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => firstPageResponse));
-                gitHubClient.Connection.Get<List<PullRequest>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 7
-                        && d["head"] == "user:ref-name"
-                        && d["state"] == "open"
-                        && d["base"] == "fake_base_branch"
-                        && d["sort"] == "created"
-                        && d["direction"] == "desc"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => secondPageResponse));
-                gitHubClient.Connection.Get<List<PullRequest>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 7
-                        && d["head"] == "user:ref-name"
-                        && d["state"] == "open"
-                        && d["base"] == "fake_base_branch"
-                        && d["sort"] == "created"
-                        && d["direction"] == "desc"
-                        && d["page"] == "1"
-                        && d["per_page"] == "2"), null)
-                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequest>>>(() => lastPageResponse));
-                var client = new ObservablePullRequestsClient(gitHubClient);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageSize = 2,
-                    PageCount = 1
-                };
-
-                var results = await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-name", Base = "fake_base_branch" }, options).ToArray();
 
                 Assert.Equal(7, results.Length);
                 Assert.Equal(firstPageResponse.Body[0].Number, results[0].Number);

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -34,6 +34,18 @@ namespace Octokit
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Query pull requests for the repository based on criteria
         /// </summary>
         /// <remarks>
@@ -44,6 +56,19 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Create a pull request for the specified repository.

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -42,7 +42,29 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name)
         {
-            return GetAllForRepository(owner, name, new PullRequestRequest());
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, new PullRequestRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(owner, name, new PullRequestRequest(), options);
         }
 
         /// <summary>
@@ -61,8 +83,29 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
             return ApiConnection.GetAll<PullRequest>(ApiUrls.PullRequests(owner, name),
-                request.ToParametersDictionary());
+                request.ToParametersDictionary(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1167 

To-do:

- [x]  Add overloads on IDeploymentPullRequestsClient
- [x]  Add overloads on IObservablePullRequestsClient
- [x]  Add unit tests for these new methods.
- [x]  Add integration tests for these new methods. 

/cc @shiftkey , @ryangribble