### PR TITLE
Add repositoryId overloads to methods on I(Observable)CommitStatusClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
         
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> GetAll(int repositoryId, string reference);
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Repository Status API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/statuses/">Repository Statuses API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableCommitStatusClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
 
         /// <summary>
@@ -24,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -35,7 +41,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
         IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -44,8 +50,8 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <param name="commitStatus">The commit status to create</param>
-        /// <returns></returns>
-        IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus commitStatus);
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -20,6 +20,16 @@ namespace Octokit.Reactive
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
+        
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        IObservable<CommitStatus> GetAll(int repositoryId, string reference);
 
         /// <summary>
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -34,6 +44,17 @@ namespace Octokit.Reactive
         IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options);
+
+        /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
@@ -45,6 +66,16 @@ namespace Octokit.Reactive
         IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -53,5 +84,14 @@ namespace Octokit.Reactive
         /// <param name="newCommitStatus">The commit status to create</param>
         /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
         IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
+
+        /// <summary>
+        /// Creates a commit status for the specified ref.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference);
         
         /// <summary>
@@ -28,7 +27,6 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         IObservable<CommitStatus> GetAll(int repositoryId, string reference);
 
         /// <summary>
@@ -40,7 +38,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -51,7 +48,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options);
 
         /// <summary>
@@ -62,7 +58,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -72,7 +67,6 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
 
         /// <summary>
@@ -82,7 +76,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
 
         /// <summary>
@@ -91,7 +84,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -31,7 +31,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +47,6 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -65,7 +63,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +81,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -101,7 +97,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +113,6 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -133,7 +127,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +143,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         public IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -38,7 +38,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return GetAll(owner, name ,reference, ApiOptions.None);                  
+            return GetAll(owner, name ,reference, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        public IObservable<CommitStatus> GetAll(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return GetAll(repositoryId, reference, ApiOptions.None);
         }
 
         /// <summary>
@@ -62,6 +77,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        public IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<CommitStatus>(ApiUrls.CommitStatuses(repositoryId, reference), options);
+        }
+
+        /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
         /// a tag name.
         /// </summary>
@@ -80,6 +112,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>Only users with pull access can see this.</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        public IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.GetCombined(repositoryId, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -92,9 +139,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
-            Ensure.ArgumentNotNull(newCommitStatus, "commitStatus");
+            Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");
 
             return _client.Create(owner, name, reference, newCommitStatus).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a commit status for the specified ref.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        public IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");
+
+            return _client.Create(repositoryId, reference, newCommitStatus).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -101,7 +101,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -133,7 +133,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +150,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         public IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Repository Status API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/statuses/">Repository Statuses API documentation</a> for more information.
+    /// </remarks>
     public class ObservableCommitStatusClient : IObservableCommitStatusClient
     {
         readonly ICommitStatusClient _client;
@@ -25,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -44,7 +50,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         public IObservable<CommitStatus> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -63,9 +69,13 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{CombinedCommitStatus}"/> of <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
         public IObservable<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
             return _client.GetCombined(owner, name, reference).ToObservable();
         }
 
@@ -75,11 +85,16 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <param name="commitStatus">The commit status to create</param>
-        /// <returns></returns>
-        public IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus commitStatus)
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="IObservable{CommitStatus}"/> of <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        public IObservable<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
-            return _client.Create(owner, name, reference, commitStatus).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(newCommitStatus, "commitStatus");
+
+            return _client.Create(owner, name, reference, newCommitStatus).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitStatusClientTests.cs
@@ -17,6 +17,7 @@ public class CommitStatusClientTests
             // to go through the rigamarole of creating it all. But ideally, that's exactly what we'd do.
 
             var github = Helper.GetAuthenticatedClient();
+
             var statuses = await github.Repository.Status.GetAll(
             "rails",
             "rails",
@@ -24,6 +25,148 @@ public class CommitStatusClientTests
             Assert.Equal(2, statuses.Count);
             Assert.Equal(CommitState.Failure, statuses[0].State);
             Assert.Equal(CommitState.Pending, statuses[1].State);
+        }
+
+        [IntegrationTest]
+        public async Task CanRetrieveStatusesWithRepositoryId()
+        {
+            // Figured it was easier to grab the public status of a public repository for now than
+            // to go through the rigamarole of creating it all. But ideally, that's exactly what we'd do.
+
+            var github = Helper.GetAuthenticatedClient();
+
+            var statuses = await github.Repository.Status.GetAll(
+            8514,
+            "94b857899506612956bb542e28e292308accb908");
+            Assert.Equal(2, statuses.Count);
+            Assert.Equal(CommitState.Failure, statuses[0].State);
+            Assert.Equal(CommitState.Pending, statuses[1].State);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStatusesWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            var statuses = await github.Repository.Status.GetAll("rails", "rails",
+                                    "94b857899506612956bb542e28e292308accb908", options);
+
+            Assert.Equal(1, statuses.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStatusesWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 1
+            };
+
+            var statuses = await github.Repository.Status.GetAll("rails", "rails",
+                                    "94b857899506612956bb542e28e292308accb908", options);
+
+            Assert.Equal(1, statuses.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctStatusesBasedOnStartPage()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var startOptions = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 1
+            };
+
+            var firstPage = await github.Repository.Status.GetAll("rails", "rails", "94b857899506612956bb542e28e292308accb908", startOptions);
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 2
+            };
+
+            var secondPage = await github.Repository.Status.GetAll("rails", "rails", "94b857899506612956bb542e28e292308accb908", skipStartOptions);
+
+            Assert.Equal(1, firstPage.Count);
+            Assert.Equal(1, secondPage.Count);
+            Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStatusesWithRepositoryIdWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            var statuses = await github.Repository.Status.GetAll(8514,
+                                    "94b857899506612956bb542e28e292308accb908", options);
+
+            Assert.Equal(1, statuses.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfStatusesWithRepositoryIdWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 1
+            };
+
+            var statuses = await github.Repository.Status.GetAll(8514,
+                                    "94b857899506612956bb542e28e292308accb908", options);
+
+            Assert.Equal(1, statuses.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctStatusesBasedOnStartPageWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var startOptions = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 1
+            };
+
+            var firstPage = await github.Repository.Status.GetAll(8514, "94b857899506612956bb542e28e292308accb908", startOptions);
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 1,
+                StartPage = 2
+            };
+
+            var secondPage = await github.Repository.Status.GetAll(8514, "94b857899506612956bb542e28e292308accb908", skipStartOptions);
+
+            Assert.Equal(1, firstPage.Count);
+            Assert.Equal(1, secondPage.Count);
+            Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
         }
     }
 
@@ -36,6 +179,21 @@ public class CommitStatusClientTests
             var status = await github.Repository.Status.GetCombined(
             "libgit2",
             "libgit2sharp",
+            "f54529997b6ad841be524654d9e9074ab8e7d41d");
+            Assert.Equal(CommitState.Success, status.State);
+            Assert.Equal("f54529997b6ad841be524654d9e9074ab8e7d41d", status.Sha);
+            Assert.Equal(2, status.TotalCount);
+            Assert.Equal(2, status.Statuses.Count);
+            Assert.True(status.Statuses.All(x => x.State == CommitState.Success));
+            Assert.Equal("The Travis CI build passed", status.Statuses[0].Description);
+        }
+
+        [IntegrationTest]
+        public async Task CanRetrieveCombinedStatusWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var status = await github.Repository.Status.GetCombined(
+            1415168,
             "f54529997b6ad841be524654d9e9074ab8e7d41d");
             Assert.Equal(CommitState.Success, status.State);
             Assert.Equal("f54529997b6ad841be524654d9e9074ab8e7d41d", status.Sha);

--- a/Octokit.Tests/Clients/CommitStatusClientTests.cs
+++ b/Octokit.Tests/Clients/CommitStatusClientTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Security.Policy;
 using System.Threading.Tasks;
 using NSubstitute;
-using Octokit.Tests.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -12,18 +10,31 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitStatusClient(connection);
 
-                client.GetAll("fake", "repo", "sha");
+                await client.GetAll("fake", "repo", "sha");
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), Arg.Any<ApiOptions>());
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), Args.ApiOptions);
             }
+
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
+
+                await client.GetAll(1, "sha");
+
+                connection.Received()
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/statuses"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitStatusClient(connection);
@@ -35,64 +46,100 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAll("fake", "repo", "sha", options);
+                await client.GetAll("fake", "repo", "sha", options);
 
                 connection.Received()
-                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), Args.ApiOptions);
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/statuses"), options);
             }
 
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
 
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAll(1, "sha", options);
+
+                connection.Received()
+                    .GetAll<CommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/statuses"), options);
+            }
+            
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
+                
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", "sha", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, "sha", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", "sha", null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetAll("", "name", "sha"));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetAll("owner", "", "sha"));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetAll("owner", "name", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetAll(null, "name", "sha"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetAll("owner", null, "sha"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetAll("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, "sha", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", "sha", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", "sha", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "name", "", ApiOptions.None));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(1, "", ApiOptions.None));
             }
         }
 
         public class TheGetCombinedMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitStatusClient(connection);
 
-                client.GetCombined("fake", "repo", "sha");
+                await client.GetCombined("fake", "repo", "sha");
 
                 connection.Received()
                     .Get<CombinedCommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/status"));
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
+
+                await client.GetCombined(1, "sha");
+
+                connection.Received()
+                    .Get<CombinedCommitStatus>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/status"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
+                
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined(null, "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined("owner", null, "sha"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined("owner", "name", null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetCombined("", "name", "sha"));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetCombined("owner", "", "sha"));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.GetCombined("owner", "name", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetCombined(null, "name", "sha"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetCombined("owner", null, "sha"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.GetCombined("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCombined(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetCombined("", "name", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetCombined("owner", "", "sha"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetCombined("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetCombined(1, ""));
             }
         }
 
@@ -112,24 +159,36 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void PostsToTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CommitStatusClient(connection);
+
+                client.Create(1, "sha", new NewCommitStatus { State = CommitState.Success });
+
+                connection.Received().Post<CommitStatus>(Arg.Is<Uri>(u =>
+                    u.ToString() == "repositories/1/statuses/sha"),
+                    Arg.Is<NewCommitStatus>(s => s.State == CommitState.Success));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new CommitStatusClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("", "name", "sha", new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("owner", "", "sha", new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("owner", "name", "", new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create(null, "name", "sha", new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", null, "sha", new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", "name", null, new NewCommitStatus()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", "name", "sha", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null, new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", "sha", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null, new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, "sha", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", "sha", new NewCommitStatus()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "name", "", new NewCommitStatus()));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create(1, "", new NewCommitStatus()));
             }
         }
 

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Reactive\ObservableCommitsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssueCommentReactionsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssueReactionsClientTests.cs" />
+    <Compile Include="Reactive\ObservableCommitStatusClientTests.cs" />
     <Compile Include="Reactive\ObservableOrganizationsClientTests.cs" />
     <Compile Include="Reactive\ObservableNotificationsClientTests.cs" />
     <Compile Include="Reactive\ObservableIssuesLabelsClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableCommitStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitStatusClientTests.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Clients
+{
+    public class ObservableCommitStatusClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                client.GetAll("fake", "repo", "sha");
+
+                gitHubClient.Received().Repository.Status.GetAll("fake", "repo", "sha");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                client.GetAll(1, "sha");
+
+                gitHubClient.Received().Repository.Status.GetAll(1, "sha");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("fake", "repo", "sha", options);
+
+                connection.Received().Repository.Status.GetAll("fake", "repo", "sha", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(1, "sha", options);
+
+                connection.Received().Repository.Status.GetAll(1, "sha", options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableCommitStatusClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", "sha"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, "sha"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", "sha", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, "sha", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", "sha", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, "sha", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", "sha"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", "sha"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "name", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", "sha", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", "sha", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "name", "", ApiOptions.None));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll(1, "", ApiOptions.None));
+            }
+        }
+
+        public class TheGetCombinedMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                client.GetCombined("fake", "repo", "sha");
+
+                gitHubClient.Received().Repository.Status.GetCombined("fake", "repo", "sha");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                client.GetCombined(1, "sha");
+
+                gitHubClient.Received().Repository.Status.GetCombined(1, "sha");
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableCommitStatusClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetCombined(null, "name", "sha"));
+                Assert.Throws<ArgumentNullException>(() => client.GetCombined("owner", null, "sha"));
+                Assert.Throws<ArgumentNullException>(() => client.GetCombined("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetCombined(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetCombined("", "name", "sha"));
+                Assert.Throws<ArgumentException>(() => client.GetCombined("owner", "", "sha"));
+                Assert.Throws<ArgumentException>(() => client.GetCombined("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetCombined(1, ""));
+            }
+        }
+
+        public class TheCreateMethodForUser
+        {
+            [Fact]
+            public void PostsToTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                var newCommitStatus = new NewCommitStatus { State = CommitState.Success };
+
+                client.Create("owner", "repo", "sha", newCommitStatus);
+
+                gitHubClient.Received(). Repository.Status.Create("owner", "repo", "sha", newCommitStatus);
+            }
+
+            [Fact]
+            public void PostsToTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitStatusClient(gitHubClient);
+
+                var newCommitStatus = new NewCommitStatus { State = CommitState.Success };
+
+                client.Create(1, "sha", newCommitStatus);
+
+                gitHubClient.Received().Repository.Status.Create(1, "sha", newCommitStatus);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableCommitStatusClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", "sha", new NewCommitStatus()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, "sha", new NewCommitStatus()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null, new NewCommitStatus()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", "sha", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null, new NewCommitStatus()));
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, "sha", null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", "sha", new NewCommitStatus()));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", "sha", new NewCommitStatus()));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "name", "", new NewCommitStatus()));
+
+                Assert.Throws<ArgumentException>(() => client.Create(1, "", new NewCommitStatus()));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableCommitStatusClient(null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -36,7 +36,24 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return GetAll(owner,name,reference,ApiOptions.None);            
+            return GetAll(owner, name, reference, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return GetAll(repositoryId, reference, ApiOptions.None);
         }
 
         /// <summary>
@@ -54,11 +71,30 @@ namespace Octokit
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");            
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference),options);
+            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(owner, name, reference), options);
+        }
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<CommitStatus>(ApiUrls.CommitStatuses(repositoryId, reference), options);
         }
 
         /// <summary>
@@ -82,6 +118,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        public Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<CombinedCommitStatus>(ApiUrls.CombinedCommitStatus(repositoryId, reference));
+        }
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <remarks>
@@ -100,6 +153,24 @@ namespace Octokit
             Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");
 
             return ApiConnection.Post<CommitStatus>(ApiUrls.CreateCommitStatus(owner, name, reference), newCommitStatus);
+        }
+
+        /// <summary>
+        /// Creates a commit status for the specified ref.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#create-a-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        public Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");
+
+            return ApiConnection.Post<CommitStatus>(ApiUrls.CreateCommitStatus(repositoryId, reference), newCommitStatus);
         }
     }
 }

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -29,7 +29,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +47,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -67,7 +65,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -88,7 +85,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -107,7 +103,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -126,7 +121,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         public Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -144,7 +138,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -164,7 +157,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         public Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -107,7 +107,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -126,7 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         public Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         public Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -50,7 +50,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +71,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
         public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -90,16 +90,16 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <param name="commitStatus">The commit status to create</param>
-        /// <returns></returns>
-        public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus commitStatus)
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
-            Ensure.ArgumentNotNull(commitStatus, "commitStatus");
+            Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");
 
-            return ApiConnection.Post<CommitStatus>(ApiUrls.CreateCommitStatus(owner, name, reference), commitStatus);
+            return ApiConnection.Post<CommitStatus>(ApiUrls.CreateCommitStatus(owner, name, reference), newCommitStatus);
         }
     }
 }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -21,7 +21,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference);
 
         /// <summary>
@@ -33,7 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference);
 
         /// <summary>
@@ -47,7 +45,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -60,7 +57,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options);
 
         /// <summary>
@@ -73,7 +69,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -85,7 +80,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
         Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
 
         /// <summary>
@@ -98,7 +92,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
 
         /// <summary>
@@ -110,7 +103,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns></returns>
         Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -31,12 +31,37 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference);
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options);
 
         /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -52,6 +77,18 @@ namespace Octokit
         Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
+        /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
+        /// a tag name.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
+
+        /// <summary>
         /// Creates a commit status for the specified ref.
         /// </summary>
         /// <remarks>
@@ -63,5 +100,17 @@ namespace Octokit
         /// <param name="newCommitStatus">The commit status to create</param>
         /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
         Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
+
+        /// <summary>
+        /// Creates a commit status for the specified ref.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/repos/statuses/#create-a-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference);
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
+        /// <returns></returns>
         Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        /// <returns></returns>
         Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{CommitStatus}"/> of <see cref="CommitStatus"/>es representing commit statuses for specified repository</returns>
         Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="CombinedCommitStatus"/> representing combined commit status for specified repository</returns>
         Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference);
 
         /// <summary>
@@ -60,8 +60,8 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        /// <param name="commitStatus">The commit status to create</param>
-        /// <returns></returns>
-        Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus commitStatus);
+        /// <param name="newCommitStatus">The commit status to create</param>
+        /// <returns>A <see cref="CommitStatus"/> representing created commit status for specified repository</returns>
+        Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus);
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)CommitStatusClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of ICommitStatusClient and IObservableCommitStatusClient).**

	  There is some divergence between XML documentation of methods in ICommitStatusClient and IObservableCommitStatusClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to ICommitStatusClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableCommitStatusClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble