### PR TITLE
Add repositoryId overloads to methods on I(Observable)BlobsClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableBlobsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableBlobsClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Blobs API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/blobs/">Git Blobs API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableBlobsClient
     {
         /// <summary>
@@ -18,6 +24,18 @@ namespace Octokit.Reactive
         IObservable<Blob> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a single Blob by SHA.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#get-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The SHA of the blob</param>
+        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<Blob> Get(int repositoryId, string reference);
+
+        /// <summary>
         /// Creates a new Blob
         /// </summary>
         /// <remarks>
@@ -28,5 +46,16 @@ namespace Octokit.Reactive
         /// <param name="newBlob">The new Blob</param>
         /// <returns>The <see cref="Blob"/> that was just created.</returns>
         IObservable<BlobReference> Create(string owner, string name, NewBlob newBlob);
+
+        /// <summary>
+        /// Creates a new Blob
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#create-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newBlob">The new Blob</param>
+        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableBlobsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableBlobsClient.cs
@@ -19,7 +19,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Blob> Get(string owner, string name, string reference);
 
@@ -31,7 +30,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Blob> Get(int repositoryId, string reference);
 
@@ -44,7 +42,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         IObservable<BlobReference> Create(string owner, string name, NewBlob newBlob);
 
         /// <summary>
@@ -55,7 +52,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableBlobsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableBlobsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Blob> Get(string owner, string name, string reference);
 
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Blob> Get(int repositoryId, string reference);
 
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         IObservable<BlobReference> Create(string owner, string name, NewBlob newBlob);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableBlobClient.cs
+++ b/Octokit.Reactive/Clients/ObservableBlobClient.cs
@@ -3,6 +3,12 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Blobs API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/blobs/">Git Blobs API documentation</a> for more information.
+    /// </remarks>
     public class ObservableBlobClient : IObservableBlobsClient
     {
         readonly IBlobsClient _client;
@@ -34,6 +40,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single Blob by SHA.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#get-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The SHA of the blob</param>
+        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        public IObservable<Blob> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.Get(repositoryId, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a new Blob
         /// </summary>
         /// <remarks>
@@ -50,6 +72,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(newBlob, "newBlob");
 
             return _client.Create(owner, name, newBlob).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a new Blob
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#create-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newBlob">The new Blob</param>
+        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        public IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob)
+        {
+            Ensure.ArgumentNotNull(newBlob, "newBlob");
+
+            return _client.Create(repositoryId, newBlob).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableBlobClient.cs
+++ b/Octokit.Reactive/Clients/ObservableBlobClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         public IObservable<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         public IObservable<Blob> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         public IObservable<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         public IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");

--- a/Octokit.Reactive/Clients/ObservableBlobClient.cs
+++ b/Octokit.Reactive/Clients/ObservableBlobClient.cs
@@ -29,7 +29,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         public IObservable<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +46,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         public IObservable<Blob> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +62,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         public IObservable<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +79,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         public IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");

--- a/Octokit.Tests.Integration/Clients/BlobClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/BlobClientTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Text;
+using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
-using System.Threading.Tasks;
-using Xunit;
 using Octokit.Tests.Integration.Helpers;
+using Xunit;
 
 public class BlobClientTests : IDisposable
 {
@@ -34,6 +34,20 @@ public class BlobClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanCreateABlobWithRepositoryId()
+    {
+        var blob = new NewBlob
+        {
+            Content = "Hello World!",
+            Encoding = EncodingType.Utf8
+        };
+
+        var result = await _fixture.Create(_context.Repository.Id, blob);
+
+        Assert.False(string.IsNullOrWhiteSpace(result.Sha));
+    }
+
+    [IntegrationTest]
     public async Task CanCreateABlobWithBase64Contents()
     {
         var utf8Bytes = Encoding.UTF8.GetBytes("Hello World!");
@@ -46,6 +60,23 @@ public class BlobClientTests : IDisposable
         };
 
         var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, blob);
+
+        Assert.False(string.IsNullOrWhiteSpace(result.Sha));
+    }
+
+    [IntegrationTest]
+    public async Task CanCreateABlobWithBase64ContentsAndWithRepositoryId()
+    {
+        var utf8Bytes = Encoding.UTF8.GetBytes("Hello World!");
+        var base64String = Convert.ToBase64String(utf8Bytes);
+
+        var blob = new NewBlob
+        {
+            Content = base64String,
+            Encoding = EncodingType.Base64
+        };
+
+        var result = await _fixture.Create(_context.Repository.Id, blob);
 
         Assert.False(string.IsNullOrWhiteSpace(result.Sha));
     }
@@ -71,6 +102,26 @@ public class BlobClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanGetABlobWithRepositoryId()
+    {
+        var newBlob = new NewBlob
+        {
+            Content = "Hello World!",
+            Encoding = EncodingType.Utf8
+        };
+
+        var result = await _fixture.Create(_context.Repository.Id, newBlob);
+        var blob = await _fixture.Get(_context.Repository.Id, result.Sha);
+
+        Assert.Equal(result.Sha, blob.Sha);
+        Assert.Equal(EncodingType.Base64, blob.Encoding);
+
+        var contents = Encoding.UTF8.GetString(Convert.FromBase64String(blob.Content));
+
+        Assert.Equal("Hello World!", contents);
+    }
+
+    [IntegrationTest]
     public async Task CanGetABlobWithBase64Text()
     {
         var utf8Bytes = Encoding.UTF8.GetBytes("Hello World!");
@@ -84,6 +135,30 @@ public class BlobClientTests : IDisposable
 
         var result = await _fixture.Create(_context.RepositoryOwner, _context.RepositoryName, newBlob);
         var blob = await _fixture.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
+
+        Assert.Equal(result.Sha, blob.Sha);
+        Assert.Equal(EncodingType.Base64, blob.Encoding);
+
+        // NOTE: it looks like the blobs you get back from the GitHub API
+        // will have an additional \n on the end. :cool:!
+        var expectedOutput = base64String + "\n";
+        Assert.Equal(expectedOutput, blob.Content);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetABlobWithBase64TextWithRepositoryId()
+    {
+        var utf8Bytes = Encoding.UTF8.GetBytes("Hello World!");
+        var base64String = Convert.ToBase64String(utf8Bytes);
+
+        var newBlob = new NewBlob
+        {
+            Content = base64String,
+            Encoding = EncodingType.Base64
+        };
+
+        var result = await _fixture.Create(_context.Repository.Id, newBlob);
+        var blob = await _fixture.Get(_context.Repository.Id, result.Sha);
 
         Assert.Equal(result.Sha, blob.Sha);
         Assert.Equal(EncodingType.Base64, blob.Encoding);

--- a/Octokit.Tests/Clients/BlobClientTests.cs
+++ b/Octokit.Tests/Clients/BlobClientTests.cs
@@ -22,14 +22,25 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new BlobsClient(connection);
 
-                client.Get("fake", "repo", "123456ABCD");
+                await client.Get("fake", "repo", "123456ABCD");
 
                 connection.Received().Get<Blob>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/blobs/123456ABCD"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new BlobsClient(connection);
+
+                await client.Get(1, "123456ABCD");
+
+                connection.Received().Get<Blob>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/blobs/123456ABCD"));
             }
 
             [Fact]
@@ -38,10 +49,11 @@ namespace Octokit.Tests.Clients
                 var client = new BlobsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
             }
         }
@@ -51,13 +63,27 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void PostsToCorrectUrl()
             {
-                var newBlob = new NewBlob();
                 var connection = Substitute.For<IApiConnection>();
                 var client = new BlobsClient(connection);
+
+                var newBlob = new NewBlob();
 
                 client.Create("fake", "repo", newBlob);
 
                 connection.Received().Post<BlobReference>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/git/blobs"), newBlob);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new BlobsClient(connection);
+
+                var newBlob = new NewBlob();
+
+                client.Create(1, newBlob);
+
+                connection.Received().Post<BlobReference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/blobs"), newBlob);
             }
 
             [Fact]
@@ -67,10 +93,11 @@ namespace Octokit.Tests.Clients
                 var client = new BlobsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewBlob()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewBlob()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewBlob()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewBlob()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewBlob()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewBlob()));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableBlobClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
@@ -12,7 +11,7 @@ namespace Octokit.Tests.Reactive
         public class TheGetMethod
         {
             [Fact]
-            public void GetsFromClientIssueComment()
+            public void RequestsCorrectUrl()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableBlobClient(gitHubClient);
@@ -23,16 +22,28 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableBlobClient(gitHubClient);
+
+                client.Get(1, "123456ABCD");
+
+                gitHubClient.Git.Blob.Received().Get(1, "123456ABCD");
+            }
+
+            [Fact]
             public async Task EnsuresArguments()
             {
                 var client = new ObservableBlobClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "123456ABCD").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "123456ABCD").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", "123456ABCD"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "123456ABCD"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "123456ABCD"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "123456ABCD"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
             }
         }
 
@@ -41,13 +52,25 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void PostsToCorrectUrl()
             {
-                var newBlob = new NewBlob();
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableBlobClient(gitHubClient);
 
+                var newBlob = new NewBlob();
                 client.Create("fake", "repo", newBlob);
 
                 gitHubClient.Git.Blob.Received().Create("fake", "repo", newBlob);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableBlobClient(gitHubClient);
+
+                var newBlob = new NewBlob();
+                client.Create(1, newBlob);
+
+                gitHubClient.Git.Blob.Received().Create(1, newBlob);
             }
 
             [Fact]
@@ -56,11 +79,12 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableBlobClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewBlob()).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewBlob()).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewBlob()).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewBlob()).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewBlob()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewBlob()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewBlob()));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewBlob()));
             }
         }
 

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -28,7 +28,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         public Task<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +45,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         public Task<Blob> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +61,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         public Task<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +78,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         public Task<BlobReference> Create(int repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -39,6 +39,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a single Blob by SHA.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#get-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The SHA of the blob</param>
+        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        public Task<Blob> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<Blob>(ApiUrls.Blob(repositoryId, reference));
+        }
+
+        /// <summary>
         /// Creates a new Blob
         /// </summary>
         /// <remarks>
@@ -55,6 +71,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(newBlob, "newBlob");
 
             return ApiConnection.Post<BlobReference>(ApiUrls.Blobs(owner, name), newBlob);
+        }
+
+        /// <summary>
+        /// Creates a new Blob
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#create-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newBlob">The new Blob</param>
+        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        public Task<BlobReference> Create(int repositoryId, NewBlob newBlob)
+        {
+            Ensure.ArgumentNotNull(newBlob, "newBlob");
+
+            return ApiConnection.Post<BlobReference>(ApiUrls.Blobs(repositoryId), newBlob);
         }
     }
 }

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         public Task<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         public Task<Blob> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         public Task<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         public Task<BlobReference> Create(int repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");

--- a/Octokit/Clients/IBlobsClient.cs
+++ b/Octokit/Clients/IBlobsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Blob> Get(string owner, string name, string reference);
 
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Blob> Get(int repositoryId, string reference);
 
@@ -44,7 +44,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         Task<BlobReference> Create(string owner, string name, NewBlob newBlob);
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        /// <returns></returns>
         Task<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit/Clients/IBlobsClient.cs
+++ b/Octokit/Clients/IBlobsClient.cs
@@ -19,7 +19,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Blob> Get(string owner, string name, string reference);
 
@@ -31,7 +30,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Blob> Get(int repositoryId, string reference);
 
@@ -44,7 +42,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         Task<BlobReference> Create(string owner, string name, NewBlob newBlob);
 
         /// <summary>
@@ -55,7 +52,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        /// <returns></returns>
         Task<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit/Clients/IBlobsClient.cs
+++ b/Octokit/Clients/IBlobsClient.cs
@@ -24,6 +24,18 @@ namespace Octokit
         Task<Blob> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a single Blob by SHA.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#get-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The SHA of the blob</param>
+        /// <returns>The <see cref="Blob"/> for the specified SHA.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<Blob> Get(int repositoryId, string reference);
+
+        /// <summary>
         /// Creates a new Blob
         /// </summary>
         /// <remarks>
@@ -34,5 +46,16 @@ namespace Octokit
         /// <param name="newBlob">The new Blob</param>
         /// <returns>The <see cref="Blob"/> that was just created.</returns>
         Task<BlobReference> Create(string owner, string name, NewBlob newBlob);
+
+        /// <summary>
+        /// Creates a new Blob
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/blobs/#create-a-blob
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newBlob">The new Blob</param>
+        /// <returns>The <see cref="Blob"/> that was just created.</returns>
+        Task<BlobReference> Create(int repositoryId, NewBlob newBlob);
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)BlobsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IBlobsClient and IObservableBlobsClient).**

	  There is some divergence between XML documentation of methods in IBlobsClient and IObservableBlobsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IBlobsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableBlobsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble