### PR TITLE
Add repositoryId overloads to methods on I(Observable)MergingClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMergingClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Merging API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/merging/">Git Merging API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableMergingClient
     {
         /// <summary>
@@ -15,5 +21,16 @@ namespace Octokit.Reactive
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
         IObservable<Merge> Create(string owner, string name, NewMerge merge);
+
+        /// <summary>
+        /// Create a merge for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/merging/#perform-a-merge
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="merge">The merge to create</param>
+        /// <returns></returns>
+        IObservable<Merge> Create(int repositoryId, NewMerge merge);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMergingClient.cs
@@ -25,6 +25,10 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Merge> Create(string owner, string name, NewMerge merge)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(merge, "merge");
+
             return _client.Create(owner, name, merge).ToObservable();
         }
 
@@ -39,6 +43,8 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Merge> Create(int repositoryId, NewMerge merge)
         {
+            Ensure.ArgumentNotNull(merge, "merge");
+
             return _client.Create(repositoryId, merge).ToObservable();
         }
     }

--- a/Octokit.Reactive/Clients/ObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMergingClient.cs
@@ -27,5 +27,19 @@ namespace Octokit.Reactive
         {
             return _client.Create(owner, name, merge).ToObservable();
         }
+
+        /// <summary>
+        /// Create a merge for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/merging/#perform-a-merge
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="merge">The merge to create</param>
+        /// <returns></returns>
+        public IObservable<Merge> Create(int repositoryId, NewMerge merge)
+        {
+            return _client.Create(repositoryId, merge).ToObservable();
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/MergingClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MergingClientTests.cs
@@ -38,6 +38,19 @@ public class MergingClientTests : IDisposable
         Assert.Equal("merge commit to master from integrationtests", merge.Commit.Message);
     }
 
+    [IntegrationTest]
+    public async Task CanCreateMergeWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newMerge = new NewMerge("master", branchName) { CommitMessage = "merge commit to master from integrationtests" };
+
+        var merge = await _fixture.Create(_context.Repository.Id, newMerge);
+        Assert.NotNull(merge);
+        Assert.NotNull(merge.Commit);
+        Assert.Equal("merge commit to master from integrationtests", merge.Commit.Message);
+    }
+
     async Task CreateTheWorld()
     {
         var master = await _github.Git.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/master");

--- a/Octokit.Tests/Clients/MergingClientTests.cs
+++ b/Octokit.Tests/Clients/MergingClientTests.cs
@@ -10,7 +10,7 @@ namespace Octokit.Tests.Clients
         public class TheCreateMethod
         {
             [Fact]
-            public void PostsToTheCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new MergingClient(connection);
@@ -28,6 +28,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MergingClient(connection);
+
+                var newMerge = new NewMerge("baseBranch", "shaToMerge")
+                {
+                    CommitMessage = "some mergingMessage"
+                };
+                client.Create(1, newMerge);
+
+                connection.Received().Post<Merge>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/merges"),
+                    Arg.Is<NewMerge>(nm => nm.Base == "baseBranch"
+                                            && nm.Head == "shaToMerge"
+                                            && nm.CommitMessage == "some mergingMessage"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new MergingClient(Substitute.For<IApiConnection>());
@@ -36,6 +54,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newMerge));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newMerge));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newMerge));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newMerge));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", null));

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseSearchIndexingClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseOrganizationClientTests.cs" />
     <Compile Include="Reactive\Enterprise\ObservableEnterpriseLicenseClientTests.cs" />
+    <Compile Include="Reactive\ObservableMergingClientTests.cs" />
     <Compile Include="Reactive\ObservableAssigneesClientTests.cs" />
     <Compile Include="Reactive\ObservableAuthorizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableBlobClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableMergingClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMergingClientTests.cs
@@ -46,13 +46,15 @@ namespace Octokit.Tests.Clients
                 var client = new ObservableMergingClient(Substitute.For<IGitHubClient>());
 
                 var newMerge = new NewMerge("baseBranch", "shaToMerge") { CommitMessage = "some mergingMessage" };
+
                 Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", newMerge));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, newMerge));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
                 Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
                 Assert.Throws<ArgumentException>(() => client.Create("", "name", newMerge));
                 Assert.Throws<ArgumentException>(() => client.Create("owner", "", newMerge));
-                Assert.Throws<ArgumentException>(() => client.Create("owner", "", null));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableMergingClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMergingClientTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class ObservableMergingClientTests
+    {
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMergingClient(gitHubClient);
+
+                var newMerge = new NewMerge("baseBranch", "shaToMerge")
+                {
+                    CommitMessage = "some mergingMessage"
+                };
+                client.Create("owner", "repo", newMerge);
+
+                gitHubClient.Repository.Merging.Received(1).Create("owner", "repo", newMerge);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMergingClient(gitHubClient);
+
+                var newMerge = new NewMerge("baseBranch", "shaToMerge")
+                {
+                    CommitMessage = "some mergingMessage"
+                };
+                client.Create(1, newMerge);
+
+                gitHubClient.Repository.Merging.Received(1).Create(1, newMerge);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableMergingClient(Substitute.For<IGitHubClient>());
+
+                var newMerge = new NewMerge("baseBranch", "shaToMerge") { CommitMessage = "some mergingMessage" };
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", newMerge));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, newMerge));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", newMerge));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", newMerge));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", null));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableMergingClient(null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IMergingClient.cs
+++ b/Octokit/Clients/IMergingClient.cs
@@ -21,5 +21,16 @@ namespace Octokit
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
         Task<Merge> Create(string owner, string name, NewMerge merge);
+
+        /// <summary>
+        /// Create a merge for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/merging/#perform-a-merge
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="merge">The merge to create</param>
+        /// <returns></returns>
+        Task<Merge> Create(int repositoryId, NewMerge merge);
     }
 }

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -36,5 +36,21 @@ namespace Octokit
 
             return ApiConnection.Post<Merge>(ApiUrls.CreateMerge(owner, name), merge);
         }
+
+        /// <summary>
+        /// Create a merge for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/merging/#perform-a-merge
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="merge">The merge to create</param>
+        /// <returns></returns>
+        public Task<Merge> Create(int repositoryId, NewMerge merge)
+        {
+            Ensure.ArgumentNotNull(merge, "merge");
+
+            return ApiConnection.Post<Merge>(ApiUrls.CreateMerge(repositoryId), merge);
+        }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)MergingClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IMergingClient and IObservableMergingClient).**

	  There is some divergence between XML documentation of methods in IMergingClient and IObservableMergingClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IMergingClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableMergingClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble
