### PR TITLE
Add ApiOptions overloads to methods on I(Observable)IssuesLabelsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -13,10 +13,23 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <returns>The list of labels</returns>
-        IObservable<Label> GetAllForIssue(string owner, string repo, int number);
+        IObservable<Label> GetAllForIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -25,111 +38,21 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns>The list of labels</returns>
-        IObservable<Label> GetAllForRepository(string owner, string repo);
+        IObservable<Label> GetAllForRepository(string owner, string name);
 
         /// <summary>
-        /// Gets a single Label by name.
+        /// Gets all  labels for the repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns>The label</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
-        IObservable<Label> Get(string owner, string repo, string name);
-
-        /// <summary>
-        /// Deletes a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string repo, string name);
-
-        /// <summary>
-        /// Creates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
-        IObservable<Label> Create(string owner, string repo, NewLabel newLabel);
-
-        /// <summary>
-        /// Updates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
-        IObservable<Label> Update(string owner, string repo, string name, LabelUpdate labelUpdate);
-
-        /// <summary>
-        /// Adds a label to an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
-        IObservable<Label> AddToIssue(string owner, string repo, int number, string[] labels);
-
-        /// <summary>
-        /// Removes a label from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
-        /// <returns></returns>
-        IObservable<Unit> RemoveFromIssue(string owner, string repo, int number, string label);
-
-        /// <summary>
-        /// Replaces all labels on the specified issues with the provided labels
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
-        IObservable<Label> ReplaceAllForIssue(string owner, string repo, int number, string[] labels);
-
-        /// <summary>
-        /// Removes all labels from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
-        IObservable<Unit> RemoveAllFromIssue(string owner, string repo, int number);
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -138,9 +61,124 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <returns></returns>
-        IObservable<Label> GetAllForMilestone(string owner, string repo, int number);
+        IObservable<Label> GetAllForMilestone(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+        Justification = "Method makes a network request")]
+        IObservable<Label> Get(string owner, string name, string labelName);
+
+        /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(string owner, string name, string labelName);
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        IObservable<Label> Create(string owner, string name, NewLabel newLabel);
+
+        /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labelName">The name of the label to remove</param>
+        /// <returns></returns>
+        IObservable<Unit> RemoveFromIssue(string owner, string name, int number, string labelName);
+
+        /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -26,12 +26,35 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <returns>The list of labels</returns>
-        public IObservable<Label> GetAllForIssue(string owner, string repo, int number)
+        public IObservable<Label> GetAllForIssue(string owner, string name, int number)
         {
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(owner, repo, number));
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForIssue(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(owner, name, number), options);
         }
 
         /// <summary>
@@ -41,11 +64,71 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns>The list of labels</returns>
-        public IObservable<Label> GetAllForRepository(string owner, string repo)
+        public IObservable<Label> GetAllForRepository(string owner, string name)
         {
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.Labels(owner, repo));
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.Labels(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <returns></returns>
+        public IObservable<Label> GetAllForMilestone(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForMilestone(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
         }
 
         /// <summary>
@@ -55,12 +138,16 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
         /// <returns>The label</returns>
-        public IObservable<Label> Get(string owner, string repo, string name)
+        public IObservable<Label> Get(string owner, string name, string labelName)
         {
-            return _client.Get(owner, repo, name).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.Get(owner, name, labelName).ToObservable();
         }
 
         /// <summary>
@@ -70,12 +157,16 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string repo, string name)
+        public IObservable<Unit> Delete(string owner, string name, string labelName)
         {
-            return _client.Delete(owner, repo, name).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.Delete(owner, name, labelName).ToObservable();
         }
 
         /// <summary>
@@ -85,12 +176,16 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
         /// <returns>The created label</returns>
-        public IObservable<Label> Create(string owner, string repo, NewLabel newLabel)
+        public IObservable<Label> Create(string owner, string name, NewLabel newLabel)
         {
-            return _client.Create(owner, repo, newLabel).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(newLabel, "newLabel");
+
+            return _client.Create(owner, name, newLabel).ToObservable();
         }
 
         /// <summary>
@@ -100,13 +195,18 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
         /// <returns>The updated label</returns>
-        public IObservable<Label> Update(string owner, string repo, string name, LabelUpdate labelUpdate)
+        public IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
-            return _client.Update(owner, repo, name, labelUpdate).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(labelName, "labelName");
+            Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
+
+            return _client.Update(owner, name, labelName, labelUpdate).ToObservable();
         }
 
         /// <summary>
@@ -116,13 +216,17 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
         /// <returns></returns>
-        public IObservable<Label> AddToIssue(string owner, string repo, int number, string[] labels)
+        public IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels)
         {
-            return _client.AddToIssue(owner, repo, number, labels)
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return _client.AddToIssue(owner, name, number, labels)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages
         }
@@ -135,13 +239,17 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
+        /// <param name="labelName">The name of the label to remove</param>
         /// <returns></returns>
-        public IObservable<Unit> RemoveFromIssue(string owner, string repo, int number, string label)
+        public IObservable<Unit> RemoveFromIssue(string owner, string name, int number, string labelName)
         {
-            return _client.RemoveFromIssue(owner, repo, number, label).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.RemoveFromIssue(owner, name, number, labelName).ToObservable();
         }
 
         /// <summary>
@@ -151,13 +259,17 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
         /// <returns></returns>
-        public IObservable<Label> ReplaceAllForIssue(string owner, string repo, int number, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
         {
-            return _client.ReplaceAllForIssue(owner, repo, number, labels)
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return _client.ReplaceAllForIssue(owner, name, number, labels)
                 .ToObservable()
                 .SelectMany(x => x);  // HACK: PUT is not compatible with GetAndFlattenPages
         }
@@ -169,27 +281,15 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <returns></returns>
-        public IObservable<Unit> RemoveAllFromIssue(string owner, string repo, int number)
+        public IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number)
         {
-            return _client.RemoveAllFromIssue(owner, repo, number).ToObservable();
-        }
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-        /// <summary>
-        /// Gets labels for every issue in a milestone
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
-        public IObservable<Label> GetAllForMilestone(string owner, string repo, int number)
-        {
-            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(owner, repo, number));
+            return _client.RemoveAllFromIssue(owner, name, number).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesLabelsClientTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -17,13 +19,14 @@ public class IssuesLabelsClientTests : IDisposable
 
         _issuesLabelsClient = github.Issue.Labels;
         _issuesClient = github.Issue;
+
         var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
         _context = github.CreateRepositoryContext(new NewRepository(repoName)).Result;
     }
 
     [IntegrationTest]
-    public async Task CanListLabelsForAnIssue()
+    public async Task CanListIssueLabelsForAnIssue()
     {
         var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
         var newLabel = new NewLabel("test label", "FFFFFF");
@@ -38,10 +41,115 @@ public class IssuesLabelsClientTests : IDisposable
         issueUpdate.AddLabel(label.Name);
         var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
         Assert.NotNull(updated);
+
         issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
         Assert.Equal(1, issueLabelsInfo.Count);
         Assert.Equal(newLabel.Color, issueLabelsInfo[0].Color);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithoutStartForAnIssue()
+    {
+        var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
+        var newLabel = new NewLabel("test label", "FFFFFF");
+
+        var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        Assert.Empty(issueLabelsInfo);
+
+        var issueUpdate = new IssueUpdate();
+        issueUpdate.AddLabel(label.Name);
+        var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+        Assert.NotNull(updated);
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1
+        };
+
+        issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+        Assert.Equal(newLabel.Color, issueLabelsInfo[0].Color);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithStartForAnIssue()
+    {
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewIssue("A test issue") { Body = "A new unassigned issue" });
+        var issueUpdate = new IssueUpdate();
+
+        var labels = new List<Label>();
+
+        for (int i = 0; i < 2; i++)
+        {
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("test label " + (i + 1), "FFFFF" + (i+1)));
+            labels.Add(label);
+            issueUpdate.AddLabel(label.Name);
+        }
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        Assert.Empty(issueLabelsInfo);
+        
+        var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+        Assert.NotNull(updated);
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 2
+        };
+
+        issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+        Assert.Equal(labels.Last().Color, issueLabelsInfo.First().Color);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctIssueLabelsBasedOnStartPageForAnIssue()
+    {
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewIssue("A test issue") { Body = "A new unassigned issue" });
+        var issueUpdate = new IssueUpdate();
+        
+        for (int i = 0; i < 2; i++)
+        {
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("test label " + (i + 1), "FFFFF" + (i + 1)));
+            issueUpdate.AddLabel(label.Name);
+        }
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+        Assert.Empty(issueLabelsInfo);
+
+        var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+        Assert.NotNull(updated);
+
+        var startOptions = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 1
+        };
+
+        var firstPage = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _issuesLabelsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, skipStartOptions);
+
+        Assert.Equal(1, firstPage.Count);
+        Assert.Equal(1, secondPage.Count);
+        Assert.NotEqual(firstPage.First().Color, secondPage.First().Color);
     }
 
     [IntegrationTest]
@@ -58,6 +166,241 @@ public class IssuesLabelsClientTests : IDisposable
         var issueLabels = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
 
         Assert.Equal(originalIssueLabels.Count + 2, issueLabels.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithoutStartForARepository()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate();
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1
+        };
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithStartForARepository()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate();
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 2
+        };
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctIssueLabelsBasedOnStartPageForARepository()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate();
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var startOptions = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 1
+        };
+
+        var firstPage = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _issuesLabelsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, skipStartOptions);
+
+        Assert.Equal(1, firstPage.Count);
+        Assert.Equal(1, secondPage.Count);
+        Assert.NotEqual(firstPage.First().Color, secondPage.First().Color);
+    }
+
+    [IntegrationTest]
+    public async Task CanListLabelsForAnMilestone()
+    {
+        var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
+        var newLabel = new NewLabel("test label", "FFFFFF");
+        var newMilestone = new NewMilestone("New Milestone");
+
+        var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+        var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+        
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number);
+        Assert.Empty(issueLabelsInfo);
+
+        var issueUpdate = new IssueUpdate { Milestone = milestone.Number };
+        issueUpdate.AddLabel(label.Name);
+
+        var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+        Assert.NotNull(updated);
+
+        issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+        Assert.Equal(label.Color, issueLabelsInfo[0].Color);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithoutStartForAMilestone()
+    {
+        var newMilestone = new NewMilestone("New Milestone");
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate { Milestone = milestone.Number };
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1
+        };
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfIssueLabelsWithStartForAMilestone()
+    {
+        var newMilestone = new NewMilestone("New Milestone");
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate { Milestone = milestone.Number };
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var options = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 2
+        };
+
+        var issueLabelsInfo = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number, options);
+
+        Assert.Equal(1, issueLabelsInfo.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctIssueLabelsBasedOnStartPageForAMilestone()
+    {
+        var newMilestone = new NewMilestone("New Milestone");
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        for (int i = 0; i < 2; i++)
+        {
+            int k = i + 1;
+            var newIssue = new NewIssue("A test issue " + k) { Body = "A new unassigned issue " + k };
+            var newLabel = new NewLabel("test label " + k, "FFFFF" + k);
+
+            var label = await _issuesLabelsClient.Create(_context.RepositoryOwner, _context.RepositoryName, newLabel);
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            var issueUpdate = new IssueUpdate { Milestone = milestone.Number };
+            issueUpdate.AddLabel(label.Name);
+            var updated = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+            Assert.NotNull(updated);
+        }
+
+        var startOptions = new ApiOptions
+        {
+            PageCount = 1,
+            PageSize = 1,
+            StartPage = 1
+        };
+
+        var firstPage = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _issuesLabelsClient.GetAllForMilestone(_context.RepositoryOwner, _context.RepositoryName, milestone.Number, skipStartOptions);
+
+        Assert.Equal(1, firstPage.Count);
+        Assert.Equal(1, secondPage.Count);
+        Assert.NotEqual(firstPage.First().Color, secondPage.First().Color);
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -28,7 +28,25 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue("fake", "repo", 42);
 
-                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"));
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForIssue("fake", "repo", 42, options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"), options);
             }
 
             [Fact]
@@ -36,9 +54,16 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None));
             }
         }
 
@@ -52,7 +77,25 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"));
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"), options);
             }
 
             [Fact]
@@ -60,21 +103,77 @@ namespace Octokit.Tests.Clients
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+            }
+        }
+
+        public class TheGetForMilestoneMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                await client.GetAllForMilestone("fake", "repo", 42);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForMilestone("fake", "repo", 42, options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42/labels"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("", "name", 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("", "name", 42, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42, ApiOptions.None));
             }
         }
 
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesLabelsClient(connection);
 
-                client.Get("fake", "repo", "label");
+                await client.Get("fake", "repo", "label");
 
                 connection.Received().Get<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels/label"));
             }
@@ -86,6 +185,11 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "label"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "label"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "label"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
             }
         }
 
@@ -112,6 +216,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue(null, "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", null, 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddToIssue("", "name", 42, labels));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddToIssue("owner", "", 42, labels));
             }
         }
 
@@ -136,6 +243,10 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue(null, "name", 42, "label"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", null, 42, "label"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("", "name", 42, "label"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("owner", "", 42, "label"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("owner", "name", 42, ""));
             }
         }
 
@@ -162,6 +273,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue(null, "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", null, 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.ReplaceAllForIssue("", "name", 42, labels));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.ReplaceAllForIssue("owner", "", 42, labels));
             }
         }
 
@@ -185,29 +299,9 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAllFromIssue(null, "name", 42));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAllFromIssue("owner", null, 42));
-            }
-        }
 
-        public class TheGetForMilestoneMethod
-        {
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new IssuesLabelsClient(connection);
-
-                client.GetAllForMilestone("fake", "repo", 42);
-
-                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42/labels"));
-            }
-
-            [Fact]
-            public async Task EnsuresNonNullArguments()
-            {
-                var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAllFromIssue("", "name", 42));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAllFromIssue("owner", "", 42));
             }
         }
     }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableIssuesLabelsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepoCollaboratorsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentStatusClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
@@ -1,0 +1,317 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableIssuesLabelsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableIssuesLabelsClient(null));
+            }
+        }
+
+        public class TheGetForIssueMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForIssue("fake", "repo", 42);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForIssue("fake", "repo", 42, options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None));
+            }
+        }
+
+        public class TheGetForRepositoryMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForRepository("fake", "repo");
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+            }
+        }
+
+        public class TheGetForMilestoneMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForMilestone("fake", "repo", 42);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForMilestone("fake", "repo", 42, options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones/42/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("", "name", 42));
+                Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42));
+                Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("", "name", 42, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42, ApiOptions.None));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.Get("fake", "repo", "label");
+
+                gitHubClient.Issue.Labels.Received().Get("fake", "repo", "label");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", "label"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "label"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "label"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "label"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+            }
+        }
+
+        public class TheAddToIssueMethod
+        {
+            readonly string[] labels = { "foo", "bar" };
+
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.AddToIssue("fake", "repo", 42, labels);
+
+                gitHubClient.Issue.Labels.Received().AddToIssue("fake", "repo", 42, labels);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.AddToIssue(null, "name", 42, labels));
+                Assert.Throws<ArgumentNullException>(() => client.AddToIssue("owner", null, 42, labels));
+                Assert.Throws<ArgumentNullException>(() => client.AddToIssue("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentException>(() => client.AddToIssue("", "name", 42, labels));
+                Assert.Throws<ArgumentException>(() => client.AddToIssue("owner", "", 42, labels));
+            }
+        }
+
+        public class TheRemoveFromIssueMethod
+        {
+            [Fact]
+            public void DeleteCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.RemoveFromIssue("fake", "repo", 42, "label");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels/label"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue(null, "name", 42, "label"));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue("owner", null, 42, "label"));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("", "name", 42, "label"));
+                Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("owner", "", 42, "label"));
+                Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("owner", "name", 42, ""));
+            }
+        }
+
+        public class TheReplaceForIssueMethod
+        {
+            readonly string[] labels = { "foo", "bar" };
+
+            [Fact]
+            public void PutsToCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.ReplaceAllForIssue("fake", "repo", 42, labels);
+
+                gitHubClient.Issue.Labels.Received().ReplaceAllForIssue("fake", "repo", 42, labels);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue(null, "name", 42, labels));
+                Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", null, 42, labels));
+                Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentException>(() => client.ReplaceAllForIssue("", "name", 42, labels));
+                Assert.Throws<ArgumentException>(() => client.ReplaceAllForIssue("owner", "", 42, labels));
+            }
+        }
+
+        public class TheRemoveAllFromIssueMethod
+        {
+            [Fact]
+            public void DeletesCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.RemoveAllFromIssue("fake", "repo", 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAllFromIssue(null, "name", 42));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAllFromIssue("owner", null, 42));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveAllFromIssue("", "name", 42));
+                Assert.Throws<ArgumentException>(() => client.RemoveAllFromIssue("owner", "", 42));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -13,10 +13,23 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <returns>The list of labels</returns>
-        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string repo, int number);
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -25,111 +38,21 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns>The list of labels</returns>
-        Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string repo);
+        Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name);
 
         /// <summary>
-        /// Gets a single Label by name.
+        /// Gets all  labels for the repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns>The label</returns>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
-        Task<Label> Get(string owner, string repo, string name);
-
-        /// <summary>
-        /// Deletes a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns></returns>
-        Task Delete(string owner, string repo, string name);
-
-        /// <summary>
-        /// Creates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
-        Task<Label> Create(string owner, string repo, NewLabel newLabel);
-
-        /// <summary>
-        /// Updates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
-        Task<Label> Update(string owner, string repo, string name, LabelUpdate labelUpdate);
-
-        /// <summary>
-        /// Adds a label to an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
-        Task<IReadOnlyList<Label>> AddToIssue(string owner, string repo, int number, string[] labels);
-
-        /// <summary>
-        /// Removes a label from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
-        /// <returns></returns>
-        Task RemoveFromIssue(string owner, string repo, int number, string label);
-
-        /// <summary>
-        /// Replaces all labels on the specified issues with the provided labels
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string repo, int number, string[] labels);
-
-        /// <summary>
-        /// Removes all labels from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
-        Task RemoveAllFromIssue(string owner, string repo, int number);
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -138,9 +61,124 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string repo, int number);
+        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+        Justification = "Method makes a network request")]
+        Task<Label> Get(string owner, string name, string labelName);
+
+        /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        Task Delete(string owner, string name, string labelName);
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        Task<Label> Create(string owner, string name, NewLabel newLabel);
+
+        /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="label">The name of the label to remove</param>
+        /// <returns></returns>
+        Task RemoveFromIssue(string owner, string name, int number, string label);
+
+        /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        Task RemoveAllFromIssue(string owner, string name, int number);
     }
 }

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -152,9 +152,9 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
+        /// <param name="labelName">The name of the label to remove</param>
         /// <returns></returns>
-        Task RemoveFromIssue(string owner, string name, int number, string label);
+        Task RemoveFromIssue(string owner, string name, int number, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -17,15 +17,35 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <returns>The list of labels</returns>
-        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string repo, int number)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(owner, repo, number));
+            return GetAllForIssue(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(owner, name, number), options);
         }
 
         /// <summary>
@@ -35,170 +55,33 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <returns>The list of labels</returns>
-        public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string repo)
+        public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-
-            return ApiConnection.GetAll<Label>(ApiUrls.Labels(owner, repo));
-        }
-
-        /// <summary>
-        /// Gets a single Label by name.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns>The label</returns>
-        public Task<Label> Get(string owner, string repo, string name)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<Label>(ApiUrls.Label(owner, repo, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
         }
 
         /// <summary>
-        /// Deletes a label.
+        /// Gets all  labels for the repository.
         /// </summary>
         /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <returns></returns>
-        public Task Delete(string owner, string repo, string name)
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.Delete(ApiUrls.Label(owner, repo, name));
-        }
-
-        /// <summary>
-        /// Creates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
-        public Task<Label> Create(string owner, string repo, NewLabel newLabel)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-            Ensure.ArgumentNotNull(newLabel, "newLabel");
-
-            return ApiConnection.Post<Label>(ApiUrls.Labels(owner, repo), newLabel);
-        }
-
-        /// <summary>
-        /// Updates a label.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="name">The name of the label</param>
-        /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
-        public Task<Label> Update(string owner, string repo, string name, LabelUpdate labelUpdate)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
-
-            return ApiConnection.Post<Label>(ApiUrls.Label(owner, repo, name), labelUpdate);
-        }
-
-        /// <summary>
-        /// Adds a label to an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string repo, int number, string[] labels)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-            Ensure.ArgumentNotNull(labels, "labels");
-
-            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, repo, number), labels);
-        }
-
-        /// <summary>
-        /// Removes a label from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
-        /// <returns></returns>
-        public Task RemoveFromIssue(string owner, string repo, int number, string label)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-            Ensure.ArgumentNotNullOrEmptyString(label, "label");
-
-            return ApiConnection.Delete(ApiUrls.IssueLabel(owner, repo, number, label));
-        }
-
-        /// <summary>
-        /// Replaces all labels on the specified issues with the provided labels
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string repo, int number, string[] labels)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-            Ensure.ArgumentNotNull(labels, "labels");
-
-            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, repo, number), labels);
-        }
-
-        /// <summary>
-        /// Removes all labels from an issue
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
-        public Task RemoveAllFromIssue(string owner, string repo, int number)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
-
-            return ApiConnection.Delete(ApiUrls.IssueLabels(owner, repo, number));
+            return ApiConnection.GetAll<Label>(ApiUrls.Labels(owner, name), options);
         }
 
         /// <summary>
@@ -208,15 +91,191 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string repo, int number)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(owner, repo, number));
+            return GetAllForMilestone(owner, name, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        public Task<Label> Get(string owner, string name, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return ApiConnection.Get<Label>(ApiUrls.Label(owner, name, labelName));
+        }
+
+        /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        public Task Delete(string owner, string name, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return ApiConnection.Delete(ApiUrls.Label(owner, name, labelName));
+        }
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        public Task<Label> Create(string owner, string name, NewLabel newLabel)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(newLabel, "newLabel");
+
+            return ApiConnection.Post<Label>(ApiUrls.Labels(owner, name), newLabel);
+        }
+
+        /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        public Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+            Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
+
+            return ApiConnection.Post<Label>(ApiUrls.Label(owner, name, labelName), labelUpdate);
+        }
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, number), labels);
+        }
+
+        /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="label">The name of the label to remove</param>
+        /// <returns></returns>
+        public Task RemoveFromIssue(string owner, string name, int number, string label)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(label, "label");
+
+            return ApiConnection.Delete(ApiUrls.IssueLabel(owner, name, number, label));
+        }
+
+        /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, number), labels);
+        }
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        public Task RemoveAllFromIssue(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return ApiConnection.Delete(ApiUrls.IssueLabels(owner, name, number));
         }
     }
 }

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -229,15 +229,15 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <param name="label">The name of the label to remove</param>
+        /// <param name="labelName">The name of the label to remove</param>
         /// <returns></returns>
-        public Task RemoveFromIssue(string owner, string name, int number, string label)
+        public Task RemoveFromIssue(string owner, string name, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(label, "label");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
-            return ApiConnection.Delete(ApiUrls.IssueLabel(owner, name, number, label));
+            return ApiConnection.Delete(ApiUrls.IssueLabel(owner, name, number, labelName));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1160

To-do:

- [x]  Add overloads on IIssuesLabelsClient
- [x]  Add overloads on IObservableIssuesLabelsClient
- [x]  Rename "repo" parameter to "name" to deliver more consistency
- [x]  Add unit tests for these new methods
- [x]  Add integration tests for these new methods 

/cc @shiftkey, @ryangribble 