### PR TITLE
Add ApiOptions overloads to methods on I(Observable)NotificationsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
@@ -66,7 +66,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request);
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -15,26 +15,72 @@ namespace Octokit.Reactive
         IObservable<Notification> GetAllForCurrent();
 
         /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<Notification> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
         IObservable<Notification> GetAllForRepository(string owner, string name);
 
         /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(NotificationsRequest request);
 
         /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
+
+        /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -111,10 +111,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="markAsRead">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
-        IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsRead);
+        IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request)
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request)
@@ -123,7 +123,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -234,6 +234,8 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription)
         {
+            Ensure.ArgumentNotNull(threadSubscription, "threadSubscription");
+
             return _notificationsClient.SetThreadSubscription(id, threadSubscription).ToObservable();
         }
 

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -25,35 +25,88 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
         public IObservable<Notification> GetAllForCurrent()
         {
-            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications());
+            return GetAllForCurrent(ApiOptions.None);
         }
-
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(string owner, string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
-            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(), request.ToParametersDictionary());
+            return GetAllForCurrent(request, ApiOptions.None);
         }
 
         /// <summary>
-        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
-        public IObservable<Notification> GetAllForRepository(string owner, string name)
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
-            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name));
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request)
@@ -62,7 +115,26 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
-            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary());
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -155,6 +155,8 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Unit> MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
+
             return _notificationsClient.MarkAsRead(markAsReadRequest).ToObservable();
         }
 
@@ -167,6 +169,9 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Unit> MarkAsReadForRepository(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return _notificationsClient.MarkAsReadForRepository(owner, name).ToObservable();
         }
 
@@ -175,12 +180,16 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="markAsRead">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
-        public IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsRead)
+        public IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest)
         {
-            return _notificationsClient.MarkAsReadForRepository(owner, name, markAsRead).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
+
+            return _notificationsClient.MarkAsReadForRepository(owner, name, markAsReadRequest).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/NotificationsClientTests.cs
+++ b/Octokit.Tests/Clients/NotificationsClientTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 
@@ -27,7 +29,72 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForCurrent();
 
-                connection.Received().GetAll<Notification>(endpoint);
+                connection.Received().GetAll<Notification>(endpoint, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlApiOptions()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCurrent(options);
+
+                connection.Received().GetAll<Notification>(endpoint, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequest()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                client.GetAllForCurrent(notificationsRequest);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2
+                                                                                                              && d["all"] == "true" && d["participating"] == "false"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCurrent(notificationsRequest, options);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2
+                                                                                                              && d["all"] == "true" && d["participating"] == "false"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new NotificationsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent((ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent((NotificationsRequest)null));
             }
         }
 
@@ -42,7 +109,87 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("banana", "split");
 
-                connection.Received().GetAll<Notification>(endpoint);
+                connection.Received().GetAll<Notification>(endpoint, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("banana", "split", options);
+
+                connection.Received().GetAll<Notification>(endpoint, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequest()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                client.GetAllForRepository("banana", "split", notificationsRequest);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"), 
+                        Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("banana", "split", notificationsRequest, options);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"), 
+                        options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new NotificationsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (NotificationsRequest)null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest()));
             }
         }
 
@@ -73,6 +220,37 @@ namespace Octokit.Tests.Clients
                 client.MarkAsReadForRepository("banana", "split");
 
                 connection.Received().Put(endpoint);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlParameterized()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var markAsReadRequest = new MarkAsReadRequest();
+
+                client.MarkAsReadForRepository("banana", "split", markAsReadRequest);
+
+                connection.Received().Put<object>(endpoint, markAsReadRequest);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new NotificationsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name", new MarkAsReadRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null, new MarkAsReadRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("", "name", new MarkAsReadRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("owner", "", new MarkAsReadRequest()));
             }
         }
 
@@ -134,6 +312,14 @@ namespace Octokit.Tests.Clients
                 client.SetThreadSubscription(1, data);
 
                 connection.Received().Put<ThreadSubscription>(endpoint, data);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new NotificationsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.SetThreadSubscription(1, null));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableOrganizationsClientTests.cs" />
+    <Compile Include="Reactive\ObservableNotificationsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesLabelsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepoCollaboratorsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
@@ -1,0 +1,360 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableObservableNotificationsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableNotificationsClient(null));
+            }
+        }
+
+        public class TheGetAllForCurrentMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.GetAllForCurrent();
+
+                connection.Received().Get<List<Notification>>(endpoint, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlApiOptions()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCurrent(options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequest()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                client.GetAllForCurrent(notificationsRequest);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2
+                                                                                                                 && d["all"] == "true" && d["participating"] == "false"), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForCurrent(notificationsRequest, options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 4
+                                                                                                                 && d["all"] == "true" && d["participating"] == "false"
+                                                                                                                 && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent((ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent((NotificationsRequest)null));
+            }
+        }
+
+        public class TheGetAllForRepository
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.GetAllForRepository("banana", "split");
+
+                connection.Received().Get<List<Notification>>(endpoint, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("banana", "split", options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequest()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                client.GetAllForRepository("banana", "split", notificationsRequest);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(
+                    d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("banana", "split", notificationsRequest, options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(
+                    d => d.Count == 4 && d["all"] == "true" && d["participating"] == "false"
+                         && d["page"] == "1" && d["per_page"] == "1"),
+                    null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (NotificationsRequest)null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest()));
+            }
+        }
+
+        public class TheMarkAsRead
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.MarkAsRead();
+
+                connection.Received().Put(endpoint);
+            }
+        }
+
+        public class TheMarkAsReadForRepository
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.MarkAsReadForRepository("banana", "split");
+
+                connection.Received().Put(endpoint);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlParameterized()
+            {
+                var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var markAsReadRequest = new MarkAsReadRequest();
+
+                client.MarkAsReadForRepository("banana", "split", markAsReadRequest);
+
+                connection.Received().Put<object>(endpoint, markAsReadRequest);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name", new MarkAsReadRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null, new MarkAsReadRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("", "name", new MarkAsReadRequest()));
+                Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("owner", "", new MarkAsReadRequest()));
+            }
+        }
+
+        public class TheGetNotification
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications/threads/1", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.Get(1);
+
+                connection.Received().Get<Notification>(endpoint, null, null);
+            }
+        }
+
+        public class TheMarkNotificationAsRead
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications/threads/1", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.MarkAsRead(1);
+
+                connection.Received().Patch(endpoint);
+            }
+        }
+
+        public class TheGetThreadSubscription
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications/threads/1/subscription", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.GetThreadSubscription(1);
+
+                connection.Received().Get<ThreadSubscription>(endpoint, null, null);
+            }
+        }
+
+        public class TheSetThreadSubscription
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications/threads/1/subscription", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+                var data = new NewThreadSubscription();
+
+                client.SetThreadSubscription(1, data);
+
+                connection.Received().Put<ThreadSubscription>(endpoint, data);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.SetThreadSubscription(1, null));
+            }
+        }
+
+        public class TheDeleteThreadSubscription
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var endpoint = new Uri("notifications/threads/1/subscription", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.DeleteThreadSubscription(1);
+
+                connection.Received().Delete(endpoint);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
-    public class ObservableObservableNotificationsClientTests
+    public class ObservableNotificationsClientTests
     {
         public class TheCtor
         {

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -23,14 +23,36 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request);
 
         /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
+
+        /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name);
@@ -38,9 +60,33 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
@@ -41,7 +41,7 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
@@ -72,7 +72,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request);
@@ -82,7 +82,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -117,10 +117,10 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="markAsRead">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
-        Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsRead);
+        Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -156,6 +156,8 @@ namespace Octokit
         /// <returns></returns>
         public Task MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
+
             return ApiConnection.Put<object>(ApiUrls.Notifications(), markAsReadRequest);
         }
 
@@ -186,6 +188,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(markAsRead, "markAsRead");
 
             return ApiConnection.Put<object>(ApiUrls.Notifications(owner, name), markAsRead);
         }

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -45,6 +45,7 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request)
@@ -57,7 +58,7 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
@@ -106,7 +107,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request)
@@ -123,7 +124,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="request"></param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -181,16 +181,16 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="markAsRead">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
-        public Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsRead)
+        public Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(markAsRead, "markAsRead");
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsRead");
 
-            return ApiConnection.Put<object>(ApiUrls.Notifications(owner, name), markAsRead);
+            return ApiConnection.Put<object>(ApiUrls.Notifications(owner, name), markAsReadRequest);
         }
 
         /// <summary>

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -26,7 +26,20 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent()
         {
-            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications());
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(), options);
         }
 
         /// <summary>
@@ -38,12 +51,29 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(request, "request");
 
-            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(), request.ToParametersDictionary());
+            return GetAllForCurrent(request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name)
@@ -51,12 +81,32 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name));
+            return GetAllForRepository(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request)
@@ -65,7 +115,26 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
-            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary());
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository.</param>
+        /// <param name="name">The name of the repository.</param>
+        /// <param name="request"></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1163 

To-do:

- [x]  Add overloads on INotificationsClient
- [x]  Add overloads on IObservableNotificationsClient
- [x]  Add unit tests for these new methods
- [x]  ~~Add integration tests for these new methods~~
        
     It's seems like now we do not have ability to create integration tests for I(Observable)NotificationsClient. I've opened issue #1333 to discuss it in details.

     

/cc @shiftkey, @ryangribble 