### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryForksClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name);
 
         /// <summary>
@@ -28,7 +27,6 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId);
 
         /// <summary>
@@ -40,7 +38,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -51,7 +48,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -63,7 +59,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request);
 
         /// <summary>
@@ -74,7 +69,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
@@ -87,7 +81,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -99,7 +92,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -111,7 +103,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork);
 
         /// <summary>
@@ -122,7 +113,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId);
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request);
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork);
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -27,11 +27,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
         IObservable<Repository> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -51,12 +72,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
         IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
@@ -69,5 +113,16 @@ namespace Octokit.Reactive
         /// <param name="fork">Used to fork a repository</param>
         /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
         IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork);
+
+        /// <summary>
+        /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -66,7 +66,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -101,7 +101,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
             return GetAll(repositoryId, request, ApiOptions.None);
@@ -134,7 +134,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -154,7 +154,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -172,7 +172,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -190,7 +190,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -106,6 +106,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
 
             return GetAll(owner, name, request, ApiOptions.None);
         }
@@ -121,6 +122,8 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
+            Ensure.ArgumentNotNull(request, "request");
+
             return GetAll(repositoryId, request, ApiOptions.None);
         }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -35,7 +35,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,7 +50,6 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -66,7 +64,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +81,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -101,7 +97,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -119,7 +114,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -137,7 +131,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -157,7 +150,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -175,7 +167,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         public IObservable<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -193,7 +184,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         public IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -135,10 +135,10 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
-                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -152,10 +152,10 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), options) :
-                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -50,6 +50,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -61,6 +74,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), options);
         }
 
         /// <summary>
@@ -87,6 +116,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request)
+        {
+            return GetAll(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
@@ -100,6 +143,24 @@ namespace Octokit.Reactive
 
             return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
                 _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return request == null ? _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), options) :
+                _connection.GetAndFlattenAllPages<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -119,6 +180,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(fork, "fork");
 
             return _client.Create(owner, name, fork).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        public IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork)
+        {
+            Ensure.ArgumentNotNull(fork, "fork");
+
+            return _client.Create(repositoryId, fork).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -426,7 +426,7 @@ namespace Octokit.Tests.Integration.Clients
                 // The fork is created asynchronously by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts instead of after.
-                Helper.DeleteRepo(Helper.Credentials.Login, "octokit.net");
+                Helper.DeleteRepo(Helper.GetAuthenticatedClient().Connection, Helper.Credentials.Login, "octokit.net");
 
                 var github = Helper.GetAuthenticatedClient();
 
@@ -460,7 +460,7 @@ namespace Octokit.Tests.Integration.Clients
                 // The fork is created asynchronously by github and therefore it cannot 
                 // be certain that the repo exists when the test ends. It is therefore deleted
                 // before the test starts.
-                Helper.DeleteRepo(Helper.Organization, "octokit.net");
+                Helper.DeleteRepo(Helper.GetAuthenticatedClient().Connection, Helper.Organization, "octokit.net");
 
                 var github = Helper.GetAuthenticatedClient();
 

--- a/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryForksClientTests.cs
@@ -21,6 +21,18 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsForksForRepositoryWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var forks = await github.Repository.Forks.GetAll(7528679);
+
+                var masterFork = forks.FirstOrDefault(fork => fork.FullName == "TeamBinary/octokit.net");
+                Assert.NotNull(masterFork);
+                Assert.Equal("TeamBinary", masterFork.Owner.Login);
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfForksWithoutStart()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -32,6 +44,22 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithoutStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var forks = await github.Repository.Forks.GetAll(7528679, options);
 
                 Assert.Equal(1, forks.Count);
             }
@@ -49,6 +77,23 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var forks = await github.Repository.Forks.GetAll(7528679, options);
 
                 Assert.Equal(1, forks.Count);
             }
@@ -84,6 +129,36 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsDistinctForksBasedOnStartPageWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll(7528679, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll(7528679, skipStartOptions);
+
+                Assert.Equal(3, firstPage.Count);
+                Assert.Equal(3, secondPage.Count);
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfForksWithoutStartParameterized()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -97,6 +172,24 @@ namespace Octokit.Tests.Integration.Clients
                 var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
 
                 var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithoutStartParameterizedWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var forks = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, options);
 
                 Assert.Equal(1, forks.Count);
             }
@@ -116,6 +209,25 @@ namespace Octokit.Tests.Integration.Clients
                 var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
 
                 var forks = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, options);
+
+                Assert.Equal(1, forks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfForksWithStartParameterizedWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var forks = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, options);
 
                 Assert.Equal(1, forks.Count);
             }
@@ -144,6 +256,38 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var secondPage = await github.Repository.Forks.GetAll("octokit", "octokit.net", repositoryForksListRequest, skipStartOptions);
+
+                Assert.Equal(3, firstPage.Count);
+                Assert.Equal(3, secondPage.Count);
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+                Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctForksBasedOnStartPageParameterizedWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Newest };
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, skipStartOptions);
 
                 Assert.Equal(3, firstPage.Count);
                 Assert.Equal(3, secondPage.Count);
@@ -191,11 +335,63 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsForksForRepositorySortingTheResultWithOldestFirstWithApiOptionsWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Oldest };
+
+                var startOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var firstPage = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, startOptions);
+                var firstPageOrdered = firstPage.OrderBy(r => r.CreatedAt).ToList();
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 3,
+                    StartPage = 1
+                };
+
+                var secondPage = await github.Repository.Forks.GetAll(7528679, repositoryForksListRequest, skipStartOptions);
+                var secondPageOrdered = secondPage.OrderBy(r => r.CreatedAt).ToList();
+
+                for (var index = 0; index < firstPage.Count; index++)
+                {
+                    Assert.Equal(firstPageOrdered[index].FullName, firstPage[index].FullName);
+                }
+
+                for (var index = 0; index < firstPage.Count; index++)
+                {
+                    Assert.Equal(secondPageOrdered[index].FullName, secondPage[index].FullName);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsForksForRepositorySortingTheResultWithOldestFirst()
             {
                 var github = Helper.GetAuthenticatedClient();
 
                 var actualForks = (await github.Repository.Forks.GetAll("octokit", "octokit.net", new RepositoryForksListRequest { Sort = Sort.Oldest })).ToArray();
+                var sortedForks = actualForks.OrderBy(fork => fork.CreatedAt).ToArray();
+
+                for (var index = 0; index < actualForks.Length; index++)
+                {
+                    Assert.Equal(sortedForks[index].FullName, actualForks[index].FullName);
+                }
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsForksForRepositorySortingTheResultWithOldestFirstWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var actualForks = (await github.Repository.Forks.GetAll(7528679, new RepositoryForksListRequest { Sort = Sort.Oldest })).ToArray();
                 var sortedForks = actualForks.OrderBy(fork => fork.CreatedAt).ToArray();
 
                 for (var index = 0; index < actualForks.Length; index++)
@@ -224,6 +420,23 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.Equal(true, forkCreated.Fork);
             }
 
+            [IntegrationTest]
+            public async Task ForkCreatedForUserLoggedInWithRepositoryId()
+            {
+                // The fork is created asynchronously by github and therefore it cannot 
+                // be certain that the repo exists when the test ends. It is therefore deleted
+                // before the test starts instead of after.
+                Helper.DeleteRepo(Helper.Credentials.Login, "octokit.net");
+
+                var github = Helper.GetAuthenticatedClient();
+
+                var forkCreated = await github.Repository.Forks.Create(7528679, new NewRepositoryFork());
+
+                Assert.NotNull(forkCreated);
+                Assert.Equal(string.Format("{0}/octokit.net", Helper.UserName), forkCreated.FullName);
+                Assert.Equal(true, forkCreated.Fork);
+            }
+
             [OrganizationTest]
             public async Task ForkCreatedForOrganization()
             {
@@ -235,6 +448,23 @@ namespace Octokit.Tests.Integration.Clients
                 var github = Helper.GetAuthenticatedClient();
 
                 var forkCreated = await github.Repository.Forks.Create("octokit", "octokit.net", new NewRepositoryFork { Organization = Helper.Organization });
+
+                Assert.NotNull(forkCreated);
+                Assert.Equal(string.Format("{0}/octokit.net", Helper.Organization), forkCreated.FullName);
+                Assert.Equal(true, forkCreated.Fork);
+            }
+
+            [OrganizationTest]
+            public async Task ForkCreatedForOrganizationWithRepositoryId()
+            {
+                // The fork is created asynchronously by github and therefore it cannot 
+                // be certain that the repo exists when the test ends. It is therefore deleted
+                // before the test starts.
+                Helper.DeleteRepo(Helper.Organization, "octokit.net");
+
+                var github = Helper.GetAuthenticatedClient();
+
+                var forkCreated = await github.Repository.Forks.Create(7528679, new NewRepositoryFork { Organization = Helper.Organization });
 
                 Assert.NotNull(forkCreated);
                 Assert.Equal(string.Format("{0}/octokit.net", Helper.Organization), forkCreated.FullName);

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -32,6 +32,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryForksClient(connection);
+
+                await client.GetAll(1);
+
+                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/forks"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -50,6 +61,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryForksClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll(1, options);
+
+                connection.Received().GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/forks"), options);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithRequestParameters()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -59,6 +88,19 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/forks"),
+                    Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithRequestParameters()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryForksClient(connection);
+
+                await client.GetAll(1, new RepositoryForksListRequest { Sort = Sort.Stargazers });
+
+                connection.Received().GetAll<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "repositories/1/forks"),
                     Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"), Args.ApiOptions);
             }
 
@@ -83,6 +125,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithRequestParametersWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryForksClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll(1, new RepositoryForksListRequest { Sort = Sort.Stargazers }, options);
+
+                connection.Received().GetAll<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "repositories/1/forks"),
+                    Arg.Is<Dictionary<string, string>>(d => d["sort"] == "stargazers"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoryForksClient(Substitute.For<IApiConnection>());
@@ -97,6 +159,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, new RepositoryForksListRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
@@ -125,6 +190,19 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryForksClient(connection);
+
+                var newRepositoryFork = new NewRepositoryFork();
+
+                client.Create(1, newRepositoryFork);
+
+                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/forks"), newRepositoryFork);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoryForksClient(Substitute.For<IApiConnection>());
@@ -132,6 +210,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryFork()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryFork()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewRepositoryFork()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewRepositoryFork()));

--- a/Octokit.Tests/Clients/RepositoryForksClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryForksClientTests.cs
@@ -156,11 +156,14 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, (RepositoryForksListRequest)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, new RepositoryForksListRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));

--- a/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
@@ -31,6 +31,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                client.GetAll(1);
+
+                gitHubClient.Received().Repository.Forks.GetAll(1);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -49,6 +60,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll(1, options);
+
+                gitHubClient.Received().Repository.Forks.GetAll(1, options);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithRequestParameters()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -60,6 +89,20 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Received().Repository.Forks.GetAll(
                     "fake", "repo", repositoryForksListRequest);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithRequestParameters()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Stargazers };
+
+                client.GetAll(1, repositoryForksListRequest);
+
+                gitHubClient.Received().Repository.Forks.GetAll(
+                    1, repositoryForksListRequest);
             }
 
             [Fact]
@@ -83,6 +126,26 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithRequestParametersWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                var repositoryForksListRequest = new RepositoryForksListRequest { Sort = Sort.Stargazers };
+
+                client.GetAll(1, repositoryForksListRequest, options);
+
+                gitHubClient.Received().Repository.Forks.GetAll(1, repositoryForksListRequest, options);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoryForksClient(Substitute.For<IGitHubClient>());
@@ -97,6 +160,9 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, new RepositoryForksListRequest(), null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
@@ -125,6 +191,19 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryForksClient(gitHubClient);
+
+                var newRepositoryFork = new NewRepositoryFork();
+
+                client.Create(1, newRepositoryFork);
+
+                gitHubClient.Received().Repository.Forks.Create(1, newRepositoryFork);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoryForksClient(Substitute.For<IGitHubClient>());
@@ -132,6 +211,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryFork()));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryFork()));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewRepositoryFork()));
                 Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewRepositoryFork()));

--- a/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryForksClientTests.cs
@@ -157,11 +157,14 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (ApiOptions)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", (RepositoryForksListRequest)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", new RepositoryForksListRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new RepositoryForksListRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", new RepositoryForksListRequest(), null));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, (RepositoryForksListRequest)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(1, new RepositoryForksListRequest(), null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -19,7 +19,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name);
 
         /// <summary>
@@ -29,7 +28,6 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId);
 
         /// <summary>
@@ -41,7 +39,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -52,7 +49,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -64,7 +60,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request);
 
         /// <summary>
@@ -75,7 +70,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
@@ -88,7 +82,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -100,7 +93,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -112,7 +104,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         Task<Repository> Create(string owner, string name, NewRepositoryFork fork);
 
         /// <summary>
@@ -123,7 +114,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         Task<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId);
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         Task<Repository> Create(string owner, string name, NewRepositoryFork fork);
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         Task<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -28,11 +28,32 @@ namespace Octokit
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -52,12 +73,35 @@ namespace Octokit
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
         Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
@@ -70,5 +114,16 @@ namespace Octokit
         /// <param name="fork">Used to fork a repository</param>
         /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
         Task<Repository> Create(string owner, string name, NewRepositoryFork fork);
+
+        /// <summary>
+        /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        Task<Repository> Create(int repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -44,7 +44,7 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -59,7 +59,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -94,7 +94,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -111,7 +111,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
             return GetAll(repositoryId, request, ApiOptions.None);
@@ -127,7 +127,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -148,7 +148,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -167,7 +167,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         public Task<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -185,7 +185,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        /// <returns></returns>
         public Task<Repository> Create(int repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -43,6 +43,19 @@ namespace Octokit
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -54,6 +67,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), options);
         }
 
         /// <summary>
@@ -80,6 +109,20 @@ namespace Octokit
         /// <remarks>
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request)
+        {
+            return GetAll(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
@@ -94,6 +137,25 @@ namespace Octokit
             return request == null
                 ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
                 ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets the list of forks defined for a repository
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to request and filter a list of repository forks</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>s representing forks of specified repository.</returns>
+        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return request == null
+                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), options) :
+                ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -113,6 +175,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(fork, "fork");
 
             return ApiConnection.Post<Repository>(ApiUrls.RepositoryForks(owner, name), fork);
+        }
+
+        /// <summary>
+        /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
+        /// </summary>
+        /// <remarks>
+        /// See <a href="http://developer.github.com/v3/repos/forks/#create-a-fork">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="fork">Used to fork a repository</param>
+        /// <returns>A <see cref="Repository"/> representing the created fork of specified repository.</returns>
+        public Task<Repository> Create(int repositoryId, NewRepositoryFork fork)
+        {
+            Ensure.ArgumentNotNull(fork, "fork");
+
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryForks(repositoryId), fork);
         }
     }
 }

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -28,7 +28,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -44,7 +43,6 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -59,7 +57,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +74,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -94,7 +90,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -111,7 +106,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
             return GetAll(repositoryId, request, ApiOptions.None);
@@ -127,7 +121,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -148,7 +141,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -167,7 +159,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         public Task<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -185,7 +176,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        /// <returns></returns>
         public Task<Repository> Create(int repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -94,6 +94,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
 
             return GetAll(owner, name, request, ApiOptions.None);
         }
@@ -108,6 +109,8 @@ namespace Octokit
         /// <param name="request">Used to request and filter a list of repository forks</param>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request)
         {
+            Ensure.ArgumentNotNull(request, "request");
+
             return GetAll(repositoryId, request, ApiOptions.None);
         }
 
@@ -125,11 +128,10 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null
-                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), options) :
-                ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(owner, name), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -143,11 +145,10 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return request == null
-                ? ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), options) :
-                ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
+            return ApiConnection.GetAll<Repository>(ApiUrls.RepositoryForks(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryForksClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryForksClient and IObservableRepositoryForksClient).**

	  There is some divergence between XML documentation of methods in IRepositoryForksClient and IObservableRepositoryForksClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryForksClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryForksClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble