### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryContentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -16,14 +16,12 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         IObservable<Readme> GetReadme(string owner, string name);
 
         /// <summary>
         /// Returns the HTML rendered README.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         IObservable<Readme> GetReadme(int repositoryId);
 
         /// <summary>
@@ -31,14 +29,12 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         IObservable<string> GetReadmeHtml(string owner, string name);
 
         /// <summary>
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         IObservable<string> GetReadmeHtml(int repositoryId);
         
         /// <summary>
@@ -47,7 +43,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name);
 
         /// <summary>
@@ -55,7 +50,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(int repositoryId);
 
         /// <summary>
@@ -65,7 +59,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat);
 
         /// <summary>
@@ -74,7 +67,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
 
         /// <summary>
@@ -85,7 +77,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
@@ -95,7 +86,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
@@ -107,7 +97,6 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
@@ -118,7 +107,6 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
@@ -130,9 +118,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContents(string owner, string name, string path);
 
         /// <summary>
@@ -143,9 +128,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContents(int repositoryId, string path);
 
         /// <summary>
@@ -153,18 +135,12 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContents(string owner, string name);
 
         /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContents(int repositoryId);
 
         /// <summary>
@@ -178,9 +154,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path);
 
         /// <summary>
@@ -193,9 +166,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path);
         
         /// <summary>
@@ -204,9 +174,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference);
 
         /// <summary>
@@ -214,9 +181,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference);
 
         /// <summary>
@@ -226,7 +190,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         IObservable<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
 
         /// <summary>
@@ -235,7 +198,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
@@ -245,7 +207,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         IObservable<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request);
 
         /// <summary>
@@ -254,7 +215,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
 
         /// <summary>
@@ -264,7 +224,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
 
         /// <summary>
@@ -273,7 +232,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -148,6 +148,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
         IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -16,7 +16,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         IObservable<Readme> GetReadme(string owner, string name);
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         IObservable<string> GetReadmeHtml(string owner, string name);
         
         /// <summary>
@@ -108,8 +108,7 @@ namespace Octokit.Reactive
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path);
-
-
+        
         /// <summary>
         /// Returns the contents of the home directory in a repository.
         /// </summary>
@@ -128,7 +127,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         IObservable<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -6,6 +6,9 @@ namespace Octokit.Reactive
     /// <summary>
     /// Client for accessing contents of files within a repository as base64 encoded content.
     /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/contents/">Repository Contents API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryContentsClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -20,12 +20,26 @@ namespace Octokit.Reactive
         IObservable<Readme> GetReadme(string owner, string name);
 
         /// <summary>
+        /// Returns the HTML rendered README.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
+        IObservable<Readme> GetReadme(int repositoryId);
+
+        /// <summary>
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         IObservable<string> GetReadmeHtml(string owner, string name);
+
+        /// <summary>
+        /// Returns just the HTML portion of the README without the surrounding HTML document. 
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
+        IObservable<string> GetReadmeHtml(int repositoryId);
         
         /// <summary>
         /// Get an archive of a given repository's contents
@@ -37,6 +51,14 @@ namespace Octokit.Reactive
         IObservable<byte[]> GetArchive(string owner, string name);
 
         /// <summary>
+        /// Get an archive of a given repository's contents
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        IObservable<byte[]> GetArchive(int repositoryId);
+
+        /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -45,6 +67,15 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <returns>A promise, containing the binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat);
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
 
         /// <summary>
         /// Get an archive of a given repository's contents, using a specific format and reference
@@ -58,6 +89,16 @@ namespace Octokit.Reactive
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
+        /// Get an archive of a given repository's contents, using a specific format and reference
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
+
+        /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -68,6 +109,17 @@ namespace Octokit.Reactive
         /// <param name="timeout"> Time span until timeout </param>
         /// <returns>The binary contents of the archive</returns>
         IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <param name="timeout"> Time span until timeout </param>
+        /// <returns>The binary contents of the archive</returns>
+        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -84,6 +136,19 @@ namespace Octokit.Reactive
         IObservable<RepositoryContent> GetAllContents(string owner, string name, string path);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContents(int repositoryId, string path);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -92,6 +157,15 @@ namespace Octokit.Reactive
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         IObservable<RepositoryContent> GetAllContents(string owner, string name);
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContents(int repositoryId);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -108,6 +182,21 @@ namespace Octokit.Reactive
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path);
+
+        /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path);
         
         /// <summary>
         /// Returns the contents of the home directory in a repository.
@@ -121,6 +210,16 @@ namespace Octokit.Reactive
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference);
 
         /// <summary>
+        /// Returns the contents of the home directory in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference);
+
+        /// <summary>
         /// Creates a commit that creates a new file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -129,6 +228,15 @@ namespace Octokit.Reactive
         /// <param name="request">Information about the file to create</param>
         /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         IObservable<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
+
+        /// <summary>
+        /// Creates a commit that creates a new file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to create</param>
+        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
+        IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
         /// Creates a commit that updates the contents of a file in a repository.
@@ -141,6 +249,15 @@ namespace Octokit.Reactive
         IObservable<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request);
 
         /// <summary>
+        /// Creates a commit that updates the contents of a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to update</param>
+        /// <returns>The updated content</returns>
+        IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
+
+        /// <summary>
         /// Creates a commit that deletes a file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -149,5 +266,14 @@ namespace Octokit.Reactive
         /// <param name="request">Information about the file to delete</param>
         /// <returns></returns>
         IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request);
+
+        /// <summary>
+        /// Creates a commit that deletes a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
+        IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -228,6 +228,14 @@ namespace Octokit.Reactive
             return _client.Repository.Content.UpdateFile(owner, name, path, request).ToObservable();
         }
 
+        /// <summary>
+        /// Creates a commit that deletes a file in a repository.
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
         public IObservable<System.Reactive.Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -21,6 +21,8 @@ namespace Octokit.Reactive
         /// <param name="client"></param>
         public ObservableRepositoryContentsClient(IGitHubClient client)
         {
+            Ensure.ArgumentNotNull(client, "client");
+
             _client = client;
         }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public IObservable<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public IObservable<string> GetReadmeHtml(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -199,7 +199,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public IObservable<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -141,7 +141,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(reference, "reference");
 
             return GetArchive(owner, name, archiveFormat, reference, TimeSpan.FromMinutes(60));
         }
@@ -156,7 +156,7 @@ namespace Octokit.Reactive
         /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
         {
-            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(reference, "reference");
 
             return GetArchive(repositoryId, archiveFormat, reference, TimeSpan.FromMinutes(60));
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -31,7 +31,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public IObservable<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -44,7 +43,6 @@ namespace Octokit.Reactive
         /// Returns the HTML rendered README.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public IObservable<Readme> GetReadme(int repositoryId)
         {
             return _client.Repository.Content.GetReadme(repositoryId).ToObservable();
@@ -55,7 +53,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public IObservable<string> GetReadmeHtml(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -68,7 +65,6 @@ namespace Octokit.Reactive
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public IObservable<string> GetReadmeHtml(int repositoryId)
         {
             return _client.Repository.Content.GetReadmeHtml(repositoryId).ToObservable();
@@ -80,7 +76,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -94,7 +89,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(int repositoryId)
         {
             return GetArchive(repositoryId, ArchiveFormat.Tarball);
@@ -107,7 +101,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -122,7 +115,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
         {
             return GetArchive(repositoryId, archiveFormat, string.Empty);
@@ -136,7 +128,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -153,7 +144,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
@@ -170,7 +160,6 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -189,7 +178,6 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.GreaterThanZero(timeout, "timeout");
@@ -207,9 +195,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContents(string owner, string name, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -229,9 +214,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContents(int repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -246,9 +228,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -263,9 +242,6 @@ namespace Octokit.Reactive
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContents(int repositoryId)
         {
             return _client
@@ -284,9 +260,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -307,9 +280,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -324,9 +294,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -341,9 +308,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -358,7 +322,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public IObservable<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -375,7 +338,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -391,7 +353,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         public IObservable<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -408,7 +369,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         public IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -424,7 +384,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         public IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -441,7 +400,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         public IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -175,6 +175,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(reference, "reference");
             Ensure.GreaterThanZero(timeout, "timeout");
 
             return _client.Repository.Content.GetArchive(owner, name, archiveFormat, reference, timeout).ToObservable();
@@ -192,6 +193,7 @@ namespace Octokit.Reactive
         public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.GreaterThanZero(timeout, "timeout");
+            Ensure.ArgumentNotNull(reference, "reference");
 
             return _client.Repository.Content.GetArchive(repositoryId, archiveFormat, reference, timeout).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -7,6 +7,9 @@ namespace Octokit.Reactive
     /// <summary>
     /// Client for accessing contents of files within a repository as base64 encoded content.
     /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/contents/">Repository Contents API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryContentsClient : IObservableRepositoryContentsClient
     {
         readonly IGitHubClient _client;

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive;
 using System.Reactive.Threading.Tasks;
 using Octokit.Reactive.Internal;
 
@@ -38,6 +39,16 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns the HTML rendered README.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{Readme}"/> of <see cref="Readme"/> representing the README.md at the specified repository.</returns>
+        public IObservable<Readme> GetReadme(int repositoryId)
+        {
+            return _client.Repository.Content.GetReadme(repositoryId).ToObservable();
+        }
+
+        /// <summary>
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -52,6 +63,16 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns just the HTML portion of the README without the surrounding HTML document. 
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{String}"/> of <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
+        public IObservable<string> GetReadmeHtml(int repositoryId)
+        {
+            return _client.Repository.Content.GetReadmeHtml(repositoryId).ToObservable();
+        }
+
+        /// <summary>
         /// Get an archive of a given repository's contents
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -60,7 +81,21 @@ namespace Octokit.Reactive
         /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetArchive(owner, name, ArchiveFormat.Tarball);
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        public IObservable<byte[]> GetArchive(int repositoryId)
+        {
+            return GetArchive(repositoryId, ArchiveFormat.Tarball);
         }
 
         /// <summary>
@@ -73,7 +108,22 @@ namespace Octokit.Reactive
         /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetArchive(owner, name, archiveFormat, string.Empty);
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
+        {
+            return GetArchive(repositoryId, archiveFormat, string.Empty);
         }
 
         /// <summary>
@@ -87,7 +137,61 @@ namespace Octokit.Reactive
         /// <returns>A promise, containing the binary contents of the archive</returns>
         public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
             return GetArchive(owner, name, archiveFormat, reference, TimeSpan.FromMinutes(60));
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, using a specific format and reference
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <returns>A promise, containing the binary contents of the archive</returns>
+        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return GetArchive(repositoryId, archiveFormat, reference, TimeSpan.FromMinutes(60));
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <param name="timeout"> Time span until timeout </param>
+        /// <returns>The binary contents of the archive</returns>
+        public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.GreaterThanZero(timeout, "timeout");
+
+            return _client.Repository.Content.GetArchive(owner, name, archiveFormat, reference, timeout).ToObservable();
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <param name="timeout"> Time span until timeout </param>
+        /// <returns>The binary contents of the archive</returns>
+        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        {
+            Ensure.GreaterThanZero(timeout, "timeout");
+
+            return _client.Repository.Content.GetArchive(repositoryId, archiveFormat, reference, timeout).ToObservable();
         }
 
         /// <summary>
@@ -114,22 +218,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Get an archive of a given repository's contents, in a specific format
+        /// Returns the contents of a file or directory in a repository.
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <param name="reference">A valid Git reference.</param>
-        /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
-        public IObservable<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContents(int repositoryId, string path)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.GreaterThanZero(timeout, "timeout");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
-            return _client.Repository.Content.GetArchive(owner, name, archiveFormat, reference, timeout).ToObservable();
+            return _client
+                .Connection
+                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(repositoryId, path));
         }
 
         /// <summary>
@@ -148,6 +253,20 @@ namespace Octokit.Reactive
             return _client
                 .Connection
                 .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty));
+        }
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContents(int repositoryId)
+        {
+            return _client
+                .Connection
+                .GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(repositoryId, string.Empty));
         }
 
         /// <summary>
@@ -175,6 +294,27 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+
+            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(repositoryId, path, reference));
+        }
+
+        /// <summary>
         /// Returns the contents of the home directory in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -190,6 +330,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, string.Empty, reference));
+        }
+
+        /// <summary>
+        /// Returns the contents of the home directory in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(repositoryId, string.Empty, reference));
         }
 
         /// <summary>
@@ -211,6 +366,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a commit that creates a new file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to create</param>
+        /// <returns>A <see cref="IObservable{RepositoryContentChangeSet}"/> of <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
+        public IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return _client.Repository.Content.CreateFile(repositoryId, path, request).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a commit that updates the contents of a file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -229,6 +399,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a commit that updates the contents of a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to update</param>
+        /// <returns>The updated content</returns>
+        public IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return _client.Repository.Content.UpdateFile(repositoryId, path, request).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a commit that deletes a file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -236,7 +421,7 @@ namespace Octokit.Reactive
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
         /// <returns></returns>
-        public IObservable<System.Reactive.Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
+        public IObservable<Unit> DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -244,6 +429,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(request, "request");
 
             return _client.Repository.Content.DeleteFile(owner, name, path, request).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a commit that deletes a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
+        public IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return _client.Repository.Content.DeleteFile(repositoryId, path, request).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -505,7 +505,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive("shiftkey", "reactivegit", ArchiveFormat.Zipball);
+                    .GetArchive("octocat", "Hello-World", ArchiveFormat.Zipball);
 
                 Assert.NotEmpty(archive);
             }
@@ -518,7 +518,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive(22718025, ArchiveFormat.Zipball); // shiftkey/reactivegit repo
+                    .GetArchive(1296269, ArchiveFormat.Zipball); // octocat/Hello-World repo
 
                 Assert.NotEmpty(archive);
             }
@@ -531,7 +531,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive("alfhenrik", "ScriptCs.OctoKit", ArchiveFormat.Tarball, "master");
+                    .GetArchive("octocat", "Hello-World", ArchiveFormat.Tarball, "master");
 
                 Assert.NotEmpty(archive);
             }
@@ -544,7 +544,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive(14065343, ArchiveFormat.Tarball, "master"); // alfhenrik/ScriptCs.OctoKit repo
+                    .GetArchive(1296269, ArchiveFormat.Tarball, "master"); // octocat/Hello-World repo
 
                 Assert.NotEmpty(archive);
             }
@@ -557,7 +557,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive("alfhenrik", "ScriptCs.OctoKit", ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60));
+                    .GetArchive("octocat", "Hello-World", ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60));
 
                 Assert.NotEmpty(archive);
             }
@@ -570,7 +570,7 @@ namespace Octokit.Tests.Integration.Clients
                 var archive = await github
                     .Repository
                     .Content
-                    .GetArchive(14065343, ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60)); // alfhenrik/ScriptCs.OctoKit repo
+                    .GetArchive(1296269, ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60)); // octocat/Hello-World repo
 
                 Assert.NotEmpty(archive);
             }

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -24,11 +24,35 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsReadmeForSeeGitWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var readme = await github.Repository.Content.GetReadme(7528679);
+                Assert.Equal("README.md", readme.Name);
+                string readMeHtml = await readme.GetHtmlContent();
+                Assert.True(readMeHtml.StartsWith("<div class="));
+                Assert.Contains(@"data-path=""README.md"" id=""file""", readMeHtml);
+                Assert.Contains("Octokit - GitHub API Client Library for .NET", readMeHtml);
+            }
+
+            [IntegrationTest]
             public async Task ReturnsReadmeHtmlForSeeGit()
             {
                 var github = Helper.GetAuthenticatedClient();
 
                 var readmeHtml = await github.Repository.Content.GetReadmeHtml("octokit", "octokit.net");
+                Assert.True(readmeHtml.StartsWith("<div class="));
+                Assert.Contains(@"data-path=""README.md"" id=""readme""", readmeHtml);
+                Assert.Contains("Octokit - GitHub API Client Library for .NET", readmeHtml);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsReadmeHtmlForSeeGitWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var readmeHtml = await github.Repository.Content.GetReadmeHtml(7528679);
                 Assert.True(readmeHtml.StartsWith("<div class="));
                 Assert.Contains(@"data-path=""README.md"" id=""readme""", readmeHtml);
                 Assert.Contains("Octokit - GitHub API Client Library for .NET", readmeHtml);
@@ -53,6 +77,21 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task GetsFileContentWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents(7528679, "Octokit.Reactive/ObservableGitHubClient.cs");
+
+                Assert.Equal(1, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octokit/octokit.net/blob/master/Octokit.Reactive/ObservableGitHubClient.cs"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
             public async Task GetsDirectoryContent()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -64,6 +103,193 @@ namespace Octokit.Tests.Integration.Clients
 
                 Assert.True(contents.Count > 2);
                 Assert.Equal(ContentType.Dir, contents.First().Type);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents(7528679, "Octokit");
+
+                Assert.True(contents.Count > 2);
+                Assert.Equal(ContentType.Dir, contents.First().Type);
+            }
+
+            [IntegrationTest]
+            public async Task GetsFileContentWholeRepo()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octocat", "Spoon-Knife");
+
+                Assert.Equal(3, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octocat/Spoon-Knife/blob/master/README.md"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsFileContentWholeRepoWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents(1300192);
+
+                Assert.Equal(3, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octocat/Spoon-Knife/blob/master/README.md"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWholeRepo()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents("octocat", "octocat.github.io");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWholeRepoWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContents(17881631);
+
+                Assert.NotEmpty(contents);
+            }
+        }
+
+        public class TheGetContentsByRefMethod
+        {
+            [IntegrationTest]
+            public async Task GetsFileContent()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit.Reactive/ObservableGitHubClient.cs", "master");
+
+                Assert.Equal(1, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octokit/octokit.net/blob/master/Octokit.Reactive/ObservableGitHubClient.cs"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsFileContentWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef(7528679, "Octokit.Reactive/ObservableGitHubClient.cs", "master");
+
+                Assert.Equal(1, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octokit/octokit.net/blob/master/Octokit.Reactive/ObservableGitHubClient.cs"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContent()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octokit", "octokit.net", "Octokit", "master");
+
+                Assert.True(contents.Count > 2);
+                Assert.Equal(ContentType.Dir, contents.First().Type);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef(7528679, "Octokit", "master");
+
+                Assert.True(contents.Count > 2);
+                Assert.Equal(ContentType.Dir, contents.First().Type);
+            }
+
+            [IntegrationTest]
+            public async Task GetsFileContentWholeRepo()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octocat", "Spoon-Knife", "master");
+
+                Assert.Equal(3, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octocat/Spoon-Knife/blob/master/README.md"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsFileContentWholeRepoWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef(1300192, "master");
+
+                Assert.Equal(3, contents.Count);
+                Assert.Equal(ContentType.File, contents.First().Type);
+                Assert.Equal(new Uri("https://github.com/octocat/Spoon-Knife/blob/master/README.md"), contents.First().HtmlUrl);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWholeRepo()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octocat", "octocat.github.io", "master");
+
+                Assert.NotEmpty(contents);
+            }
+
+            [IntegrationTest]
+            public async Task GetsDirectoryContentWholeRepoWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef(17881631, "master");
+
+                Assert.NotEmpty(contents);
             }
         }
 
@@ -103,6 +329,47 @@ namespace Octokit.Tests.Integration.Clients
                 await fixture.DeleteFile(
                     repository.Owner.Login,
                     repository.Name,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CrudTestWithRepositoryId()
+        {
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
+
+                var file = await fixture.CreateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "Some Content"));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "New Content", fileSha));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Id,
                     "somefile.txt",
                     new DeleteFileRequest("Deleted file", fileSha));
 
@@ -158,43 +425,155 @@ namespace Octokit.Tests.Integration.Clients
             }
         }
 
-        [IntegrationTest(Skip = "this will probably take too long")]
-        public async Task GetsArchiveAsTarball()
+        [IntegrationTest]
+        public async Task CrudTestWithNamedBranchWithRepositoryId()
         {
-            var github = Helper.GetAuthenticatedClient();
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+            var branchName = "other-branch";
 
-            var archive = await github
-                .Repository
-                .Content
-                .GetArchive("octokit", "octokit.net");
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
 
-            Assert.NotEmpty(archive);
+                var master = await client.Git.Reference.Get(Helper.UserName, repository.Name, "heads/master");
+                await client.Git.Reference.Create(Helper.UserName, repository.Name, new NewReference("refs/heads/" + branchName, master.Object.Sha));
+                var file = await fixture.CreateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "Some Content", branchName));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "New Content", fileSha, branchName));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha, branchName));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                    () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
         }
 
-        [IntegrationTest]
-        public async Task GetsArchiveAsZipball()
+        public class TheGetArchiveMethod
         {
-            var github = Helper.GetAuthenticatedClient();
+            [IntegrationTest(Skip = "this will probably take too long")]
+            public async Task GetsArchiveAsTarball()
+            {
+                var github = Helper.GetAuthenticatedClient();
 
-            var archive = await github
-                .Repository
-                .Content
-                .GetArchive("shiftkey", "reactivegit", ArchiveFormat.Zipball);
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive("octokit", "octokit.net");
 
-            Assert.NotEmpty(archive);
-        }
+                Assert.NotEmpty(archive);
+            }
 
-        [IntegrationTest]
-        public async Task GetsArchiveForReleaseBranchAsTarball()
-        {
-            var github = Helper.GetAuthenticatedClient();
+            [IntegrationTest]
+            public async Task GetsArchiveAsTarballWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
 
-            var archive = await github
-                .Repository
-                .Content
-                .GetArchive("alfhenrik", "ScriptCs.OctoKit", ArchiveFormat.Tarball, "master");
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive(1296269); // octocat/Hello-World repo
 
-            Assert.NotEmpty(archive);
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveAsZipball()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive("shiftkey", "reactivegit", ArchiveFormat.Zipball);
+
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveAsZipballWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive(22718025, ArchiveFormat.Zipball); // shiftkey/reactivegit repo
+
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveForReleaseBranchAsTarball()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive("alfhenrik", "ScriptCs.OctoKit", ArchiveFormat.Tarball, "master");
+
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveForReleaseBranchAsTarballWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive(14065343, ArchiveFormat.Tarball, "master"); // alfhenrik/ScriptCs.OctoKit repo
+
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveForReleaseBranchAsTarballWithTimeout()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive("alfhenrik", "ScriptCs.OctoKit", ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60));
+
+                Assert.NotEmpty(archive);
+            }
+
+            [IntegrationTest]
+            public async Task GetsArchiveForReleaseBranchAsTarballWithTimeoutWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var archive = await github
+                    .Repository
+                    .Content
+                    .GetArchive(14065343, ArchiveFormat.Tarball, "master", TimeSpan.FromMinutes(60)); // alfhenrik/ScriptCs.OctoKit repo
+
+                Assert.NotEmpty(archive);
+            }
         }
     }
 }

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -47,6 +47,46 @@ namespace Octokit.Tests.Clients
                 Assert.Equal("<html>README</html>", htmlReadme);
                 connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
             }
+
+            [Fact]
+            public async Task ReturnsReadmeWithRepositoryId()
+            {
+                string encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+                var readmeInfo = new ReadmeResponse(
+                    encodedContent,
+                    "README.md",
+                    "https://github.example.com/readme",
+                    "https://github.example.com/readme.md",
+                    "base64");
+                var connection = Substitute.For<IApiConnection>();
+                connection.Get<ReadmeResponse>(Args.Uri, null).Returns(Task.FromResult(readmeInfo));
+                connection.GetHtml(Args.Uri, null).Returns(Task.FromResult("<html>README</html>"));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var readme = await contentsClient.GetReadme(1);
+
+                Assert.Equal("README.md", readme.Name);
+                connection.Received().Get<ReadmeResponse>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/readme"),
+                    null);
+                connection.DidNotReceive().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme"),
+                    null);
+                var htmlReadme = await readme.GetHtmlContent();
+                Assert.Equal("<html>README</html>", htmlReadme);
+                connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReadme(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReadme("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReadme("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReadme("owner", ""));
+            }
         }
 
         public class TheGetReadmeHtmlMethod
@@ -63,14 +103,126 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/readme"), null);
                 Assert.Equal("<html>README</html>", readme);
             }
+
+            [Fact]
+            public async Task ReturnsReadmeHtmlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetHtml(Args.Uri, null).Returns(Task.FromResult("<html>README</html>"));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var readme = await contentsClient.GetReadmeHtml(1);
+
+                connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "repositories/1/readme"), null);
+                Assert.Equal("<html>README</html>", readme);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReadmeHtml(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReadmeHtml("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReadmeHtml("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReadmeHtml("owner", ""));
+            }
         }
 
         public class TheGetContentsMethod
         {
             [Fact]
+            public async Task ReturnsContents()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents(1, "readme.md");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/readme.md"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContents()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents("fake", "repo");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContents(1);
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(null, "name", "path"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", null, "path"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContents(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("", "name", "path"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "", "path"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContents(1, ""));
+            }
+        }
+
+        public class TheGetContentsByRefMethod
+        {
+            [Fact]
             public async Task ReturnsContentsByRef()
             {
-                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
+                var result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
@@ -82,44 +234,132 @@ namespace Octokit.Tests.Clients
                 Assert.Equal(1, contents.Count);
             }
 
-
             [Fact]
-            public async Task ReturnsContents()
+            public async Task ReturnsContentsByRefWithRepositoryId()
             {
-                List<RepositoryContent> result = new List<RepositoryContent> { new RepositoryContent() };
+                var result = new List<RepositoryContent> { new RepositoryContent() };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
                 var contentsClient = new RepositoryContentsClient(connection);
 
-                var contents = await contentsClient.GetAllContents("fake", "repo", "readme.md");
+                var contents = await contentsClient.GetAllContentsByRef(1, "readme.md", "master");
 
-                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md"));
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/readme.md?ref=master"));
                 Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsByRef()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsByRefWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetAll<RepositoryContent>(Args.Uri).Returns(Task.FromResult(result.AsReadOnly() as IReadOnlyList<RepositoryContent>));
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var contents = await contentsClient.GetAllContentsByRef(1, "master");
+
+                connection.Received().GetAll<RepositoryContent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/?ref=master"));
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "path", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(1, null, "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(1, "path", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContentsByRef(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("", "name", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "path", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, "", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, "path", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, ""));
             }
         }
 
         public class TheCreateFileMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
-            public void PassesRequestObject()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -139,30 +379,67 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateFile("org", null, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateFile("org", "repo", null, new CreateFileRequest("message", "myfilecontents", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateFile("org", "repo", "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateFile(1, null, new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateFile(1, "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateFile("", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateFile("org", "", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateFile("org", "repo", "", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateFile(1, "", new CreateFileRequest("message", "myfilecontents", "mybranch")));
             }
         }
 
         public class TheDeleteFileMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+                await client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
-            public void PassesRequestObject()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                connection.Received().Delete(
+                    Arg.Any<Uri>(),
+                    Arg.Is<DeleteFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
 
                 connection.Received().Delete(
                     Arg.Any<Uri>(),
@@ -182,30 +459,68 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteFile("org", null, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteFile("org", "repo", null, new DeleteFileRequest("message", "1234abc", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteFile("org", "repo", "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteFile(1, null, new DeleteFileRequest("message", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteFile(1, "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.DeleteFile("", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.DeleteFile("org", "", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.DeleteFile("org", "repo", "", new DeleteFileRequest("message", "1234abc", "mybranch")));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.DeleteFile(1, "", new DeleteFileRequest("message", "1234abc", "mybranch")));
             }
         }
 
         public class TheUpdateFileMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
 
             [Fact]
-            public void PassesRequestObject()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObject()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoriesId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -226,23 +541,164 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateFile("org", null, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateFile("org", "repo", null, new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateFile("org", "repo", "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateFile(1, null, new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateFile(1, "path/to/file", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateFile("", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateFile("org", "", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateFile("org", "repo", "", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.UpdateFile(1, "", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
             }
         }
 
         public class TheGetArchiveMethod
         {
             [Fact]
-            public void EnsurePassingCorrectParameters()
+            public async Task RequestsCorrectUrl1()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                client.GetArchive("org", "repo", ArchiveFormat.Tarball, "dev");
+                await client.GetArchive("org", "repo");
 
-                const string expectedUri = "repos/org/repo/tarball/dev";
+                const string expectedUri = "repos/org/repo/tarball/";
                 var expectedTimeSpan = TimeSpan.FromMinutes(60);
 
                 connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl1WithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive(1);
+
+                const string expectedUri = "repositories/1/tarball/";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl2()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive("org", "repo", ArchiveFormat.Zipball);
+
+                const string expectedUri = "repos/org/repo/zipball/";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl2WithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive(1, ArchiveFormat.Zipball);
+
+                const string expectedUri = "repositories/1/zipball/";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl3()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref");
+
+                const string expectedUri = "repos/org/repo/zipball/ref";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl3WithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive(1, ArchiveFormat.Zipball, "ref");
+
+                const string expectedUri = "repositories/1/zipball/ref";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl4()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+
+                const string expectedUri = "repos/org/repo/zipball/ref";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrl4WithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.GetArchive(1, ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+
+                const string expectedUri = "repositories/1/zipball/ref";
+                var expectedTimeSpan = TimeSpan.FromMinutes(60);
+
+                connection.Connection.Received().Get<byte[]>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri), Arg.Is<TimeSpan>(span => span == expectedTimeSpan));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(null, "repo"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball, "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball, "ref"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, null, TimeSpan.MaxValue));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(1, ArchiveFormat.Tarball, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetArchive(1, ArchiveFormat.Tarball, null, TimeSpan.MaxValue));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("", "repo"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball, "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball, "ref"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetArchive(1, ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
             }
         }
     }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Reactive\ObservableRepositoryCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesEventsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryContentsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryForksClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryPagesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -1,0 +1,779 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octokit.Internal;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryContentsClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => new ObservableRepositoryContentsClient(null));
+            }
+        }
+
+        public class TheGetReadmeMethod
+        {
+            [Fact]
+            public async Task ReturnsReadme()
+            {
+                string encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+                var readmeInfo = new ReadmeResponse(
+                    encodedContent,
+                    "README.md",
+                    "https://github.example.com/readme",
+                    "https://github.example.com/readme.md",
+                    "base64");
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetHtml(new Uri(readmeInfo.Url)).Returns(Task.FromResult("<html>README</html>"));
+                var readmeFake = new Readme(readmeInfo, apiConnection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+
+                gitHubClient.Repository.Content.GetReadme("fake", "repo").Returns(Task.FromResult(readmeFake));
+
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+                gitHubClient.Connection.GetHtml(Args.Uri, null)
+                    .Returns(Task.FromResult(apiResponse));
+
+                var readme = await contentsClient.GetReadme("fake", "repo");
+
+                Assert.Equal("README.md", readme.Name);
+
+                gitHubClient.Repository.Content.Received(1).GetReadme("fake", "repo");
+                gitHubClient.Connection.DidNotReceive().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme"),
+                    Args.EmptyDictionary);
+
+                var htmlReadme = await readme.GetHtmlContent();
+                Assert.Equal("<html>README</html>", htmlReadme);
+                apiConnection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
+            }
+            
+            [Fact]
+            public async Task ReturnsReadmeWithRepositoryId()
+            {
+                string encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello world"));
+                var readmeInfo = new ReadmeResponse(
+                    encodedContent,
+                    "README.md",
+                    "https://github.example.com/readme",
+                    "https://github.example.com/readme.md",
+                    "base64");
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetHtml(new Uri(readmeInfo.Url)).Returns(Task.FromResult("<html>README</html>"));
+                var readmeFake = new Readme(readmeInfo, apiConnection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+
+                gitHubClient.Repository.Content.GetReadme(1).Returns(Task.FromResult(readmeFake));
+
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+                gitHubClient.Connection.GetHtml(Args.Uri, null)
+                    .Returns(Task.FromResult(apiResponse));
+
+                var readme = await contentsClient.GetReadme(1);
+
+                Assert.Equal("README.md", readme.Name);
+
+                gitHubClient.Repository.Content.Received(1).GetReadme(1);
+                gitHubClient.Connection.DidNotReceive().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme"),
+                    Args.EmptyDictionary);
+
+                var htmlReadme = await readme.GetHtmlContent();
+                Assert.Equal("<html>README</html>", htmlReadme);
+                apiConnection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "https://github.example.com/readme.md"), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetReadme(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetReadme("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetReadme("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetReadme("owner", ""));
+            }
+        }
+
+        public class TheGetReadmeHtmlMethod
+        {
+            [Fact]
+            public async Task ReturnsReadmeHtml()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+
+                connection.GetHtml(Args.Uri, null).Returns(Task.FromResult(apiResponse));
+
+                var readme = await contentsClient.GetReadmeHtml("fake", "repo");
+
+                connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/readme"), null);
+                Assert.Equal("<html>README</html>", readme);
+            }
+
+            [Fact]
+            public async Task ReturnsReadmeHtmlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<string> apiResponse = new ApiResponse<string>(new Response(), "<html>README</html>");
+
+                connection.GetHtml(Args.Uri, null).Returns(Task.FromResult(apiResponse));
+
+                var readme = await contentsClient.GetReadmeHtml(1);
+
+                connection.Received().GetHtml(Arg.Is<Uri>(u => u.ToString() == "repositories/1/readme"), null);
+                Assert.Equal("<html>README</html>", readme);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetReadmeHtml(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetReadmeHtml("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetReadmeHtml("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetReadmeHtml("owner", ""));
+            }
+        }
+
+        public class TheGetContentsMethod
+        {
+            [Fact]
+            public async Task ReturnsContents()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents(1).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContents()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents("fake", "repo").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContents(1).ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(null, "name", "path"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", null, "path"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContents(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("", "name", "path"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "", "path"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContents("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllContents(1, ""));
+            }
+        }
+
+        public class TheGetContentsByRefMethod
+        {
+            [Fact]
+            public async Task ReturnsContentsByRef()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master", "readme.md").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/readme.md?ref=master"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsContentsByRefWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef(1, "master", "readme.md").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/readme.md?ref=master"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsByRef()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef("fake", "repo", "master").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/?ref=master"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public async Task ReturnsAllContentsByRefWithRepositoryId()
+            {
+                var result = new List<RepositoryContent> { new RepositoryContent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<List<RepositoryContent>> response = new ApiResponse<List<RepositoryContent>>
+                    (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                    );
+                connection.Get<List<RepositoryContent>>(Args.Uri, null, null)
+                    .Returns(Task.FromResult(response));
+
+                var contents = await contentsClient.GetAllContentsByRef(1, "master").ToList();
+
+                connection.Received().Get<List<RepositoryContent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contents/?ref=master"), null, null);
+                Assert.Equal(1, contents.Count);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(null, "name", "path", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", null, "path", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", null, "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef("owner", "name", "path", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(1, null, "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(1, "path", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContentsByRef(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("", "name", "path", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "", "path", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef("owner", "name", "path", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, "path", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, ""));
+            }
+        }
+
+        public class TheCreateFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile(null, "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", null, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", "repo", null, new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile("org", "repo", "path/to/file", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile(1, null, new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.CreateFile(1, "path/to/file", null));
+
+                Assert.Throws<ArgumentException>(() => client.CreateFile("", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.CreateFile("org", "", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.CreateFile("org", "repo", "", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+
+                Assert.Throws<ArgumentException>(() => client.CreateFile(1, "", new CreateFileRequest("message", "myfilecontents", "mybranch")));
+            }
+        }
+
+        public class TheDeleteFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.DeleteFile("org", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Delete(
+                    Arg.Any<Uri>(),
+                    Arg.Is<DeleteFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.DeleteFile(1, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Delete(
+                    Arg.Any<Uri>(),
+                    Arg.Is<DeleteFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile(null, "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", null, "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", "repo", null, new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile("org", "repo", "path/to/file", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile(1, null, new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.DeleteFile(1, "path/to/file", null));
+
+                Assert.Throws<ArgumentException>(() => client.DeleteFile("", "repo", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.DeleteFile("org", "", "path/to/file", new DeleteFileRequest("message", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.DeleteFile("org", "repo", "", new DeleteFileRequest("message", "1234abc", "mybranch")));
+
+                Assert.Throws<ArgumentException>(() => client.DeleteFile(1, "", new DeleteFileRequest("message", "1234abc", "mybranch")));
+            }
+        }
+
+        public class TheUpdateFileMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObject()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoriesId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "myfilecontents"
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile(null, "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", null, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", "repo", null, new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile("org", "repo", "path/to/file", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile(1, null, new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentNullException>(() => client.UpdateFile(1, "path/to/file", null));
+
+                Assert.Throws<ArgumentException>(() => client.UpdateFile("", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.UpdateFile("org", "", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+                Assert.Throws<ArgumentException>(() => client.UpdateFile("org", "repo", "", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+
+                Assert.Throws<ArgumentException>(() => client.UpdateFile(1, "", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch")));
+            }
+        }
+
+        public class TheGetArchiveMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl1()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive("org", "repo");
+                
+                gitHubClient.Received().Repository.Content.GetArchive("org", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl1WithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive(1);
+
+                gitHubClient.Received().Repository.Content.GetArchive(1);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl2()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive("org", "repo", ArchiveFormat.Zipball);
+
+                gitHubClient.Received().Repository.Content.GetArchive("org", "repo", ArchiveFormat.Zipball);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl2WithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive(1, ArchiveFormat.Zipball);
+
+                gitHubClient.Received().Repository.Content.GetArchive(1, ArchiveFormat.Zipball);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl3()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref");
+
+                gitHubClient.Received().Repository.Content.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl3WithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive(1, ArchiveFormat.Zipball, "ref");
+                
+                gitHubClient.Received().Repository.Content.GetArchive(1, ArchiveFormat.Zipball, "ref");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl4()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+
+                gitHubClient.Received().Repository.Content.GetArchive("org", "repo", ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl4WithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.GetArchive(1, ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+
+                gitHubClient.Received().Repository.Content.GetArchive(1, ArchiveFormat.Zipball, "ref", TimeSpan.FromMinutes(60));
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(null, "repo"));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball, "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball, "ref"));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(null, "repo", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", null, ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, null, TimeSpan.MaxValue));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(1, ArchiveFormat.Tarball, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetArchive(1, ArchiveFormat.Tarball, null, TimeSpan.MaxValue));
+
+                Assert.Throws<ArgumentException>(() => client.GetArchive("", "repo"));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("org", ""));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball, "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball, "ref"));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("", "repo", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+                Assert.Throws<ArgumentException>(() => client.GetArchive("org", "", ArchiveFormat.Tarball, "ref", TimeSpan.MaxValue));
+
+                Assert.Throws<ArgumentException>(() => client.GetArchive("org", "repo", ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
+
+                Assert.Throws<ArgumentException>(() => client.GetArchive(1, ArchiveFormat.Tarball, "ref", TimeSpan.Zero));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -163,6 +163,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
         Task DeleteFile(string owner, string name, string path, DeleteFileRequest request);
     }
 

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -79,7 +79,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
+        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         Task<Readme> GetReadme(string owner, string name);
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
+        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         Task<string> GetReadmeHtml(string owner, string name);
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -22,9 +22,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path);
 
         /// <summary>
@@ -35,9 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path);
 
         /// <summary>
@@ -48,9 +42,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name);
 
         /// <summary>
@@ -60,9 +51,6 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId);
 
         /// <summary>
@@ -75,9 +63,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
 
         /// <summary>
@@ -89,9 +74,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference);
 
         /// <summary>
@@ -104,9 +86,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference);
 
         /// <summary>
@@ -118,9 +97,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference);
 
         /// <summary>
@@ -132,7 +108,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         Task<Readme> GetReadme(string owner, string name);
 
         /// <summary>
@@ -143,7 +118,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         Task<Readme> GetReadme(int repositoryId);
 
         /// <summary>
@@ -155,7 +129,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         Task<string> GetReadmeHtml(string owner, string name);
 
         /// <summary>
@@ -166,7 +139,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         Task<string> GetReadmeHtml(int repositoryId);
 
         /// <summary>
@@ -175,7 +147,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name);
 
         /// <summary>
@@ -183,7 +154,6 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(int repositoryId);
 
         /// <summary>
@@ -193,7 +163,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat);
 
         /// <summary>
@@ -202,7 +171,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
 
         /// <summary>
@@ -213,7 +181,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
@@ -223,7 +190,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
@@ -235,7 +201,6 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
@@ -246,7 +211,6 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
@@ -256,7 +220,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
 
         /// <summary>
@@ -265,7 +228,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
@@ -275,7 +237,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         Task<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request);
 
         /// <summary>
@@ -284,7 +245,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
 
         /// <summary>
@@ -294,7 +254,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         Task DeleteFile(string owner, string name, string path, DeleteFileRequest request);
 
         /// <summary>
@@ -303,7 +262,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         Task DeleteFile(int repositoryId, string path, DeleteFileRequest request);
     }
 

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -28,6 +28,19 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -39,6 +52,18 @@ namespace Octokit
         /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
         /// </returns>
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name);
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -56,6 +81,20 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -71,6 +110,20 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference);
 
         /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference);
+
+        /// <summary>
         /// Gets the preferred README for the specified repository.
         /// </summary>
         /// <remarks>
@@ -81,6 +134,17 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         Task<Readme> GetReadme(string owner, string name);
+
+        /// <summary>
+        /// Gets the preferred README for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
+        Task<Readme> GetReadme(int repositoryId);
 
         /// <summary>
         /// Gets the preferred README's HTML for the specified repository.
@@ -95,6 +159,17 @@ namespace Octokit
         Task<string> GetReadmeHtml(string owner, string name);
 
         /// <summary>
+        /// Gets the preferred README's HTML for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
+        Task<string> GetReadmeHtml(int repositoryId);
+
+        /// <summary>
         /// Get an archive of a given repository's contents
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -102,6 +177,14 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name);
+
+        /// <summary>
+        /// Get an archive of a given repository's contents
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The binary contents of the archive</returns>
+        Task<byte[]> GetArchive(int repositoryId);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -114,6 +197,15 @@ namespace Octokit
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat);
 
         /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <returns>The binary contents of the archive</returns>
+        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
+
+        /// <summary>
         /// Get an archive of a given repository's contents, using a specific format and reference
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -123,6 +215,16 @@ namespace Octokit
         /// <param name="reference">A valid Git reference.</param>
         /// <returns>The binary contents of the archive</returns>
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference);
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, using a specific format and reference
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <returns>The binary contents of the archive</returns>
+        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -137,6 +239,17 @@ namespace Octokit
         Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <param name="timeout"> Time span until timeout </param>
+        /// <returns>The binary contents of the archive</returns>
+        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
+
+        /// <summary>
         /// Creates a commit that creates a new file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -145,6 +258,15 @@ namespace Octokit
         /// <param name="request">Information about the file to create</param>
         /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request);
+
+        /// <summary>
+        /// Creates a commit that creates a new file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to create</param>
+        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
+        Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
         /// Creates a commit that updates the contents of a file in a repository.
@@ -157,6 +279,15 @@ namespace Octokit
         Task<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request);
 
         /// <summary>
+        /// Creates a commit that updates the contents of a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to update</param>
+        /// <returns>The updated content</returns>
+        Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
+
+        /// <summary>
         /// Creates a commit that deletes a file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -165,6 +296,15 @@ namespace Octokit
         /// <param name="request">Information about the file to delete</param>
         /// <returns></returns>
         Task DeleteFile(string owner, string name, string path, DeleteFileRequest request);
+
+        /// <summary>
+        /// Creates a commit that deletes a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
+        Task DeleteFile(int repositoryId, string path, DeleteFileRequest request);
     }
 
     /// <summary>

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -8,6 +8,9 @@ namespace Octokit
     /// <summary>
     /// Client for accessing contents of files within a repository as base64 encoded content.
     /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/contents/">Repository Contents API documentation</a> for more information.
+    /// </remarks>
     public interface IRepositoryContentsClient
     {
         /// <summary>

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -7,6 +7,9 @@ namespace Octokit
     /// <summary>
     /// Client for accessing contents of files within a repository as base64 encoded content.
     /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/contents/">Repository Contents API documentation</a> for more information.
+    /// </remarks>
     public class RepositoryContentsClient : ApiClient, IRepositoryContentsClient
     {
         /// <summary>

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -258,6 +258,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
         public Task DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
+        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public async Task<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
+        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public Task<string> GetReadmeHtml(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -220,7 +220,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -36,6 +36,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
             var url = ApiUrls.RepositoryContent(owner, name, path);
 
@@ -55,6 +56,8 @@ namespace Octokit
         /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path)
         {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+
             var url = ApiUrls.RepositoryContent(repositoryId, path);
 
             return ApiConnection.GetAll<RepositoryContent>(url);
@@ -327,6 +330,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(reference, "reference");
 
             return GetArchive(owner, name, archiveFormat, reference, TimeSpan.FromMinutes(60));
         }
@@ -341,6 +345,8 @@ namespace Octokit
         /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
         {
+            Ensure.ArgumentNotNull(reference, "reference");
+
             return GetArchive(repositoryId, archiveFormat, reference, TimeSpan.FromMinutes(60));
         }
 
@@ -358,6 +364,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(reference, "reference");
             Ensure.GreaterThanZero(timeout, "timeout");
 
             var endpoint = ApiUrls.RepositoryArchiveLink(owner, name, archiveFormat, reference);
@@ -378,6 +385,7 @@ namespace Octokit
         /// <returns>The binary contents of the archive</returns>
         public async Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
+            Ensure.ArgumentNotNull(reference, "reference");
             Ensure.GreaterThanZero(timeout, "timeout");
 
             var endpoint = ApiUrls.RepositoryArchiveLink(repositoryId, archiveFormat, reference);

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -29,9 +29,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,9 +48,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -71,9 +65,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -91,9 +82,6 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId)
         {
             var url = ApiUrls.RepositoryContent(repositoryId, string.Empty);
@@ -112,9 +100,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -136,9 +121,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -158,9 +140,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -181,9 +160,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        /// <returns>
-        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
-        /// </returns>
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -202,7 +178,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public async Task<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -222,7 +197,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
         public async Task<Readme> GetReadme(int repositoryId)
         {
             var endpoint = ApiUrls.RepositoryReadme(repositoryId);
@@ -240,7 +214,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public Task<string> GetReadmeHtml(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -257,7 +230,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
         public Task<string> GetReadmeHtml(int repositoryId)
         {
             return ApiConnection.GetHtml(ApiUrls.RepositoryReadme(repositoryId), null);
@@ -269,7 +241,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -283,7 +254,6 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(int repositoryId)
         {
             return GetArchive(repositoryId, ArchiveFormat.Tarball, string.Empty);
@@ -296,7 +266,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -311,7 +280,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
         {
             return GetArchive(repositoryId, archiveFormat, string.Empty);
@@ -325,7 +293,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -342,7 +309,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
@@ -359,7 +325,6 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         public async Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -382,7 +347,6 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        /// <returns>The binary contents of the archive</returns>
         public async Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNull(reference, "reference");
@@ -402,7 +366,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -420,7 +383,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
         public Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -437,7 +399,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         public Task<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -455,7 +416,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        /// <returns>The updated content</returns>
         public Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -472,7 +432,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         public Task DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -490,7 +449,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        /// <returns></returns>
         public Task DeleteFile(int repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -43,6 +43,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path)
+        {
+            var url = ApiUrls.RepositoryContent(repositoryId, path);
+
+            return ApiConnection.GetAll<RepositoryContent>(url);
+        }
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -59,6 +77,23 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             var url = ApiUrls.RepositoryContent(owner, name, string.Empty);
+
+            return ApiConnection.GetAll<RepositoryContent>(url);
+        }
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId)
+        {
+            var url = ApiUrls.RepositoryContent(repositoryId, string.Empty);
 
             return ApiConnection.GetAll<RepositoryContent>(url);
         }
@@ -90,6 +125,28 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the contents of a file or directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            var url = ApiUrls.RepositoryContent(repositoryId, path, reference);
+
+            return ApiConnection.GetAll<RepositoryContent>(url);
+        }
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <remarks>
@@ -108,6 +165,27 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             var url = ApiUrls.RepositoryContent(owner, name, string.Empty, reference);
+
+            return ApiConnection.GetAll<RepositoryContent>(url);
+        }
+
+        /// <summary>
+        /// Returns the contents of the root directory in a repository.
+        /// </summary>
+        /// <remarks>
+        /// If given a path to a single file, this method returns a collection containing only that file.
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        /// <returns>
+        /// A collection of <see cref="RepositoryContent"/> representing the content at the specified path
+        /// </returns>
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            var url = ApiUrls.RepositoryContent(repositoryId, string.Empty, reference);
 
             return ApiConnection.GetAll<RepositoryContent>(url);
         }
@@ -134,6 +212,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets the preferred README for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Readme"/> representing the README.md at the specified repository.</returns>
+        public async Task<Readme> GetReadme(int repositoryId)
+        {
+            var endpoint = ApiUrls.RepositoryReadme(repositoryId);
+            var readmeInfo = await ApiConnection.Get<ReadmeResponse>(endpoint, null).ConfigureAwait(false);
+
+            return new Readme(readmeInfo, ApiConnection);
+        }
+
+        /// <summary>
         /// Gets the preferred README's HTML for the specified repository.
         /// </summary>
         /// <remarks>
@@ -152,6 +247,20 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets the preferred README's HTML for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/contents/#get-the-readme">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="string"/> contains the HTML representation of README.md at the specified repository.</returns>
+        public Task<string> GetReadmeHtml(int repositoryId)
+        {
+            return ApiConnection.GetHtml(ApiUrls.RepositoryReadme(repositoryId), null);
+        }
+
+        /// <summary>
         /// Get an archive of a given repository's contents
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
@@ -160,7 +269,21 @@ namespace Octokit
         /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetArchive(owner, name, ArchiveFormat.Tarball, string.Empty);
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The binary contents of the archive</returns>
+        public Task<byte[]> GetArchive(int repositoryId)
+        {
+            return GetArchive(repositoryId, ArchiveFormat.Tarball, string.Empty);
         }
 
         /// <summary>
@@ -173,7 +296,22 @@ namespace Octokit
         /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetArchive(owner, name, archiveFormat, string.Empty);
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <returns>The binary contents of the archive</returns>
+        public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
+        {
+            return GetArchive(repositoryId, archiveFormat, string.Empty);
         }
 
         /// <summary>
@@ -187,7 +325,23 @@ namespace Octokit
         /// <returns>The binary contents of the archive</returns>
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetArchive(owner, name, archiveFormat, reference, TimeSpan.FromMinutes(60));
+        }
+
+        /// <summary>
+        /// Get an archive of a given repository's contents, using a specific format and reference
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <returns>The binary contents of the archive</returns>
+        public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
+        {
+            return GetArchive(repositoryId, archiveFormat, reference, TimeSpan.FromMinutes(60));
         }
 
         /// <summary>
@@ -214,6 +368,26 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get an archive of a given repository's contents, in a specific format
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        /// <param name="reference">A valid Git reference.</param>
+        /// <param name="timeout"> Time span until timeout </param>
+        /// <returns>The binary contents of the archive</returns>
+        public async Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        {
+            Ensure.GreaterThanZero(timeout, "timeout");
+
+            var endpoint = ApiUrls.RepositoryArchiveLink(repositoryId, archiveFormat, reference);
+
+            var response = await Connection.Get<byte[]>(endpoint, timeout).ConfigureAwait(false);
+
+            return response.Body;
+        }
+
+        /// <summary>
         /// Creates a commit that creates a new file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -229,6 +403,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, "request");
 
             var createUrl = ApiUrls.RepositoryContent(owner, name, path);
+            return ApiConnection.Put<RepositoryContentChangeSet>(createUrl, request);
+        }
+
+        /// <summary>
+        /// Creates a commit that creates a new file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to create</param>
+        /// <returns>A <see cref="RepositoryContentChangeSet"/> representing file created at the specified repository.</returns>
+        public Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            var createUrl = ApiUrls.RepositoryContent(repositoryId, path);
             return ApiConnection.Put<RepositoryContentChangeSet>(createUrl, request);
         }
 
@@ -252,6 +442,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a commit that updates the contents of a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to update</param>
+        /// <returns>The updated content</returns>
+        public Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            var updateUrl = ApiUrls.RepositoryContent(repositoryId, path);
+            return ApiConnection.Put<RepositoryContentChangeSet>(updateUrl, request);
+        }
+
+        /// <summary>
         /// Creates a commit that deletes a file in a repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -267,6 +473,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, "request");
 
             var deleteUrl = ApiUrls.RepositoryContent(owner, name, path);
+            return ApiConnection.Delete(deleteUrl, request);
+        }
+
+        /// <summary>
+        /// Creates a commit that deletes a file in a repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="path">The path to the file</param>
+        /// <param name="request">Information about the file to delete</param>
+        /// <returns></returns>
+        public Task DeleteFile(int repositoryId, string path, DeleteFileRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(path, "path");
+            Ensure.ArgumentNotNull(request, "request");
+
+            var deleteUrl = ApiUrls.RepositoryContent(repositoryId, path);
             return ApiConnection.Delete(deleteUrl, request);
         }
     }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryContentsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryContentsClient and IObservableRepositoryContentsClient).**

	  There is some divergence between XML documentation of methods in IRepositoryContentsClient and IObservableRepositoryContentsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryContentsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryContentsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble