### PR TITLE
Add repositoryId overloads to methods on I(Observable)TagsClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTagsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<GitTag> Get(string owner, string name, string reference);
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<GitTag> Get(int repositoryId, string reference);
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         IObservable<GitTag> Create(string owner, string name, NewTag tag);
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         IObservable<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTagsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<GitTag> Get(string owner, string name, string reference);
@@ -33,7 +32,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<GitTag> Get(int repositoryId, string reference);
@@ -47,7 +45,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         IObservable<GitTag> Create(string owner, string name, NewTag tag);
 
         /// <summary>
@@ -58,7 +55,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         IObservable<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTagsClient.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Tags API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/tags/">Git Tags API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableTagsClient
     {
         /// <summary>
@@ -14,10 +20,23 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-            Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         IObservable<GitTag> Get(string owner, string name, string reference);
+
+        /// <summary>
+        /// Gets a tag for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#get-a-tag
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the tag</param>
+        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        IObservable<GitTag> Get(int repositoryId, string reference);
 
         /// <summary>
         /// Create a tag for a given repository
@@ -28,7 +47,18 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
         IObservable<GitTag> Create(string owner, string name, NewTag tag);
+
+        /// <summary>
+        /// Create a tag for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#create-a-tag-object
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="tag">The tag to create</param>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        IObservable<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTagsClient.cs
@@ -3,6 +3,12 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Tags API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/tags/">Git Tags API documentation</a> for more information.
+    /// </remarks>
     public class ObservableTagsClient : IObservableTagsClient
     {
         readonly ITagsClient _client;
@@ -23,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
         public IObservable<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -31,6 +37,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return _client.Get(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets a tag for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#get-a-tag
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the tag</param>
+        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        public IObservable<GitTag> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.Get(repositoryId, reference).ToObservable();
         }
 
         /// <summary>
@@ -42,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
         public IObservable<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -50,6 +72,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(tag, "tag");
 
             return _client.Create(owner, name, tag).ToObservable();
+        }
+
+        /// <summary>
+        /// Create a tag for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#create-a-tag-object
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="tag">The tag to create</param>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        public IObservable<GitTag> Create(int repositoryId, NewTag tag)
+        {
+            Ensure.ArgumentNotNull(tag, "tag");
+
+            return _client.Create(repositoryId, tag).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTagsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         public IObservable<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="IObservable{GitTag}"/> of <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         public IObservable<GitTag> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         public IObservable<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         public IObservable<GitTag> Create(int repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");

--- a/Octokit.Reactive/Clients/ObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTagsClient.cs
@@ -29,7 +29,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         public IObservable<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +46,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         public IObservable<GitTag> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +62,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         public IObservable<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +79,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         public IObservable<GitTag> Create(int repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");

--- a/Octokit.Tests.Integration/Clients/TagsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TagsClientTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Threading.Tasks;
+using Octokit.Tests.Integration.Helpers;
+using Xunit;
+
+namespace Octokit.Tests.Integration.Clients
+{
+    public class TagsClientTests
+    {
+        public class TheCreateMethod
+        {
+            readonly RepositoryContext context;
+            readonly ITagsClient fixture;
+            readonly string sha;
+
+            public TheCreateMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                fixture = github.Git.Tag;
+                context = github.CreateRepositoryContext("public-repo").Result;
+
+                var blob = new NewBlob
+                {
+                    Content = "Hello World!",
+                    Encoding = EncodingType.Utf8
+                };
+                var blobResult = github.Git.Blob.Create(context.RepositoryOwner, context.RepositoryName, blob).Result;
+
+                sha = blobResult.Sha;
+            }
+
+            [IntegrationTest]
+            public async Task CreatesTagForRepository()
+            {
+                var newTag = new NewTag { Message = "Hello", Type = TaggedType.Blob, Object = sha, Tag = "tag" };
+
+                var tag = await fixture.Create(context.Repository.Id, newTag);
+
+                Assert.Equal(tag.Object.Type, TaggedType.Blob);
+                Assert.Equal(tag.Message, "Hello");
+                Assert.Equal(tag.Object.Sha, sha);
+            }
+
+            [IntegrationTest]
+            public async Task CreatesTagForRepositoryWithRepositoryId()
+            {
+                var newTag = new NewTag { Message = "Hello", Type = TaggedType.Tree, Object = sha, Tag = "tag" };
+
+                var tag = await fixture.Create(context.Repository.Id, newTag);
+
+                Assert.Equal(tag.Object.Type, TaggedType.Blob);
+                Assert.Equal(tag.Message, "Hello");
+                Assert.Equal(tag.Object.Sha, sha);
+            }
+        }
+
+        public class TheGetMethod
+        {
+            readonly RepositoryContext context;
+            readonly ITagsClient fixture;
+            readonly string sha;
+
+            public TheGetMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                fixture = github.Git.Tag;
+                context = github.CreateRepositoryContext("public-repo").Result;
+
+                var blob = new NewBlob
+                {
+                    Content = "Hello World!",
+                    Encoding = EncodingType.Utf8
+                };
+                var blobResult = github.Git.Blob.Create(context.RepositoryOwner, context.RepositoryName, blob).Result;
+
+                sha = blobResult.Sha;
+            }
+
+            [IntegrationTest]
+            public async Task CreatesTagForRepository()
+            {
+                var newTag = new NewTag { Message = "Hello", Type = TaggedType.Blob, Object = sha, Tag = "tag" };
+
+                var tag = await fixture.Create(context.RepositoryOwner, context.RepositoryName, newTag);
+                var gitTag = await fixture.Get(context.RepositoryOwner, context.RepositoryName, tag.Sha);
+
+                Assert.NotNull(gitTag);
+                Assert.Equal(gitTag.Object.Type, TaggedType.Blob);
+                Assert.Equal(gitTag.Message, "Hello");
+                Assert.Equal(gitTag.Object.Sha, sha);
+            }
+
+            [IntegrationTest]
+            public async Task CreatesTagForRepositoryWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var newTag = new NewTag { Message = "Hello", Type = TaggedType.Blob, Object = sha, Tag = "tag" };
+
+                var tag = await github.Git.Tag.Create(context.Repository.Id, newTag);
+
+                var gitTag = await github.Git.Tag.Get(context.Repository.Id, tag.Sha);
+
+                Assert.NotNull(gitTag);
+                Assert.Equal(gitTag.Object.Type, TaggedType.Blob);
+                Assert.Equal(gitTag.Message, "Hello");
+                Assert.Equal(gitTag.Object.Sha, sha);
+            }
+        }
+    }
+}

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Clients\SearchClientTests.cs" />
     <Compile Include="Clients\StarredClientTests.cs" />
     <Compile Include="Clients\StatisticsClientTests.cs" />
+    <Compile Include="Clients\TagsClientTests.cs" />
     <Compile Include="Clients\TreeClientTests.cs" />
     <Compile Include="Clients\UserAdministrationClientTests.cs" />
     <Compile Include="Clients\UserEmailsClientTests.cs" />

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -10,14 +10,25 @@ public class TagsClientTests
     public class TheGetMethod
     {
         [Fact]
-        public void RequestsCorrectUrl()
+        public async Task RequestsCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new TagsClient(connection);
 
-            client.Get("owner", "repo", "reference");
+            await client.Get("owner", "repo", "reference");
 
             connection.Received().Get<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/tags/reference"));
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new TagsClient(connection);
+
+            await client.Get(1, "reference");
+
+            connection.Received().Get<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/tags/reference"));
         }
 
         [Fact]
@@ -28,9 +39,14 @@ public class TagsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "reference"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "reference"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(1, null));
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference"));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference"));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get(1, ""));
         }
     }
 
@@ -49,6 +65,18 @@ public class TagsClientTests
         }
 
         [Fact]
+        public void PostsToTheCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new TagsClient(connection);
+
+            client.Create(1, new NewTag { Type = TaggedType.Tree });
+
+            connection.Received().Post<GitTag>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/tags"),
+                                            Arg.Is<NewTag>(nt => nt.Type == TaggedType.Tree));
+        }
+
+        [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var client = new TagsClient(Substitute.For<IApiConnection>());
@@ -56,6 +84,9 @@ public class TagsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewTag()));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewTag()));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewTag()));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewTag()));
         }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Reactive\ObservableRepositoryHooksClientTests.cs" />
     <Compile Include="Reactive\ObservableStarredClientTests.cs" />
     <Compile Include="Reactive\ObservableStatisticsClientTests.cs" />
+    <Compile Include="Reactive\ObservableTagsClientTests.cs" />
     <Compile Include="Reactive\ObservableTeamsClientTests.cs" />
     <Compile Include="Reactive\ObservableTreesClientTests.cs" />
     <Compile Include="Reactive\ObservableFollowersTest.cs" />

--- a/Octokit.Tests/Reactive/ObservableTagsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTagsClientTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class TagsClientTests
+    {
+        public class TheGetMethod
+        {
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableTagsClient(gitHubClient);
+
+                client.Get("owner", "repo", "reference");
+
+                gitHubClient.Received().Git.Tag.Get("owner", "repo", "reference");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableTagsClient(gitHubClient);
+
+                client.Get(1, "reference");
+
+                gitHubClient.Received().Git.Tag.Get(1, "reference");
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableTagsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Get(1, ""));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void PostsToTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableTagsClient(gitHubClient);
+
+                var newTag = new NewTag { Type = TaggedType.Tree };
+
+                client.Create("owner", "repo", newTag);
+
+                gitHubClient.Received().Git.Tag.Create("owner", "repo", newTag);
+            }
+
+            [Fact]
+            public void PostsToTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableTagsClient(gitHubClient);
+
+                var newTag = new NewTag { Type = TaggedType.Tree };
+
+                client.Create(1, newTag);
+
+                gitHubClient.Received().Git.Tag.Create(1, newTag);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableTagsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewTag()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewTag()));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewTag()));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewTag()));
+            }
+        }
+
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableTagsClient(null));
+            }
+        }
+    }
+}

--- a/Octokit/Clients/ITagsClient.cs
+++ b/Octokit/Clients/ITagsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GitTag> Get(string owner, string name, string reference);
@@ -33,7 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GitTag> Get(int repositoryId, string reference);
@@ -47,7 +45,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         Task<GitTag> Create(string owner, string name, NewTag tag);
 
         /// <summary>
@@ -58,7 +55,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         Task<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit/Clients/ITagsClient.cs
+++ b/Octokit/Clients/ITagsClient.cs
@@ -20,10 +20,23 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GitTag> Get(string owner, string name, string reference);
+
+        /// <summary>
+        /// Gets a tag for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#get-a-tag
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the tag</param>
+        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Method makes a network request")]
+        Task<GitTag> Get(int repositoryId, string reference);
 
         /// <summary>
         /// Create a tag for a given repository
@@ -34,7 +47,18 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
         Task<GitTag> Create(string owner, string name, NewTag tag);
+
+        /// <summary>
+        /// Create a tag for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#create-a-tag-object
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="tag">The tag to create</param>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        Task<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit/Clients/ITagsClient.cs
+++ b/Octokit/Clients/ITagsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GitTag> Get(string owner, string name, string reference);
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<GitTag> Get(int repositoryId, string reference);
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         Task<GitTag> Create(string owner, string name, NewTag tag);
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         Task<GitTag> Create(int repositoryId, NewTag tag);
     }
 }

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -28,7 +28,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         public Task<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +45,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
         public Task<GitTag> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +61,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         public Task<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +78,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
         public Task<GitTag> Create(int repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         public Task<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        /// <returns></returns>
         public Task<GitTag> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         public Task<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        /// <returns></returns>
         public Task<GitTag> Create(int repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
         public Task<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -36,6 +36,22 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return ApiConnection.Get<GitTag>(ApiUrls.Tag(owner, name, reference));
+        }
+
+        /// <summary>
+        /// Gets a tag for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#get-a-tag
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the tag</param>
+        /// <returns>A <see cref="GitTag"/> representing git tag for specified repository and reference</returns>
+        public Task<GitTag> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<GitTag>(ApiUrls.Tag(repositoryId, reference));
         }
 
         /// <summary>
@@ -47,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
         public Task<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -55,6 +71,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(tag, "tag");
 
             return ApiConnection.Post<GitTag>(ApiUrls.CreateTag(owner, name), tag);
+        }
+
+        /// <summary>
+        /// Create a tag for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/tags/#create-a-tag-object
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="tag">The tag to create</param>
+        /// <returns>A <see cref="GitTag"/> representing created git tag for specified repository</returns>
+        public Task<GitTag> Create(int repositoryId, NewTag tag)
+        {
+            Ensure.ArgumentNotNull(tag, "tag");
+
+            return ApiConnection.Post<GitTag>(ApiUrls.CreateTag(repositoryId), tag);
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)TagsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of ITagsClient and IObservableTagsClient).**

	  There is some divergence between XML documentation of methods in ITagsClient and IObservableTagsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to ITagsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableTagsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble