### PR TITLE
Add permission attribute to collaborators and team's repositories

### DIFF
--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -224,7 +224,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.TeamRepositories(id), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.TeamRepositories(id), null, AcceptHeaders.OrganizationPermissionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Helpers/ConnectionExtensions.cs
+++ b/Octokit.Reactive/Helpers/ConnectionExtensions.cs
@@ -37,6 +37,15 @@ namespace Octokit.Reactive.Internal
             return GetPages(url, parameters, (pageUrl, pageParams) => connection.Get<List<T>>(pageUrl, pageParams, accepts).ToObservable());
         }
 
+        public static IObservable<T> GetAndFlattenAllPages<T>(this IConnection connection, Uri url, IDictionary<string, string> parameters, string accepts, ApiOptions options)
+        {
+            return GetPagesWithOptions(url, parameters, options, (pageUrl, pageParams, o) =>
+            {
+                var passingParameters = Pagination.Setup(parameters, options);
+                return connection.Get<List<T>>(pageUrl, passingParameters, accepts).ToObservable();
+            });
+        }
+
         static IObservable<T> GetPages<T>(Uri uri, IDictionary<string, string> parameters,
             Func<Uri, IDictionary<string, string>, IObservable<IApiResponse<List<T>>>> getPageFunc)
         {

--- a/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
@@ -24,6 +24,8 @@ public class RepositoryCollaboratorClientTests
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName);
                 Assert.NotNull(collaborators);
                 Assert.Equal(2, collaborators.Count);
+                Assert.NotNull(collaborators[0].Permissions);
+                Assert.NotNull(collaborators[1].Permissions);
             }
         }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
@@ -26,6 +26,8 @@ public class ObservableRepositoryCollaboratorClientTests
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName).ToList();
                 Assert.NotNull(collaborators);
                 Assert.Equal(2, collaborators.Count);
+                Assert.NotNull(collaborators[0].Permissions);
+                Assert.NotNull(collaborators[1].Permissions);
             }
         }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -4,15 +4,16 @@ using System.Threading.Tasks;
 using Octokit;
 using Octokit.Reactive;
 using Octokit.Tests.Integration;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 public class ObservableTeamsClientTests
 {
-    public class TheGetMembersMethod
+    public class TheGetAllMembersMethod
     {
         readonly Team _team;
 
-        public TheGetMembersMethod()
+        public TheGetAllMembersMethod()
         {
             var github = Helper.GetAuthenticatedClient();
 
@@ -23,12 +24,43 @@ public class ObservableTeamsClientTests
         public async Task GetsAllMembersWhenAuthenticated()
         {
             var github = Helper.GetAuthenticatedClient();
-
             var client = new ObservableTeamsClient(github);
 
-            var member = await client.GetAllMembers(_team.Id, ApiOptions.None);
+            var observable = client.GetAllMembers(_team.Id, ApiOptions.None);
+            var members = await observable.ToList();
 
-            Assert.Equal(Helper.UserName, member.Login);
+            Assert.True(members.Count > 0);
+            Assert.True(members.Any(x => x.Login == Helper.UserName));
+        }
+    }
+
+    public class TheGetAllRepositoriesMethod
+    {
+        readonly Team _team;
+
+        public TheGetAllRepositoriesMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            _team = github.Organization.Team.GetAll(Helper.Organization).Result.First();
+        }
+
+        [OrganizationTest]
+        public async Task GetsAllRepositories()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var client = new ObservableTeamsClient(github);
+
+            using (var repositoryContext = await github.CreateRepositoryContext(Helper.Organization, new NewRepository(Helper.MakeNameWithTimestamp("teamrepo"))))
+            {
+                client.AddRepository(_team.Id, Helper.Organization, repositoryContext.RepositoryName);
+
+                var observable = client.GetAllRepositories(_team.Id, ApiOptions.None);
+                var repos = await observable.ToList();
+
+                Assert.True(repos.Count() > 0);
+                Assert.NotNull(repos[0].Permissions);
+            }
         }
     }
 }

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepoCollaboratorsClient(connection);
 
                 client.GetAll("owner", "test");
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), null, "application/vnd.github.ironman-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -51,7 +51,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("owner", "test", options);
 
                 connection.Received()
-                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), options);
+                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), null, "application/vnd.github.ironman-preview+json", options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -220,7 +220,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheRRemoveMembershipMethod
+        public class TheRemoveMembershipMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -255,6 +255,8 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"),
+                    null,
+                    "application/vnd.github.ironman-preview+json",
                     Args.ApiOptions);
             }
         }

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -57,7 +57,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, repo), options);
+            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, repo), null, AcceptHeaders.OrganizationPermissionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -276,22 +276,7 @@ namespace Octokit
 
             var endpoint = ApiUrls.TeamRepositories(id);
 
-            return ApiConnection.GetAll<Repository>(endpoint, options);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="Repository"/>(ies) associated with the given team. 
-        /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#list-team-repos">API documentation</a> for more information.
-        /// </remarks>
-        /// <returns>A list of the team's <see cref="Repository"/>(ies).</returns>
-        public Task<IReadOnlyList<Repository>> GetRepositories(int id)
-        {
-            var endpoint = ApiUrls.TeamRepositories(id);
-
-            return ApiConnection.GetAll<Repository>(endpoint);
+            return ApiConnection.GetAll<Repository>(endpoint, null, AcceptHeaders.OrganizationPermissionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -8,6 +8,8 @@
 
         public const string RedirectsPreviewThenStableVersionJson = "application/vnd.github.quicksilver-preview+json; charset=utf-8, application/vnd.github.v3+json; charset=utf-8";
 
+        public const string OrganizationPermissionsPreview = "application/vnd.github.ironman-preview+json";
+
         public const string LicensesApiPreview = "application/vnd.github.drax-preview+json";
 
         public const string ProtectedBranchesApiPreview = "application/vnd.github.loki-preview+json";
@@ -20,6 +22,6 @@
 
         public const string SquashCommitPreview = "application/vnd.github.polaris-preview+json";
 
-        public const string MigrationsApiPreview = "  application/vnd.github.wyandotte-preview+json";
+        public const string MigrationsApiPreview = "application/vnd.github.wyandotte-preview+json";
     }
 }

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -13,13 +13,16 @@ namespace Octokit
     {
         public User() { }
 
-        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
+        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, RepositoryPermissions permissions, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
             : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
         {
+            Permissions = permissions;
             SiteAdmin = siteAdmin;
             LdapDistinguishedName = ldapDistinguishedName;
             SuspendedAt = suspendedAt;
         }
+
+        public RepositoryPermissions Permissions { get; protected set; }
 
         /// <summary>
         /// Whether or not the user is an administrator of the site


### PR DESCRIPTION
Fixes #1319

Added/ensured `Permissions` are supported for:

## Repository Collaborators
Added `Permission` attribute to `User` object, updated tests for Repository Collaborators to ensure field is populated.  Although preview period has ended I decided to pass the preview accepts header anyway since GHE 2.5 requires it

## Team's Repositories
Found that `Repository` already had `Permissions` attribute and the Team's Repositories call was already working (once preview period ended).  Added accept header so it works on GHE 2.5 and added some integration tests to ensure the property is being deserialized