### PR TITLE
Include reactions on issue comments

### DIFF
--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -7,6 +7,9 @@ namespace Octokit.Reactive
 {
     public class ObservableIssueCommentsClient : IObservableIssueCommentsClient
     {
+        //TODO: Remove this once PR #1335 has been merged
+        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview";
+
         readonly IIssueCommentsClient _client;
         readonly IConnection _connection;
 
@@ -63,7 +66,8 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), options);
+            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), null, ReactionsPreview, options);
         }
 
         /// <summary>
@@ -97,7 +101,8 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), options);
+            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -7,9 +7,6 @@ namespace Octokit.Reactive
 {
     public class ObservableIssueCommentsClient : IObservableIssueCommentsClient
     {
-        //TODO: Remove this once PR #1335 has been merged
-        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview";
-
         readonly IIssueCommentsClient _client;
         readonly IConnection _connection;
 
@@ -66,8 +63,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), null, ReactionsPreview, options);
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>
@@ -101,8 +97,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, ReactionsPreview, options);
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -18,12 +18,30 @@ public class IssueCommentsClientTests
     }
 
     [IntegrationTest]
+    public async Task CanDeserializeIssueCommentWhenGettingAllForRepository()
+    {
+        var comments = await _issueCommentsClient.GetAllForRepository("alfhenrik-test", "repo-with-issue-comment-reactions");
+
+        Assert.True(comments.Count > 0);
+        var comment = comments[0];
+        Assert.NotNull(comment.Reactions);
+        Assert.Equal(3, comment.Reactions.TotalCount);
+        Assert.Equal(1, comment.Reactions.Plus1);
+        Assert.Equal(1, comment.Reactions.Hooray);
+        Assert.Equal(1, comment.Reactions.Heart);
+        Assert.Equal(0, comment.Reactions.Laugh);
+        Assert.Equal(0, comment.Reactions.Confused);
+        Assert.Equal(0, comment.Reactions.Minus1);
+    }
+
+    [IntegrationTest]
     public async Task CanDeserializeIssueComment()
     {
         var comments = await _issueCommentsClient.GetAllForIssue("alfhenrik-test", "repo-with-issue-comment-reactions", 1);
 
         Assert.True(comments.Count > 0);
         var comment = comments[0];
+        Assert.NotNull(comment.Reactions);
         Assert.Equal(3, comment.Reactions.TotalCount);
         Assert.Equal(1, comment.Reactions.Plus1);
         Assert.Equal(1, comment.Reactions.Hooray);

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit;
+using Octokit.Tests.Integration;
+using Xunit;
+
+public class IssueCommentsClientTests
+{
+    private readonly IIssueCommentsClient _issueCommentsClient;
+
+    public IssueCommentsClientTests()
+    {
+        var github = Helper.GetAuthenticatedClient();
+        _issueCommentsClient = github.Issue.Comment;
+    }
+
+    [IntegrationTest]
+    public async Task CanDeserializeIssueComment()
+    {
+        var comments = await _issueCommentsClient.GetAllForIssue("alfhenrik-test", "repo-with-issue-comment-reactions", 1);
+
+        Assert.True(comments.Count > 0);
+        var comment = comments[0];
+        Assert.Equal(3, comment.Reactions.TotalCount);
+        Assert.Equal(1, comment.Reactions.Plus1);
+        Assert.Equal(1, comment.Reactions.Hooray);
+        Assert.Equal(1, comment.Reactions.Heart);
+        Assert.Equal(0, comment.Reactions.Laugh);
+        Assert.Equal(0, comment.Reactions.Confused);
+        Assert.Equal(0, comment.Reactions.Minus1);
+    }
+}

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -22,7 +22,7 @@ public class IssueCommentsClientTests
     {
         var comments = await _issueCommentsClient.GetAllForRepository("alfhenrik-test", "repo-with-issue-comment-reactions");
 
-        Assert.True(comments.Count > 0);
+        Assert.NotEmpty(comments);
         var comment = comments[0];
         Assert.NotNull(comment.Reactions);
         Assert.Equal(3, comment.Reactions.TotalCount);
@@ -39,7 +39,7 @@ public class IssueCommentsClientTests
     {
         var comments = await _issueCommentsClient.GetAllForIssue("alfhenrik-test", "repo-with-issue-comment-reactions", 1);
 
-        Assert.True(comments.Count > 0);
+        Assert.NotEmpty(comments);
         var comment = comments[0];
         Assert.NotNull(comment.Reactions);
         Assert.Equal(3, comment.Reactions.TotalCount);

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Clients\GitHubClientTests.cs" />
     <Compile Include="Clients\IssueCommentReactionsClientTests.cs" />
     <Compile Include="Clients\IssueReactionsClientTests.cs" />
+    <Compile Include="Clients\IssueCommentsClientTests.cs" />
     <Compile Include="Clients\MergingClientTests.cs" />
     <Compile Include="Clients\CommitsClientTests.cs" />
     <Compile Include="Clients\CommitStatusClientTests.cs" />

--- a/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
@@ -93,7 +93,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var comments = await _issueCommentsClient.GetAllForRepository("alfhenrik-test", "repo-with-issue-comment-reactions").ToList();
 
-                Assert.True(comments.Count > 0);
+                Assert.NotEmpty(comments);
                 var comment = comments[0];
                 Assert.NotNull(comment.Reactions);
                 Assert.Equal(3, comment.Reactions.TotalCount);
@@ -110,7 +110,7 @@ namespace Octokit.Tests.Integration.Reactive
             {
                 var comments = await _issueCommentsClient.GetAllForIssue("alfhenrik-test", "repo-with-issue-comment-reactions", 1).ToList();
 
-                Assert.True(comments.Count > 0);
+                Assert.NotEmpty(comments);
                 var comment = comments[0];
                 Assert.NotNull(comment.Reactions);
                 Assert.Equal(3, comment.Reactions.TotalCount);

--- a/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssueCommentsClientTests.cs
@@ -87,6 +87,40 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstPageIssueComments[3].Id, secondPageIssueComments[3].Id);
                 Assert.NotEqual(firstPageIssueComments[4].Id, secondPageIssueComments[4].Id);
             }
+
+            [IntegrationTest]
+            public async Task ReturnsAllIssueCommentsWithReactions()
+            {
+                var comments = await _issueCommentsClient.GetAllForRepository("alfhenrik-test", "repo-with-issue-comment-reactions").ToList();
+
+                Assert.True(comments.Count > 0);
+                var comment = comments[0];
+                Assert.NotNull(comment.Reactions);
+                Assert.Equal(3, comment.Reactions.TotalCount);
+                Assert.Equal(1, comment.Reactions.Plus1);
+                Assert.Equal(1, comment.Reactions.Hooray);
+                Assert.Equal(1, comment.Reactions.Heart);
+                Assert.Equal(0, comment.Reactions.Laugh);
+                Assert.Equal(0, comment.Reactions.Confused);
+                Assert.Equal(0, comment.Reactions.Minus1);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsIssueCommentWithReactions()
+            {
+                var comments = await _issueCommentsClient.GetAllForIssue("alfhenrik-test", "repo-with-issue-comment-reactions", 1).ToList();
+
+                Assert.True(comments.Count > 0);
+                var comment = comments[0];
+                Assert.NotNull(comment.Reactions);
+                Assert.Equal(3, comment.Reactions.TotalCount);
+                Assert.Equal(1, comment.Reactions.Plus1);
+                Assert.Equal(1, comment.Reactions.Hooray);
+                Assert.Equal(1, comment.Reactions.Heart);
+                Assert.Equal(0, comment.Reactions.Laugh);
+                Assert.Equal(0, comment.Reactions.Confused);
+                Assert.Equal(0, comment.Reactions.Minus1);
+            }
         }
     }
 }

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -20,7 +20,10 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"));
+                connection.Received().Get<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"), 
+                    Arg.Any<Dictionary<string, string>>(), 
+                    Arg.Is<string>(s => s == "application/vnd.github.squirrel-girl-preview"));
             }
 
             [Fact]
@@ -45,7 +48,11 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), Args.ApiOptions);
+                connection.Received().GetAll<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    Arg.Is<string>(s => s == "application/vnd.github.squirrel-girl-preview"),
+                    Args.ApiOptions);
             }
 
             [Fact]
@@ -62,7 +69,11 @@ namespace Octokit.Tests.Clients
                 };
                 client.GetAllForRepository("fake", "repo", options);
 
-                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"), options);
+                connection.Received().GetAll<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    Arg.Is<string>(s => s == "application/vnd.github.squirrel-girl-preview"),
+                    options);
             }
 
             [Fact]
@@ -91,7 +102,11 @@ namespace Octokit.Tests.Clients
 
                 client.GetAllForIssue("fake", "repo", 3);
 
-                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), Args.ApiOptions);
+                connection.Received().GetAll<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    Arg.Is<string>(s => s == "application/vnd.github.squirrel-girl-preview"),
+                    Args.ApiOptions);
             }
 
             [Fact]
@@ -108,7 +123,11 @@ namespace Octokit.Tests.Clients
                 };
                 client.GetAllForIssue("fake", "repo", 3, options);
 
-                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), options);
+                connection.Received().GetAll<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"), 
+                    Arg.Any<Dictionary<string, string>>(),
+                    Arg.Is<string>(s => s == "application/vnd.github.squirrel-girl-preview"), 
+                    options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -250,5 +250,51 @@ namespace Octokit.Tests.Clients
             Assert.Equal(issueResponseJson, response.HttpResponse.Body);
             Assert.Equal(1, response.Body.Id);
         }
+
+        [Fact]
+        public void CanDeserializeIssueCommentWithReactions()
+        {
+            const string issueResponseJson =
+                "{\"id\": 1," +
+                "\"url\": \"https://api.github.com/repos/octocat/Hello-World/issues/comments/1\"," +
+                "\"html_url\": \"https://github.com/octocat/Hello-World/issues/1347#issuecomment-1\"," +
+                "\"body\": \"Me too\"," +
+                "\"user\": {" +
+                "\"login\": \"octocat\"," +
+                "\"id\": 1," +
+                "\"avatar_url\": \"https://github.com/images/error/octocat_happy.gif\"," +
+                "\"gravatar_id\": \"somehexcode\"," +
+                "\"url\": \"https://api.github.com/users/octocat\"" +
+                "}," +
+                "\"created_at\": \"2011-04-14T16:00:49Z\"," +
+                "\"updated_at\": \"2011-04-14T16:00:49Z\"," +
+                "\"reactions\": {" +
+                "\"total_count\": 5," +
+                "\"+1\": 3," +
+                "\"-1\": 1," +
+                "\"laugh\": 0," +
+                "\"confused\": 0," +
+                "\"heart\": 1," +
+                "\"hooray\": 0," +
+                "\"url\": \"https://api.github.com/repos/octocat/Hello-World/issues/comments/1/reactions\"" +
+                "}" +
+                "}";
+            var httpResponse = new Response(
+                HttpStatusCode.OK,
+                issueResponseJson,
+                new Dictionary<string, string>(),
+                "application/json");
+
+            var jsonPipeline = new JsonHttpPipeline();
+
+            var response = jsonPipeline.DeserializeResponse<IssueComment>(httpResponse);
+
+            Assert.NotNull(response.Body);
+            Assert.Equal(issueResponseJson, response.HttpResponse.Body);
+            Assert.Equal(1, response.Body.Id);
+            Assert.NotNull(response.Body.Reactions);
+            Assert.Equal(5, response.Body.Reactions.TotalCount);
+            Assert.Equal(3, response.Body.Reactions.Plus1);
+        }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -46,7 +46,9 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), Args.EmptyDictionary, null);
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), 
+                    Args.EmptyDictionary, 
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -64,7 +66,9 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo", options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), Arg.Any<Dictionary<string, string>>(), null);
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), 
+                    Arg.Any<Dictionary<string, string>>(),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -94,7 +98,9 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), Args.EmptyDictionary, null);
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    Args.EmptyDictionary,
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -112,7 +118,9 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), Arg.Any<Dictionary<string, string>>(), null);
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    Arg.Any<Dictionary<string, string>>(),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -11,9 +11,6 @@ namespace Octokit
     /// </remarks>
     public class IssueCommentsClient : ApiClient, IIssueCommentsClient
     {
-        //TODO: Remove this once PR #1335 has been merged
-        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview";
-
         /// <summary>
         /// Instantiates a new GitHub Issue Comments API client.
         /// </summary>
@@ -35,8 +32,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
-            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id), null, ReactionsPreview);
+            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id), null, AcceptHeaders.ReactionsPreview);
         }
 
         /// <summary>
@@ -68,8 +64,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), null, ReactionsPreview, options);
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>
@@ -102,8 +97,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, ReactionsPreview, options);
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -11,6 +11,9 @@ namespace Octokit
     /// </remarks>
     public class IssueCommentsClient : ApiClient, IIssueCommentsClient
     {
+        //TODO: Remove this once PR #1335 has been merged
+        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview";
+
         /// <summary>
         /// Instantiates a new GitHub Issue Comments API client.
         /// </summary>
@@ -32,7 +35,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id));
+            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
+            return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(owner, name, id), null, ReactionsPreview);
         }
 
         /// <summary>
@@ -64,7 +68,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), options);
+            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), null, ReactionsPreview, options);
         }
 
         /// <summary>
@@ -97,7 +102,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), options);
+            //TODO: Use AcceptHeaders.ReactionsPreview once PR #1335 has been merged
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -55,7 +55,7 @@ namespace Octokit
         /// </summary>
         public User User { get; protected set; }
 
-        public IssueCommentReactions Reactions { get; protected set; }
+        public ReactionSummary Reactions { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -55,7 +55,7 @@ namespace Octokit
         /// </summary>
         public User User { get; protected set; }
 
-        public IssueCommentReactions Reactions { get; set; }
+        public IssueCommentReactions Reactions { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -55,6 +55,8 @@ namespace Octokit
         /// </summary>
         public User User { get; protected set; }
 
+        public IssueCommentReactions Reactions { get; set; }
+
         internal string DebuggerDisplay
         {
             get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} CreatedAt: {1}", Id, CreatedAt); }

--- a/Octokit/Models/Response/IssueCommentReactions.cs
+++ b/Octokit/Models/Response/IssueCommentReactions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    public class IssueCommentReactions
+    {
+        public int TotalCount { get; set; }
+        [Parameter(Key = "+1")]
+        public int Plus1 { get; set; }
+        [Parameter(Key = "-1")]
+        public int Minus1 { get; set; }
+        public int Laugh { get; set; }
+        public int Confused { get; set; }
+        public int Heart { get; set; }
+        public int Hooray { get; set; }
+        public Uri Url { get; set; }
+    }
+}

--- a/Octokit/Models/Response/IssueCommentReactions.cs
+++ b/Octokit/Models/Response/IssueCommentReactions.cs
@@ -1,19 +1,39 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Globalization;
 using Octokit.Internal;
 
 namespace Octokit
 {
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class IssueCommentReactions
     {
-        public int TotalCount { get; set; }
+        public int TotalCount { get; protected set; }
         [Parameter(Key = "+1")]
-        public int Plus1 { get; set; }
+        public int Plus1 { get; protected set; }
         [Parameter(Key = "-1")]
-        public int Minus1 { get; set; }
-        public int Laugh { get; set; }
-        public int Confused { get; set; }
-        public int Heart { get; set; }
-        public int Hooray { get; set; }
-        public Uri Url { get; set; }
+        public int Minus1 { get; protected set; }
+        public int Laugh { get; protected set; }
+        public int Confused { get; protected set; }
+        public int Heart { get; protected set; }
+        public int Hooray { get; protected set; }
+        public Uri Url { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(
+                    CultureInfo.InvariantCulture, 
+                    "TotalCount: {0} +1: {1} -1: {2} Laugh: {3} Confused: {4} Heart: {5} Hooray: {6}", 
+                    TotalCount, 
+                    Plus1, 
+                    Minus1, 
+                    Laugh, 
+                    Confused, 
+                    Heart, 
+                    Hooray);
+            }
+        }
     }
 }

--- a/Octokit/Models/Response/ReactionSummary.cs
+++ b/Octokit/Models/Response/ReactionSummary.cs
@@ -6,7 +6,7 @@ using Octokit.Internal;
 namespace Octokit
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    public class IssueCommentReactions
+    public class ReactionSummary
     {
         public int TotalCount { get; protected set; }
         [Parameter(Key = "+1")]

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -483,6 +483,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Models\Response\PullRequest.cs" />
     <Compile Include="Models\Request\RepositoryIssueRequest.cs" />
     <Compile Include="Models\Request\MilestoneRequest.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
     <Compile Include="Models\Response\Reference.cs" />
     <Compile Include="Models\Response\PullRequestMerge.cs" />
     <Compile Include="Models\Response\RepositoryContributor.cs" />
@@ -483,7 +484,6 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -494,7 +494,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -494,6 +494,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -490,7 +490,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -490,6 +490,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -480,6 +480,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -480,7 +480,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -487,6 +487,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -487,7 +487,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -189,7 +189,7 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
     <Compile Include="Models\Response\GitIgnoreTemplate.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
-    <Compile Include="Models\Response\IssueCommentReactions.cs" />
+    <Compile Include="Models\Response\ReactionSummary.cs" />
     <Compile Include="Models\Response\License.cs" />
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\Merge.cs" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Models\Response\Enterprise\AdminStatsUsers.cs" />
     <Compile Include="Models\Response\GitIgnoreTemplate.cs" />
     <Compile Include="Models\Response\GpgKey.cs" />
+    <Compile Include="Models\Response\IssueCommentReactions.cs" />
     <Compile Include="Models\Response\License.cs" />
     <Compile Include="Models\Response\LicenseMetadata.cs" />
     <Compile Include="Models\Response\Merge.cs" />


### PR DESCRIPTION
- [x] Add Reactions object to IssueCommentsClient
- [x] Add Reactions object to ObservableIssueCommentsClient
- [x] Add tests
- [x] Add integration tests
- [x] Fix builds due to broken tests
- [x] Come to think of it, `IssueCommentReactions` should be renamed, so it can be used on the other relevant payloads.
- [x] Use `AcceptHeaders.ReactionsPreview` instead of local `ReactionsPreview` constant (once #1335 has been merged)

Fixes #1295