### PR TITLE
Add repositoryId overloads to methods on I(Observable)CommitsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Commits API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/commits/">Git Commits API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableCommitsClient
     {
         /// <summary>
@@ -14,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Commit> Get(string owner, string name, string reference);
@@ -28,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
         IObservable<Commit> Create(string owner, string name, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -26,6 +26,19 @@ namespace Octokit.Reactive
         IObservable<Commit> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a commit for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#get-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the commit</param>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Method makes a network request")]
+        IObservable<Commit> Get(int repositoryId, string reference);
+
+        /// <summary>
         /// Create a commit for a given repository
         /// </summary>
         /// <remarks>
@@ -36,5 +49,16 @@ namespace Octokit.Reactive
         /// <param name="commit">The commit to create</param>
         /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
         IObservable<Commit> Create(string owner, string name, NewCommit commit);
+        
+        /// <summary>
+        /// Create a commit for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#create-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="commit">The commit to create</param>
+        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        IObservable<Commit> Create(int repositoryId, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Commit> Get(string owner, string name, string reference);
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Commit> Get(int repositoryId, string reference);
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         IObservable<Commit> Create(string owner, string name, NewCommit commit);
         
         /// <summary>
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         IObservable<Commit> Create(int repositoryId, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Commit> Get(string owner, string name, string reference);
@@ -33,7 +32,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Commit> Get(int repositoryId, string reference);
@@ -47,7 +45,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         IObservable<Commit> Create(string owner, string name, NewCommit commit);
         
         /// <summary>
@@ -58,7 +55,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         IObservable<Commit> Create(int repositoryId, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         public IObservable<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         public IObservable<Commit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         public IObservable<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         public IObservable<Commit> Create(int repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -29,7 +29,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         public IObservable<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +46,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         public IObservable<Commit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -64,7 +62,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         public IObservable<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +79,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         public IObservable<Commit> Create(int repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -40,6 +40,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a commit for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#get-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the commit</param>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        public IObservable<Commit> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _client.Get(repositoryId, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Create a commit for a given repository
         /// </summary>
         /// <remarks>
@@ -56,6 +72,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(commit, "commit");
 
             return _client.Create(owner, name, commit).ToObservable();
+        }
+
+        /// <summary>
+        /// Create a commit for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#create-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="commit">The commit to create</param>
+        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
+        public IObservable<Commit> Create(int repositoryId, NewCommit commit)
+        {
+            Ensure.ArgumentNotNull(commit, "commit");
+
+            return _client.Create(repositoryId, commit).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -3,6 +3,12 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Git Commits API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/commits/">Git Commits API documentation</a> for more information.
+    /// </remarks>
     public class ObservableCommitsClient : IObservableCommitsClient
     {
         readonly ICommitsClient _client;
@@ -10,6 +16,7 @@ namespace Octokit.Reactive
         public ObservableCommitsClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
+
             _client = client.Git.Commit;
         }
 
@@ -22,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
         public IObservable<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Commit}"/> of <see cref="Commit"/> representing created commit for specified repository</returns>
         public IObservable<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitsClientTests.cs
@@ -60,4 +60,42 @@ public class CommitsClientTests
 
         Assert.Equal(commit.Verification.Reason, VerificationReason.UnknownKey);
     }
+
+    [IntegrationTest]
+    public async Task CanCreateAndRetrieveCommitWithRepositoryId()
+    {
+        var github = Helper.GetAuthenticatedClient();
+        var fixture = github.Git.Commit;
+
+        using (var context = await github.CreateRepositoryContext("public-repo"))
+        {
+            var owner = context.Repository.Owner.Login;
+
+            var blob = new NewBlob
+            {
+                Content = "Hello World!",
+                Encoding = EncodingType.Utf8
+            };
+            var blobResult = await github.Git.Blob.Create(owner, context.Repository.Name, blob);
+
+            var newTree = new NewTree();
+            newTree.Tree.Add(new NewTreeItem
+            {
+                Type = TreeType.Blob,
+                Mode = FileMode.File,
+                Path = "README.md",
+                Sha = blobResult.Sha
+            });
+
+            var treeResult = await github.Git.Tree.Create(owner, context.Repository.Name, newTree);
+
+            var newCommit = new NewCommit("test-commit", treeResult.Sha);
+
+            var commit = await fixture.Create(context.Repository.Id, newCommit);
+            Assert.NotNull(commit);
+
+            var retrieved = await fixture.Get(context.Repository.Id, commit.Sha);
+            Assert.NotNull(retrieved);
+        }
+    }
 }

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -18,7 +18,8 @@ public class CommitsClientTests
 
             await client.Get("owner", "repo", "reference");
 
-            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"));
+            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"), null, 
+                "application/vnd.github.cryptographer-preview+sha");
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/CommitsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitsClientTests.cs
@@ -11,6 +11,28 @@ public class CommitsClientTests
     public class TheGetMethod
     {
         [Fact]
+        public async Task RequestsCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new CommitsClient(connection);
+
+            await client.Get("owner", "repo", "reference");
+
+            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"));
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new CommitsClient(connection);
+
+            await client.Get(1, "reference");
+
+            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/commits/reference"));
+        }
+
+        [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var client = new CommitsClient(Substitute.For<IApiConnection>());
@@ -18,20 +40,14 @@ public class CommitsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "reference"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "reference"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(1, null));
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference"));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference"));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
-        }
 
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new CommitsClient(connection);
-
-            client.Get("owner", "repo", "reference");
-
-            connection.Received().Get<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits/reference"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.cryptographer-preview+sha");
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Get(1, ""));
         }
     }
 
@@ -48,9 +64,26 @@ public class CommitsClientTests
             client.Create("owner", "repo", newCommit);
 
             connection.Received().Post<Commit>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/commits"),
-                                               Arg.Is<NewCommit>(nc => nc.Message == "message"
-                                                                    && nc.Tree == "tree"
-                                                                    && nc.Parents.Count() == 2));
+                Arg.Is<NewCommit>(nc => nc.Message == "message"
+                    && nc.Tree == "tree"
+                    && nc.Parents.Count() == 2));
+        }
+
+        [Fact]
+        public void PostsToTheCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new CommitsClient(connection);
+
+            var parents = new List<string> { "sha-reference1", "sha-reference2" };
+            var newCommit = new NewCommit("message", "tree", parents);
+
+            client.Create(1, newCommit);
+
+            connection.Received().Post<Commit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/commits"),
+                Arg.Is<NewCommit>(nc => nc.Message == "message"
+                    && nc.Tree == "tree"
+                    && nc.Parents.Count() == 2));
         }
 
         [Fact]
@@ -59,9 +92,13 @@ public class CommitsClientTests
             var client = new CommitsClient(Substitute.For<IApiConnection>());
 
             var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
+
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newCommit));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newCommit));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit));
         }

--- a/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitsClientTests.cs
@@ -21,19 +21,6 @@ namespace Octokit.Tests.Reactive
         public class TheGetMethod
         {
             [Fact]
-            public async Task EnsureNonNullArguments()
-            {
-                var client = new ObservableCommitsClient(Substitute.For<IGitHubClient>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "reference").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "reference").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", "").ToTask());
-            }
-
-            [Fact]
             public async Task RequestsCorrectUrl()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -43,33 +30,79 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Git.Commit.Received(1).Get("owner", "name", "reference");
             }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitsClient(gitHubClient);
+
+                client.Get(1, "reference");
+
+                gitHubClient.Git.Commit.Received(1).Get(1, "reference");
+            }
+
+            [Fact]
+            public void EnsureNonNullArguments()
+            {
+                var client = new ObservableCommitsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", ""));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, ""));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Get(1, ""));
+            }
         }
 
         public class TheCreateMethod
         {
+            [Fact]
+            public async Task PostsToTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitsClient(gitHubClient);
+
+                var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
+
+                client.Create("owner", "name", newCommit);
+
+                gitHubClient.Git.Commit.Received().Create("owner", "name", newCommit);
+            }
+
+            [Fact]
+            public async Task PostsToTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCommitsClient(gitHubClient);
+
+                var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
+
+                client.Create(1, newCommit);
+
+                gitHubClient.Git.Commit.Received().Create(1, newCommit);
+            }
+
             [Fact]
             public async Task EnsureNonNullArguments()
             {
                 var client = new ObservableCommitsClient(Substitute.For<IGitHubClient>());
                 var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newCommit).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newCommit).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newCommit).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newCommit).ToTask());
-            }
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", newCommit));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, newCommit));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
 
-            [Fact]
-            public async Task RequestsCorrectUrl()
-            {
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableCommitsClient(gitHubClient);
-                var newCommit = new NewCommit("message", "tree", new[] { "parent1", "parent2" });
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
 
-                client.Create("owner", "name", newCommit);
-
-                gitHubClient.Git.Commit.Received().Create("owner", "name", newCommit);
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", newCommit));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", newCommit));
             }
         }
     }

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -39,6 +39,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a commit for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#get-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the commit</param>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        public Task<Commit> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<Commit>(ApiUrls.Commit(repositoryId, reference));
+        }
+
+        /// <summary>
         /// Create a commit for a given repository
         /// </summary>
         /// <remarks>
@@ -55,6 +71,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(commit, "commit");
 
             return ApiConnection.Post<Commit>(ApiUrls.CreateCommit(owner, name), commit);
+        }
+
+        /// <summary>
+        /// Create a commit for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#create-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="commit">The commit to create</param>
+        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        public Task<Commit> Create(int repositoryId, NewCommit commit)
+        {
+            Ensure.ArgumentNotNull(commit, "commit");
+
+            return ApiConnection.Post<Commit>(ApiUrls.CreateCommit(repositoryId), commit);
         }
     }
 }

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         public Task<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         public Task<Commit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         public Task<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         public Task<Commit> Create(int repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
         public Task<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
         public Task<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -28,7 +28,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         public Task<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +45,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         public Task<Commit> Get(int repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -63,7 +61,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         public Task<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +78,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         public Task<Commit> Create(int repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");

--- a/Octokit/Clients/ICommitsClient.cs
+++ b/Octokit/Clients/ICommitsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<Commit> Get(string owner, string name, string reference);
@@ -34,7 +34,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
         Task<Commit> Create(string owner, string name, NewCommit commit);
     }
 }

--- a/Octokit/Clients/ICommitsClient.cs
+++ b/Octokit/Clients/ICommitsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<Commit> Get(string owner, string name, string reference);
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<Commit> Get(int repositoryId, string reference);
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         Task<Commit> Create(string owner, string name, NewCommit commit);
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        /// <returns></returns>
         Task<Commit> Create(int repositoryId, NewCommit commit);
     }
 }

--- a/Octokit/Clients/ICommitsClient.cs
+++ b/Octokit/Clients/ICommitsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<Commit> Get(string owner, string name, string reference);
@@ -33,7 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         Task<Commit> Get(int repositoryId, string reference);
@@ -47,7 +45,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         Task<Commit> Create(string owner, string name, NewCommit commit);
 
         /// <summary>
@@ -58,7 +55,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="commit">The commit to create</param>
-        /// <returns></returns>
         Task<Commit> Create(int repositoryId, NewCommit commit);
     }
 }

--- a/Octokit/Clients/ICommitsClient.cs
+++ b/Octokit/Clients/ICommitsClient.cs
@@ -26,6 +26,19 @@ namespace Octokit
         Task<Commit> Get(string owner, string name, string reference);
 
         /// <summary>
+        /// Gets a commit for a given repository by sha reference
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#get-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">Tha sha reference of the commit</param>
+        /// <returns>A <see cref="Commit"/> representing commit for specified repository and reference</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Method makes a network request")]
+        Task<Commit> Get(int repositoryId, string reference);
+
+        /// <summary>
         /// Create a commit for a given repository
         /// </summary>
         /// <remarks>
@@ -36,5 +49,16 @@ namespace Octokit
         /// <param name="commit">The commit to create</param>
         /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
         Task<Commit> Create(string owner, string name, NewCommit commit);
+
+        /// <summary>
+        /// Create a commit for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/commits/#create-a-commit
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="commit">The commit to create</param>
+        /// <returns>A <see cref="Commit"/> representing created commit for specified repository</returns>
+        Task<Commit> Create(int repositoryId, NewCommit commit);
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)CommitsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of ICommitsClient and IObservableCommitsClient).**

	  There is some divergence between XML documentation of methods in ICommitsClient and IObservableCommitsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to ICommitsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableCommitsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble