### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryCommitsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         IObservable<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -28,7 +27,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         IObservable<CompareResult> Compare(int repositoryId, string @base, string head);
 
@@ -38,7 +36,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<GitHubCommit> Get(string owner, string name, string reference);
@@ -48,7 +45,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<GitHubCommit> Get(int repositoryId, string reference);
@@ -58,14 +54,12 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId);
 
         /// <summary>
@@ -74,7 +68,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -82,7 +75,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -91,7 +83,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -99,7 +90,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
@@ -109,7 +99,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -118,7 +107,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -127,7 +115,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         IObservable<string> GetSha1(string owner, string name, string reference);
 
         /// <summary>
@@ -135,7 +122,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         IObservable<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Commits API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/commits/">Repository Commits API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryCommitsClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         IObservable<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -22,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<GitHubCommit> Get(string owner, string name, string reference);
@@ -32,7 +38,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name);
 
         /// <summary>
@@ -41,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -50,7 +56,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -60,7 +66,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -69,7 +75,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
         IObservable<string> GetSha1(string owner, string name, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -23,6 +23,16 @@ namespace Octokit.Reactive
         IObservable<CompareResult> Compare(string owner, string name, string @base, string head);
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        IObservable<CompareResult> Compare(int repositoryId, string @base, string head);
+
+        /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -36,10 +46,27 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference for the commit</param>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Method makes a network request")]
+        IObservable<GitHubCommit> Get(int repositoryId, string reference);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        IObservable<GitHubCommit> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -53,11 +80,27 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -70,6 +113,15 @@ namespace Octokit.Reactive
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
+
+        /// <summary>
         /// Get the SHA-1 of a commit reference
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -77,5 +129,13 @@ namespace Octokit.Reactive
         /// <param name="reference">The repository reference</param>
         /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
         IObservable<string> GetSha1(string owner, string name, string reference);
+
+        /// <summary>
+        /// Get the SHA-1 of a commit reference
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The repository reference</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        IObservable<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         IObservable<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         IObservable<CompareResult> Compare(int repositoryId, string @base, string head);
 
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<GitHubCommit> Get(string owner, string name, string reference);
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<GitHubCommit> Get(int repositoryId, string reference);
@@ -58,14 +58,14 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId);
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         IObservable<string> GetSha1(string owner, string name, string reference);
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         IObservable<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Commits API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/commits/">Repository Commits API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryCommitsClient : IObservableRepositoryCommitsClient
     {
         readonly IConnection _connection;
@@ -24,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
         public IObservable<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             return _commit.Compare(owner, name, @base, head).ToObservable();
@@ -36,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
         public IObservable<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,7 +57,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -66,7 +72,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +88,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -99,7 +105,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -115,7 +121,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
         public IObservable<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -37,6 +37,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        public IObservable<CompareResult> Compare(int repositoryId, string @base, string head)
+        {
+            return _commit.Compare(repositoryId, @base, head).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -55,6 +67,19 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference for the commit</param>
+        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        public IObservable<GitHubCommit> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _commit.Get(repositoryId, reference).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
@@ -64,6 +89,16 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAll(owner, name, new CommitRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public IObservable<GitHubCommit> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -85,6 +120,19 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAll(repositoryId, new CommitRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
@@ -101,6 +149,19 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAll(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
@@ -111,8 +172,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<GitHubCommit>(ApiUrls.RepositoryCommits(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<GitHubCommit>(ApiUrls.RepositoryCommits(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -129,6 +206,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return _commit.GetSha1(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
+        /// Get the SHA-1 of a commit reference
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The repository reference</param>
+        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        public IObservable<string> GetSha1(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _commit.GetSha1(repositoryId, reference).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -30,7 +30,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         public IObservable<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +46,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         public IObservable<CompareResult> Compare(int repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
@@ -62,7 +60,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +74,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -90,7 +86,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -103,7 +98,6 @@ namespace Octokit.Reactive
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
@@ -115,7 +109,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -130,7 +123,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -144,7 +136,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -159,7 +150,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -174,7 +164,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -191,7 +180,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -206,7 +194,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         public IObservable<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -221,7 +208,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         public IObservable<string> GetSha1(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -33,6 +33,11 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
         public IObservable<CompareResult> Compare(string owner, string name, string @base, string head)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(@base, "base");
+            Ensure.ArgumentNotNullOrEmptyString(head, "head");
+
             return _commit.Compare(owner, name, @base, head).ToObservable();
         }
 
@@ -45,6 +50,9 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
         public IObservable<CompareResult> Compare(int repositoryId, string @base, string head)
         {
+            Ensure.ArgumentNotNullOrEmptyString(@base, "base");
+            Ensure.ArgumentNotNullOrEmptyString(head, "head");
+
             return _commit.Compare(repositoryId, @base, head).ToObservable();
         }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         public IObservable<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         public IObservable<CompareResult> Compare(int repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        /// <returns>A <see cref="IObservable{CompareResult}"/> of <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -103,7 +103,7 @@ namespace Octokit.Reactive
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -130,7 +130,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -159,7 +159,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -191,7 +191,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -206,7 +206,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         public IObservable<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -221,7 +221,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="IObservable{GitHubCommit}"/> of <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         public IObservable<string> GetSha1(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -12,6 +12,12 @@ public class RepositoryCommitsClientTests
     public class TestsWithExistingRepositories
     {
         readonly IRepositoryCommitsClient _fixture;
+        const int octokitNetRepositoryId = 7528679;
+        const string octokitNetRepositoryOwner = "octokit";
+        const string octokitNetRepositorName = "octokit.net";
+        const int reactiveGitRepositoryId = 22718025;
+        const string reactiveGitRepositoryOwner = "shiftkey";
+        const string reactiveGitRepositorName = "ReactiveGit";
 
         public TestsWithExistingRepositories()
         {
@@ -23,35 +29,35 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetMergeBaseCommit()
         {
-            var compareResult = await _fixture.Compare("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var compareResult = await _fixture.Compare(octokitNetRepositoryOwner, octokitNetRepositorName, "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(compareResult.MergeBaseCommit);
         }
 
         [IntegrationTest]
         public async Task CanGetMergeBaseCommitWithRepositoryId()
         {
-            var compareResult = await _fixture.Compare(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var compareResult = await _fixture.Compare(octokitNetRepositoryId, "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(compareResult.MergeBaseCommit);
         }
 
         [IntegrationTest]
         public async Task CanGetCommit()
         {
-            var commit = await _fixture.Get("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var commit = await _fixture.Get(octokitNetRepositoryOwner, octokitNetRepositorName, "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(commit);
         }
 
         [IntegrationTest]
         public async Task CanGetCommitWithRepositoryId()
         {
-            var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var commit = await _fixture.Get(octokitNetRepositoryId, "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(commit);
         }
 
         [IntegrationTest]
         public async Task CanGetCommitWithFiles()
         {
-            var commit = await _fixture.Get("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var commit = await _fixture.Get(octokitNetRepositoryOwner, octokitNetRepositorName, "65a22f4d2cff94a286ac3e96440c810c5509196f");
 
             Assert.True(commit.Files.Any(file => file.Filename.EndsWith("IConnection.cs")));
         }
@@ -59,7 +65,7 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetCommitWithFilesWithRepositoryId()
         {
-            var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            var commit = await _fixture.Get(octokitNetRepositoryId, "65a22f4d2cff94a286ac3e96440c810c5509196f");
 
             Assert.True(commit.Files.Any(file => file.Filename.EndsWith("IConnection.cs")));
         }
@@ -67,14 +73,14 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetListOfCommits()
         {
-            var list = await _fixture.GetAll("shiftkey", "ReactiveGit");
+            var list = await _fixture.GetAll(reactiveGitRepositoryOwner, reactiveGitRepositorName);
             Assert.NotEmpty(list);
         }
 
         [IntegrationTest]
         public async Task CanGetListOfCommitsWithRepositoryId()
         {
-            var list = await _fixture.GetAll(22718025);
+            var list = await _fixture.GetAll(reactiveGitRepositoryId);
             Assert.NotEmpty(list);
         }
 
@@ -87,7 +93,7 @@ public class RepositoryCommitsClientTests
                 PageCount = 1
             };
 
-            var commits = await _fixture.GetAll("shiftkey", "ReactiveGit", options);
+            var commits = await _fixture.GetAll(reactiveGitRepositoryOwner, reactiveGitRepositorName, options);
             Assert.Equal(5, commits.Count);
         }
 
@@ -100,7 +106,7 @@ public class RepositoryCommitsClientTests
                 PageCount = 1
             };
 
-            var commits = await _fixture.GetAll(22718025, options);
+            var commits = await _fixture.GetAll(reactiveGitRepositoryId, options);
             Assert.Equal(5, commits.Count);
         }
 
@@ -114,7 +120,7 @@ public class RepositoryCommitsClientTests
                 StartPage = 2
             };
 
-            var commits = await _fixture.GetAll("shiftkey", "ReactiveGit", options);
+            var commits = await _fixture.GetAll(reactiveGitRepositoryOwner, reactiveGitRepositorName, options);
             Assert.Equal(5, commits.Count);
         }
 
@@ -128,7 +134,7 @@ public class RepositoryCommitsClientTests
                 StartPage = 2
             };
 
-            var commits = await _fixture.GetAll(22718025, options);
+            var commits = await _fixture.GetAll(reactiveGitRepositoryId, options);
             Assert.Equal(5, commits.Count);
         }
 
@@ -148,8 +154,8 @@ public class RepositoryCommitsClientTests
                 StartPage = 2
             };
 
-            var firstCommit = await _fixture.GetAll("shiftkey", "ReactiveGit", startOptions);
-            var secondCommit = await _fixture.GetAll("shiftkey", "ReactiveGit", skipStartOptions);
+            var firstCommit = await _fixture.GetAll(reactiveGitRepositoryOwner, reactiveGitRepositorName, startOptions);
+            var secondCommit = await _fixture.GetAll(reactiveGitRepositoryOwner, reactiveGitRepositorName, skipStartOptions);
 
             Assert.NotEqual(firstCommit[0].Sha, secondCommit[0].Sha);
             Assert.NotEqual(firstCommit[1].Sha, secondCommit[1].Sha);
@@ -174,8 +180,8 @@ public class RepositoryCommitsClientTests
                 StartPage = 2
             };
 
-            var firstCommit = await _fixture.GetAll(22718025, startOptions);
-            var secondCommit = await _fixture.GetAll(22718025, skipStartOptions);
+            var firstCommit = await _fixture.GetAll(reactiveGitRepositoryId, startOptions);
+            var secondCommit = await _fixture.GetAll(reactiveGitRepositoryId, skipStartOptions);
 
             Assert.NotEqual(firstCommit[0].Sha, secondCommit[0].Sha);
             Assert.NotEqual(firstCommit[1].Sha, secondCommit[1].Sha);
@@ -188,7 +194,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsBySha()
         {
             var request = new CommitRequest { Sha = "08b363d45d6ae8567b75dfa45c032a288584afd4" };
-            var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            var list = await _fixture.GetAll(octokitNetRepositoryOwner, octokitNetRepositorName, request);
             Assert.NotEmpty(list);
         }
 
@@ -196,7 +202,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsByShaWithRepositoryId()
         {
             var request = new CommitRequest { Sha = "08b363d45d6ae8567b75dfa45c032a288584afd4" };
-            var list = await _fixture.GetAll(7528679, request);
+            var list = await _fixture.GetAll(octokitNetRepositoryId, request);
             Assert.NotEmpty(list);
         }
 
@@ -204,7 +210,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsByPath()
         {
             var request = new CommitRequest { Path = "Octokit.Reactive/IObservableGitHubClient.cs" };
-            var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            var list = await _fixture.GetAll(octokitNetRepositoryOwner, octokitNetRepositorName, request);
             Assert.NotEmpty(list);
         }
 
@@ -212,7 +218,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsByPathWithRepositoryId()
         {
             var request = new CommitRequest { Path = "Octokit.Reactive/IObservableGitHubClient.cs" };
-            var list = await _fixture.GetAll(7528679, request);
+            var list = await _fixture.GetAll(octokitNetRepositoryId, request);
             Assert.NotEmpty(list);
         }
 
@@ -220,7 +226,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsByAuthor()
         {
             var request = new CommitRequest { Author = "kzu" };
-            var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            var list = await _fixture.GetAll(octokitNetRepositoryOwner, octokitNetRepositorName, request);
             Assert.NotEmpty(list);
         }
 
@@ -228,7 +234,7 @@ public class RepositoryCommitsClientTests
         public async Task CanGetListOfCommitsByAuthorWithRepositoryId()
         {
             var request = new CommitRequest { Author = "kzu" };
-            var list = await _fixture.GetAll(7528679, request);
+            var list = await _fixture.GetAll(octokitNetRepositoryId, request);
             Assert.NotEmpty(list);
         }
 
@@ -240,7 +246,7 @@ public class RepositoryCommitsClientTests
             var until = new DateTimeOffset(2014, 1, 8, 0, 0, 0, offset);
 
             var request = new CommitRequest { Since = since, Until = until };
-            var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            var list = await _fixture.GetAll(octokitNetRepositoryOwner, octokitNetRepositorName, request);
             Assert.NotEmpty(list);
         }
 
@@ -252,14 +258,14 @@ public class RepositoryCommitsClientTests
             var until = new DateTimeOffset(2014, 1, 8, 0, 0, 0, offset);
 
             var request = new CommitRequest { Since = since, Until = until };
-            var list = await _fixture.GetAll(7528679, request);
+            var list = await _fixture.GetAll(octokitNetRepositoryId, request);
             Assert.NotEmpty(list);
         }
 
         [IntegrationTest]
         public async Task CanGetCommitWithRenamedFiles()
         {
-            var commit = await _fixture.Get("octokit", "octokit.net", "997e955f38eb0c2c36e55b1588455fa857951dbf");
+            var commit = await _fixture.Get(octokitNetRepositoryOwner, octokitNetRepositorName, "997e955f38eb0c2c36e55b1588455fa857951dbf");
 
             Assert.True(commit.Files
                 .Where(file => file.Status == "renamed")
@@ -269,7 +275,7 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetCommitWithRenamedFilesWithRepositoryId()
         {
-            var commit = await _fixture.Get(7528679, "997e955f38eb0c2c36e55b1588455fa857951dbf");
+            var commit = await _fixture.Get(octokitNetRepositoryId, "997e955f38eb0c2c36e55b1588455fa857951dbf");
 
             Assert.True(commit.Files
                 .Where(file => file.Status == "renamed")
@@ -279,7 +285,7 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetSha1()
         {
-            var sha1 = await _fixture.GetSha1("octokit", "octokit.net", "master");
+            var sha1 = await _fixture.GetSha1(octokitNetRepositoryOwner, octokitNetRepositorName, "master");
 
             Assert.NotNull(sha1);
         }
@@ -287,7 +293,7 @@ public class RepositoryCommitsClientTests
         [IntegrationTest]
         public async Task CanGetSha1WithRepositoryId()
         {
-            var sha1 = await _fixture.GetSha1(7528679, "master");
+            var sha1 = await _fixture.GetSha1(octokitNetRepositoryId, "master");
 
             Assert.NotNull(sha1);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -28,7 +28,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetMergeBaseCommitByRepositoryId()
+        public async Task CanGetMergeBaseCommitWithRepositoryId()
         {
             var compareResult = await _fixture.Compare(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(compareResult.MergeBaseCommit);
@@ -42,7 +42,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetCommitByRepositoryId()
+        public async Task CanGetCommitWithRepositoryId()
         {
             var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(commit);
@@ -57,7 +57,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetCommitWithFilesByRepositoryId()
+        public async Task CanGetCommitWithFilesWithRepositoryId()
         {
             var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
 
@@ -72,7 +72,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetListOfCommitsByRepositoryId()
+        public async Task CanGetListOfCommitsWithRepositoryId()
         {
             var list = await _fixture.GetAll(22718025);
             Assert.NotEmpty(list);
@@ -92,7 +92,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetCorrectCountOfCommitsWithoutStartByRepositoryId()
+        public async Task CanGetCorrectCountOfCommitsWithoutStartWithRepositoryId()
         {
             var options = new ApiOptions
             {
@@ -119,7 +119,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetCorrectCountOfCommitsWithStartByRepositoryId()
+        public async Task CanGetCorrectCountOfCommitsWithStartWithRepositoryId()
         {
             var options = new ApiOptions
             {
@@ -159,7 +159,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task ReturnsDistinctResultsBasedOnStartByRepositoryId()
+        public async Task ReturnsDistinctResultsBasedOnStartWithRepositoryId()
         {
             var startOptions = new ApiOptions
             {
@@ -193,7 +193,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetListOfCommitsByShaByRepositoryId()
+        public async Task CanGetListOfCommitsByShaWithRepositoryId()
         {
             var request = new CommitRequest { Sha = "08b363d45d6ae8567b75dfa45c032a288584afd4" };
             var list = await _fixture.GetAll(7528679, request);
@@ -209,7 +209,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetListOfCommitsByPathByRepositoryId()
+        public async Task CanGetListOfCommitsByPathWithRepositoryId()
         {
             var request = new CommitRequest { Path = "Octokit.Reactive/IObservableGitHubClient.cs" };
             var list = await _fixture.GetAll(7528679, request);
@@ -225,7 +225,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetListOfCommitsByAuthorByRepositoryId()
+        public async Task CanGetListOfCommitsByAuthorWithRepositoryId()
         {
             var request = new CommitRequest { Author = "kzu" };
             var list = await _fixture.GetAll(7528679, request);
@@ -245,7 +245,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetListOfCommitsByDateRangeByRepositoryId()
+        public async Task CanGetListOfCommitsByDateRangeWithRepositoryId()
         {
             var offset = new TimeSpan(1, 0, 0);
             var since = new DateTimeOffset(2014, 1, 1, 0, 0, 0, offset);
@@ -267,7 +267,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetCommitWithRenamedFilesByRepositoryId()
+        public async Task CanGetCommitWithRenamedFilesWithRepositoryId()
         {
             var commit = await _fixture.Get(7528679, "997e955f38eb0c2c36e55b1588455fa857951dbf");
 
@@ -285,7 +285,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanGetSha1ByRepositoryId()
+        public async Task CanGetSha1WithRepositoryId()
         {
             var sha1 = await _fixture.GetSha1(7528679, "master");
 
@@ -322,7 +322,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanCompareReferencesByRepositoryId()
+        public async Task CanCompareReferencesWithRepositoryId()
         {
             await CreateTheWorld();
 
@@ -348,7 +348,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanCompareReferencesOtherWayRoundByRepositoryId()
+        public async Task CanCompareReferencesOtherWayRoundWithRepositoryId()
         {
             await CreateTheWorld();
 
@@ -374,7 +374,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task ReturnsUrlsToResourcesByRepositoryId()
+        public async Task ReturnsUrlsToResourcesWithRepositoryId()
         {
             await CreateTheWorld();
 
@@ -402,7 +402,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task CanCompareUsingShaByRepositoryId()
+        public async Task CanCompareUsingShaWithRepositoryId()
         {
             await CreateTheWorld();
 
@@ -427,7 +427,7 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
-        public async Task GetSha1FromRepositoryByRepositoryId()
+        public async Task GetSha1FromRepositoryWithRepositoryId()
         {
             var reference = await CreateTheWorld();
 

--- a/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommitsClientTests.cs
@@ -28,9 +28,23 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetMergeBaseCommitByRepositoryId()
+        {
+            var compareResult = await _fixture.Compare(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            Assert.NotNull(compareResult.MergeBaseCommit);
+        }
+
+        [IntegrationTest]
         public async Task CanGetCommit()
         {
             var commit = await _fixture.Get("octokit", "octokit.net", "65a22f4d2cff94a286ac3e96440c810c5509196f");
+            Assert.NotNull(commit);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCommitByRepositoryId()
+        {
+            var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
             Assert.NotNull(commit);
         }
 
@@ -43,9 +57,24 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetCommitWithFilesByRepositoryId()
+        {
+            var commit = await _fixture.Get(7528679, "65a22f4d2cff94a286ac3e96440c810c5509196f");
+
+            Assert.True(commit.Files.Any(file => file.Filename.EndsWith("IConnection.cs")));
+        }
+
+        [IntegrationTest]
         public async Task CanGetListOfCommits()
         {
             var list = await _fixture.GetAll("shiftkey", "ReactiveGit");
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetListOfCommitsByRepositoryId()
+        {
+            var list = await _fixture.GetAll(22718025);
             Assert.NotEmpty(list);
         }
 
@@ -63,6 +92,19 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommitsWithoutStartByRepositoryId()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var commits = await _fixture.GetAll(22718025, options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
         public async Task CanGetCorrectCountOfCommitsWithStart()
         {
             var options = new ApiOptions
@@ -73,6 +115,20 @@ public class RepositoryCommitsClientTests
             };
 
             var commits = await _fixture.GetAll("shiftkey", "ReactiveGit", options);
+            Assert.Equal(5, commits.Count);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetCorrectCountOfCommitsWithStartByRepositoryId()
+        {
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var commits = await _fixture.GetAll(22718025, options);
             Assert.Equal(5, commits.Count);
         }
 
@@ -103,10 +159,44 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartByRepositoryId()
+        {
+            var startOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var firstCommit = await _fixture.GetAll(22718025, startOptions);
+            var secondCommit = await _fixture.GetAll(22718025, skipStartOptions);
+
+            Assert.NotEqual(firstCommit[0].Sha, secondCommit[0].Sha);
+            Assert.NotEqual(firstCommit[1].Sha, secondCommit[1].Sha);
+            Assert.NotEqual(firstCommit[2].Sha, secondCommit[2].Sha);
+            Assert.NotEqual(firstCommit[3].Sha, secondCommit[3].Sha);
+            Assert.NotEqual(firstCommit[4].Sha, secondCommit[4].Sha);
+        }
+
+        [IntegrationTest]
         public async Task CanGetListOfCommitsBySha()
         {
             var request = new CommitRequest { Sha = "08b363d45d6ae8567b75dfa45c032a288584afd4" };
             var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetListOfCommitsByShaByRepositoryId()
+        {
+            var request = new CommitRequest { Sha = "08b363d45d6ae8567b75dfa45c032a288584afd4" };
+            var list = await _fixture.GetAll(7528679, request);
             Assert.NotEmpty(list);
         }
 
@@ -119,10 +209,26 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetListOfCommitsByPathByRepositoryId()
+        {
+            var request = new CommitRequest { Path = "Octokit.Reactive/IObservableGitHubClient.cs" };
+            var list = await _fixture.GetAll(7528679, request);
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
         public async Task CanGetListOfCommitsByAuthor()
         {
             var request = new CommitRequest { Author = "kzu" };
             var list = await _fixture.GetAll("octokit", "octokit.net", request);
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetListOfCommitsByAuthorByRepositoryId()
+        {
+            var request = new CommitRequest { Author = "kzu" };
+            var list = await _fixture.GetAll(7528679, request);
             Assert.NotEmpty(list);
         }
 
@@ -139,6 +245,18 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetListOfCommitsByDateRangeByRepositoryId()
+        {
+            var offset = new TimeSpan(1, 0, 0);
+            var since = new DateTimeOffset(2014, 1, 1, 0, 0, 0, offset);
+            var until = new DateTimeOffset(2014, 1, 8, 0, 0, 0, offset);
+
+            var request = new CommitRequest { Since = since, Until = until };
+            var list = await _fixture.GetAll(7528679, request);
+            Assert.NotEmpty(list);
+        }
+
+        [IntegrationTest]
         public async Task CanGetCommitWithRenamedFiles()
         {
             var commit = await _fixture.Get("octokit", "octokit.net", "997e955f38eb0c2c36e55b1588455fa857951dbf");
@@ -149,9 +267,27 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanGetCommitWithRenamedFilesByRepositoryId()
+        {
+            var commit = await _fixture.Get(7528679, "997e955f38eb0c2c36e55b1588455fa857951dbf");
+
+            Assert.True(commit.Files
+                .Where(file => file.Status == "renamed")
+                .All(file => string.IsNullOrEmpty(file.PreviousFileName) == false));
+        }
+
+        [IntegrationTest]
         public async Task CanGetSha1()
         {
             var sha1 = await _fixture.GetSha1("octokit", "octokit.net", "master");
+
+            Assert.NotNull(sha1);
+        }
+
+        [IntegrationTest]
+        public async Task CanGetSha1ByRepositoryId()
+        {
+            var sha1 = await _fixture.GetSha1(7528679, "master");
 
             Assert.NotNull(sha1);
         }
@@ -186,6 +322,19 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanCompareReferencesByRepositoryId()
+        {
+            await CreateTheWorld();
+
+            var result = await _fixture.Compare(_context.Repository.Id, "master", "my-branch");
+
+            Assert.Equal(1, result.TotalCommits);
+            Assert.Equal(1, result.Commits.Count);
+            Assert.Equal(1, result.AheadBy);
+            Assert.Equal(0, result.BehindBy);
+        }
+
+        [IntegrationTest]
         public async Task CanCompareReferencesOtherWayRound()
         {
             await CreateTheWorld();
@@ -199,11 +348,37 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanCompareReferencesOtherWayRoundByRepositoryId()
+        {
+            await CreateTheWorld();
+
+            var result = await _fixture.Compare(_context.Repository.Id, "my-branch", "master");
+
+            Assert.Equal(0, result.TotalCommits);
+            Assert.Equal(0, result.Commits.Count);
+            Assert.Equal(0, result.AheadBy);
+            Assert.Equal(1, result.BehindBy);
+        }
+
+        [IntegrationTest]
         public async Task ReturnsUrlsToResources()
         {
             await CreateTheWorld();
 
             var result = await _fixture.Compare(Helper.UserName, _context.RepositoryName, "my-branch", "master");
+
+            Assert.NotNull(result.DiffUrl);
+            Assert.NotNull(result.HtmlUrl);
+            Assert.NotNull(result.PatchUrl);
+            Assert.NotNull(result.PermalinkUrl);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsUrlsToResourcesByRepositoryId()
+        {
+            await CreateTheWorld();
+
+            var result = await _fixture.Compare(_context.Repository.Id, "my-branch", "master");
 
             Assert.NotNull(result.DiffUrl);
             Assert.NotNull(result.HtmlUrl);
@@ -227,11 +402,36 @@ public class RepositoryCommitsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanCompareUsingShaByRepositoryId()
+        {
+            await CreateTheWorld();
+
+            var master = await _github.Git.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/master");
+            var branch = await _github.Git.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/my-branch");
+
+            var result = await _fixture.Compare(_context.Repository.Id, master.Object.Sha, branch.Object.Sha);
+
+            Assert.Equal(1, result.Commits.Count);
+            Assert.Equal(1, result.AheadBy);
+            Assert.Equal(0, result.BehindBy);
+        }
+
+        [IntegrationTest]
         public async Task GetSha1FromRepository()
         {
             var reference = await CreateTheWorld();
 
             var sha1 = await _fixture.GetSha1(Helper.UserName, _context.RepositoryName, "my-branch");
+
+            Assert.Equal(reference.Object.Sha, sha1);
+        }
+
+        [IntegrationTest]
+        public async Task GetSha1FromRepositoryByRepositoryId()
+        {
+            var reference = await CreateTheWorld();
+
+            var sha1 = await _fixture.GetSha1(_context.Repository.Id, "my-branch");
 
             Assert.Equal(reference.Object.Sha, sha1);
         }

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Clients
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
-                () => new RepositoryCommitsClient(null));
+                    () => new RepositoryCommitsClient(null));
             }
         }
 

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -1,5 +1,7 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -12,47 +14,342 @@ namespace Octokit.Tests.Clients
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
-                    () => new RepositoryCommitsClient(null));
+                () => new RepositoryCommitsClient(null));
+            }
+        }
+
+        public class TheCompareMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.Compare("fake", "repo", "base", "head");
+
+                connection.Received().Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/compare/base...head"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.Compare(1, "base", "head");
+
+                connection.Received().Get<CompareResult>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/compare/base...head"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare(null, "name", "base", "head"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", null, "base", "head"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "name", null, "head"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare("owner", "name", "base", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare(1, null, "head"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Compare(1, "base", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("", "name", "base", "head"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "", "base", "head"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "name", "", "head"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare("owner", "name", "base", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare(1, "", "head"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Compare(1, "base", ""));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.Get("fake", "repo", "reference");
+
+                connection.Received().Get<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/reference"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.Get(1, "reference");
+
+                connection.Received().Get<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/reference"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(1, ""));
             }
         }
 
         public class TheGetAllMethod
         {
             [Fact]
-            public void EnsuresNonEmptyArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoryCommitsClient(connection);
-                var options = new ApiOptions();
-                var request = new CommitRequest();
-
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", request, options));
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", request, options));
-            }
-
-            [Fact]
-            public void EnsuresNonNullArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoryCommitsClient(connection);
-                var options = new ApiOptions();
-                var request = new CommitRequest();
-
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", request, options));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, request, options));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, options));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", request, null));
-
-            }
-
-            [Fact]
-            public void GetsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
 
-                client.GetAll("fake", "repo", new CommitRequest(), new ApiOptions());
+                await client.GetAll("fake", "repo");
+
                 connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits"), Args.EmptyDictionary, Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.GetAll(1);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits"), Args.EmptyDictionary, Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll("fake", "repo", options);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits"), Args.EmptyDictionary, options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll(1, options);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits"), Args.EmptyDictionary, options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlParameterized()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                await client.GetAll("fake", "repo", commitRequest);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits"),
+                    Arg.Is<IDictionary<string, string>>(d => d["author"] == "author" && d["sha"] == "sha"
+                        && d["path"] == "path" && !d.ContainsKey("since") && !d.ContainsKey("until")), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryIdParameterized()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                await client.GetAll(1, commitRequest);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits"),
+                    Arg.Is<IDictionary<string, string>>(d => d["author"] == "author" && d["sha"] == "sha"
+                        && d["path"] == "path" && !d.ContainsKey("since") && !d.ContainsKey("until")), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsParameterized()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll("fake", "repo", commitRequest, options);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits"), Arg.Is<IDictionary<string, string>>(d => d["author"] == "author" && d["sha"] == "sha"
+                    && d["path"] == "path" && !d.ContainsKey("since") && !d.ContainsKey("until")), options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryIdWithApiOptionsParameterized()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll(1, commitRequest, options);
+
+                connection.Received().GetAll<GitHubCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits"), Arg.Is<IDictionary<string, string>>(d => d["author"] == "author" && d["sha"] == "sha"
+                    && d["path"] == "path" && !d.ContainsKey("since") && !d.ContainsKey("until")), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new CommitRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new CommitRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (CommitRequest)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new CommitRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new CommitRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", new CommitRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, (CommitRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, new CommitRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", new CommitRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", new CommitRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", new CommitRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", new CommitRequest(), ApiOptions.None));
+            }
+        }
+
+        public class TheGetSha1Method
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.GetSha1("fake", "repo", "ref");
+
+                connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/ref"), 
+                    null, "application/vnd.github.chitauri-preview+sha");
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlByRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await client.GetSha1(1, "ref");
+
+                connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/ref"),
+                    null, "application/vnd.github.chitauri-preview+sha");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryCommitsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSha1(null, "name", "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSha1("owner", null, "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSha1("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSha1(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("", "name", "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "", "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1(1, ""));
             }
         }
     }

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryId()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryId()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -123,7 +123,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryId()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -152,7 +152,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryIdWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -192,7 +192,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryIdParameterized()
+            public async Task RequestsCorrectUrlWithRepositoryIdParameterized()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -242,7 +242,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryIdWithApiOptionsParameterized()
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptionsParameterized()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -322,7 +322,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task RequestsCorrectUrlByRepositoryId()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryHooksClientTests.cs" />
+    <Compile Include="Reactive\ObservableRespositoryCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableStarredClientTests.cs" />
     <Compile Include="Reactive\ObservableStatisticsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRespositoryCommitsClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryId()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -78,7 +78,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryId()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -122,7 +122,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryId()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -151,7 +151,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryIdWithApiOptions()
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -189,7 +189,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryIdParameterized()
+            public void RequestsCorrectUrlWithRepositoryIdParameterized()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -236,7 +236,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryIdWithApiOptionsParameterized()
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptionsParameterized()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
@@ -314,7 +314,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlByRepositoryId()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);

--- a/Octokit.Tests/Reactive/ObservableRespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRespositoryCommitsClientTests.cs
@@ -1,0 +1,347 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class RespositoryCommitsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableRepositoryCommitsClient(null));
+            }
+        }
+
+        public class TheCompareMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.Compare("fake", "repo", "base", "head");
+
+                gitHubClient.Received().Repository.Commit.Compare("fake", "repo", "base", "head");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.Compare(1, "base", "head");
+
+                gitHubClient.Received().Repository.Commit.Compare(1, "base", "head");
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Compare(null, "name", "base", "head"));
+                Assert.Throws<ArgumentNullException>(() => client.Compare("owner", null, "base", "head"));
+                Assert.Throws<ArgumentNullException>(() => client.Compare("owner", "name", null, "head"));
+                Assert.Throws<ArgumentNullException>(() => client.Compare("owner", "name", "base", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Compare(1, null, "head"));
+                Assert.Throws<ArgumentNullException>(() => client.Compare(1, "base", null));
+
+                Assert.Throws<ArgumentException>(() => client.Compare("", "name", "base", "head"));
+                Assert.Throws<ArgumentException>(() => client.Compare("owner", "", "base", "head"));
+                Assert.Throws<ArgumentException>(() => client.Compare("owner", "name", "", "head"));
+                Assert.Throws<ArgumentException>(() => client.Compare("owner", "name", "base", ""));
+                Assert.Throws<ArgumentException>(() => client.Compare(1, "", "head"));
+                Assert.Throws<ArgumentException>(() => client.Compare(1, "base", ""));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.Get("fake", "repo", "reference");
+
+                gitHubClient.Received().Repository.Commit.Get("fake", "repo", "reference");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.Get(1, "reference");
+
+                gitHubClient.Received().Repository.Commit.Get(1, "reference");
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Get(1, ""));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.GetAll("fake", "repo");
+
+                gitHubClient.Received().Repository.Commit.GetAll("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.GetAll(1);
+
+                gitHubClient.Received().Repository.Commit.GetAll(1);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("fake", "repo", options);
+
+                gitHubClient.Received().Repository.Commit.GetAll("fake", "repo", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll(1, options);
+
+                gitHubClient.Received().Repository.Commit.GetAll(1, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlParameterized()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                client.GetAll("fake", "repo", commitRequest);
+
+                gitHubClient.Received().Repository.Commit.GetAll("fake", "repo", commitRequest);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryIdParameterized()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                client.GetAll(1, commitRequest);
+
+                gitHubClient.Received().Repository.Commit.GetAll(1, commitRequest);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsParameterized()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("fake", "repo", commitRequest, options);
+
+                gitHubClient.Received().Repository.Commit.GetAll("fake", "repo", commitRequest, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryIdWithApiOptionsParameterized()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                var commitRequest = new CommitRequest
+                {
+                    Author = "author",
+                    Sha = "sha",
+                    Path = "path",
+                    Since = null,
+                    Until = null
+                };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll(1, commitRequest, options);
+
+                gitHubClient.Received().Repository.Commit.GetAll(1, commitRequest, options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(connection);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new CommitRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new CommitRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (CommitRequest)null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new CommitRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new CommitRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", new CommitRequest(), null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, (CommitRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, new CommitRequest(), null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", new CommitRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", new CommitRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", new CommitRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", new CommitRequest(), ApiOptions.None));
+            }
+        }
+
+        public class TheGetSha1Method
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.GetSha1("fake", "repo", "ref");
+
+                gitHubClient.Received().Repository.Commit.GetSha1("fake", "repo", "ref");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlByRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(gitHubClient);
+
+                client.GetSha1(1, "ref");
+
+                gitHubClient.Received().Repository.Commit.GetSha1(1, "ref");
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommitsClient(connection);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetSha1(null, "name", "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetSha1("owner", null, "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetSha1("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetSha1(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetSha1("", "name", "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetSha1("owner", "", "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetSha1("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetSha1(1, ""));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -19,7 +19,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         Task<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -29,7 +28,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         Task<CompareResult> Compare(int repositoryId, string @base, string head);
 
@@ -39,7 +37,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
         Task<GitHubCommit> Get(string owner, string name, string reference);
@@ -49,7 +46,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
         Task<GitHubCommit> Get(int repositoryId, string reference);
@@ -59,14 +55,12 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId);
 
         /// <summary>
@@ -75,7 +69,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -83,7 +76,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -92,7 +84,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -100,7 +91,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
@@ -110,7 +100,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -119,7 +108,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -128,7 +116,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         Task<string> GetSha1(string owner, string name, string reference);
 
         /// <summary>
@@ -136,7 +123,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         Task<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -24,6 +24,16 @@ namespace Octokit
         Task<CompareResult> Compare(string owner, string name, string @base, string head);
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
+        Task<CompareResult> Compare(int repositoryId, string @base, string head);
+
+        /// <summary>
         /// Gets a single commit for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -35,12 +45,29 @@ namespace Octokit
         Task<GitHubCommit> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a single commit for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference for the commit (SHA)</param>
+        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Makes a network request")]
+        Task<GitHubCommit> Get(int repositoryId, string reference);
+
+        /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -54,11 +81,27 @@ namespace Octokit
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request);
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -71,6 +114,15 @@ namespace Octokit
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
+
+        /// <summary>
         /// Get the SHA-1 of a commit reference
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -78,5 +130,13 @@ namespace Octokit
         /// <param name="reference">The repository reference</param>
         /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
         Task<string> GetSha1(string owner, string name, string reference);
+
+        /// <summary>
+        /// Get the SHA-1 of a commit reference
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The repository reference</param>
+        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        Task<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         Task<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
         Task<GitHubCommit> Get(string owner, string name, string reference);
@@ -39,7 +39,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -67,15 +67,16 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
+
         /// <summary>
         /// Get the SHA-1 of a commit reference
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
         Task<string> GetSha1(string owner, string name, string reference);
     }
 }

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         Task<CompareResult> Compare(string owner, string name, string @base, string head);
 
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
         Task<CompareResult> Compare(int repositoryId, string @base, string head);
 
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
         Task<GitHubCommit> Get(string owner, string name, string reference);
@@ -49,7 +49,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
         Task<GitHubCommit> Get(int repositoryId, string reference);
@@ -59,14 +59,14 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request);
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         Task<string> GetSha1(string owner, string name, string reference);
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         Task<string> GetSha1(int repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
         public Task<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
         public Task<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -55,7 +55,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,14 +78,14 @@ namespace Octokit
 
             return GetAll(owner, name, new CommitRequest(), options);
         }
-        
+
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -102,7 +102,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +118,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
         public Task<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         public Task<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        /// <returns></returns>
         public Task<CompareResult> Compare(int repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         public Task<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +70,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        /// <returns></returns>
         public Task<GitHubCommit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -83,7 +83,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -96,7 +96,7 @@ namespace Octokit
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
@@ -108,7 +108,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -122,7 +122,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options)
         {
             return GetAll(repositoryId, new CommitRequest(), options);
@@ -134,7 +134,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -149,7 +149,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -196,7 +196,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         public Task<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -211,7 +211,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        /// <returns></returns>
         public Task<string> GetSha1(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -35,6 +35,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Compare two references in a repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="base">The reference to use as the base commit</param>
+        /// <param name="head">The reference to use as the head commit</param>
+        /// <returns>A <see cref="CompareResult"/> for the specified references.</returns>
+        public Task<CompareResult> Compare(int repositoryId, string @base, string head)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(@base, "base");
+            Ensure.ArgumentNotNullOrEmptyString(head, "head");
+
+            return ApiConnection.Get<CompareResult>(ApiUrls.RepoCompare(repositoryId, @base, head));
+        }
+
+        /// <summary>
         /// Gets a single commit for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -48,6 +63,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return ApiConnection.Get<GitHubCommit>(ApiUrls.RepositoryCommit(owner, name, reference));
+        }
+
+        /// <summary>
+        /// Gets a single commit for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference for the commit (SHA)</param>
+        /// <returns>A <see cref="GitHubCommit"/> for the specified commit SHA.</returns>
+        public Task<GitHubCommit> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<GitHubCommit>(ApiUrls.RepositoryCommit(repositoryId, reference));
         }
 
         /// <summary>
@@ -67,6 +95,16 @@ namespace Octokit
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -77,6 +115,17 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAll(owner, name, new CommitRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options)
+        {
+            return GetAll(repositoryId, new CommitRequest(), options);
         }
 
         /// <summary>
@@ -98,6 +147,19 @@ namespace Octokit
         /// <summary>
         /// Gets all commits for a given repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAll(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
@@ -108,8 +170,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<GitHubCommit>(ApiUrls.RepositoryCommits(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets all commits for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter list of commits returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{GitHubCommit}"/> of <see cref="GitHubCommit"/>s for the specified repository.</returns>
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<GitHubCommit>(ApiUrls.RepositoryCommits(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -126,6 +204,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(owner, name, reference), null, AcceptHeaders.CommitReferenceSha1Preview);
+        }
+
+        /// <summary>
+        /// Get the SHA-1 of a commit reference
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The repository reference</param>
+        /// <returns>A <see cref="string"/> for the specified repository reference.</returns>
+        public Task<string> GetSha1(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(repositoryId, reference), null, AcceptHeaders.CommitReferenceSha1Preview);
         }
     }
 }

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -23,7 +23,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         public Task<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +39,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        /// <returns></returns>
         public Task<CompareResult> Compare(int repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
@@ -55,7 +53,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
         public Task<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +67,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        /// <returns></returns>
         public Task<GitHubCommit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -83,7 +79,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -96,7 +91,6 @@ namespace Octokit
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
@@ -108,7 +102,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -122,7 +115,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options)
         {
             return GetAll(repositoryId, new CommitRequest(), options);
@@ -134,7 +126,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -149,7 +140,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -164,7 +154,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -181,7 +170,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -196,7 +184,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         public Task<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -211,7 +198,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The repository reference</param>
-        /// <returns></returns>
         public Task<string> GetSha1(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryCommitsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryCommitsClient and IObservableRepositoryCommitsClient).**

	  There is some divergence between XML documentation of methods in IRepositoryCommitsClient and IObservableRepositoryCommitsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryCommitsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryCommitsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble
