### PR TITLE
Add ApiOptions overloads to methods on I(Observable)RepositoryForksClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -2,41 +2,72 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Forks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryForksClient
     {
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<Repository> GetAll(string owner, string repositoryName);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(string owner, string name);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<Repository> GetAll(string owner, string repositoryName, ApiOptions options);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(string owner, string name, ApiOptions options);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options);
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<Repository> Create(string owner, string repositoryName, NewRepositoryFork fork);
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -9,7 +9,28 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
         /// <returns></returns>
+        IObservable<Repository> GetAll(string owner, string repositoryName);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        IObservable<Repository> GetAll(string owner, string repositoryName, ApiOptions options);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -57,7 +57,6 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNull(request, "request");
 
             return GetAll(owner, repositoryName, request, ApiOptions.None);
         }
@@ -71,10 +70,10 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
+            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options) :
+                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Forks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryForksClient : IObservableRepositoryForksClient
     {
         readonly IRepositoryForksClient _client;
@@ -24,70 +30,95 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<Repository> GetAll(string owner, string repositoryName)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<Repository> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), options);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, request, ApiOptions.None);
+            return GetAll(owner, name, request, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options) :
-                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
+            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
+                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<Repository> Create(string owner, string repositoryName, NewRepositoryFork fork)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        public IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(fork, "fork");
 
-            return _client.Create(owner, repositoryName, fork).ToObservable();
+            return _client.Create(owner, name, fork).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -16,8 +16,36 @@ namespace Octokit.Reactive
         public ObservableRepositoryForksClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
+
             _client = client.Repository.Forks;
             _connection = client.Connection;
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public IObservable<Repository> GetAll(string owner, string repositoryName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+
+            return GetAll(owner, repositoryName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public IObservable<Repository> GetAll(string owner, string repositoryName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options);
         }
 
         /// <summary>
@@ -29,10 +57,24 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(request, "request");
 
-            return request == null
-                ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName))
-                : _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary());
+            return GetAll(owner, repositoryName, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public IObservable<Repository> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -13,7 +13,7 @@ namespace Octokit.Tests.Integration.Clients
             {
                 var github = Helper.GetAuthenticatedClient();
 
-                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", null);
+                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net");
 
                 var masterFork = forks.FirstOrDefault(fork => fork.FullName == "TeamBinary/octokit.net");
                 Assert.NotNull(masterFork);

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -21,6 +21,176 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctForksBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", skipStartOptions);
+
+                Assert.Equal(3, firstPage.Count);
+                Assert.Equal(3, secondPage.Count);
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithoutStartParameterized()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithStartParameterized()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctForksBasedOnStartPageParameterized()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, skipStartOptions);
+
+                Assert.Equal(3, firstPage.Count);
+                Assert.Equal(3, secondPage.Count);
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsForksForRepositorySortingTheResultWithOldestFirstWithApiOptions()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Oldest };
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, startOptions);
+                var firstPageOrdered = firstPage.OrderBy(r => r.CreatedAt).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, skipStartOptions);
+                var secondPageOrdered = secondPage.OrderBy(r => r.CreatedAt).ToList();
+
+                for (var index = 0; index < firstPage.Count; index++)
+                {
+                    Assert.Equal(firstPageOrdered[index].FullName, firstPage[index].FullName);
+                }
+
+                for (var index = 0; index < firstPage.Count; index++)
+                {
+                    Assert.Equal(secondPageOrdered[index].FullName, secondPage[index].FullName);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsForksForRepositorySortingTheResultWithOldestFirst()
             {
                 var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -21,36 +21,93 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.Forks.GetAll("fake", "repo");
+                await client.Forks.GetAll("fake", "repo");
 
-                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"));
+                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithRequestParameters()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.Forks.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers });
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.Forks.GetAll("fake", "repo", options);
+
+                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"), options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRequestParameters()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.Forks.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers });
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"),
-                    Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"));
+                    Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRequestParametersWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.Forks.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers }, options);
+
+                connection.Received().GetAll<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"),
+                    Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"), options);
             }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryForksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", new RepositoryForksListRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", new RepositoryForksListRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", new RepositoryForksListRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", new RepositoryForksListRequest(), ApiOptions.None));
             }
         }
 
@@ -61,6 +118,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
+
                 var newRepositoryFork = new NewRepositoryFork();
 
                 client.Forks.Create("fake", "repo", newRepositoryFork);
@@ -71,23 +129,14 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryForksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.Create(null, "name", new NewRepositoryFork()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.Create("owner", null, new NewRepositoryFork()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.Create("owner", "name", null));
-            }
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryFork()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryFork()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
 
-            [Fact]
-            public void UsesTheSuppliedHook()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                var newRepositoryFork = new NewRepositoryFork { Organization = "aName" };
-
-                client.Forks.Create("owner", "repo", newRepositoryFork);
-
-                connection.Received().Post<Repository>(Arg.Any<Uri>(), newRepositoryFork);
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewRepositoryFork()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewRepositoryFork()));
             }
         }
     }

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -1,7 +1,7 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Clients
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
-                    () => new RepositoryForksClient(null));
+                () => new RepositoryForksClient(null));
             }
         }
 
@@ -24,9 +24,9 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryForksClient(connection);
 
-                await client.Forks.GetAll("fake", "repo");
+                await client.GetAll("fake", "repo");
 
                 connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"), Args.ApiOptions);
             }
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryForksClient(connection);
 
                 var options = new ApiOptions
                 {
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                await client.Forks.GetAll("fake", "repo", options);
+                await client.GetAll("fake", "repo", options);
 
                 connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"), options);
             }
@@ -53,9 +53,9 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrlWithRequestParameters()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryForksClient(connection);
 
-                await client.Forks.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers });
+                await client.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers });
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"),
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrlWithRequestParametersWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryForksClient(connection);
 
                 var options = new ApiOptions
                 {
@@ -75,7 +75,7 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                await client.Forks.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers }, options);
+                await client.GetAll("fake", "repo", new RepositoryForksListRequest { Sort = Sort.Stargazers }, options);
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"),
@@ -94,10 +94,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
@@ -117,11 +115,11 @@ namespace Octokit.Tests.Clients
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryForksClient(connection);
 
                 var newRepositoryFork = new NewRepositoryFork();
 
-                client.Forks.Create("fake", "repo", newRepositoryFork);
+                client.Create("fake", "repo", newRepositoryFork);
 
                 connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"), newRepositoryFork);
             }

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.Forks.GetAll("fake", "repo", null);
+                client.Forks.GetAll("fake", "repo");
 
                 connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"));
             }
@@ -49,8 +49,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll(null, "name", null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll("owner", null, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Forks.GetAll("owner", null));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Reactive\ObservableRepositoryCommentsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesEventsClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryCommitsClientTests.cs" />
+    <Compile Include="Reactive\ObservableRepositoryForksClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryPagesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepositoryDeployKeysClientTests.cs" />
     <Compile Include="Reactive\ObservableGistsTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
@@ -94,10 +94,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));

--- a/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableRepositoryForksClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(
+                () => new ObservableRepositoryForksClient(null));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                client.GetAll("fake", "repo");
+
+                gitHubClient.Received().Repository.Forks.GetAll("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("fake", "repo", options);
+
+                gitHubClient.Received().Repository.Forks.GetAll("fake", "repo", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRequestParameters()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Stargazers };
+
+                client.GetAll("fake", "repo", repositoryForksListRequest);
+
+                gitHubClient.Received().Repository.Forks.GetAll(
+                    "fake", "repo", repositoryForksListRequest);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRequestParametersWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Stargazers };
+
+                client.GetAll("fake", "repo", repositoryForksListRequest, options);
+
+                gitHubClient.Received().Repository.Forks.GetAll("fake", "name", repositoryForksListRequest, options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryForksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", new RepositoryForksListRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", new RepositoryForksListRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", new RepositoryForksListRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", new RepositoryForksListRequest(), ApiOptions.None));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var newRepositoryFork = new NewRepositoryFork();
+
+                client.Create("fake", "repo", newRepositoryFork);
+
+                gitHubClient.Received().Repository.Forks.Create("fake", "repo", newRepositoryFork);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryForksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryFork()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryFork()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewRepositoryFork()));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewRepositoryFork()));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -10,7 +10,28 @@ namespace Octokit
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
         /// <returns></returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, ApiOptions options);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request);
+        
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -3,41 +3,72 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Repository Forks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.
+    /// </remarks>
     public interface IRepositoryForksClient
     {
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string name);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, ApiOptions options);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request);
-        
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request);
+
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options);
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<Repository> Create(string owner, string repositoryName, NewRepositoryFork fork);
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        Task<Repository> Create(string owner, string name, NewRepositoryFork fork);
     }
 }

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Repository Forks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.
+    /// </remarks>
     public class RepositoryForksClient : ApiClient, IRepositoryForksClient
     {
         /// <summary>
@@ -17,71 +23,96 @@ namespace Octokit
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), options);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, request, ApiOptions.None);
+            return GetAll(owner, name, request, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of forks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null 
-                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options) :
-                  ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
+            return request == null
+                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
+                ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<Repository> Create(string owner, string repositoryName, NewRepositoryFork fork)
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        public Task<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(fork, "fork");
 
-            return ApiConnection.Post<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), fork);
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryForks(owner, name), fork);
         }
     }
 }

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -50,7 +50,6 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNull(request, "request");
 
             return GetAll(owner, repositoryName, request, ApiOptions.None);
         }
@@ -64,10 +63,11 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
-            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
+            return request == null 
+                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options) :
+                  ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -19,14 +19,55 @@ namespace Octokit
         /// </summary>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request)
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
 
-            return request == null
-                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName))
-                : ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary());
+            return GetAll(owner, repositoryName, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), options);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAll(owner, repositoryName, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Repository>> GetAll(string owner, string repositoryName, RepositoryForksListRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, repositoryName), request.ToParametersDictionary(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1176 

To-do:

- [x]  Add overloads on IRepositoryForksClient
- [x]  Add overloads on IObservableRepositoryForksClient
- [x]  Add unit tests for these new methods
- [x]  Add integration tests for these new methods
- [x]  Modified XML documentation of methods

/cc @shiftkey, @ryangribble 