### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryPagesClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Page> Get(string owner, string name);
 
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Page> Get(int repositoryId);
 
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetAll(string owner, string name);
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetAll(int repositoryId);
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetLatest(string owner, string name);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         IObservable<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -24,6 +24,17 @@ namespace Octokit.Reactive
         IObservable<Page> Get(string owner, string name);
 
         /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<Page> Get(int repositoryId);
+
+        /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -33,6 +44,16 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
         IObservable<PagesBuild> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -47,6 +68,17 @@ namespace Octokit.Reactive
         IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options);
+
+        /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -56,5 +88,15 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
         IObservable<PagesBuild> GetLatest(string owner, string name);
+
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -19,7 +19,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Page> Get(string owner, string name);
 
@@ -30,7 +29,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Page> Get(int repositoryId);
 
@@ -42,7 +40,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetAll(string owner, string name);
 
         /// <summary>
@@ -52,7 +49,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetAll(int repositoryId);
 
         /// <summary>
@@ -64,7 +60,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -75,7 +70,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -86,7 +80,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetLatest(string owner, string name);
 
         /// <summary>
@@ -96,7 +89,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         IObservable<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -3,52 +3,58 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Pages API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryPagesClient
     {
         /// <summary>
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Page> Get(string owner, string repositoryName);
+        IObservable<Page> Get(string owner, string name);
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        IObservable<PagesBuild> GetAll(string owner, string repositoryName);
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        IObservable<PagesBuild> GetAll(string owner, string repositoryName, ApiOptions options);
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        IObservable<PagesBuild> GetLatest(string owner, string repositoryName);
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        IObservable<PagesBuild> GetLatest(string owner, string name);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -32,7 +32,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         public IObservable<Page> Get(string owner, string name)
         {
@@ -49,7 +48,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<Page> Get(int repositoryId)
         {
             return _client.Get(repositoryId).ToObservable();
@@ -63,7 +61,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -79,7 +76,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -94,7 +90,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -112,7 +107,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -128,7 +122,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -144,7 +137,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PagesBuild> GetLatest(int repositoryId)
         {
             return _client.GetLatest(repositoryId).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         public IObservable<Page> Get(string owner, string name)
         {
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Page> Get(int repositoryId)
         {
             return _client.Get(repositoryId).ToObservable();
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -128,7 +128,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public IObservable<PagesBuild> GetLatest(int repositoryId)
         {
             return _client.GetLatest(repositoryId).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -43,6 +43,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
+        public IObservable<Page> Get(int repositoryId)
+        {
+            return _client.Get(repositoryId).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -57,6 +70,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
@@ -79,6 +105,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PagesBuild>(ApiUrls.RepositoryPageBuilds(repositoryId), options);
+        }
+
+        /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -93,6 +135,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.GetLatest(owner, name).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetLatest(int repositoryId)
+        {
+            return _client.GetLatest(repositoryId).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -5,6 +5,12 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Pages API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/pages/">Repository Pages API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryPagesClient : IObservableRepositoryPagesClient
     {
         readonly IRepositoryPagesClient _client;
@@ -22,71 +28,71 @@ namespace Octokit.Reactive
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing page metadata of specified repository.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        public IObservable<Page> Get(string owner, string repositoryName)
+        public IObservable<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Get(owner, repositoryName).ToObservable();
+            return _client.Get(owner, name).ToObservable();
         }
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public IObservable<PagesBuild> GetAll(string owner, string repositoryName)
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public IObservable<PagesBuild> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <returns>A <see cref="IObservable{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<PagesBuild>(ApiUrls.RepositoryPageBuilds(owner, repositoryName), options);
+            return _connection.GetAndFlattenAllPages<PagesBuild>(ApiUrls.RepositoryPageBuilds(owner, name), options);
         }
 
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public IObservable<PagesBuild> GetLatest(string owner, string repositoryName)
+        /// <returns>A <see cref="IObservable{Page}"/> of <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        public IObservable<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.GetLatest(owner, repositoryName).ToObservable();
+            return _client.GetLatest(owner, name).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
@@ -10,6 +10,7 @@ public class RepositoryPagesClientTests
         readonly IRepositoryPagesClient _repositoryPagesClient;
         const string owner = "octokit";
         const string name = "octokit.net";
+        const int repositoryId = 7528679;
 
         public TheGetMethod()
         {
@@ -21,6 +22,13 @@ public class RepositoryPagesClientTests
         public async Task ReturnsMetadata()
         {
             var data = await _repositoryPagesClient.Get(owner, name);
+            Assert.Equal("https://api.github.com/repos/octokit/octokit.net/pages", data.Url);
+        }
+
+        [IntegrationTest(Skip= "These tests require repository admin rights - see https://github.com/octokit/octokit.net/issues/1263 for discussion")]
+        public async Task ReturnsMetadataWithRepositoryId()
+        {
+            var data = await _repositoryPagesClient.Get(repositoryId);
             Assert.Equal("https://api.github.com/repos/octokit/octokit.net/pages", data.Url);
         }
     }

--- a/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryPagesClientTests.cs
@@ -1,6 +1,6 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -13,21 +13,32 @@ namespace Octokit.Tests.Clients
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
-                    () => new RepositoryPagesClient(null));
+                () => new RepositoryPagesClient(null));
             }
         }
 
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryPagesClient(connection);
 
-                client.Get("fake", "repo");
+                await client.Get("fake", "repo");
 
                 connection.Received().Get<Page>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await client.Get(1);
+
+                connection.Received().Get<Page>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pages"));
             }
 
             [Fact]
@@ -44,14 +55,61 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryPagesClient(connection);
 
-                client.GetAll("fake", "repo");
+                await client.GetAll("fake", "repo");
 
                 connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await client.GetAll(1);
+
+                connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pages/builds"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll("fake", "repo", options);
+
+                connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds"), options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAll(1, options);
+
+                connection.Received().GetAll<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pages/builds"), options);
             }
 
             [Fact]
@@ -63,13 +121,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", new ApiOptions()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, new ApiOptions()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
-            }
 
-            [Fact]
-            public async Task EnsuresNonEmptyArguments()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoryPagesClient(connection);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", new ApiOptions()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", new ApiOptions()));
@@ -79,14 +132,25 @@ namespace Octokit.Tests.Clients
         public class TheGetLatestBuildMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryPagesClient(connection);
 
-                client.GetLatest("fake", "repo");
+                await client.GetLatest("fake", "repo");
 
                 connection.Received().Get<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pages/builds/latest"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryPagesClient(connection);
+
+                await client.GetLatest(1);
+
+                connection.Received().Get<PagesBuild>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pages/builds/latest"));
             }
 
             [Fact]
@@ -95,8 +159,8 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryPagesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetLatest(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetLatest("owner", null));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryPagesClientTests.cs
@@ -16,38 +16,150 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetAllMethod
+        public class TheGetMethod
         {
             [Fact]
             public void RequestsCorrectUrl()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoryPagesClient(githubClient);
-                var options = new ApiOptions();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
 
-                client.GetAll("fake", "repo", options);
-                githubClient.Received().Repository.Page.GetAll("fake", "repo", options);
+                client.Get("fake", "repo");
+
+                gitHubClient.Received().Repository.Page.Get("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                client.Get(1);
+
+                gitHubClient.Received().Repository.Page.Get(1);
             }
 
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoryPagesClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "repo", new ApiOptions()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, new ApiOptions()));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                client.GetAll("fake", "repo");
+
+                gitHubClient.Received().Repository.Page.GetAll("fake", "repo");
             }
 
             [Fact]
-            public void EnsuresNonEmptyArguments()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoryPagesClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
 
-                Assert.Throws<ArgumentException>(() => client.GetAll("", "repo", new ApiOptions()));
-                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", new ApiOptions()));
+                client.GetAll(1);
+
+                gitHubClient.Received().Repository.Page.GetAll(1);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll("fake", "repo", options);
+
+                gitHubClient.Received().Repository.Page.GetAll("fake", "repo", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAll(1, options);
+
+                gitHubClient.Received().Repository.Page.GetAll(1, options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "repo", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "repo", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+            }
+        }
+
+        public class TheGetLatestBuildMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                client.GetLatest("fake", "repo");
+
+                gitHubClient.Received().Repository.Page.GetLatest("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                client.GetLatest(1);
+
+                gitHubClient.Received().Repository.Page.GetLatest(1);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryPagesClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetLatest(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetLatest("owner", null));
             }
         }
     }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Page> Get(string owner, string name);
 
@@ -31,7 +31,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Page> Get(int repositoryId);
 
@@ -43,7 +43,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name);
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId);
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<PagesBuild> GetLatest(string owner, string name);
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         Task<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -25,6 +25,17 @@ namespace Octokit
         Task<Page> Get(string owner, string name);
 
         /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<Page> Get(int repositoryId);
+
+        /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -34,6 +45,16 @@ namespace Octokit
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -48,6 +69,17 @@ namespace Octokit
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options);
+
+        /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -57,5 +89,15 @@ namespace Octokit
         /// </remarks>
         /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
         Task<PagesBuild> GetLatest(string owner, string name);
+
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        Task<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -16,46 +16,46 @@ namespace Octokit
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Page> Get(string owner, string repositoryName);
+        Task<Page> Get(string owner, string name);
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string repositoryName);
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string repositoryName, ApiOptions options);
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        Task<PagesBuild> GetLatest(string owner, string repositoryName);
+        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        Task<PagesBuild> GetLatest(string owner, string name);
     }
 }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -20,7 +20,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Page> Get(string owner, string name);
 
@@ -31,7 +30,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Page> Get(int repositoryId);
 
@@ -43,7 +41,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name);
 
         /// <summary>
@@ -53,7 +50,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId);
 
         /// <summary>
@@ -65,7 +61,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -76,7 +71,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -87,7 +81,6 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<PagesBuild> GetLatest(string owner, string name);
 
         /// <summary>
@@ -97,7 +90,6 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         Task<PagesBuild> GetLatest(int repositoryId);
     }
 }

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -27,7 +27,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +42,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<Page> Get(int repositoryId)
         {
             return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(repositoryId));
@@ -57,7 +55,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -73,7 +70,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -88,7 +84,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -107,7 +102,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -124,7 +118,6 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -140,7 +133,6 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
         public Task<PagesBuild> GetLatest(int repositoryId)
         {
             return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(repositoryId));

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +43,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<Page> Get(int repositoryId)
         {
             return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(repositoryId));
@@ -57,7 +57,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -73,7 +73,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -88,7 +88,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -107,7 +107,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -124,7 +124,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -140,7 +140,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        /// <returns></returns>
         public Task<PagesBuild> GetLatest(int repositoryId)
         {
             return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(repositoryId));

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -23,53 +23,53 @@ namespace Octokit
         /// Gets the page metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public Task<Page> Get(string owner, string repositoryName)
+        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        public Task<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(owner, repositoryName));
+            return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(owner, name));
         }
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string repositoryName)
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            var endpoint = ApiUrls.RepositoryPageBuilds(owner, repositoryName);
+            var endpoint = ApiUrls.RepositoryPageBuilds(owner, name);
             return ApiConnection.GetAll<PagesBuild>(endpoint, options);
         }
 
@@ -77,17 +77,17 @@ namespace Octokit
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        /// <returns></returns>
-        public Task<PagesBuild> GetLatest(string owner, string repositoryName)
+        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        public Task<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(owner, repositoryName));
+            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(owner, name));
         }
     }
 }

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -37,6 +37,19 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets the page metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="Page"/> representing page metadata of specified repository.</returns>
+        public Task<Page> Get(int repositoryId)
+        {
+            return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(repositoryId));
+        }
+
+        /// <summary>
         /// Gets all build metadata for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -51,6 +64,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
@@ -74,6 +100,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all build metadata for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options to change the API response</param>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="IReadOnlyList{PagesBuild}"/> of <see cref="PagesBuild"/>s representing pages build metadata of specified repository.</returns>
+        public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            var endpoint = ApiUrls.RepositoryPageBuilds(repositoryId);
+            return ApiConnection.GetAll<PagesBuild>(endpoint, options);
+        }
+
+        /// <summary>
         /// Gets the build metadata for the last build for a given repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -88,6 +131,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(owner, name));
+        }
+
+        /// <summary>
+        /// Gets the build metadata for the last build for a given repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        ///  <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
+        /// </remarks>
+        /// <returns>A <see cref="Page"/> representing latest pages build metadata of specified repository.</returns>
+        public Task<PagesBuild> GetLatest(int repositoryId)
+        {
+            return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(repositoryId));
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryPagesClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryPagesClient and IObservableRepositoryPagesClient).**

	  There is some divergence between XML documentation of methods in IRepositoryPagesClient and IObservableRepositoryPagesClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryPagesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryPagesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added only one new integration test for now because of #1263

/cc @shiftkey, @ryangribble