### PR TITLE
Add ApiOption overloads to methods on I(Observable)OrganizationsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -33,11 +33,28 @@ namespace Octokit.Reactive
         IObservable<Organization> GetAllForCurrent();
 
         /// <summary>
+        /// Returns all the organizations for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
+            Justification = "Method makes a network request")]
+        IObservable<Organization> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Returns all the organizations for the specified user
         /// </summary>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
         IObservable<Organization> GetAll(string user);
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Organization> GetAll(string user, ApiOptions options);
 
         /// <summary>
         /// Update the specified organization with data from <see cref="OrganizationUpdate"/>.

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -102,6 +102,9 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="Organization"/></returns>
         public IObservable<Organization> Update(string organizationName, OrganizationUpdate updateRequest)
         {
+            Ensure.ArgumentNotNullOrEmptyString(organizationName, "organizationName");
+            Ensure.ArgumentNotNull(updateRequest, "updateRequest");
+
             return _client.Update(organizationName, updateRequest).ToObservable();
         }
     }

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -52,6 +52,18 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Organization> GetAllForCurrent()
         {
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all the organizations for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Organization> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations());
         }
 
@@ -65,6 +77,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
             return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations(user));
+        }
+
+        /// <summary>
+        /// Returns all the organizations for the specified user
+        /// </summary>
+        /// <param name="user">The login for the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Organization> GetAll(string user, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.Organizations(user), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
@@ -117,7 +117,7 @@ namespace Octokit.Tests.Integration.Clients
 
                 var secondPage = await _organizationsClient.GetAllForCurrent(skipStartOptions);
 
-                Assert.NotEqual(firstPage[0].Name, secondPage[0].Name);
+                Assert.NotEqual(firstPage[0].Login, secondPage[0].Login);
             }
         }
     }

--- a/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationClientTests.cs
@@ -1,0 +1,124 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class OrganizationClientTests
+    {
+        public class TheGetAllMethod
+        {
+            readonly IGitHubClient _github;
+            readonly IOrganizationsClient _organizationsClient;
+
+            public TheGetAllMethod()
+            {
+                _github = EnterpriseHelper.GetAuthenticatedClient();
+
+                _organizationsClient = _github.Organization;
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task CanListOrganizations()
+            {
+                string orgLogin = Helper.MakeNameWithTimestamp("MyOrganization");
+                string orgName = string.Concat(orgLogin, " Display Name");
+
+                var newOrganization = new NewOrganization(orgLogin, EnterpriseHelper.UserName, orgName);
+                var organization = await
+                    _github.Enterprise.Organization.Create(newOrganization);
+
+                Assert.NotNull(organization);
+
+                var milestones = await _organizationsClient.GetAllForCurrent();
+
+                Assert.NotEmpty(milestones);
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task ReturnsCorrectCountOfOrganizationsWithoutStart()
+            {
+                string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
+                string orgName1 = string.Concat(orgLogin1, " Display Name 1");
+                string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
+                string orgName2 = string.Concat(orgLogin2, " Display Name 2");
+                
+                var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
+                var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
+                await _github.Enterprise.Organization.Create(newOrganization1);
+                await _github.Enterprise.Organization.Create(newOrganization2);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var organizations = await _organizationsClient.GetAllForCurrent(options);
+
+                Assert.Equal(2, organizations.Count);
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task ReturnsCorrectCountOfOrganizationsWithStart()
+            {
+                string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
+                string orgName1 = string.Concat(orgLogin1, " Display Name 1");
+                string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
+                string orgName2 = string.Concat(orgLogin2, " Display Name 2");
+
+                var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
+                var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
+                await _github.Enterprise.Organization.Create(newOrganization1);
+                await _github.Enterprise.Organization.Create(newOrganization2);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2,
+                };
+
+                var organizations = await _organizationsClient.GetAllForCurrent(options);
+
+                Assert.Equal(1, organizations.Count);
+            }
+
+            [GitHubEnterpriseTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPage()
+            {
+                string orgLogin1 = Helper.MakeNameWithTimestamp("MyOrganization1");
+                string orgName1 = string.Concat(orgLogin1, " Display Name 1");
+                string orgLogin2 = Helper.MakeNameWithTimestamp("MyOrganization2");
+                string orgName2 = string.Concat(orgLogin2, " Display Name 2");
+                string orgLogin3 = Helper.MakeNameWithTimestamp("MyOrganization3");
+                string orgName3 = string.Concat(orgLogin3, " Display Name 3");
+
+                var newOrganization1 = new NewOrganization(orgLogin1, EnterpriseHelper.UserName, orgName1);
+                var newOrganization2 = new NewOrganization(orgLogin2, EnterpriseHelper.UserName, orgName2);
+                var newOrganization3 = new NewOrganization(orgLogin3, EnterpriseHelper.UserName, orgName3);
+                await _github.Enterprise.Organization.Create(newOrganization1);
+                await _github.Enterprise.Organization.Create(newOrganization2);
+                await _github.Enterprise.Organization.Create(newOrganization3);
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await _organizationsClient.GetAllForCurrent(startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await _organizationsClient.GetAllForCurrent(skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Name, secondPage[0].Name);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationsClientTests.cs
@@ -1,0 +1,7 @@
+﻿namespace Octokit.Tests.Integration.Clients
+{
+    public class OrganizationsClientTests
+    {
+        
+    }
+}

--- a/Octokit.Tests.Integration/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationsClientTests.cs
@@ -1,7 +1,0 @@
-﻿namespace Octokit.Tests.Integration.Clients
-{
-    public class OrganizationsClientTests
-    {
-        
-    }
-}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Clients\IssuesEventsClientTests.cs" />
     <Compile Include="Clients\MigrationsClientTests.cs" />
     <Compile Include="Clients\MilestonesClientTests.cs" />
+    <Compile Include="Clients\OrganizationClientTests.cs" />
     <Compile Include="Clients\OrganizationMembersClientTests.cs" />
     <Compile Include="Clients\PullRequestsClientTests.cs" />
     <Compile Include="Clients\ReferencesClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -95,7 +95,6 @@
     <Compile Include="Clients\MigrationsClientTests.cs" />
     <Compile Include="Clients\MilestonesClientTests.cs" />
     <Compile Include="Clients\OrganizationMembersClientTests.cs" />
-    <Compile Include="Clients\OrganizationsClientTests.cs" />
     <Compile Include="Clients\PullRequestsClientTests.cs" />
     <Compile Include="Clients\ReferencesClientTests.cs" />
     <Compile Include="Clients\RepositoryCommitsClientTests.cs" />

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Clients\MigrationsClientTests.cs" />
     <Compile Include="Clients\MilestonesClientTests.cs" />
     <Compile Include="Clients\OrganizationMembersClientTests.cs" />
+    <Compile Include="Clients\OrganizationsClientTests.cs" />
     <Compile Include="Clients\PullRequestsClientTests.cs" />
     <Compile Include="Clients\ReferencesClientTests.cs" />
     <Compile Include="Clients\RepositoryCommitsClientTests.cs" />

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(""));
             }
         }
 
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, new OrganizationUpdate()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("org", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("", new OrganizationUpdate()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", new OrganizationUpdate()));
             }
         }
     }

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -23,72 +23,137 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
-                var client = Substitute.For<IApiConnection>();
-                var orgsClient = new OrganizationsClient(client);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-                orgsClient.Get("orgName");
+                await client.Get("orgName");
 
-                client.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"));
+                connection.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"));
             }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var orgs = new OrganizationsClient(Substitute.For<IApiConnection>());
+                var client = new OrganizationsClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => orgs.Get(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(""));
             }
         }
 
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
-                var client = Substitute.For<IApiConnection>();
-                var orgs = new OrganizationsClient(client);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-                orgs.GetAll("username");
+                await client.GetAll("username");
 
-                client.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"));
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll("username", options);
+
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
             }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var orgs = new OrganizationsClient(Substitute.For<IApiConnection>());
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => orgs.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("username", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
             }
         }
 
         public class TheGetAllForCurrentMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
-                var client = Substitute.For<IApiConnection>();
-                var orgs = new OrganizationsClient(client);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-                orgs.GetAllForCurrent();
+                await client.GetAllForCurrent();
 
-                client.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"));
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForCurrent(options);
+
+                connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));
             }
         }
 
         public class TheUpdateMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
-                var client = Substitute.For<IApiConnection>();
-                var orgs = new OrganizationsClient(client);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
 
-                orgs.Update("initrode", new OrganizationUpdate());
+                await client.Update("initrode", new OrganizationUpdate());
 
-                client.Received().Patch<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/initrode"), Args.OrganizationUpdate);
+                connection.Received().Patch<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/initrode"), Args.OrganizationUpdate);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, new OrganizationUpdate()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("org", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("", new OrganizationUpdate()));
             }
         }
     }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableOrganizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesLabelsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepoCollaboratorsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Get("orgName");
 
-                //gitHubClient.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"));
+                gitHubClient.Received().Organization.Get("orgName");
             }
 
             [Fact]
@@ -50,7 +50,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("username");
 
-                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
+                gitHubClient.Received().Organization.GetAll("username");
             }
 
             [Fact]
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("username", options);
 
-                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
+                gitHubClient.Received().Organization.GetAll("username", options);
             }
 
             [Fact]
@@ -96,7 +96,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrent();
 
-                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), Args.ApiOptions);
+                gitHubClient.Received().Organization.GetAllForCurrent();
             }
 
             [Fact]
@@ -114,7 +114,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrent(options);
 
-                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), options);
+                gitHubClient.Received().Organization.GetAllForCurrent(options);
             }
 
             [Fact]
@@ -135,9 +135,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableOrganizationsClient(gitHubClient);
 
-                client.Update("initrode", new OrganizationUpdate());
+                var organizationUpdate = new OrganizationUpdate();
+                client.Update("initrode", organizationUpdate);
 
-                //gitHubClient.Received().Patch<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/initrode"), Args.OrganizationUpdate);
+                gitHubClient.Received().Organization.Update("initrode", organizationUpdate);
             }
 
             [Fact]
@@ -149,7 +150,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.Update(null, new OrganizationUpdate()));
                 Assert.Throws<ArgumentNullException>(() => client.Update("org", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.Update("", new OrganizationUpdate()));
+                Assert.Throws<ArgumentException>(() => client.Update("", new OrganizationUpdate()));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableOrganizationsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableOrganizationsClient(null));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                client.Get("orgName");
+
+                //gitHubClient.Received().Get<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgName"));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableOrganizationsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null));
+
+                Assert.Throws<ArgumentException>(() => client.Get(""));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                client.GetAll("username");
+
+                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("username", options);
+
+                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("username", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll(""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", ApiOptions.None));
+            }
+        }
+
+        public class TheGetAllForCurrentMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                client.GetAllForCurrent();
+
+                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCurrent(options);
+
+                //gitHubClient.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "user/orgs"), options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent(null));
+            }
+        }
+
+        public class TheUpdateMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                client.Update("initrode", new OrganizationUpdate());
+
+                //gitHubClient.Received().Patch<Organization>(Arg.Is<Uri>(u => u.ToString() == "orgs/initrode"), Args.OrganizationUpdate);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(null, new OrganizationUpdate()));
+                Assert.Throws<ArgumentNullException>(() => client.Update("org", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Update("", new OrganizationUpdate()));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -44,11 +44,30 @@ namespace Octokit
         Task<IReadOnlyList<Organization>> GetAllForCurrent();
 
         /// <summary>
+        /// Returns all <see cref="Organization" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the current user's <see cref="Organization"/>s.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
+            Justification = "Method makes a network request")]
+        Task<IReadOnlyList<Organization>> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         Task<IReadOnlyList<Organization>> GetAll(string user);
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <param name="user">The login of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options);
 
         /// <summary>
         /// Update the specified organization with data from <see cref="OrganizationUpdate"/>.

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -67,7 +67,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations());
+            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations(), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -54,19 +54,48 @@ namespace Octokit
         /// <returns>A list of the current user's <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAllForCurrent()
         {
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the current user's <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
             return ApiConnection.GetAll<Organization>(ApiUrls.Organizations());
         }
 
         /// <summary>
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
+        /// <param name="user">The login of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAll(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations(user));
+            return GetAll(user, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all <see cref="Organization" />s for the specified user.
+        /// </summary>
+        /// <param name="user">The login of the user</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        public Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Organization>(ApiUrls.Organizations(user), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1165 

To-do:

- [x]  Add overloads on IOrganizationsClient
- [x]  Add overloads on IObservableOrganizationsClient
- [x]  Add unit tests for these new methods
- [x]  Add integration tests for these new methods

    I had to use [GitHubEnterpriseTest] to get these tests done, because I should create organizations firstly.

/cc @shiftkey, @ryangribble 