### PR TITLE
Add repositoryId overloads to methods on I(Observable)WatchedClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -103,7 +103,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -17,7 +17,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<User> GetAllWatchers(string owner, string name);
 
         /// <summary>
@@ -25,7 +24,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<User> GetAllWatchers(int repositoryId);
 
         /// <summary>
@@ -35,7 +33,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<User> GetAllWatchers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -44,14 +41,12 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Repository> GetAllForCurrent();
 
@@ -60,7 +55,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<Repository> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -68,7 +62,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<Repository> GetAllForUser(string user);
 
         /// <summary>
@@ -77,7 +70,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<Repository> GetAllForUser(string user, ApiOptions options);
 
         /// <summary>
@@ -86,7 +78,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<bool> CheckWatched(string owner, string name);
 
         /// <summary>
@@ -94,7 +85,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         IObservable<bool> CheckWatched(int repositoryId);
 
         /// <summary>
@@ -103,7 +93,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -111,7 +100,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
@@ -119,7 +107,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(string owner, string name);
@@ -128,7 +115,6 @@ namespace Octokit.Reactive
         /// Unstars a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(int repositoryId);

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Watching API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/activity/watching/">Watching API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableWatchedClient
     {
         /// <summary>
@@ -17,12 +23,29 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the watchers for the passed repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        IObservable<User> GetAllWatchers(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
         IObservable<User> GetAllWatchers(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API's response.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
@@ -67,6 +90,14 @@ namespace Octokit.Reactive
         IObservable<bool> CheckWatched(string owner, string name);
 
         /// <summary>
+        /// Check if a repository is watched by the current authenticated user
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        IObservable<bool> CheckWatched(int repositoryId);
+
+        /// <summary>
         /// Stars a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
@@ -74,6 +105,14 @@ namespace Octokit.Reactive
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
         /// <returns>A <c>bool</c> representing the success of starring</returns>
         IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
+
+        /// <summary>
+        /// Stars a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
         /// Unstars a repository for the authenticated user.
@@ -84,5 +123,14 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(string owner, string name);
+
+        /// <summary>
+        /// Unstars a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
+            Justification = "Unwatch is consistent with the GitHub website")]
+        IObservable<bool> UnwatchRepo(int repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         IObservable<User> GetAllWatchers(string owner, string name);
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         IObservable<User> GetAllWatchers(int repositoryId);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         IObservable<User> GetAllWatchers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -44,14 +44,14 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/></returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Repository> GetAllForCurrent();
 
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/></returns>
+        /// <returns></returns>
         IObservable<Repository> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> watched by the specified user</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAllForUser(string user);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> watched by the specified user</returns>
+        /// <returns></returns>
         IObservable<Repository> GetAllForUser(string user, ApiOptions options);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         IObservable<bool> CheckWatched(string owner, string name);
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         IObservable<bool> CheckWatched(int repositoryId);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(string owner, string name);
@@ -128,7 +128,7 @@ namespace Octokit.Reactive
         /// Unstars a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         IObservable<bool> UnwatchRepo(int repositoryId);

--- a/Octokit.Reactive/Clients/ObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/ObservableWatchedClient.cs
@@ -29,7 +29,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<User> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +42,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<User> GetAllWatchers(int repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
@@ -56,7 +54,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<User> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -72,7 +69,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +80,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<Repository> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -95,7 +90,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<Repository> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -108,7 +102,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<Repository> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -122,7 +115,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<Repository> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -137,7 +129,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -151,7 +142,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns></returns>
         public IObservable<bool> CheckWatched(int repositoryId)
         {
             return _client.CheckWatched(repositoryId).ToObservable();
@@ -163,7 +153,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         public IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -178,7 +167,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         public IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
@@ -191,7 +179,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns></returns>
         public IObservable<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -204,7 +191,6 @@ namespace Octokit.Reactive
         /// Unstars a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<bool> UnwatchRepo(int repositoryId)
         {
             return _client.UnwatchRepo(repositoryId).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/ObservableWatchedClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Watching API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/activity/watching/">Watching API documentation</a> for more information.
+    /// </remarks>
     public class ObservableWatchedClient : IObservableWatchedClient
     {
         private readonly IWatchedClient _client;
@@ -35,6 +41,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the watchers for the passed repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        public IObservable<User> GetAllWatchers(int repositoryId)
+        {
+            return GetAllWatchers(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
@@ -47,6 +64,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Watchers(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API's response.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        public IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Watchers(repositoryId), options);
         }
 
         /// <summary>
@@ -116,6 +147,17 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Check if a repository is watched by the current authenticated user
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        public IObservable<bool> CheckWatched(int repositoryId)
+        {
+            return _client.CheckWatched(repositoryId).ToObservable();
+        }
+
+        /// <summary>
         /// Stars a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
@@ -126,8 +168,22 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(newSubscription, "newSubscription");
 
             return _client.WatchRepo(owner, name, newSubscription).ToObservable();
+        }
+
+        /// <summary>
+        /// Stars a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        public IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
+        {
+            Ensure.ArgumentNotNull(newSubscription, "newSubscription");
+
+            return _client.WatchRepo(repositoryId, newSubscription).ToObservable();
         }
 
         /// <summary>
@@ -142,6 +198,16 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.UnwatchRepo(owner, name).ToObservable();
+        }
+
+        /// <summary>
+        /// Unstars a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        public IObservable<bool> UnwatchRepo(int repositoryId)
+        {
+            return _client.UnwatchRepo(repositoryId).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/ObservableWatchedClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         public IObservable<User> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         public IObservable<User> GetAllWatchers(int repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
@@ -56,7 +56,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         public IObservable<User> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s watching the passed repository</returns>
+        /// <returns></returns>
         public IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/></returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -95,7 +95,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> of <see cref="Repository"/></returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -108,7 +108,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> watched by the specified user</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -122,7 +122,7 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> watched by the specified user</returns>
+        /// <returns></returns>
         public IObservable<Repository> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -137,7 +137,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public IObservable<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -151,7 +151,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public IObservable<bool> CheckWatched(int repositoryId)
         {
             return _client.CheckWatched(repositoryId).ToObservable();
@@ -163,7 +163,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -178,7 +178,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         public IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
@@ -191,7 +191,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public IObservable<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -204,7 +204,7 @@ namespace Octokit.Reactive
         /// Unstars a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public IObservable<bool> UnwatchRepo(int repositoryId)
         {
             return _client.UnwatchRepo(repositoryId).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/ObservableWatchedClient.cs
@@ -163,7 +163,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         public IObservable<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -178,7 +178,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         public IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");

--- a/Octokit.Tests.Integration/Clients/WatchedClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/WatchedClientTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Octokit.Tests.Integration.Helpers;
 using Xunit;
 
 namespace Octokit.Tests.Integration.Clients
@@ -160,6 +162,16 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task CanRetrieveResultsWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var repositories = await github.Activity.Watching.GetAllWatchers(7528679);
+
+                Assert.NotEmpty(repositories);
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfRepositoriesWithoutStart()
             {
                 var github = Helper.GetAuthenticatedClient();
@@ -171,6 +183,22 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var repositories = await github.Activity.Watching.GetAllWatchers("octokit", "octokit.net", options);
+
+                Assert.Equal(3, repositories.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfRepositoriesWithoutStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var repositories = await github.Activity.Watching.GetAllWatchers(7528679, options);
 
                 Assert.Equal(3, repositories.Count);
             }
@@ -188,6 +216,23 @@ namespace Octokit.Tests.Integration.Clients
                 };
 
                 var repositories = await github.Activity.Watching.GetAllWatchers("octokit", "octokit.net", options);
+
+                Assert.Equal(3, repositories.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfRepositoriesWithStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var repositories = await github.Activity.Watching.GetAllWatchers(7528679, options);
 
                 Assert.Equal(3, repositories.Count);
             }
@@ -215,6 +260,156 @@ namespace Octokit.Tests.Integration.Clients
                 var secondPage = await github.Activity.Watching.GetAllWatchers("octokit", "octokit.net", skipStartOptions);
 
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctPullRequestsBasedOnStartPageWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Activity.Watching.GetAllWatchers(7528679, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Activity.Watching.GetAllWatchers(7528679, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+        }
+
+        public class TheCheckWatchedMethod
+        {
+            readonly IWatchedClient _watchingClient;
+            readonly RepositoryContext _context;
+
+            public TheCheckWatchedMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _watchingClient = github.Activity.Watching;
+
+                _context = github.CreateRepositoryContext("public-repo").Result;
+            }
+
+            [IntegrationTest]
+            public async Task CheckWatched()
+            {
+                var check = await _watchingClient.CheckWatched(_context.RepositoryOwner, _context.RepositoryName);
+
+                Assert.True(check);
+            }
+
+            [IntegrationTest]
+            public async Task CheckWatchedWithRepositoryId()
+            {
+                var check = await _watchingClient.CheckWatched(_context.Repository.Id);
+
+                Assert.True(check);
+            }
+        }
+
+        public class TheWatchRepoMethod
+        {
+            readonly IWatchedClient _watchingClient;
+
+            public TheWatchRepoMethod()
+            {
+                var gitHubClient = Helper.GetAuthenticatedClient();
+
+                _watchingClient = gitHubClient.Activity.Watching;
+            }
+
+            [IntegrationTest]
+            public async Task WatchRepo()
+            {
+                var newSubscription = new NewSubscription
+                {
+                    Subscribed = true
+                };
+
+                await _watchingClient.UnwatchRepo("octocat", "hello-worId");
+
+                var subscription = await _watchingClient.WatchRepo("octocat", "hello-worId", newSubscription);
+                Assert.NotNull(subscription);
+
+                var newWatchers = await _watchingClient.GetAllWatchers("octocat", "hello-worId");
+                var @default = newWatchers.FirstOrDefault(user => user.Login == Helper.UserName);
+                Assert.NotNull(@default);
+            }
+
+            [IntegrationTest]
+            public async Task WatchRepoWithRepositoryId()
+            {
+                var newSubscription = new NewSubscription();
+
+                await _watchingClient.UnwatchRepo(18221276);
+
+                var subscription = await _watchingClient.WatchRepo(18221276, newSubscription);
+                Assert.NotNull(subscription);
+
+                var newWatchers = await _watchingClient.GetAllWatchers(18221276);
+                var @default = newWatchers.FirstOrDefault(user => user.Login == Helper.UserName);
+                Assert.NotNull(@default);
+            }
+        }
+
+        public class TheUnwatchRepoMethod
+        {
+            readonly IWatchedClient _watchingClient;
+
+            public TheUnwatchRepoMethod()
+            {
+                var gitHubClient = Helper.GetAuthenticatedClient();
+
+                _watchingClient = gitHubClient.Activity.Watching;
+            }
+
+            [IntegrationTest]
+            public async Task WatchRepo()
+            {
+                var newSubscription = new NewSubscription
+                {
+                    Subscribed = true
+                };
+
+                await _watchingClient.UnwatchRepo("octocat", "hello-worId");
+
+                var subscription = await _watchingClient.WatchRepo("octocat", "hello-worId", newSubscription);
+                Assert.NotNull(subscription);
+
+                await _watchingClient.UnwatchRepo("octocat", "hello-worId");
+
+                var newWatchers = await _watchingClient.GetAllWatchers("octocat", "hello-worId");
+                var @default = newWatchers.FirstOrDefault(user => user.Login == Helper.UserName);
+                Assert.Null(@default);
+            }
+
+            [IntegrationTest]
+            public async Task WatchRepoWithRepositoryId()
+            {
+                var newSubscription = new NewSubscription();
+
+                await _watchingClient.UnwatchRepo(18221276);
+
+                var subscription = await _watchingClient.WatchRepo(18221276, newSubscription);
+                Assert.NotNull(subscription);
+
+                await _watchingClient.UnwatchRepo(18221276);
+
+                var newWatchers = await _watchingClient.GetAllWatchers(18221276);
+                var @default = newWatchers.FirstOrDefault(user => user.Login == Helper.UserName);
+                Assert.Null(@default);
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableWatchedClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableWatchedClientTests.cs
@@ -117,7 +117,21 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableWatchedClient(gitHubClient);
 
                 client.GetAllWatchers("jugglingnutcase", "katiejamie");
+
                 connection.Received().Get<List<User>>(ApiUrls.Watchers("jugglingnutcase", "katiejamie"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableWatchedClient(gitHubClient);
+
+                client.GetAllWatchers(1);
+
+                connection.Received().Get<List<User>>(ApiUrls.Watchers(1), Args.EmptyDictionary, null);
             }
 
             [Fact]
@@ -136,7 +150,28 @@ namespace Octokit.Tests.Reactive
                 };
 
                 client.GetAllWatchers("jugglingnutcase", "katiejamie", options);
+
                 connection.Received().Get<List<User>>(ApiUrls.Watchers("jugglingnutcase", "katiejamie"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableWatchedClient(gitHubClient);
+
+                ApiOptions options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllWatchers(1, options);
+
+                connection.Received().Get<List<User>>(ApiUrls.Watchers(1), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
             }
 
             [Fact]
@@ -150,6 +185,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllWatchers("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllWatchers("owner", "name", null));
 
+                Assert.Throws<ArgumentNullException>(() => client.GetAllWatchers(1, null));
+
                 Assert.Throws<ArgumentException>(() => client.GetAllWatchers("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllWatchers("owner", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllWatchers("", "name", ApiOptions.None));
@@ -160,18 +197,7 @@ namespace Octokit.Tests.Reactive
         public class TheCheckWatchedMethod
         {
             [Fact]
-            public void EnsuresNonNullArguments()
-            {
-                var client = new ObservableWatchedClient(Substitute.For<IGitHubClient>());
-
-                Assert.Throws<ArgumentNullException>(() => client.CheckWatched(null, "name"));
-                Assert.Throws<ArgumentNullException>(() => client.CheckWatched("owner", null));
-                Assert.Throws<ArgumentException>(() => client.CheckWatched("", "name"));
-                Assert.Throws<ArgumentException>(() => client.CheckWatched("owner", ""));
-            }
-
-            [Fact]
-            public void CallIntoClient()
+            public void RequestsCorrectUrl()
             {
                 var gitHub = Substitute.For<IGitHubClient>();
                 var client = new ObservableWatchedClient(gitHub);
@@ -180,24 +206,35 @@ namespace Octokit.Tests.Reactive
 
                 gitHub.Activity.Watching.Received().CheckWatched("owner", "name");
             }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHub = Substitute.For<IGitHubClient>();
+                var client = new ObservableWatchedClient(gitHub);
+
+                client.CheckWatched(1);
+
+                gitHub.Activity.Watching.Received().CheckWatched(1);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableWatchedClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.CheckWatched(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.CheckWatched("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.CheckWatched("", "name"));
+                Assert.Throws<ArgumentException>(() => client.CheckWatched("owner", ""));
+            }
         }
 
         public class TheWatchRepoMethod
         {
             [Fact]
-            public void EnsuresNonNullArguments()
-            {
-                var client = new ObservableWatchedClient(Substitute.For<IGitHubClient>());
-                var subscription = new NewSubscription();
-
-                Assert.Throws<ArgumentNullException>(() => client.WatchRepo(null, "name", subscription));
-                Assert.Throws<ArgumentNullException>(() => client.WatchRepo("owner", null, subscription));
-                Assert.Throws<ArgumentException>(() => client.WatchRepo("", "name", subscription));
-                Assert.Throws<ArgumentException>(() => client.WatchRepo("owner", "", subscription));
-            }
-
-            [Fact]
-            public void CallIntoClient()
+            public void RequestsCorrectUrl()
             {
                 var gitHub = Substitute.For<IGitHubClient>();
                 var client = new ObservableWatchedClient(gitHub);
@@ -206,23 +243,40 @@ namespace Octokit.Tests.Reactive
 
                 gitHub.Activity.Watching.Received().WatchRepo("owner", "name", Arg.Any<NewSubscription>());
             }
-        }
 
-        public class TheUnWatchRepoMethod
-        {
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHub = Substitute.For<IGitHubClient>();
+                var client = new ObservableWatchedClient(gitHub);
+
+                client.WatchRepo(1, new NewSubscription());
+
+                gitHub.Activity.Watching.Received().WatchRepo(1, Arg.Any<NewSubscription>());
+            }
+
             [Fact]
             public void EnsuresNonNullArguments()
             {
                 var client = new ObservableWatchedClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.UnwatchRepo(null, "name"));
-                Assert.Throws<ArgumentNullException>(() => client.UnwatchRepo("owner", null));
-                Assert.Throws<ArgumentException>(() => client.UnwatchRepo("", "name"));
-                Assert.Throws<ArgumentException>(() => client.UnwatchRepo("owner", ""));
-            }
+                var subscription = new NewSubscription();
 
+                Assert.Throws<ArgumentNullException>(() => client.WatchRepo(null, "name", subscription));
+                Assert.Throws<ArgumentNullException>(() => client.WatchRepo("owner", null, subscription));
+                Assert.Throws<ArgumentNullException>(() => client.WatchRepo("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.WatchRepo(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.WatchRepo("", "name", subscription));
+                Assert.Throws<ArgumentException>(() => client.WatchRepo("owner", "", subscription));
+            }
+        }
+
+        public class TheUnWatchRepoMethod
+        {
             [Fact]
-            public void CallIntoClient()
+            public void RequestsCorrectUrl()
             {
                 var gitHub = Substitute.For<IGitHubClient>();
                 var client = new ObservableWatchedClient(gitHub);
@@ -230,6 +284,29 @@ namespace Octokit.Tests.Reactive
                 client.UnwatchRepo("owner", "name");
 
                 gitHub.Activity.Watching.Received().UnwatchRepo("owner", "name");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHub = Substitute.For<IGitHubClient>();
+                var client = new ObservableWatchedClient(gitHub);
+
+                client.UnwatchRepo(1);
+
+                gitHub.Activity.Watching.Received().UnwatchRepo(1);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableWatchedClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.UnwatchRepo(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.UnwatchRepo("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.UnwatchRepo("", "name"));
+                Assert.Throws<ArgumentException>(() => client.UnwatchRepo("owner", ""));
             }
         }
     }

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -18,7 +18,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name);
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId);
 
         /// <summary>
@@ -36,7 +34,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -45,7 +42,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -96,7 +92,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<bool> CheckWatched(string owner, string name);
 
         /// <summary>
@@ -104,7 +99,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<bool> CheckWatched(int repositoryId);
 
         /// <summary>
@@ -113,7 +107,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -121,7 +114,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
@@ -129,7 +121,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(string owner, string name);
@@ -138,7 +129,6 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(int repositoryId);

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name);
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         Task<bool> CheckWatched(string owner, string name);
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         Task<bool> CheckWatched(int repositoryId);
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(string owner, string name);
@@ -138,7 +138,7 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(int repositoryId);

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -24,12 +24,29 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the watchers for the passed repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing API's response.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user.
@@ -83,6 +100,14 @@ namespace Octokit
         Task<bool> CheckWatched(string owner, string name);
 
         /// <summary>
+        /// Check if a repository is watched by the current authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        Task<bool> CheckWatched(int repositoryId);
+
+        /// <summary>
         /// Watches a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
@@ -90,6 +115,14 @@ namespace Octokit
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
         /// <returns>A <c>bool</c> representing the success of watching</returns>
         Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription);
+
+        /// <summary>
+        /// Watches a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
 
         /// <summary>
         /// Unwatches a repository for the authenticated user.
@@ -100,5 +133,14 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
         Task<bool> UnwatchRepo(string owner, string name);
+
+        /// <summary>
+        /// Unwatches a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
+            Justification = "Unwatch is consistent with the GitHub website")]
+        Task<bool> UnwatchRepo(int repositoryId);
     }
 }

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -27,7 +27,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +40,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
@@ -54,7 +52,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +67,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -143,7 +139,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public async Task<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -167,7 +162,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public async Task<bool> CheckWatched(int repositoryId)
         {
             try
@@ -189,7 +183,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         public Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -204,7 +197,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns></returns>
         public Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
@@ -217,7 +209,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns></returns>
         public async Task<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -240,7 +231,6 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public async Task<bool> UnwatchRepo(int repositoryId)
         {
             try

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -189,7 +189,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         public Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -204,7 +204,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
         public Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +41,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -143,7 +143,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public async Task<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -167,7 +167,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public async Task<bool> CheckWatched(int repositoryId)
         {
             try
@@ -189,7 +189,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         public Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -204,7 +204,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        /// <returns>A <see cref="Subscription"/> representing the subscription on specified repository.</returns>
+        /// <returns></returns>
         public Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
@@ -217,7 +217,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public async Task<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -240,7 +240,7 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        /// <returns></returns>
         public async Task<bool> UnwatchRepo(int repositoryId)
         {
             try

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -39,6 +39,17 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the watchers for the passed repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId)
+        {
+            return GetAllWatchers(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
@@ -51,6 +62,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<User>(ApiUrls.Watchers(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the watchers for the passed repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing API's response.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s watching the passed repository.</returns>
+        public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Watchers(repositoryId), options);
         }
 
         /// <summary>
@@ -138,6 +163,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Check if a repository is watched by the current authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        public async Task<bool> CheckWatched(int repositoryId)
+        {
+            try
+            {
+                var endpoint = ApiUrls.Watched(repositoryId);
+                var subscription = await ApiConnection.Get<Subscription>(endpoint).ConfigureAwait(false);
+
+                return subscription != null;
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Watches a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
@@ -154,6 +200,19 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Watches a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        /// <returns>A <c>bool</c> representing the success of watching</returns>
+        public Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
+        {
+            Ensure.ArgumentNotNull(newSubscription, "newSubscription");
+
+            return ApiConnection.Put<Subscription>(ApiUrls.Watched(repositoryId), newSubscription);
+        }
+
+        /// <summary>
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
@@ -167,6 +226,26 @@ namespace Octokit
             try
             {
                 var endpoint = ApiUrls.Watched(owner, name);
+                var statusCode = await Connection.Delete(endpoint).ConfigureAwait(false);
+
+                return statusCode == HttpStatusCode.NoContent;
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Unwatches a repository for the authenticated user.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <c>bool</c> representing the success of the operation</returns>
+        public async Task<bool> UnwatchRepo(int repositoryId)
+        {
+            try
+            {
+                var endpoint = ApiUrls.Watched(repositoryId);
                 var statusCode = await Connection.Delete(endpoint).ConfigureAwait(false);
 
                 return statusCode == HttpStatusCode.NoContent;

--- a/Octokit/Models/Request/NewSubscription.cs
+++ b/Octokit/Models/Request/NewSubscription.cs
@@ -5,7 +5,7 @@ namespace Octokit
 {
     /// <summary>
     /// Used to watch a repository (subscribe to repository's notifications). Called by the 
-    /// <see cref="IWatchedClient.WatchRepo"/> method.
+    /// <see cref="IWatchedClient.WatchRepo(string,string,NewSubscription)"/> method.
     /// </summary>
     /// <remarks>
     /// API: https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
@@ -19,7 +19,7 @@ namespace Octokit
         /// <remarks>
         /// If you would like to watch a repository, set subscribed to true. If you would like to ignore notifications
         /// made within a repository, set ignored to true. If you would like to stop watching a repository, delete the 
-        /// repository’s subscription completely using the <see cref="IWatchedClient.UnwatchRepo"/> method.
+        /// repository’s subscription completely using the <see cref="IWatchedClient.UnwatchRepo(string,string)"/> method.
         /// </remarks>
         public bool Subscribed { get; set; }
 


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)WatchedClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IWatchedClient and IObservableWatchedClient).**

	  There is some divergence between XML documentation of methods in IWatchedClient and IObservableWatchedClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IWatchedClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableWatchedClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble