### PR TITLE
Add repositoryId overloads to methods on I(Observable)DeploymentStatusClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -21,7 +21,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
@@ -33,7 +32,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId);
 
         /// <summary>
@@ -47,7 +45,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -60,7 +57,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -74,7 +70,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
@@ -87,7 +82,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -2,6 +2,13 @@ using System;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Repository Deployment Statuses API.
+    /// Gets and creates Deployment Statuses.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/deployments/">Repository Deployment Statuses API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableDeploymentStatusClient
     {
         /// <summary>
@@ -14,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
@@ -28,7 +35,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -42,7 +49,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -31,12 +31,37 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId);
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -51,5 +76,18 @@ namespace Octokit.Reactive
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+
+        /// <summary>
+        /// Creates a new status for the given deployment. Users with push access can create deployment
+        /// statuses for a given deployment.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
+        IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -4,6 +4,13 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive.Clients
 {
+    /// <summary>
+    /// A client for GitHub's Repository Deployment Statuses API.
+    /// Gets and creates Deployment Statuses.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/deployments/">Repository Deployment Statuses API documentation</a> for more information.
+    /// </remarks>
     public class ObservableDeploymentStatusClient : IObservableDeploymentStatusClient
     {
         private readonly IDeploymentStatusClient _client;
@@ -27,7 +34,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +54,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +76,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             return _client.Create(owner, name, deploymentId, newDeploymentStatus).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -108,6 +108,8 @@ namespace Octokit.Reactive.Clients
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         public IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
 
             return _client.Create(owner, name, deploymentId, newDeploymentStatus).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -34,7 +34,6 @@ namespace Octokit.Reactive.Clients
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -52,7 +51,6 @@ namespace Octokit.Reactive.Clients
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
@@ -69,7 +67,6 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -90,7 +87,6 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -110,7 +106,6 @@ namespace Octokit.Reactive.Clients
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
@@ -128,7 +123,6 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -50,6 +50,21 @@ namespace Octokit.Reactive.Clients
         /// <remarks>
         /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId)
+        {
+            return GetAll(repositoryId, deploymentId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
@@ -66,6 +81,25 @@ namespace Octokit.Reactive.Clients
         }
 
         /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<DeploymentStatus>(
+                ApiUrls.DeploymentStatuses(repositoryId, deploymentId), options);
+        }
+
+        /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
         /// statuses for a given deployment.
         /// </summary>
@@ -79,7 +113,27 @@ namespace Octokit.Reactive.Clients
         /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public IObservable<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
+            Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
+
             return _client.Create(owner, name, deploymentId, newDeploymentStatus).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a new status for the given deployment. Users with push access can create deployment
+        /// statuses for a given deployment.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
+        public IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        {
+            Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
+
+            return _client.Create(repositoryId, deploymentId, newDeploymentStatus).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/DeploymentStatusClientTests.cs
@@ -56,6 +56,17 @@ public class DeploymentStatusClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanCreateDeploymentStatusWithRepositoryId()
+    {
+        var newStatus = new NewDeploymentStatus(DeploymentState.Success);
+
+        var status = await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus);
+
+        Assert.NotNull(status);
+        Assert.Equal(DeploymentState.Success, status.State);
+    }
+
+    [IntegrationTest]
     public async Task CanReadDeploymentStatuses()
     {
         var newStatus = new NewDeploymentStatus(DeploymentState.Success) { LogUrl = "http://test.com/log", EnvironmentUrl = "http:test.com/staging" };
@@ -67,6 +78,18 @@ public class DeploymentStatusClientTests : IDisposable
         Assert.Equal(DeploymentState.Success, statuses[0].State);
         Assert.Equal(newStatus.LogUrl, statuses[0].LogUrl);
         Assert.Equal(newStatus.EnvironmentUrl, statuses[0].EnvironmentUrl);
+    }
+
+    [IntegrationTest]
+    public async Task CanReadDeploymentStatusesWithRepositoryId()
+    {
+        var newStatus = new NewDeploymentStatus(DeploymentState.Success);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus);
+
+        var statuses = await _deploymentsClient.Status.GetAll(_context.Repository.Id, _deployment.Id);
+
+        Assert.NotEmpty(statuses);
+        Assert.Equal(DeploymentState.Success, statuses[0].State);
     }
 
     [IntegrationTest]
@@ -91,6 +114,27 @@ public class DeploymentStatusClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfDeploymentStatusesWithoutStartWithRepositoryId()
+    {
+        var newStatus1 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus2 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus3 = new NewDeploymentStatus(DeploymentState.Success);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus1);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus2);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var deploymentStatuses = await _deploymentsClient.Status.GetAll(_context.Repository.Id, _deployment.Id, options);
+
+        Assert.Equal(3, deploymentStatuses.Count);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfDeploymentStatusesWithStart()
     {
         var newStatus1 = new NewDeploymentStatus(DeploymentState.Success);
@@ -108,6 +152,28 @@ public class DeploymentStatusClientTests : IDisposable
         };
 
         var deploymentStatuses = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, options);
+
+        Assert.Equal(1, deploymentStatuses.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfDeploymentStatusesWithStartWithRepositoryId()
+    {
+        var newStatus1 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus2 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus3 = new NewDeploymentStatus(DeploymentState.Success);
+        await _deploymentsClient.Status.Create(_context.Repository.Id,_deployment.Id, newStatus1);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus2);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var deploymentStatuses = await _deploymentsClient.Status.GetAll(_context.Repository.Id, _deployment.Id, options);
 
         Assert.Equal(1, deploymentStatuses.Count);
     }
@@ -138,6 +204,36 @@ public class DeploymentStatusClientTests : IDisposable
         };
 
         var secondPage = await _deploymentsClient.Status.GetAll(_context.RepositoryOwner, _context.RepositoryName, _deployment.Id, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctDeploymentStatusesBasedOnStartPageWithRepositoryId()
+    {
+        var newStatus1 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus2 = new NewDeploymentStatus(DeploymentState.Success);
+        var newStatus3 = new NewDeploymentStatus(DeploymentState.Success);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus1);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus2);
+        await _deploymentsClient.Status.Create(_context.Repository.Id, _deployment.Id, newStatus3);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _deploymentsClient.Status.GetAll(_context.Repository.Id, _deployment.Id, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _deploymentsClient.Status.GetAll(_context.Repository.Id, _deployment.Id, skipStartOptions);
 
         Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
     }

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -18,7 +18,11 @@ public class DeploymentStatusClientTests
 
             await client.GetAll("owner", "name", 1);
 
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
+            connection.Received().GetAll<
+                DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                null,
+                "application/vnd.github.ant-man-preview+json",
+                Args.ApiOptions);
         }
 
         [Fact]
@@ -49,7 +53,11 @@ public class DeploymentStatusClientTests
 
             await client.GetAll("owner", "name", 1, options);
 
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
+            connection.Received().GetAll<DeploymentStatus>(
+                Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                null,
+                "application/vnd.github.ant-man-preview+json",
+                options);
         }
 
         [Fact]
@@ -123,7 +131,8 @@ public class DeploymentStatusClientTests
             client.Create("owner", "repo", 1, newDeploymentStatus);
 
             connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                Arg.Any<NewDeploymentStatus>());
+                newDeploymentStatus,
+                "application/vnd.github.ant-man-preview+json");
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit;
@@ -167,20 +166,6 @@ public class DeploymentStatusClientTests
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create(whitespace, "repo", 1, newDeploymentStatus));
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", whitespace, 1, newDeploymentStatus));
-        }
-
-        [Fact]
-        public void PostsToCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/repo/deployments/1/statuses";
-
-            client.Create("owner", "repo", 1, newDeploymentStatus);
-
-            connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                                                         Arg.Any<NewDeploymentStatus>(),
-                                                         Arg.Any<string>());
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentStatusClientTests.cs
@@ -11,6 +11,68 @@ public class DeploymentStatusClientTests
     public class TheGetAllMethod
     {
         [Fact]
+        public async Task RequestsCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repos/owner/name/deployments/1/statuses";
+
+            await client.GetAll("owner", "name", 1);
+
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repositories/1/deployments/1/statuses";
+
+            await client.GetAll(1, 1);
+
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repos/owner/name/deployments/1/statuses";
+
+            var options = new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            await client.GetAll("owner", "name", 1, options);
+
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repositories/1/deployments/1/statuses";
+
+            var options = new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            await client.GetAll(1, 1, options);
+
+            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), options);
+        }
+
+        [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
@@ -21,16 +83,11 @@ public class DeploymentStatusClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
-        }
 
-        [Fact]
-        public async Task EnsuresNonEmptyArguments()
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, 1, null));
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
-
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
         }
@@ -51,60 +108,37 @@ public class DeploymentStatusClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(whitespace, "name", 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", whitespace, 1, ApiOptions.None));
         }
-
-        [Fact]
-        public void RequestsCorrectUrl()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/name/deployments/1/statuses";
-
-            client.GetAll("owner", "name", 1);
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl), 
-                                                           Arg.Any<IDictionary<string, string>>(),
-                                                           Arg.Any<string>(),
-                                                           Args.ApiOptions);
-        }
-
-        [Fact]
-        public void RequestsCorrectUrlWithApiOptions()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/name/deployments/1/statuses";
-
-            var options = new ApiOptions
-            {
-                StartPage = 1,
-                PageCount = 1,
-                PageSize = 1
-            };
-
-            client.GetAll("owner", "name", 1, options);
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                                                           Arg.Any<IDictionary<string, string>>(),
-                                                           Arg.Any<string>(), 
-                                                           options);
-        }
-
-        [Fact]
-        public void RequestsCorrectUrlWithPreviewAcceptHeaders()
-        {
-            var connection = Substitute.For<IApiConnection>();
-            var client = new DeploymentStatusClient(connection);
-            var expectedUrl = "repos/owner/name/deployments/1/statuses";
-
-            client.GetAll("owner", "name", 1);
-            connection.Received().GetAll<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
-                                                           Arg.Any<IDictionary<string, string>>(),
-                                                           Arg.Is<string>(a => a == AcceptHeaders.DeploymentApiPreview),
-                                                           Args.ApiOptions);
-        }
     }
 
     public class TheCreateMethod
     {
         readonly NewDeploymentStatus newDeploymentStatus = new NewDeploymentStatus(DeploymentState.Success);
+
+        [Fact]
+        public void PostsToCorrectUrl()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repos/owner/repo/deployments/1/statuses";
+
+            client.Create("owner", "repo", 1, newDeploymentStatus);
+
+            connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                Arg.Any<NewDeploymentStatus>());
+        }
+
+        [Fact]
+        public void PostsToCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new DeploymentStatusClient(connection);
+            var expectedUrl = "repositories/1/deployments/1/statuses";
+
+            client.Create(1, 1, newDeploymentStatus);
+
+            connection.Received().Post<DeploymentStatus>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                Arg.Any<NewDeploymentStatus>());
+        }
 
         [Fact]
         public async Task EnsuresNonNullArguments()
@@ -113,15 +147,12 @@ public class DeploymentStatusClientTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, newDeploymentStatus));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, newDeploymentStatus));
-        }
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
 
-        [Fact]
-        public async Task EnsuresNonEmptyArguments()
-        {
-            var client = new DeploymentStatusClient(Substitute.For<IApiConnection>());
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, 1, null));
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, newDeploymentStatus));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, newDeploymentStatus));
         }
 
         [Theory]

--- a/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentStatusClientTests.cs
@@ -23,22 +23,84 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var expectedUri = string.Format("repos/{0}/{1}/deployments/{2}/statuses", "owner", "repo", 1);
+
+                _client.GetAll("owner", "repo", 1);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri),
+                                                      Args.EmptyDictionary,
+                                                      null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var expectedUri = string.Format("repositories/{0}/deployments/{1}/statuses", 1, 1);
+
+                _client.GetAll(1, 1);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri),
+                                                      Args.EmptyDictionary,
+                                                      null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var expectedUri = string.Format("repos/{0}/{1}/deployments/{2}/statuses", "owner", "repo", 1);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                _client.GetAll("owner", "repo", 1, options);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri),
+                                                      Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2),
+                                                      null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var expectedUri = string.Format("repositories/{0}/deployments/{1}/statuses", 1, 1);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                _client.GetAll(1, 1, options);
+
+                _githubClient.Connection.Received(1)
+                    .Get<List<DeploymentStatus>>(Arg.Is<Uri>(uri => uri.ToString() == expectedUri),
+                                                      Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2),
+                                                      null);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo", 1));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null, 1));
-
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, "repo", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll("owner", "repo", 1, null));
-            }
 
-            [Fact]
-            public void EnsuresNonEmptyArguments()
-            {
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(1, 1, null));
+
                 Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1));
                 Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1));
-
                 Assert.Throws<ArgumentException>(() => _client.GetAll("", "repo", 1, ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => _client.GetAll("owner", "", 1, ApiOptions.None));
             }
@@ -55,39 +117,6 @@ namespace Octokit.Tests.Reactive
                     async whitespace => await _client.GetAll(whitespace, "repo", 1, ApiOptions.None));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
                     async whitespace => await _client.GetAll("owner", whitespace, 1, ApiOptions.None));
-            }
-
-            [Fact]
-            public void RequestsCorrectUrl()
-            {
-                var expectedUri = ApiUrls.DeploymentStatuses("owner", "repo", 1);
-
-                _client.GetAll("owner", "repo", 1);
-
-                _githubClient.Connection.Received(1)
-                    .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
-                                                      Args.EmptyDictionary,
-                                                      null);
-            }
-
-            [Fact]
-            public void RequestsCorrectUrlWitApiOptions()
-            {
-                var expectedUri = ApiUrls.DeploymentStatuses("owner", "repo", 1);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                _client.GetAll("owner", "repo", 1, options);
-
-                _githubClient.Connection.Received(1)
-                    .Get<List<DeploymentStatus>>(Arg.Is(expectedUri),
-                                                      Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2),
-                                                      null);
             }
         }
 
@@ -109,18 +138,42 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresNonNullArguments()
+            public void CallsIntoDeploymentStatusClient()
             {
-                SetupWithNonReactiveClient();
-                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
-                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, 1, new NewDeploymentStatus(DeploymentState.Success)));
-                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", "repo", 1, null));
+                SetupWithoutNonReactiveClient();
+
+                var newStatus = new NewDeploymentStatus(DeploymentState.Success);
+
+                _client.Create("owner", "repo", 1, newStatus);
+
+                _githubClient.Repository.Deployment.Status.Received(1)
+                    .Create("owner", "repo", 1, newStatus);
             }
 
             [Fact]
-            public async Task EnsuresNonEmptyArguments()
+            public void CallsIntoDeploymentStatusClientWithRepositoryId()
+            {
+                SetupWithoutNonReactiveClient();
+
+                var newStatus = new NewDeploymentStatus(DeploymentState.Success);
+
+                _client.Create(1, 1, newStatus);
+
+                _githubClient.Repository.Deployment.Status.Received(1)
+                    .Create(1, 1, newStatus);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentNullException>(() => _client.Create(null, "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
+                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", null, 1, new NewDeploymentStatus(DeploymentState.Success)));
+                Assert.Throws<ArgumentNullException>(() => _client.Create("owner", "repo", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => _client.Create(1, 1, null));
+
                 Assert.Throws<ArgumentException>(() => _client.Create("", "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
                 Assert.Throws<ArgumentException>(() => _client.Create("owner", "", 1, new NewDeploymentStatus(DeploymentState.Success)));
             }
@@ -129,24 +182,11 @@ namespace Octokit.Tests.Reactive
             public async Task EnsureNonWhitespaceArguments()
             {
                 SetupWithNonReactiveClient();
+
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
                     async whitespace => await _client.Create(whitespace, "repo", 1, new NewDeploymentStatus(DeploymentState.Success)));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
                     async whitespace => await _client.Create("owner", whitespace, 1, new NewDeploymentStatus(DeploymentState.Success)));
-            }
-
-            [Fact]
-            public void CallsIntoDeploymentStatusClient()
-            {
-                SetupWithoutNonReactiveClient();
-
-                var newStatus = new NewDeploymentStatus(DeploymentState.Success);
-                _client.Create("owner", "repo", 1, newStatus);
-                _githubClient.Repository.Deployment.Status.Received(1)
-                    .Create(Arg.Is("owner"),
-                            Arg.Is("repo"),
-                            Arg.Is(1),
-                            Arg.Is(newStatus));
             }
         }
 

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -43,6 +43,21 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId)
+        {
+            return GetAll(repositoryId, deploymentId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
@@ -58,6 +73,24 @@ namespace Octokit
                                                           null,
                                                           AcceptHeaders.DeploymentApiPreview,
                                                           options);
+        }
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<DeploymentStatus>(ApiUrls.DeploymentStatuses(repositoryId, deploymentId), options);
         }
 
         /// <summary>
@@ -81,6 +114,25 @@ namespace Octokit
             return ApiConnection.Post<DeploymentStatus>(ApiUrls.DeploymentStatuses(owner, name, deploymentId),
                                                         newDeploymentStatus,
                                                         AcceptHeaders.DeploymentApiPreview);
+        }
+
+        /// <summary>
+        /// Creates a new status for the given deployment. Users with push access can create deployment
+        /// statuses for a given deployment.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="newDeploymentStatus"></param>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
+        public Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        {
+            Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
+
+            return ApiConnection.Post<DeploymentStatus>(ApiUrls.DeploymentStatuses(repositoryId, deploymentId),
+                                                        newDeploymentStatus);
         }
     }
 }

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <param name="newDeploymentStatus"></param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -120,7 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <param name="newDeploymentStatus"></param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         public Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -27,7 +27,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +44,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
@@ -62,7 +60,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -85,7 +82,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -104,7 +100,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -126,7 +121,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +71,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -22,7 +22,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
@@ -34,7 +33,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId);
 
         /// <summary>
@@ -48,7 +46,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -61,7 +58,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -75,7 +71,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
@@ -88,7 +83,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All deployment statuses for the given deployment.</returns>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus"></param>
-        /// <returns></returns>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <param name="newDeploymentStatus"></param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        /// <param name="newDeploymentStatus"></param>
+        /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -32,12 +32,37 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId);
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
         Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
+        /// view deployments.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#list-deployment-statuses
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{DeploymentStatus}"/> of <see cref="DeploymentStatus"/>es for the given deployment.</returns>
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -52,5 +77,18 @@ namespace Octokit
         /// <param name="newDeploymentStatus"></param>
         /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
         Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+
+        /// <summary>
+        /// Creates a new status for the given deployment. Users with push access can create deployment
+        /// statuses for a given deployment.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/repos/deployments/#create-a-deployment-status
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="deploymentId">The id of the deployment.</param>
+        /// <param name="newDeploymentStatus"></param>
+        /// <returns>A <see cref="DeploymentStatus"/> representing created deployment status.</returns>
+        Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)DeploymentStatusClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IDeploymentStatusClient and IObservableDeploymentStatusClient).**

	  There is some divergence between XML documentation of methods in IDeploymentStatusClient and IObservableDeploymentStatusClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IDeploymentStatusClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableDeploymentStatusClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble