### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoryHooksClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(string owner, string name);
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(int repositoryId);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options);
         
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
         IObservable<RepositoryHook> Get(string owner, string name, int hookId);
 
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
         IObservable<RepositoryHook> Get(int repositoryId, int hookId);
 
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets a single hook by Id
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -102,7 +102,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
@@ -124,7 +124,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
@@ -145,7 +145,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -164,7 +164,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -4,73 +4,95 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Webhooks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/hooks/">Webhooks API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableRepositoryHooksClient
     {
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
-        /// <returns></returns>
-        IObservable<RepositoryHook> GetAll(string owner, string repositoryName);
+        /// <param name="name">The repository's name</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        IObservable<RepositoryHook> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        IObservable<RepositoryHook> GetAll(string owner, string repositoryName, ApiOptions options);
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
-        /// Gets a single hook defined for a repository by id
+        /// Gets a single hook by Id
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
-        IObservable<RepositoryHook> Get(string owner, string repositoryName, int hookId);
+        IObservable<RepositoryHook> Get(string owner, string name, int hookId);
 
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<RepositoryHook> Create(string owner, string repositoryName, NewRepositoryHook hook);
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        IObservable<RepositoryHook> Edit(string owner, string repositoryName, int hookId, EditRepositoryHook hook);
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
         /// <returns></returns>
-        IObservable<Unit> Test(string owner, string repositoryName, int hookId);
+        IObservable<Unit> Test(string owner, string name, int hookId);
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        IObservable<Unit> Ping(string owner, string repositoryName, int hookId);
+        IObservable<Unit> Ping(string owner, string name, int hookId);
 
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="repositoryName"></param>
-        /// <param name="hookId"></param>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string repositoryName, int hookId);
+        IObservable<Unit> Delete(string owner, string name, int hookId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(string owner, string name);
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(int repositoryId);
 
         /// <summary>
@@ -36,7 +34,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options);
         
         /// <summary>
@@ -45,7 +42,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -55,7 +51,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
         IObservable<RepositoryHook> Get(string owner, string name, int hookId);
 
@@ -65,7 +60,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
         IObservable<RepositoryHook> Get(int repositoryId, int hookId);
 
@@ -76,7 +70,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
@@ -85,7 +78,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
@@ -96,7 +88,6 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -106,7 +97,6 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -118,7 +108,6 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Test(string owner, string name, int hookId);
 
         /// <summary>
@@ -129,7 +118,6 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Test(int repositoryId, int hookId);
 
         /// <summary>
@@ -139,7 +127,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Ping(string owner, string name, int hookId);
 
         /// <summary>
@@ -148,7 +135,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Ping(int repositoryId, int hookId);
 
         /// <summary>
@@ -158,7 +144,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int hookId);
 
         /// <summary>
@@ -167,7 +152,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         IObservable<Unit> Delete(int repositoryId, int hookId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -24,12 +24,29 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        IObservable<RepositoryHook> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
         IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options);
+        
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id
@@ -43,6 +60,16 @@ namespace Octokit.Reactive
         IObservable<RepositoryHook> Get(string owner, string name, int hookId);
 
         /// <summary>
+        /// Gets a single hook by Id
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
+        IObservable<RepositoryHook> Get(int repositoryId, int hookId);
+
+        /// <summary>
         /// Creates a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -51,6 +78,15 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
         IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
+
+        /// <summary>
+        /// Creates a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hook">The hook's parameters</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
@@ -62,6 +98,16 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
         IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
+
+        /// <summary>
+        /// Edits a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
@@ -76,6 +122,17 @@ namespace Octokit.Reactive
         IObservable<Unit> Test(string owner, string name, int hookId);
 
         /// <summary>
+        /// Tests a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        /// <returns></returns>
+        IObservable<Unit> Test(int repositoryId, int hookId);
+
+        /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -86,6 +143,15 @@ namespace Octokit.Reactive
         IObservable<Unit> Ping(string owner, string name, int hookId);
 
         /// <summary>
+        /// This will trigger a ping event to be sent to the hook.
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        IObservable<Unit> Ping(int repositoryId, int hookId);
+
+        /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -94,5 +160,14 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int hookId);
+
+        /// <summary>
+        /// Deletes a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, int hookId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -92,7 +92,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Get(int repositoryId, int hookId)
         {
             return _client.Get(repositoryId, hookId).ToObservable();
@@ -120,7 +120,7 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -136,7 +136,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's owner</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -152,7 +152,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -169,7 +169,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         public IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -46,6 +46,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public IObservable<RepositoryHook> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
@@ -58,6 +69,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(repositoryId), options);
         }
 
         /// <summary>
@@ -77,6 +102,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single hook by Id
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        public IObservable<RepositoryHook> Get(int repositoryId, int hookId)
+        {
+            return _client.Get(repositoryId, hookId).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -91,6 +128,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(hook, "hook");
 
             return _client.Create(owner, name, hook).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hook">The hook's parameters</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        public IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
+        {
+            Ensure.ArgumentNotNull(hook, "hook");
+
+            return _client.Create(repositoryId, hook).ToObservable();
         }
 
         /// <summary>
@@ -112,6 +163,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Edits a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        public IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
+        {
+            Ensure.ArgumentNotNull(hook, "hook");
+
+            return _client.Edit(repositoryId, hookId, hook).ToObservable();
+        }
+
+        /// <summary>
         /// Tests a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -127,6 +193,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Test(owner, name, hookId).ToObservable();
+        }
+
+        /// <summary>
+        /// Tests a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        /// <returns></returns>
+        public IObservable<Unit> Test(int repositoryId, int hookId)
+        {
+            return _client.Test(repositoryId, hookId).ToObservable();
         }
 
         /// <summary>
@@ -146,6 +226,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// This will trigger a ping event to be sent to the hook.
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public IObservable<Unit> Ping(int repositoryId, int hookId)
+        {
+            return _client.Ping(repositoryId, hookId).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -159,6 +251,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Delete(owner, name, hookId).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, int hookId)
+        {
+            return _client.Delete(repositoryId, hookId).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -30,7 +30,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -44,7 +43,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -57,7 +55,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -73,7 +70,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -88,7 +84,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -103,7 +98,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Get(int repositoryId, int hookId)
         {
             return _client.Get(repositoryId, hookId).ToObservable();
@@ -116,7 +110,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -132,7 +125,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -148,7 +140,6 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -165,7 +156,6 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -182,7 +172,6 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -199,7 +188,6 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Test(int repositoryId, int hookId)
         {
             return _client.Test(repositoryId, hookId).ToObservable();
@@ -212,7 +200,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -227,7 +214,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Ping(int repositoryId, int hookId)
         {
             return _client.Ping(repositoryId, hookId).ToObservable();
@@ -240,7 +226,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -255,7 +240,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public IObservable<Unit> Delete(int repositoryId, int hookId)
         {
             return _client.Delete(repositoryId, hookId).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -15,11 +15,7 @@ namespace Octokit.Reactive
     {
         readonly IRepositoryHooksClient _client;
         readonly IConnection _connection;
-
-        /// <summary>
-        /// Initializes a new GitHub Webhooks API client.
-        /// </summary>
-        /// <param name="client"></param>
+        
         public ObservableRepositoryHooksClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
@@ -74,7 +70,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -104,7 +100,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets a single hook by Id
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -133,7 +129,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -165,7 +161,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
@@ -198,7 +194,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
@@ -228,7 +224,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
@@ -256,7 +252,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
-        /// <param name="repositoryId">The repository's owner</param>
+        /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -5,11 +5,21 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Webhooks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/hooks/">Webhooks API documentation</a> for more information.
+    /// </remarks>
     public class ObservableRepositoryHooksClient : IObservableRepositoryHooksClient
     {
         readonly IRepositoryHooksClient _client;
         readonly IConnection _connection;
 
+        /// <summary>
+        /// Initializes a new GitHub Webhooks API client.
+        /// </summary>
+        /// <param name="client"></param>
         public ObservableRepositoryHooksClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
@@ -21,118 +31,134 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
-        /// <returns></returns>
-        public IObservable<RepositoryHook> GetAll(string owner, string repositoryName)
+        /// <param name="name">The repository's name</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public IObservable<RepositoryHook> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        public IObservable<RepositoryHook> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IObservable{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public IObservable<RepositoryHook> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), options);
+            return _connection.GetAndFlattenAllPages<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), options);
         }
 
         /// <summary>
-        /// Gets a single hook defined for a repository by id
+        /// Gets a single hook by Id
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<RepositoryHook> Get(string owner, string repositoryName, int hookId)
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        public IObservable<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Get(owner, repositoryName, hookId).ToObservable();
+            return _client.Get(owner, name, hookId).ToObservable();
         }
 
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<RepositoryHook> Create(string owner, string repositoryName, NewRepositoryHook hook)
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        public IObservable<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(hook, "hook");
 
-            return _client.Create(owner, repositoryName, hook).ToObservable();
+            return _client.Create(owner, name, hook).ToObservable();
         }
 
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public IObservable<RepositoryHook> Edit(string owner, string repositoryName, int hookId, EditRepositoryHook hook)
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        public IObservable<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(hook, "hook");
 
-            return _client.Edit(owner, repositoryName, hookId, hook).ToObservable();
+            return _client.Edit(owner, name, hookId, hook).ToObservable();
         }
 
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
         /// <returns></returns>
-        public IObservable<Unit> Test(string owner, string repositoryName, int hookId)
+        public IObservable<Unit> Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Test(owner, repositoryName, hookId).ToObservable();
+            return _client.Test(owner, name, hookId).ToObservable();
         }
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        public IObservable<Unit> Ping(string owner, string repositoryName, int hookId)
+        public IObservable<Unit> Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Ping(owner, repositoryName, hookId).ToObservable();
+            return _client.Ping(owner, name, hookId).ToObservable();
         }
 
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="repositoryName"></param>
-        /// <param name="hookId"></param>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string repositoryName, int hookId)
+        public IObservable<Unit> Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.Delete(owner, repositoryName, hookId).ToObservable();
+            return _client.Delete(owner, name, hookId).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryHooksClientTests.cs
@@ -32,6 +32,19 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsAllHooksFromRepositoryWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryId);
+
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
+
+                var actualHook = hooks[0];
+                AssertHook(_fixture.ExpectedHook, actualHook);
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfHooksWithoutStart()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -43,6 +56,22 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options);
+
+                Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithoutStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                
+                var options = new ApiOptions
+                {
+                    PageSize = 5,
+                    PageCount = 1
+                };
+
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryId, options);
 
                 Assert.Equal(_fixture.ExpectedHooks.Count, hooks.Count);
             }
@@ -60,6 +89,23 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName, options);
+
+                Assert.Equal(1, hooks.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfHooksWithStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 3
+                };
+
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryId, options);
 
                 Assert.Equal(1, hooks.Count);
             }
@@ -89,6 +135,32 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
                 Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
             }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Repository.Hooks.GetAll(_fixture.RepositoryId, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Repository.Hooks.GetAll(_fixture.RepositoryId, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+                Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+            }
         }
 
         [Collection(RepositoriesHooksCollection.Name)]
@@ -110,6 +182,16 @@ namespace Octokit.Tests.Integration.Clients
 
                 AssertHook(_fixture.ExpectedHook, actualHook);
             }
+
+            [IntegrationTest]
+            public async Task GetHookByCreatedIdWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var actualHook = await github.Repository.Hooks.Get(_fixture.RepositoryId, _fixture.ExpectedHook.Id);
+
+                AssertHook(_fixture.ExpectedHook, actualHook);
+            }
         }
 
         public class TheCreateMethod
@@ -125,12 +207,14 @@ namespace Octokit.Tests.Integration.Clients
                 var url = "http://test.com/example";
                 var contentType = WebHookContentType.Json;
                 var secret = "53cr37";
+
                 var config = new Dictionary<string, string>
                 {
                     { "hostname", "http://hostname.url" },
                     { "username", "username" },
                     { "password", "password" }
                 };
+
                 var parameters = new NewRepositoryWebHook("windowsazure", config, url)
                 {
                     Events = new[] { "push" },
@@ -140,6 +224,50 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var hook = await github.Repository.Hooks.Create(Helper.UserName, repository.Name, parameters.ToRequest());
+
+                var baseHookUrl = CreateExpectedBaseHookUrl(repository.Url, hook.Id);
+                var webHookConfig = CreateExpectedConfigDictionary(config, url, contentType, secret);
+
+                Assert.Equal("windowsazure", hook.Name);
+                Assert.Equal(new[] { "push" }.ToList(), hook.Events.ToList());
+                Assert.Equal(baseHookUrl, hook.Url);
+                Assert.Equal(baseHookUrl + "/test", hook.TestUrl);
+                Assert.Equal(baseHookUrl + "/pings", hook.PingUrl);
+                Assert.NotNull(hook.CreatedAt);
+                Assert.NotNull(hook.UpdatedAt);
+                Assert.Equal(webHookConfig.Keys, hook.Config.Keys);
+                Assert.Equal(webHookConfig.Values, hook.Config.Values);
+                Assert.Equal(false, hook.Active);
+            }
+
+            [IntegrationTest]
+            public async Task CreateAWebHookForTestRepositoryWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repoName = Helper.MakeNameWithTimestamp("create-hooks-test");
+                var repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+
+                var url = "http://test.com/example";
+                var contentType = WebHookContentType.Json;
+                var secret = "53cr37";
+
+                var config = new Dictionary<string, string>
+                {
+                    { "hostname", "http://hostname.url" },
+                    { "username", "username" },
+                    { "password", "password" }
+                };
+
+                var parameters = new NewRepositoryWebHook("windowsazure", config, url)
+                {
+                    Events = new[] { "push" },
+                    Active = false,
+                    ContentType = contentType,
+                    Secret = secret
+                };
+
+                var hook = await github.Repository.Hooks.Create(repository.Id, parameters.ToRequest());
 
                 var baseHookUrl = CreateExpectedBaseHookUrl(repository.Url, hook.Id);
                 var webHookConfig = CreateExpectedConfigDictionary(config, url, contentType, secret);
@@ -193,7 +321,25 @@ namespace Octokit.Tests.Integration.Clients
                     AddEvents = new[] { "pull_request" }
                 };
 
-                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHook.Id, editRepositoryHook);
+                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHooks[0].Id, editRepositoryHook);
+
+                var expectedConfig = new Dictionary<string, string> { { "content_type", "json" }, { "url", "http://test.com/example" } };
+                Assert.Equal(new[] { "deployment", "pull_request" }.ToList(), actualHook.Events.ToList());
+                Assert.Equal(expectedConfig.Keys, actualHook.Config.Keys);
+                Assert.Equal(expectedConfig.Values, actualHook.Config.Values);
+            }
+
+            [IntegrationTest]
+            public async Task EditHookWithNoNewConfigRetainsTheOldConfigWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var editRepositoryHook = new EditRepositoryHook
+                {
+                    AddEvents = new[] { "pull_request" }
+                };
+
+                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryId, _fixture.ExpectedHooks[1].Id, editRepositoryHook);
 
                 var expectedConfig = new Dictionary<string, string> { { "content_type", "json" }, { "url", "http://test.com/example" } };
                 Assert.Equal(new[] { "deployment", "pull_request" }.ToList(), actualHook.Events.ToList());
@@ -211,7 +357,25 @@ namespace Octokit.Tests.Integration.Clients
                     AddEvents = new[] { "pull_request" }
                 };
 
-                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHook.Id, editRepositoryHook);
+                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHooks[2].Id, editRepositoryHook);
+
+                var expectedConfig = new Dictionary<string, string> { { "project", "GEZDGORQFY2TCNZRGY2TSMBVGUYDK" } };
+                Assert.Equal(new[] { "push", "pull_request" }.ToList(), actualHook.Events.ToList());
+                Assert.Equal(expectedConfig.Keys, actualHook.Config.Keys);
+                Assert.Equal(expectedConfig.Values, actualHook.Config.Values);
+            }
+
+            [IntegrationTest]
+            public async Task EditHookWithNewInformationWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var editRepositoryHook = new EditRepositoryHook(new Dictionary<string, string> { { "project", "GEZDGORQFY2TCNZRGY2TSMBVGUYDK" } })
+                {
+                    AddEvents = new[] { "pull_request" }
+                };
+
+                var actualHook = await github.Repository.Hooks.Edit(_fixture.RepositoryId, _fixture.ExpectedHooks[3].Id, editRepositoryHook);
 
                 var expectedConfig = new Dictionary<string, string> { { "project", "GEZDGORQFY2TCNZRGY2TSMBVGUYDK" } };
                 Assert.Equal(new[] { "deployment", "pull_request" }.ToList(), actualHook.Events.ToList());
@@ -237,6 +401,14 @@ namespace Octokit.Tests.Integration.Clients
 
                 await github.Repository.Hooks.Test(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHook.Id);
             }
+
+            [IntegrationTest]
+            public async Task TestACreatedHookWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                await github.Repository.Hooks.Test(_fixture.RepositoryId, _fixture.ExpectedHook.Id);
+            }
         }
 
         [Collection(RepositoriesHooksCollection.Name)]
@@ -255,6 +427,14 @@ namespace Octokit.Tests.Integration.Clients
                 var github = Helper.GetAuthenticatedClient();
 
                 await github.Repository.Hooks.Ping(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHook.Id);
+            }
+
+            [IntegrationTest]
+            public async Task PingACreatedHookWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                await github.Repository.Hooks.Ping(_fixture.RepositoryId, _fixture.ExpectedHook.Id);
             }
         }
 
@@ -276,7 +456,18 @@ namespace Octokit.Tests.Integration.Clients
                 await github.Repository.Hooks.Delete(_fixture.RepositoryOwner, _fixture.RepositoryName, _fixture.ExpectedHook.Id);
                 var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryOwner, _fixture.RepositoryName);
 
-                Assert.Equal(4, hooks.Count);
+                Assert.Empty(hooks.Where(hook => hook.Id == _fixture.ExpectedHook.Id));
+            }
+
+            [IntegrationTest]
+            public async Task DeleteCreatedWebHookWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                await github.Repository.Hooks.Delete(_fixture.RepositoryId, _fixture.ExpectedHooks[1].Id);
+                var hooks = await github.Repository.Hooks.GetAll(_fixture.RepositoryId);
+
+                Assert.Empty(hooks.Where(hook => hook.Id == _fixture.ExpectedHooks[1].Id));
             }
         }
 

--- a/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
+++ b/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
@@ -29,6 +29,8 @@ namespace Octokit.Tests.Integration.fixtures
 
         public string RepositoryName { get { return _repository.Name; } }
 
+        public int RepositoryId { get { return _repository.Id; } }
+
         public RepositoryHook ExpectedHook { get { return _hook; } }
 
         public IList<RepositoryHook> ExpectedHooks { get { return _hooks; } }

--- a/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
+++ b/Octokit.Tests/Clients/RepositoryHooksClientTest.cs
@@ -21,22 +21,34 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
 
-                client.Hooks.GetAll("fake", "repo");
+                await client.GetAll("fake", "repo");
 
                 connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), 
                     Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
+
+                await client.GetAll(1);
+
+                connection.Received().GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks"), 
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
 
                 var options = new ApiOptions
                 {
@@ -45,7 +57,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.Hooks.GetAll("fake", "repo", options);
+                await client.GetAll("fake", "repo", options);
 
                 connection.Received(1)
                     .GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"),
@@ -53,35 +65,79 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAll(1, options);
+
+                connection.Received(1)
+                    .GetAll<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks"),
+                        options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.GetAll(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
             }
         }
 
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
 
-                client.Hooks.Get("fake", "repo", 12345678);
+                await client.Get("fake", "repo", 12345678);
 
                 connection.Received().Get<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678"));
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
+
+                await client.Get(1, 12345678);
+
+                connection.Received().Get<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks/12345678"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Get(null, "name", 123));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Get("owner", null, 123));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 123));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 123));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 123));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 123));
             }
         }
 
@@ -91,35 +147,43 @@ namespace Octokit.Tests.Clients
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
+
                 var hook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
 
-                client.Hooks.Create("fake", "repo", hook);
+                client.Create("fake", "repo", hook);
 
                 connection.Received().Post<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks"), hook);
             }
 
             [Fact]
-            public async Task EnsuresNonNullArguments()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
 
-                var config = new Dictionary<string, string> { { "config", "" } };
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Create(null, "name", new NewRepositoryHook("name", config)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Create("owner", null, new NewRepositoryHook("name", config)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Create("owner", "name", null));
+                var hook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
+
+                client.Create(1, hook);
+
+                connection.Received().Post<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks"), hook);
             }
 
             [Fact]
-            public void UsesTheSuppliedHook()
+            public async Task EnsuresNonNullArguments()
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                var newRepositoryHook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                client.Hooks.Create("owner", "repo", newRepositoryHook);
+                var config = new Dictionary<string, string> { { "config", "" } };
 
-                connection.Received().Post<RepositoryHook>(Arg.Any<Uri>(), newRepositoryHook);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryHook("name", config)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryHook("name", config)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewRepositoryHook("name", config)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewRepositoryHook("name", config)));
             }
         }
 
@@ -129,34 +193,41 @@ namespace Octokit.Tests.Clients
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
+
                 var hook = new EditRepositoryHook();
 
-                client.Hooks.Edit("fake", "repo", 12345678, hook);
+                client.Edit("fake", "repo", 12345678, hook);
 
                 connection.Received().Patch<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678"), hook);
             }
 
             [Fact]
-            public async Task EnsuresNonNullArguments()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Edit(null, "name", 12345678, new EditRepositoryHook()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Edit("owner", null, 12345678, new EditRepositoryHook()));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Edit("owner", "name", 12345678, null));
+                var hook = new EditRepositoryHook();
+
+                client.Edit(1, 12345678, hook);
+
+                connection.Received().Patch<RepositoryHook>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks/12345678"), hook);
             }
 
             [Fact]
-            public void UsesTheSuppliedHook()
+            public async Task EnsuresNonNullArguments()
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
-                var editRepositoryHook = new EditRepositoryHook { Active = false };
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                client.Hooks.Edit("owner", "repo", 12345678, editRepositoryHook);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "name", 12345678, new EditRepositoryHook()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, 12345678, new EditRepositoryHook()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", "name", 12345678, null));
 
-                connection.Received().Patch<RepositoryHook>(Arg.Any<Uri>(), editRepositoryHook);
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(1, 12345678, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "name", 12345678, new EditRepositoryHook()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("owner", "", 12345678, new EditRepositoryHook()));
             }
         }
 
@@ -166,43 +237,71 @@ namespace Octokit.Tests.Clients
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
 
-                client.Hooks.Test("fake", "repo", 12345678);
+                client.Test("fake", "repo", 12345678);
 
                 connection.Received().Post(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678/tests"));
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
+
+                client.Test(1, 12345678);
+
+                connection.Received().Post(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks/12345678/tests"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Test(null, "name", 12345678));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Test("owner", null, 12345678));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Test(null, "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Test("owner", null, 12345678));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Test("", "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Test("owner", "", 12345678));
             }
         }
 
         public class ThePingMethod
         {
             [Fact]
-            public async Task EnsuresNonNullArguments()
-            {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Ping(null, "name", 12345678));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Ping("owner", null, 12345678));
-            }
-
-            [Fact]
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
 
-                client.Hooks.Ping("fake", "repo", 12345678);
+                client.Ping("fake", "repo", 12345678);
 
                 connection.Received().Post(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678/pings"));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
+
+                client.Ping(1, 12345678);
+
+                connection.Received().Post(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks/12345678/pings"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Ping(null, "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Ping("owner", null, 12345678));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Ping("", "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Ping("owner", "", 12345678));
             }
         }
 
@@ -212,20 +311,34 @@ namespace Octokit.Tests.Clients
             public void RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoriesClient(connection);
+                var client = new RepositoryHooksClient(connection);
 
-                client.Hooks.Delete("fake", "repo", 12345678);
+                client.Delete("fake", "repo", 12345678);
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/hooks/12345678"));
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryHooksClient(connection);
+
+                client.Delete(1, 12345678);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/hooks/12345678"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+                var client = new RepositoryHooksClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Delete(null, "name", 12345678));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Hooks.Delete("owner", null, 12345678));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 12345678));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 12345678));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 12345678));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryHooksClientTests.cs
@@ -8,81 +8,331 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableRepositoryHooksClientTests
     {
-        public class ObservableAuthorizationsClientTests
-        {
-            const string owner = "owner";
-            const string repositoryName = "name";
-
-            public class TheGetAllMethod
-            {
-                [Fact]
-                public void GetsCorrectUrl()
-                {
-                    var client = Substitute.For<IGitHubClient>();
-                    var authEndpoint = new ObservableRepositoryHooksClient(client);
-                    var expectedUrl = string.Format("repos/{0}/{1}/hooks", owner, repositoryName);
-
-                    authEndpoint.GetAll(owner, repositoryName);
-
-                    client.Connection.Received(1).Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                        Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 0), null);
-                }
-
-                [Fact]
-                public void GetsCorrectUrlWithApiOption()
-                {
-                    var gitHubClient = Substitute.For<IGitHubClient>();
-                    var hooksClient = new ObservableRepositoryHooksClient(gitHubClient);
-                    var expectedUrl = string.Format("repos/{0}/{1}/hooks", owner, repositoryName);
-
-                    // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
-                    var options = new ApiOptions
-                    {
-                        StartPage = 1,
-                        PageCount = 1,
-                        PageSize = 1
-                    };
-
-                    hooksClient.GetAll(owner, repositoryName, options);
-                    gitHubClient.Connection.Received(1)
-                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
-                            null);
-
-                    // StartPage is setted => only 1 option (StartPage) in dictionary
-                    options = new ApiOptions
-                    {
-                        StartPage = 1
-                    };
-
-                    hooksClient.GetAll(owner, repositoryName, options);
-                    gitHubClient.Connection.Received(1)
-                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
-                            null);
-
-                    // PageCount is setted => none of options in dictionary
-                    options = new ApiOptions
-                    {
-                        PageCount = 1
-                    };
-
-                    hooksClient.GetAll(owner, repositoryName, options);
-                    gitHubClient.Connection.Received(1)
-                        .Get<List<RepositoryHook>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                            Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
-                            null);
-                }
-            }
-        }
-
         public class TheCtor
         {
             [Fact]
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(
-                    () => new ObservableRepositoryHooksClient(null));
+                () => new ObservableRepositoryHooksClient(null));
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.GetAll("fake", "repo");
+
+                gitHubClient.Received().Repository.Hooks.GetAll("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.GetAll(1);
+
+                gitHubClient.Received().Repository.Hooks.GetAll(1);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("fake", "repo", options);
+
+                gitHubClient.Received(1).Repository.Hooks.GetAll("fake", "repo", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(1, options);
+
+                gitHubClient.Received(1).Repository.Hooks.GetAll(1, options);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Get("fake", "repo", 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Get("fake", "repo", 12345678);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Get(1, 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Get(1, 12345678);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", 123));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, 123));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", 123));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", 123));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var hook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
+
+                client.Create("fake", "repo", hook);
+
+                gitHubClient.Received().Repository.Hooks.Create("fake", "repo", hook);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var hook = new NewRepositoryHook("name", new Dictionary<string, string> { { "config", "" } });
+
+                client.Create(1, hook);
+
+                gitHubClient.Received().Repository.Hooks.Create(1, hook);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                var config = new Dictionary<string, string> { { "config", "" } };
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewRepositoryHook("name", config)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewRepositoryHook("name", config)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewRepositoryHook("name", config)));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewRepositoryHook("name", config)));
+            }
+        }
+
+        public class TheEditMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var hook = new EditRepositoryHook();
+
+                client.Edit("fake", "repo", 12345678, hook);
+
+                gitHubClient.Received().Repository.Hooks.Edit("fake", "repo", 12345678, hook);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                var hook = new EditRepositoryHook();
+
+                client.Edit(1, 12345678, hook);
+
+                gitHubClient.Received().Repository.Hooks.Edit(1, 12345678, hook);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Edit(null, "name", 12345678, new EditRepositoryHook()));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, 12345678, new EditRepositoryHook()));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", "name", 12345678, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Edit(1, 12345678, null));
+
+                Assert.Throws<ArgumentException>(() => client.Edit("", "name", 12345678, new EditRepositoryHook()));
+                Assert.Throws<ArgumentException>(() => client.Edit("owner", "", 12345678, new EditRepositoryHook()));
+            }
+        }
+
+        public class TheTestMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Test("fake", "repo", 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Test("fake", "repo", 12345678);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Test(1, 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Test(1, 12345678);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Test(null, "name", 12345678));
+                Assert.Throws<ArgumentNullException>(() => client.Test("owner", null, 12345678));
+
+                Assert.Throws<ArgumentException>(() => client.Test("", "name", 12345678));
+                Assert.Throws<ArgumentException>(() => client.Test("owner", "", 12345678));
+            }
+        }
+
+        public class ThePingMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Ping("fake", "repo", 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Ping("fake", "repo", 12345678);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Ping(1, 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Ping(1, 12345678);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Ping(null, "name", 12345678));
+                Assert.Throws<ArgumentNullException>(() => client.Ping("owner", null, 12345678));
+
+                Assert.Throws<ArgumentException>(() => client.Ping("", "name", 12345678));
+                Assert.Throws<ArgumentException>(() => client.Ping("owner", "", 12345678));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Delete("fake", "repo", 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Delete("fake", "repo", 12345678);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryHooksClient(gitHubClient);
+
+                client.Delete(1, 12345678);
+
+                gitHubClient.Received().Repository.Hooks.Delete(1, 12345678);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryHooksClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", 12345678));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, 12345678));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name", 12345678));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "", 12345678));
             }
         }
     }

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -4,73 +4,95 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Repository Webhooks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/hooks/">Webhooks API documentation</a> for more information.
+    /// </remarks>
     public interface IRepositoryHooksClient
     {
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
-        /// <returns></returns>
-        Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName);
+        /// <param name="name">The repository's name</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName, ApiOptions options);
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id
         /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="repositoryName"></param>
-        /// <param name="hookId"></param>
-        /// <returns></returns>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
-        Task<RepositoryHook> Get(string owner, string repositoryName, int hookId);
+        Task<RepositoryHook> Get(string owner, string name, int hookId);
 
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<RepositoryHook> Create(string owner, string repositoryName, NewRepositoryHook hook);
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        Task<RepositoryHook> Edit(string owner, string repositoryName, int hookId, EditRepositoryHook hook);
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
         /// <returns></returns>
-        Task Test(string owner, string repositoryName, int hookId);
+        Task Test(string owner, string name, int hookId);
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        Task Ping(string owner, string repositoryName, int hookId);
+        Task Ping(string owner, string name, int hookId);
 
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        Task Delete(string owner, string repositoryName, int hookId);
+        Task Delete(string owner, string name, int hookId);
     }
 }

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -18,7 +18,6 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name);
         
         /// <summary>
@@ -26,7 +25,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId);
 
         /// <summary>
@@ -36,7 +34,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -45,7 +42,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -55,7 +51,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
         Task<RepositoryHook> Get(string owner, string name, int hookId);
 
@@ -65,7 +60,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
         Task<RepositoryHook> Get(int repositoryId, int hookId);
 
@@ -76,7 +70,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
@@ -85,7 +78,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
@@ -96,7 +88,6 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -106,7 +97,6 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -118,7 +108,6 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         Task Test(string owner, string name, int hookId);
 
         /// <summary>
@@ -129,7 +118,6 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         Task Test(int repositoryId, int hookId);
 
         /// <summary>
@@ -139,7 +127,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task Ping(string owner, string name, int hookId);
 
         /// <summary>
@@ -148,7 +135,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task Ping(int repositoryId, int hookId);
 
         /// <summary>
@@ -158,7 +144,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task Delete(string owner, string name, int hookId);
 
         /// <summary>
@@ -167,7 +152,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         Task Delete(int repositoryId, int hookId);
     }
 }

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name);
         
         /// <summary>
@@ -26,7 +26,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
         Task<RepositoryHook> Get(string owner, string name, int hookId);
 
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
         Task<RepositoryHook> Get(int repositoryId, int hookId);
 
@@ -76,7 +76,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -20,6 +20,14 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name);
+        
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
@@ -30,6 +38,15 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
         Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id
@@ -43,6 +60,16 @@ namespace Octokit
         Task<RepositoryHook> Get(string owner, string name, int hookId);
 
         /// <summary>
+        /// Gets a single hook by Id
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
+        Task<RepositoryHook> Get(int repositoryId, int hookId);
+
+        /// <summary>
         /// Creates a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -51,6 +78,15 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
         Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook);
+
+        /// <summary>
+        /// Creates a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hook">The hook's parameters</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
@@ -62,6 +98,16 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
         Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook);
+
+        /// <summary>
+        /// Edits a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
@@ -76,6 +122,17 @@ namespace Octokit
         Task Test(string owner, string name, int hookId);
 
         /// <summary>
+        /// Tests a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        /// <returns></returns>
+        Task Test(int repositoryId, int hookId);
+
+        /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -86,6 +143,15 @@ namespace Octokit
         Task Ping(string owner, string name, int hookId);
 
         /// <summary>
+        /// This will trigger a ping event to be sent to the hook.
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        Task Ping(int repositoryId, int hookId);
+
+        /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -94,5 +160,14 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
         Task Delete(string owner, string name, int hookId);
+
+        /// <summary>
+        /// Deletes a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        Task Delete(int repositoryId, int hookId);
     }
 }

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -38,6 +38,17 @@ namespace Octokit
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
@@ -50,6 +61,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets the list of hooks defined for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(repositoryId), options);
         }
 
         /// <summary>
@@ -69,6 +94,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a single hook by Id
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        public Task<RepositoryHook> Get(int repositoryId, int hookId)
+        {
+            return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId));
+        }
+
+        /// <summary>
         /// Creates a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -83,6 +120,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(hook, "hook");
 
             return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), hook.ToRequest());
+        }
+
+        /// <summary>
+        /// Creates a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hook">The hook's parameters</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        public Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
+        {
+            Ensure.ArgumentNotNull(hook, "hook");
+
+            return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(repositoryId), hook.ToRequest());
         }
 
         /// <summary>
@@ -104,6 +155,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Edits a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        public Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
+        {
+            Ensure.ArgumentNotNull(hook, "hook");
+
+            return ApiConnection.Patch<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId), hook);
+        }
+
+        /// <summary>
         /// Tests a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -119,6 +185,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Post(ApiUrls.RepositoryHookTest(owner, name, hookId));
+        }
+
+        /// <summary>
+        /// Tests a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        /// <returns></returns>
+        public Task Test(int repositoryId, int hookId)
+        {
+            return ApiConnection.Post(ApiUrls.RepositoryHookTest(repositoryId, hookId));
         }
 
         /// <summary>
@@ -138,6 +218,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// This will trigger a ping event to be sent to the hook.
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public Task Ping(int repositoryId, int hookId)
+        {
+            return ApiConnection.Post(ApiUrls.RepositoryHookPing(repositoryId, hookId));
+        }
+
+        /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
         /// <param name="owner">The repository's owner</param>
@@ -151,6 +243,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Delete(ApiUrls.RepositoryHookById(owner, name, hookId));
+        }
+
+        /// <summary>
+        /// Deletes a hook for a repository
+        /// </summary>
+        /// <param name="repositoryId">The repository's ID</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, int hookId)
+        {
+            return ApiConnection.Delete(ApiUrls.RepositoryHookById(repositoryId, hookId));
         }
     }
 }

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -26,7 +26,6 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +39,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -53,7 +51,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +66,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +80,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -99,7 +94,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Get(int repositoryId, int hookId)
         {
             return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId));
@@ -112,7 +106,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -128,7 +121,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -144,7 +136,6 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -161,7 +152,6 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -178,7 +168,6 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         public Task Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -195,7 +184,6 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        /// <returns></returns>
         public Task Test(int repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookTest(repositoryId, hookId));
@@ -208,7 +196,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -223,7 +210,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task Ping(int repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookPing(repositoryId, hookId));
@@ -236,7 +222,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -251,7 +236,6 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
         public Task Delete(int repositoryId, int hookId)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryHookById(repositoryId, hookId));

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -3,10 +3,16 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Repository Webhooks API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/repos/hooks/">Webhooks API documentation</a> for more information.
+    /// </remarks>
     public class RepositoryHooksClient : ApiClient, IRepositoryHooksClient
     {
         /// <summary>
-        /// Initializes a new GitHub Repos API client.
+        /// Initializes a new GitHub Webhooks API client.
         /// </summary>
         /// <param name="apiConnection">An API connection.</param>
         public RepositoryHooksClient(IApiConnection apiConnection)
@@ -17,118 +23,134 @@ namespace Octokit
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
-        /// <returns></returns>
-        public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName)
+        /// <param name="name">The repository's name</param>
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repositoryName, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
         /// <param name="owner">The repository's owner</param>
-        /// <param name="repositoryName">The repository's name</param>
+        /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string repositoryName, ApiOptions options)
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), options);
+            return ApiConnection.GetAll<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), options);
         }
 
         /// <summary>
         /// Gets a single hook by Id
         /// </summary>
-        /// <param name="owner"></param>
-        /// <param name="repositoryName"></param>
-        /// <param name="hookId"></param>
-        /// <returns></returns>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        public Task<RepositoryHook> Get(string owner, string repositoryName, int hookId)
+        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        public Task<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(owner, repositoryName, hookId));
+            return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(owner, name, hookId));
         }
 
         /// <summary>
         /// Creates a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<RepositoryHook> Create(string owner, string repositoryName, NewRepositoryHook hook)
+        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        public Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(hook, "hook");
 
-            return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(owner, repositoryName), hook.ToRequest());
+            return ApiConnection.Post<RepositoryHook>(ApiUrls.RepositoryHooks(owner, name), hook.ToRequest());
         }
 
         /// <summary>
         /// Edits a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
+        /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns></returns>
-        public Task<RepositoryHook> Edit(string owner, string repositoryName, int hookId, EditRepositoryHook hook)
+        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        public Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(hook, "hook");
 
-            return ApiConnection.Patch<RepositoryHook>(ApiUrls.RepositoryHookById(owner, repositoryName, hookId), hook);
+            return ApiConnection.Patch<RepositoryHook>(ApiUrls.RepositoryHookById(owner, name, hookId), hook);
         }
 
         /// <summary>
         /// Tests a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
         /// <returns></returns>
-        public Task Test(string owner, string repositoryName, int hookId)
+        public Task Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Post(ApiUrls.RepositoryHookTest(owner, repositoryName, hookId));
+            return ApiConnection.Post(ApiUrls.RepositoryHookTest(owner, name, hookId));
         }
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        public Task Ping(string owner, string repositoryName, int hookId)
+        public Task Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Post(ApiUrls.RepositoryHookPing(owner, repositoryName, hookId));
+            return ApiConnection.Post(ApiUrls.RepositoryHookPing(owner, name, hookId));
         }
 
         /// <summary>
         /// Deletes a hook for a repository
         /// </summary>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
         /// <returns></returns>
-        public Task Delete(string owner, string repositoryName, int hookId)
+        public Task Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Delete(ApiUrls.RepositoryHookById(owner, repositoryName, hookId));
+            return ApiConnection.Delete(ApiUrls.RepositoryHookById(owner, name, hookId));
         }
     }
 }

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +40,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The repository's ID</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="IReadOnlyList{RepositoryHook}"/> of <see cref="RepositoryHook"/>s representing hooks for specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +84,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing hook for specified hook id</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Get(int repositoryId, int hookId)
         {
             return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId));
@@ -112,7 +112,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -128,7 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The repository's ID</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing created hook for specified repository</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -161,7 +161,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        /// <returns>A <see cref="RepositoryHook"/> representing modified hook for specified repository</returns>
+        /// <returns></returns>
         public Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoryHooksClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepositoryHooksClient and IObservableRepositoryHooksClient).**

	  There is some divergence between XML documentation of methods in IRepositoryHooksClient and IObservableRepositoryHooksClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepositoryHooksClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoryHooksClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble