### PR TITLE
Add support for code searches without a search term

### DIFF
--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -58,6 +58,20 @@ public class SearchClientTests
     }
 
     [IntegrationTest]
+    public async Task SearchForFileNameInCodeWithoutTerm()
+    {
+        var request = new SearchCodeRequest()
+        {
+            FileName = "readme.md",
+            Repos = new RepositoryCollection { "octokit/octokit.net" }
+        };
+
+        var repos = await _gitHubClient.Search.SearchCode(request);
+
+        Assert.NotEmpty(repos.Items);
+    }
+
+    [IntegrationTest]
     public async Task SearchForWordInCode()
     {
         var request = new SearchIssuesRequest("windows");

--- a/Octokit/Models/Request/BaseSearchRequest.cs
+++ b/Octokit/Models/Request/BaseSearchRequest.cs
@@ -85,7 +85,14 @@ namespace Octokit
             get
             {
                 var mergedParameters = string.Join("+", MergedQualifiers());
-                return Term + (mergedParameters.IsNotBlank() ? "+" + mergedParameters : "");
+                if (string.IsNullOrEmpty(Term))
+                {
+                    return mergedParameters;
+                }
+                else
+                {
+                    return Term + (mergedParameters.IsNotBlank() ? "+" + mergedParameters : "");
+                }
             }
         }
 

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -18,6 +18,14 @@ namespace Octokit
         /// <summary>
         /// Initializes a new instance of the <see cref="SearchCodeRequest"/> class.
         /// </summary>
+        public SearchCodeRequest() : base()
+        {
+            Repos = new RepositoryCollection();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchCodeRequest"/> class.
+        /// </summary>
         /// <param name="term">The search term.</param>
         public SearchCodeRequest(string term) : base(term)
         {


### PR DESCRIPTION
This change adds a parameter-less constructor to `SearchCodeRequest` and modifies `BaseSearchRequest` to handle the case where the 'Term' is null.  This supports the scenario of searching for a filename without specifying a search term, as in this search: https://github.com/dotnet/corefx/search?utf8=%E2%9C%93&q=filename%3Aproject.json