### PR TITLE
correcting a couple of integration tests

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -230,7 +230,7 @@ public class RepositoriesClientTests
             }
         }
 
-        [PaidAccountTest]
+        [PaidAccountTest(Skip="Paid plans now have unlimited repositories. We shouldn't test this now.")]
         public async Task ThrowsPrivateRepositoryQuotaExceededExceptionWhenOverQuota()
         {
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
@@ -357,9 +357,18 @@ public class RepositoryCommentsClientTests
 
             await _github.Repository.Comment.Delete(_context.RepositoryOwner, _context.RepositoryName, result.Id);
 
-            var retrievedAfter = await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+            var notFound = false;
 
-            Assert.Null(retrievedAfter);
+            try
+            {
+                await _github.Repository.Comment.Get(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+            }
+            catch (NotFoundException)
+            {
+                notFound = true;
+            }
+
+            Assert.True(notFound);
         }
 
         public void Dispose()


### PR DESCRIPTION
Preparing another release now that we're closing to wrapping up all the `ApiOptions` changes, and found a couple of integration tests that needed updating:

 - as GitHub now supports unlimited repositories for paid plans, we cannot really check for quotas. I'll clean up that test later.
 - deleting a comment and then trying to retrieve it should return a 404 - I'm not sure why that test has been that way for so long, but let's test the correct behaviour here.