### PR TITLE
Rename client.User.Keys to client.User.GitSshKey

### DIFF
--- a/Octokit.Reactive/Clients/IObservableUsersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUsersClient.cs
@@ -50,7 +50,16 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
+        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
         IObservableUserKeysClient Keys { get; }
+
+        /// <summary>
+        /// A client for GitHub's User Keys API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
+        ///</remarks>
+        IObservableUserKeysClient GitSshKey { get; }
 
         /// <summary>
         /// A client for GitHub's UserUser GPG Keys API.

--- a/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUserKeysClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(client, "client");
 
-            _client = client.User.Keys;
+            _client = client.User.GitSshKey;
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableUsersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUsersClient.cs
@@ -16,7 +16,10 @@ namespace Octokit.Reactive
 
             Followers = new ObservableFollowersClient(client);
             Email = new ObservableUserEmailsClient(client);
+#pragma warning disable CS0618 // Type or member is obsolete
             Keys = new ObservableUserKeysClient(client);
+#pragma warning restore CS0618 // Type or member is obsolete
+            GitSshKey = new ObservableUserKeysClient(client);
             GpgKey = new ObservableUserGpgKeysClient(client);
             Administration = new ObservableUserAdministrationClient(client);
         }
@@ -77,7 +80,16 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
+        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
         public IObservableUserKeysClient Keys { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's User Keys API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
+        ///</remarks>
+        public IObservableUserKeysClient GitSshKey { get; private set; }
 
         /// <summary>
         /// A client for GitHub's UserUser GPG Keys API.

--- a/Octokit.Tests.Integration/Clients/UserKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserKeysClientTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Integration.Clients
 
             using (var context = await github.CreatePublicKeyContext())
             {
-                var keys = await github.User.Keys.GetAllForCurrent();
+                var keys = await github.User.GitSshKey.GetAllForCurrent();
                 Assert.NotEmpty(keys);
 
                 var first = keys[0];
@@ -30,7 +30,7 @@ namespace Octokit.Tests.Integration.Clients
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var keys = await github.User.Keys.GetAll("shiftkey");
+            var keys = await github.User.GitSshKey.GetAll("shiftkey");
             Assert.NotEmpty(keys);
 
             var first = keys[0];
@@ -47,7 +47,7 @@ namespace Octokit.Tests.Integration.Clients
 
             using (var context = await github.CreatePublicKeyContext())
             {
-                var key = await github.User.Keys.Get(context.KeyId);
+                var key = await github.User.GitSshKey.Get(context.KeyId);
 
                 Assert.Equal(key.Title, context.KeyTitle);
                 Assert.Equal(key.Key, context.KeyData);
@@ -62,17 +62,17 @@ namespace Octokit.Tests.Integration.Clients
             string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
             var github = Helper.GetAuthenticatedClient();
 
-            var key = await github.User.Keys.Create(new NewPublicKey(keyTitle, keyData));
+            var key = await github.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
 
             Assert.NotNull(key);
             Assert.Equal(key.Title, "title");
             Assert.Equal(key.Key, keyData);
 
             // Delete key
-            await github.User.Keys.Delete(key.Id);
+            await github.User.GitSshKey.Delete(key.Id);
 
             // Verify key no longer exists
-            var keys = await github.User.Keys.GetAllForCurrent();
+            var keys = await github.User.GitSshKey.GetAllForCurrent();
             Assert.False(keys.Any(k => k.Title == keyTitle && k.Key == keyData));
         }
     }

--- a/Octokit.Tests.Integration/Helper.cs
+++ b/Octokit.Tests.Integration/Helper.cs
@@ -154,7 +154,7 @@ namespace Octokit.Tests.Integration
             try
             {
                 var client = new GitHubClient(connection);
-                client.User.Keys.Delete(keyId).Wait(TimeSpan.FromSeconds(15));
+                client.User.GitSshKey.Delete(keyId).Wait(TimeSpan.FromSeconds(15));
             }
             catch { }
         }

--- a/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/GithubClientExtensions.cs
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Integration.Helpers
             string keyTitle = "title";
             string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
 
-            var key = await client.User.Keys.Create(new NewPublicKey(keyTitle, keyData));
+            var key = await client.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
 
             return new PublicKeyContext(client.Connection, key);
         }

--- a/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Integration.Helpers
             string keyTitle = "title";
             string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
 
-            var key = await client.User.Keys.Create(new NewPublicKey(keyTitle, keyData));
+            var key = await client.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
 
             return new PublicKeyContext(client.Connection, key);
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableUserKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableUserKeysClientTests.cs
@@ -21,7 +21,7 @@ namespace Octokit.Tests.Integration.Clients
         {
             using (var context = await _github.CreatePublicKeyContext())
             {
-                var observable = _github.User.Keys.GetAllForCurrent();
+                var observable = _github.User.GitSshKey.GetAllForCurrent();
                 var keys = await observable.ToList();
 
                 Assert.NotEmpty(keys);
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanGetAllForGivenUser()
         {
-            var observable = _github.User.Keys.GetAll("shiftkey");
+            var observable = _github.User.GitSshKey.GetAll("shiftkey");
             var keys = await observable.ToList();
 
             Assert.NotEmpty(keys);
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Integration.Clients
         {
             using (var context = await _github.CreatePublicKeyContext())
             {
-                var observable = _github.User.Keys.Get(context.KeyId);
+                var observable = _github.User.GitSshKey.Get(context.KeyId);
                 var key = await observable;
 
                 Assert.Equal(key.Title, context.KeyTitle);
@@ -69,7 +69,7 @@ namespace Octokit.Tests.Integration.Clients
             string keyTitle = "title";
             string keyData = "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEAjo4DqFKg8dOxiz/yjypmN1A4itU5QOStyYrfOFuTinesU/2zm9hqxJ5BctIhgtSHJ5foxkhsiBji0qrUg73Q25BThgNg8YFE8njr4EwjmqSqW13akx/zLV0GFFU0SdJ2F6rBldhi93lMnl0ex9swBqa3eLTY8C+HQGBI6MQUMw+BKp0oFkz87Kv+Pfp6lt/Uo32ejSxML1PT5hTH5n+fyl0ied+sRmPGZWmWoHB5Bc9mox7lB6I6A/ZgjtBqbEEn4HQ2/6vp4ojKfSgA4Mm7XMu0bZzX0itKjH1QWD9Lr5apV1cmZsj49Xf8SHucTtH+bq98hb8OOXEGFzplwsX2MQ==";
 
-            var observable = _github.User.Keys.Create(new NewPublicKey(keyTitle, keyData));
+            var observable = _github.User.GitSshKey.Create(new NewPublicKey(keyTitle, keyData));
             var key = await observable;
 
             Assert.NotNull(key);
@@ -77,10 +77,10 @@ namespace Octokit.Tests.Integration.Clients
             Assert.Equal(key.Key, keyData);
 
             // Delete key
-            await _github.User.Keys.Delete(key.Id);
+            await _github.User.GitSshKey.Delete(key.Id);
 
             // Verify key no longer exists
-            var keys = await _github.User.Keys.GetAllForCurrent().ToList();
+            var keys = await _github.User.GitSshKey.GetAllForCurrent().ToList();
             Assert.False(keys.Any(k => k.Title == keyTitle && k.Key == keyData));
         }
     }

--- a/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableUserKeysClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCurrent();
 
-                gitHubClient.User.Keys.Received().GetAllForCurrent(Arg.Any<ApiOptions>());
+                gitHubClient.User.GitSshKey.Received().GetAllForCurrent(Arg.Any<ApiOptions>());
             }
         }
 
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("auser");
 
-                gitHubClient.User.Keys.Received().GetAll("auser", Arg.Any<ApiOptions>());
+                gitHubClient.User.GitSshKey.Received().GetAll("auser", Arg.Any<ApiOptions>());
             }
         }
 
@@ -45,7 +45,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Get(1);
 
-                gitHubClient.User.Keys.Received().Get(1);
+                gitHubClient.User.GitSshKey.Received().Get(1);
             }
         }
 
@@ -59,7 +59,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Create(new NewPublicKey("title", "ABCDEFG"));
 
-                gitHubClient.User.Keys.Received().Create(
+                gitHubClient.User.GitSshKey.Received().Create(
                     Arg.Is<NewPublicKey>(a =>
                         a.Title == "title" &&
                         a.Key == "ABCDEFG"));
@@ -76,7 +76,7 @@ namespace Octokit.Tests.Reactive
 
                 client.Delete(1);
 
-                gitHubClient.User.Keys.Received().Delete(1);
+                gitHubClient.User.GitSshKey.Received().Delete(1);
             }
         }
 

--- a/Octokit/Clients/IUsersClient.cs
+++ b/Octokit/Clients/IUsersClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -25,7 +26,16 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
+        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
         IUserKeysClient Keys { get; }
+
+        /// <summary>
+        /// A client for GitHub's User Keys API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
+        ///</remarks>
+        IUserKeysClient GitSshKey { get; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Gpg")]
         IUserGpgKeysClient GpgKey { get; }

--- a/Octokit/Clients/UsersClient.cs
+++ b/Octokit/Clients/UsersClient.cs
@@ -21,7 +21,10 @@ namespace Octokit
         {
             Email = new UserEmailsClient(apiConnection);
             Followers = new FollowersClient(apiConnection);
+#pragma warning disable CS0618 // Type or member is obsolete
             Keys = new UserKeysClient(apiConnection);
+#pragma warning restore CS0618 // Type or member is obsolete
+            GitSshKey = new UserKeysClient(apiConnection);
             GpgKey = new UserGpgKeysClient(apiConnection);
 
             Administration = new UserAdministrationClient(apiConnection);
@@ -41,7 +44,16 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
+        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
         public IUserKeysClient Keys { get; private set; }
+
+        /// <summary>
+        /// A client for GitHub's User Keys API
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
+        ///</remarks>
+        public IUserKeysClient GitSshKey { get; private set; }
 
         /// <summary>
         /// A client for GitHub's UserUser GPG Keys API.


### PR DESCRIPTION
Fixes #1253 

In both the normal and reactive clients and interfaces,
- Rename `client.User.Keys` to `client.User.GitSshKey`
- Mark `client.User.Keys` as `[Obsolete]`

This has been done on top of #1343 so the commit list in this PR should tidy itself up once #1343 is merged