### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryDeployKeysClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -26,6 +26,18 @@ namespace Octokit.Reactive
         IObservable<DeployKey> Get(string owner, string name, int number);
 
         /// <summary>
+        /// Get a single deploy key by number for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<DeployKey> Get(int repositoryId, int number);
+
+        /// <summary>
         /// Get all deploy keys for a repository.
         /// </summary>
         /// <remarks>
@@ -42,11 +54,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        IObservable<DeployKey> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deploy key for a repository.
@@ -61,6 +94,17 @@ namespace Octokit.Reactive
         IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
+        /// Creates a new deploy key for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#create"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
+
+        /// <summary>
         /// Deletes a deploy key from a repository.
         /// </summary>
         /// <remarks>
@@ -71,5 +115,16 @@ namespace Octokit.Reactive
         /// <param name="number">The id of the deploy key to delete.</param>
         /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a deploy key from a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<DeployKey> Get(string owner, string name, int number);
 
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<DeployKey> Get(int repositoryId, int number);
 
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> GetAll(string owner, string name);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> GetAll(int repositoryId);
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Deploy Keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/keys/">Deploy Keys API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryDeployKeysClient
     {
         /// <summary>
@@ -15,6 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<DeployKey> Get(string owner, string name, int number);
 
@@ -26,6 +33,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         IObservable<DeployKey> GetAll(string owner, string name);
 
         /// <summary>
@@ -37,6 +45,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -48,7 +57,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
         IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -21,7 +21,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<DeployKey> Get(string owner, string name, int number);
 
@@ -33,7 +32,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<DeployKey> Get(int repositoryId, int number);
 
@@ -45,7 +43,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns></returns>
         IObservable<DeployKey> GetAll(string owner, string name);
 
         /// <summary>
@@ -55,7 +52,6 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns></returns>
         IObservable<DeployKey> GetAll(int repositoryId);
 
         /// <summary>
@@ -67,7 +63,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -78,7 +73,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -90,7 +84,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -101,7 +94,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -113,7 +105,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int number);
 
         /// <summary>
@@ -124,7 +115,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -43,6 +43,20 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Get a single deploy key by number for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        public IObservable<DeployKey> Get(int repositoryId, int number)
+        {
+            return _client.Get(repositoryId, number).ToObservable();
+        }
+
+        /// <summary>
         /// Get all deploy keys for a repository.
         /// </summary>
         /// <remarks>
@@ -65,6 +79,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        public IObservable<DeployKey> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
@@ -76,6 +103,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name), options);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        public IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options)
+        {
+            return _connection.GetAndFlattenAllPages<DeployKey>(ApiUrls.RepositoryDeployKeys(repositoryId), options);
         }
 
         /// <summary>
@@ -105,6 +146,29 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a new deploy key for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#create"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        public IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
+        {
+            Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
+
+
+            if (string.IsNullOrWhiteSpace(newDeployKey.Title))
+                throw new ArgumentException("The new deploy key's title must not be null.");
+
+            if (string.IsNullOrWhiteSpace(newDeployKey.Key))
+                throw new ArgumentException("The new deploy key's key must not be null.");
+
+            return _client.Create(repositoryId, newDeployKey).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a deploy key from a repository.
         /// </summary>
         /// <remarks>
@@ -120,6 +184,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Delete(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a deploy key from a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, int number)
+        {
+            return _client.Delete(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -116,6 +116,8 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         public IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             return _connection.GetAndFlattenAllPages<DeployKey>(ApiUrls.RepositoryDeployKeys(repositoryId), options);
         }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -95,7 +95,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -130,7 +130,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -155,7 +155,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         public IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -5,6 +5,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Deploy Keys API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/keys/">Deploy Keys API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryDeployKeysClient : IObservableRepositoryDeployKeysClient
     {
         readonly IRepositoryDeployKeysClient _client;
@@ -27,6 +33,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
         public IObservable<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,6 +50,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         public IObservable<DeployKey> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -60,6 +68,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         public IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +87,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeployKey"/> of <see cref="DeployKey"/> representing created deploy key.</returns>
         public IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -33,7 +33,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -50,7 +49,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -64,7 +62,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -80,7 +77,6 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -95,7 +91,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<DeployKey> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -113,7 +108,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -130,7 +124,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -155,7 +148,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         public IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
@@ -179,7 +171,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -196,7 +187,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(int repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();

--- a/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryDeployKeysClientTests.cs
@@ -23,14 +23,25 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void GetsADeployKey()
+            public async Task RequestsCorrectUrl()
             {
                 var apiConnection = Substitute.For<IApiConnection>();
                 var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
 
-                deployKeysClient.Get("user", "repo", 42);
+                await deployKeysClient.Get("user", "repo", 42);
 
                 apiConnection.Received().Get<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys/42"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var apiConnection = Substitute.For<IApiConnection>();
+                var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
+
+                await deployKeysClient.Get(1, 42);
+
+                apiConnection.Received().Get<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/keys/42"));
             }
 
             [Fact]
@@ -39,8 +50,9 @@ namespace Octokit.Tests.Clients
                 var deployKeysClient = new RepositoryDeployKeysClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Get(null, "repo", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Get("", "repo", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Get("user", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Get("", "repo", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Get("user", "", 1));
             }
         }
@@ -48,18 +60,29 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void GetsAListOfDeployKeys()
+            public async Task RequestsCorrectUrl()
             {
                 var apiConnection = Substitute.For<IApiConnection>();
                 var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
 
-                deployKeysClient.GetAll("user", "repo");
+                await deployKeysClient.GetAll("user", "repo");
 
                 apiConnection.Received().GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"), Args.ApiOptions);
             }
 
             [Fact]
-            public void GetsAListOfDeployKeysWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var apiConnection = Substitute.For<IApiConnection>();
+                var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
+
+                await deployKeysClient.GetAll(1);
+
+                apiConnection.Received().GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/keys"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryDeployKeysClient(connection);
@@ -71,10 +94,30 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAll("user", "repo", options);
+                await client.GetAll("user", "repo", options);
 
                 connection.Received(1)
                     .GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"),
+                        options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryDeployKeysClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAll(1, options);
+
+                connection.Received(1)
+                    .GetAll<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/keys"),
                         options);
             }
 
@@ -83,37 +126,49 @@ namespace Octokit.Tests.Clients
             {
                 var deployKeysClient = new RepositoryDeployKeysClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null));
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, null));
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, null));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll("user", "repo", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.GetAll(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("user", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("", "repo", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.GetAll("user", "", ApiOptions.None));
             }
         }
 
         public class TheCreateMethod
         {
             [Fact]
-            public void SendsCreateToCorrectUrl()
+            public void CreatesCorrectUrl()
             {
                 var apiConnection = Substitute.For<IApiConnection>();
                 var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
 
-                deployKeysClient.Create("user", "repo", new NewDeployKey { Key = "ABC123", Title = "user@repo" });
+                var newDeployKey = new NewDeployKey { Key = "ABC123", Title = "user@repo" };
+
+                deployKeysClient.Create("user", "repo", newDeployKey);
 
                 apiConnection.Received().Post<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys"),
-                    Args.NewDeployKey);
+                    newDeployKey);
+            }
+
+            [Fact]
+            public void CreatesCorrectUrlWithRepositoryId()
+            {
+                var apiConnection = Substitute.For<IApiConnection>();
+                var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
+
+                var newDeployKey = new NewDeployKey { Key = "ABC123", Title = "user@repo" };
+
+                deployKeysClient.Create(1, newDeployKey);
+
+                apiConnection.Received().Post<DeployKey>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/keys"),
+                    newDeployKey);
             }
 
             [Fact]
@@ -122,10 +177,14 @@ namespace Octokit.Tests.Clients
                 var deployKeysClient = new RepositoryDeployKeysClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Create(null, "repo", new NewDeployKey()));
-                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("", "repo", new NewDeployKey()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Create("user", null, new NewDeployKey()));
-                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("user", "", new NewDeployKey()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Create("user", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("", "repo", new NewDeployKey()));
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("user", "", new NewDeployKey()));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey()));
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey { Key = "ABC123" }));
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey { Title = "user@repo" }));
@@ -135,14 +194,25 @@ namespace Octokit.Tests.Clients
         public class TheDeleteMethod
         {
             [Fact]
-            public void DeletesCorrectUrl()
+            public async Task DeletesCorrectUrl()
             {
                 var apiConnection = Substitute.For<IApiConnection>();
                 var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
 
-                deployKeysClient.Delete("user", "repo", 42);
+                await deployKeysClient.Delete("user", "repo", 42);
 
                 apiConnection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/user/repo/keys/42"));
+            }
+
+            [Fact]
+            public async Task DeletesCorrectUrlWithRepositoryId()
+            {
+                var apiConnection = Substitute.For<IApiConnection>();
+                var deployKeysClient = new RepositoryDeployKeysClient(apiConnection);
+
+                await deployKeysClient.Delete(1, 42);
+
+                apiConnection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/keys/42"));
             }
 
             [Fact]
@@ -151,8 +221,9 @@ namespace Octokit.Tests.Clients
                 var deployKeysClient = new RepositoryDeployKeysClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Delete(null, "repo", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Delete("", "repo", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deployKeysClient.Delete("user", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Delete("", "repo", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => deployKeysClient.Delete("user", "", 1));
             }
         }

--- a/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryDeployKeysClientTests.cs
@@ -20,14 +20,25 @@ namespace Octokit.Tests.Reactive
         public class TheGetMethod
         {
             [Fact]
-            public void CallsIntoClient()
+            public void RequestsCorrectUrl()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var deployKeysClient = new ObservableRepositoryDeployKeysClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
 
                 deployKeysClient.Get("user", "repo", 42);
 
-                githubClient.Repository.DeployKeys.Received(1).Get("user", "repo", 42);
+                gitHubClient.Repository.DeployKeys.Received(1).Get("user", "repo", 42);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+
+                deployKeysClient.Get(1, 42);
+
+                gitHubClient.Repository.DeployKeys.Received(1).Get(1, 42);
             }
 
             [Fact]
@@ -35,29 +46,30 @@ namespace Octokit.Tests.Reactive
             {
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Get(null, "repo", 42));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.Get("", "repo", 42));
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Get("user", null, 42));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.Get("user", "", 42));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Get(null, "repo", 1));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Get("user", null, 1));
+
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Get("", "repo", 1));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Get("user", "", 1));
             }
         }
 
         public class TheGetAllMethod
         {
             [Fact]
-            public void CallsIntoClient()
+            public void RequestsCorrectUrl()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var deployKeysClient = new ObservableRepositoryDeployKeysClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
 
                 deployKeysClient.GetAll("user", "repo");
 
-                githubClient.Connection.Received(1).Get<List<DeployKey>>(
+                gitHubClient.Connection.Received(1).Get<List<DeployKey>>(
                     new Uri("repos/user/repo/keys", UriKind.Relative), Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
             }
 
             [Fact]
-            public void GetsCorrectUrlWithApiOptions()
+            public void RequestsCorrectUrlWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
@@ -103,41 +115,95 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+                var expectedUrl = "repositories/1/keys";
+
+                // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                deployKeysClient.GetAll(1, options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                        null);
+
+                // StartPage is setted => only 1 option (StartPage) in dictionary
+                options = new ApiOptions
+                {
+                    StartPage = 1
+                };
+
+                deployKeysClient.GetAll(1, options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                        null);
+
+                // PageCount is setted => none of options in dictionary
+                options = new ApiOptions
+                {
+                    PageCount = 1
+                };
+
+                deployKeysClient.GetAll(1, options);
+                gitHubClient.Connection.Received(1)
+                    .Get<List<DeployKey>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                        null);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null));
-
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, null));
-
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", null));
-                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, null));
-
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(null, "repo", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll("user", "repo", null));
 
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.GetAll(1, null));
+
                 Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("user", ""));
                 Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("", "repo"));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("", "repo", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.GetAll("user", "", ApiOptions.None));
             }
         }
 
         public class TheCreateMethod
         {
             [Fact]
-            public void CallsIntoClient()
+            public void CreatesCorrectUrl()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var deployKeysClient = new ObservableRepositoryDeployKeysClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
                 var data = new NewDeployKey { Key = "ABC123", Title = "user@repo" };
 
                 deployKeysClient.Create("user", "repo", data);
 
-                githubClient.Repository.DeployKeys.Received(1).Create("user", "repo", data);
+                gitHubClient.Repository.DeployKeys.Received(1).Create("user", "repo", data);
+            }
+
+            [Fact]
+            public void CreatesCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+                var data = new NewDeployKey { Key = "ABC123", Title = "user@repo" };
+
+                deployKeysClient.Create(1, data);
+
+                gitHubClient.Repository.DeployKeys.Received(1).Create(1, data);
             }
 
             [Fact]
@@ -146,12 +212,54 @@ namespace Octokit.Tests.Reactive
                 var deployKeysClient = new ObservableRepositoryDeployKeysClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.Create(null, "repo", new NewDeployKey()));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("", "repo", new NewDeployKey()));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.Create("user", null, new NewDeployKey()));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "", new NewDeployKey()));
                 Assert.Throws<ArgumentNullException>(() => deployKeysClient.Create("user", "repo", null));
-                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey { Title = "user@repo" }));
+
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Create(1, null));
+
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("", "repo", new NewDeployKey()));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "", new NewDeployKey()));
+
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey()));
                 Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey { Key = "ABC123" }));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Create("user", "repo", new NewDeployKey { Title = "user@repo" }));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void CreatesCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+
+                deployKeysClient.Delete("user", "repo", 42);
+
+                gitHubClient.Repository.DeployKeys.Received(1).Delete("user", "repo", 42);
+            }
+
+            [Fact]
+            public void CreatesCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(gitHubClient);
+
+                deployKeysClient.Delete(1, 42);
+
+                gitHubClient.Repository.DeployKeys.Received(1).Delete(1, 42);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var deployKeysClient = new ObservableRepositoryDeployKeysClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Delete(null, "repo", 1));
+                Assert.Throws<ArgumentNullException>(() => deployKeysClient.Delete("user", null, 1));
+
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Delete("", "repo", 1));
+                Assert.Throws<ArgumentException>(() => deployKeysClient.Delete("user", "", 1));
             }
         }
     }

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<DeployKey> Get(string owner, string name, int number);
 
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<DeployKey> Get(int repositoryId, int number);
 
@@ -45,7 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId);
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -26,6 +26,18 @@ namespace Octokit
         Task<DeployKey> Get(string owner, string name, int number);
 
         /// <summary>
+        /// Get a single deploy key by number for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<DeployKey> Get(int repositoryId, int number);
+
+        /// <summary>
         /// Get all deploy keys for a repository.
         /// </summary>
         /// <remarks>
@@ -42,11 +54,32 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deploy key for a repository.
@@ -61,6 +94,17 @@ namespace Octokit
         Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
+        /// Creates a new deploy key for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#create"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
+
+        /// <summary>
         /// Deletes a deploy key from a repository.
         /// </summary>
         /// <remarks>
@@ -71,5 +115,16 @@ namespace Octokit
         /// <param name="number">The id of the deploy key to delete.</param>
         /// <returns></returns>
         Task Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a deploy key from a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <returns></returns>
+        Task Delete(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -21,6 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<DeployKey> Get(string owner, string name, int number);
 
@@ -32,6 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name);
 
         /// <summary>
@@ -43,6 +45,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -54,7 +57,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
         Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -21,7 +21,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<DeployKey> Get(string owner, string name, int number);
 
@@ -33,7 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<DeployKey> Get(int repositoryId, int number);
 
@@ -45,7 +43,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name);
 
         /// <summary>
@@ -55,7 +52,6 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId);
 
         /// <summary>
@@ -67,7 +63,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -78,7 +73,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -90,7 +84,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -101,7 +94,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>
@@ -113,7 +105,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         Task Delete(string owner, string name, int number);
 
         /// <summary>
@@ -124,7 +115,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         Task Delete(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -32,6 +32,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
         public Task<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,6 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -65,6 +67,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -83,7 +86,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
         public Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         public Task<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -49,7 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        /// <returns></returns>
         public Task<DeployKey> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
@@ -63,7 +63,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -79,7 +79,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -94,7 +94,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -112,7 +112,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -129,7 +129,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         public Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -153,7 +153,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        /// <returns></returns>
         public Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -32,7 +32,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         public Task<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -49,7 +48,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        /// <returns></returns>
         public Task<DeployKey> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
@@ -63,7 +61,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -79,7 +76,6 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -94,7 +90,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -112,7 +107,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -129,7 +123,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         public Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -153,7 +146,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        /// <returns></returns>
         public Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
@@ -176,7 +168,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -193,7 +184,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        /// <returns></returns>
         public Task Delete(int repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, number));

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -42,6 +42,20 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get a single deploy key by number for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#get"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key.</param>
+        /// <returns>A <see cref="DeployKey"/> representing the deploy key of repository for the particular number.</returns>
+        public Task<DeployKey> Get(int repositoryId, int number)
+        {
+            return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
+        }
+
+        /// <summary>
         /// Get all deploy keys for a repository.
         /// </summary>
         /// <remarks>
@@ -64,6 +78,19 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
@@ -75,6 +102,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<DeployKey>(ApiUrls.RepositoryDeployKeys(owner, name), options);
+        }
+
+        /// <summary>
+        /// Get all deploy keys for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeployKey}"/> of <see cref="DeployKey"/>s representing the deploy keys for specified repository.</returns>
+        public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<DeployKey>(ApiUrls.RepositoryDeployKeys(repositoryId), options);
         }
 
         /// <summary>
@@ -103,6 +146,28 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a new deploy key for a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#create"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        /// <returns>A <see cref="DeployKey"/> representing created deploy key.</returns>
+        public Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
+        {
+            Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
+
+            if (string.IsNullOrWhiteSpace(newDeployKey.Title))
+                throw new ArgumentException("The new deploy key's title must not be null.");
+
+            if (string.IsNullOrWhiteSpace(newDeployKey.Key))
+                throw new ArgumentException("The new deploy key's key must not be null.");
+
+            return ApiConnection.Post<DeployKey>(ApiUrls.RepositoryDeployKeys(repositoryId), newDeployKey);
+        }
+
+        /// <summary>
         /// Deletes a deploy key from a repository.
         /// </summary>
         /// <remarks>
@@ -116,9 +181,22 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(number, "number");
 
             return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(owner, name, number));
+        }
+
+        /// <summary>
+        /// Deletes a deploy key from a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/keys/#delete"> API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="number">The id of the deploy key to delete.</param>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, number));
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryDeployKeysClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryDeployKeysClient and IObservableRepositoryDeployKeysClient).**

	  There is some divergence between XML documentation of methods in IRepositoryDeployKeysClient and IObservableRepositoryDeployKeysClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryDeployKeysClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryDeployKeysClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble