### PR TITLE
Add ApiOptions overloads to methods on I(Observable)OrganizationMembersClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationMembersClient.cs
@@ -46,9 +46,56 @@ namespace Octokit.Reactive
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, ApiOptions options);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
         /// <returns></returns>
         IObservable<User> GetAll(string org, OrganizationMembersFilter filter);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options);
 
         /// <summary>
         /// <para>
@@ -92,10 +139,59 @@ namespace Octokit.Reactive
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, OrganizationMembersRole role, ApiOptions options);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns></returns>
         IObservable<User> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<User> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options);
 
         /// <summary>
         /// List all users who have publicized their membership of the organization.
@@ -104,6 +200,15 @@ namespace Octokit.Reactive
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
         IObservable<User> GetAllPublic(string org);
+
+        /// <summary>
+        /// List all users who have publicized their membership of the organization.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<User> GetAllPublic(string org, ApiOptions options);
 
         /// <summary>
         /// Check if a user is, publicly or privately, a member of the organization.

--- a/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationMembersClient.cs
@@ -46,7 +46,36 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org));
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org), options);
         }
 
         /// <summary>
@@ -74,7 +103,37 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter));
+            return GetAll(org, filter, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter), options);
         }
 
         /// <summary>
@@ -102,7 +161,37 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, role));
+            return GetAll(org, role, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersRole role, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, role), options);
         }
 
         /// <summary>
@@ -131,7 +220,38 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter, role));
+            return GetAll(org, filter, role, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The members filter, <see cref="OrganizationMembersFilter"/> </param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Members(org, filter, role), options);
         }
 
         /// <summary>
@@ -144,7 +264,22 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PublicMembers(org));
+            return GetAllPublic(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who have publicized their membership of the organization.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<User> GetAllPublic(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PublicMembers(org), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationMembersClientTests.cs
@@ -20,8 +20,64 @@ namespace Octokit.Tests.Integration.Clients
             [IntegrationTest]
             public async Task ReturnsMembers()
             {
-                var members = _gitHub.Organization.Member.GetAll(_organizationFixture);
-                Assert.NotNull(members);
+                var members = await 
+                    _gitHub.Organization.Member.GetAll(_organizationFixture);
+                Assert.NotEmpty(members);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfMembersWithoutStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var members = await _gitHub.Organization.Member.GetAll(_organizationFixture, options);
+                
+                Assert.Equal(1, members.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfMembersWithStart()
+            {
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var members = await _gitHub.Organization.Member.GetAll(_organizationFixture, options);
+
+                Assert.Equal(1, members.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctMembersBasedOnStartPage()
+            {
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var firstPage = await _gitHub.Organization.Member.GetAll(_organizationFixture, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await _gitHub.Organization.Member.GetAll(_organizationFixture, skipStartOptions);
+
+                Assert.Equal(1, firstPage.Count);
+                Assert.Equal(1, secondPage.Count);
+                Assert.NotEqual(firstPage.First().Id, secondPage.First().Id);
             }
 
             [IntegrationTest(Skip = "TwoFactor filter can't be used unless the requester is an organization owner")]

--- a/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationMembersClientTests.cs
@@ -33,16 +33,51 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org");
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", options);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members"), options);
             }
 
             [Fact]
             public async Task EnsureNonNullArguments()
             {
-                var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
+                var client = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.GetAll(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("org", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, ApiOptions.None));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, OrganizationMembersRole.Admin));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, OrganizationMembersRole.Admin, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Admin, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, OrganizationMembersRole.Admin));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, OrganizationMembersRole.Admin, ApiOptions.None));
             }
 
             [Fact]
@@ -53,7 +88,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.All);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all"), Args.ApiOptions);
             }
 
             [Fact]
@@ -64,7 +99,25 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void TwoFactorFilterRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled"), options);
             }
 
             [Fact]
@@ -75,7 +128,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersRole.All);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=all"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=all"), Args.ApiOptions);
             }
 
             [Fact]
@@ -86,7 +139,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersRole.Admin);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=admin"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=admin"), Args.ApiOptions);
             }
 
             [Fact]
@@ -97,7 +150,25 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersRole.Member);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=member"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=member"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void MemberRoleFilterRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersRole.Member, options);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=member"), options);
             }
 
             [Fact]
@@ -108,7 +179,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.All);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=all"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=all"), Args.ApiOptions);
             }
 
             [Fact]
@@ -119,7 +190,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Admin);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=admin"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=admin"), Args.ApiOptions);
             }
 
             [Fact]
@@ -130,7 +201,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Member);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=member"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=all&role=member"), Args.ApiOptions);
             }
 
             [Fact]
@@ -141,7 +212,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.All);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=all"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=all"), Args.ApiOptions);
             }
 
             [Fact]
@@ -152,7 +223,7 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Admin);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=admin"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=admin"), Args.ApiOptions);
             }
 
             [Fact]
@@ -163,30 +234,70 @@ namespace Octokit.Tests.Clients
 
                 orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Member);
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=member"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=member"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void TwoFactorFilterPlusMemberRoleRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembersClient = new OrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Member, options);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=member"), options);
             }
         }
 
         public class TheGetPublicMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var client = Substitute.For<IApiConnection>();
                 var orgMembers = new OrganizationMembersClient(client);
 
-                orgMembers.GetAllPublic("org");
+                await orgMembers.GetAllPublic("org");
 
-                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members"));
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IApiConnection>();
+                var orgMembers = new OrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await orgMembers.GetAllPublic("org", options);
+
+                client.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/public_members"), options);
             }
 
             [Fact]
             public async Task EnsureNonNullArguments()
             {
-                var orgMembers = new OrganizationMembersClient(Substitute.For<IApiConnection>());
+                var client = new OrganizationMembersClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => orgMembers.GetAllPublic(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => orgMembers.GetAllPublic(""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic("org", null));
+                
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -35,12 +35,103 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationMembersClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("org", options);
+
+                gitHubClient.Connection.Received(1).Get<List<User>>(
+                    new Uri("orgs/org/members", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("").ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("org", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, ApiOptions.None));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, OrganizationMembersRole.Admin));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, OrganizationMembersRole.Admin, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, OrganizationMembersRole.Admin, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll(""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, OrganizationMembersRole.Admin));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, OrganizationMembersRole.Admin, ApiOptions.None));
+            }
+
+            [Fact]
+            public void TwoFactorFilterRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var orgMembersClient = new ObservableOrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
+
+                client.Connection.Received(1).Get<List<User>>(
+                    new Uri("orgs/org/members?filter=2fa_disabled", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void MemberRoleFilterRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var orgMembersClient = new ObservableOrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersRole.Member, options);
+
+                client.Connection.Received().Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?role=member"), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void TwoFactorFilterPlusMemberRoleRequestTheCorrectUrlWithApiOptions()
+            {
+                var client = Substitute.For<IGitHubClient>();
+                var orgMembersClient = new ObservableOrganizationMembersClient(client);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                orgMembersClient.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, OrganizationMembersRole.Member, options);
+
+                client.Connection.Received().Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/members?filter=2fa_disabled&role=member"), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
             }
         }
 
@@ -59,12 +150,35 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationMembersClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllPublic("org", options);
+
+                gitHubClient.Connection.Received(1).Get<List<User>>(
+                    new Uri("orgs/org/public_members", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableOrganizationMembersClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPublic(null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPublic("").ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.GetAllPublic(null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllPublic(null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllPublic("org", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllPublic(""));
+                Assert.Throws<ArgumentException>(() => client.GetAllPublic("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org");
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("orgs/org/members", UriKind.Relative), null, null);
+                    new Uri("orgs/org/members", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationMembersClientTests.cs
@@ -146,7 +146,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllPublic("org");
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    new Uri("orgs/org/public_members", UriKind.Relative), null, null);
+                    new Uri("orgs/org/public_members", UriKind.Relative), Args.EmptyDictionary, null);
             }
 
             [Fact]

--- a/Octokit/Clients/IOrganizationMembersClient.cs
+++ b/Octokit/Clients/IOrganizationMembersClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -53,9 +52,56 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
         Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options);
 
         /// <summary>
         /// <para>
@@ -99,10 +145,59 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role, ApiOptions options);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The users</returns>
         Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role);
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options);
 
         /// <summary>
         /// List all users who have publicized their membership of the organization.
@@ -111,6 +206,15 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllPublic(string org);
+
+        /// <summary>
+        /// List all users who have publicized their membership of the organization.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<User>> GetAllPublic(string org, ApiOptions options);
 
         /// <summary>
         /// Check if a user is, publicly or privately, a member of the organization.

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Octokit.Internal;
@@ -78,7 +77,36 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Members(org));
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org), options);
         }
 
         /// <summary>
@@ -106,7 +134,37 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter));
+            return GetAll(org, filter, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter), options);
         }
 
         /// <summary>
@@ -134,7 +192,37 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Members(org, role));
+            return GetAll(org, role, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org, role), options);
         }
 
         /// <summary>
@@ -163,7 +251,38 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter, role));
+            return GetAll(org, filter, role, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// <para>
+        /// List all users who are members of an organization. A member is a user that
+        /// belongs to at least 1 team in the organization.
+        /// </para>
+        /// <para>
+        /// If the authenticated user is also an owner of this organization then both
+        /// concealed and public member will be returned.
+        /// </para>
+        /// <para>
+        /// If the requester is not an owner of the organization the query will be redirected
+        /// to the public members list.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/orgs/members/#members-list">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Members(org, filter, role), options);
         }
 
         /// <summary>
@@ -176,7 +295,22 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
 
-            return ApiConnection.GetAll<User>(ApiUrls.PublicMembers(org));
+            return GetAllPublic(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who have publicized their membership of the organization.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<User>> GetAllPublic(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, "org");
+            Ensure.ArgumentNotNull(org, "org");
+
+            return ApiConnection.GetAll<User>(ApiUrls.PublicMembers(org), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -308,7 +308,7 @@ namespace Octokit
         public Task<IReadOnlyList<User>> GetAllPublic(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, "org");
-            Ensure.ArgumentNotNull(org, "org");
+            Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<User>(ApiUrls.PublicMembers(org), options);
         }


### PR DESCRIPTION
Fixes #1164

To-do:

- [x]  Add overloads on IOrganizationMembersClient 
- [x]  Add overloads on IObservableOrganizationMembersClient 
- [x]  Add unit tests for these new methods
- [x]  Add integration tests for these new methods 
        Added only for  GetAll(string org) overload, the others overloads are skipped, so I decide do not add them. If I have to, please let me know :smile: 

/cc @shiftkey, @ryangribble 