### PR TITLE
Add repositoryId overloads to methods on I(Observable)IssuesEventsClient 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
         
         /// <summary>
@@ -31,7 +30,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -44,7 +42,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -56,7 +53,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -67,7 +63,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -77,7 +72,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -89,7 +83,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -100,7 +93,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -112,7 +104,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(string owner, string name, int number);
@@ -125,7 +116,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(int repositoryId, int number);

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
         
         /// <summary>
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(string owner, string name, int number);
@@ -125,7 +125,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(int repositoryId, int number);

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Events API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/events/">Issue Events API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableIssuesEventsClient
     {
         /// <summary>
@@ -14,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +33,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -38,7 +44,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -50,7 +56,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -62,7 +68,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(string owner, string name, int number);

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -22,6 +22,17 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
+        
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        IObservable<EventInfo> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -35,6 +46,18 @@ namespace Octokit.Reactive
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -53,11 +76,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        IObservable<IssueEvent> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single event
@@ -72,5 +116,18 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<IssueEvent> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single event
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#get-a-single-event
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The event id</param>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+        Justification = "Method makes a network request")]
+        IObservable<IssueEvent> Get(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -116,7 +116,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -131,7 +131,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -149,7 +149,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -166,7 +166,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -183,7 +183,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         public IObservable<IssueEvent> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Events API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/events/">Issue Events API documentation</a> for more information.
+    /// </remarks>
     public class ObservableIssuesEventsClient : IObservableIssuesEventsClient
     {
         readonly IIssuesEventsClient _client;
@@ -26,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +51,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -63,7 +69,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +87,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -100,7 +106,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
         public IObservable<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -32,7 +32,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -49,7 +48,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -65,7 +63,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -84,7 +81,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -100,7 +96,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -116,7 +111,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -131,7 +125,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -149,7 +142,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -166,7 +158,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -183,7 +174,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         public IObservable<IssueEvent> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -47,6 +47,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number)
+        {
+            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
@@ -59,6 +73,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<EventInfo>(ApiUrls.IssuesEvents(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<EventInfo>(ApiUrls.IssuesEvents(repositoryId, number), options);
         }
 
         /// <summary>
@@ -84,6 +115,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        public IObservable<IssueEvent> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -95,6 +139,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IObservable{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        public IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(repositoryId), options);
         }
 
         /// <summary>
@@ -113,6 +173,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Get(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets a single event
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#get-a-single-event
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The event id</param>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        public IObservable<IssueEvent> Get(int repositoryId, int number)
+        {
+            return _client.Get(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
-using Xunit;
 using Octokit.Tests.Integration.Helpers;
+using Xunit;
 
 public class IssuesEventsClientTests : IDisposable
 {
@@ -34,8 +33,7 @@ public class IssuesEventsClientTests : IDisposable
         var issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
         Assert.Empty(issueEventInfo);
 
-        var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
 
@@ -52,8 +50,7 @@ public class IssuesEventsClientTests : IDisposable
         var issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.Repository.Id, issue.Number);
         Assert.Empty(issueEventInfo);
 
-        var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         issueEventInfo = await _issuesEventsClient.GetAllForIssue(_context.Repository.Id, issue.Number);
 
@@ -159,7 +156,7 @@ public class IssuesEventsClientTests : IDisposable
         };
 
         var firstPage = await _issuesEventsClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number, startOptions);
-        
+
         var skipStartOptions = new ApiOptions
         {
             PageSize = 1,
@@ -188,7 +185,7 @@ public class IssuesEventsClientTests : IDisposable
         };
 
         var firstPage = await _issuesEventsClient.GetAllForIssue(_context.Repository.Id, issue.Number, startOptions);
-        
+
         var skipStartOptions = new ApiOptions
         {
             PageSize = 1,
@@ -209,21 +206,18 @@ public class IssuesEventsClientTests : IDisposable
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
 
         var issue1 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
         var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
 
         // close and open issue1
-        var closed1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed1 = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed1);
-        var reopened1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Open })
-            .Result;
+        var reopened1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Open });
         Assert.NotNull(reopened1);
 
         // close issue2
-        var closed2 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed2 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed2);
 
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
@@ -240,21 +234,18 @@ public class IssuesEventsClientTests : IDisposable
         var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
 
         var issue1 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
         var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
-        Thread.Sleep(1000);
+        await Task.Delay(1000);
 
         // close and open issue1
-        var closed1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed1 = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed1);
-        var reopened1 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Open })
-            .Result;
+        var reopened1 = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number, new IssueUpdate { State = ItemState.Open });
         Assert.NotNull(reopened1);
 
         // close issue2
-        var closed2 = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed2 = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed2);
 
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.Repository.Id);
@@ -408,8 +399,7 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
         int issueEventId = issueEvents[0].Id;
@@ -425,8 +415,7 @@ public class IssuesEventsClientTests : IDisposable
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed })
-            .Result;
+        var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.Repository.Id);
         int issueEventId = issueEvents[0].Id;

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -31,6 +31,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesEventsClient(connection);
+
+                await client.GetAllForIssue(1, 42);
+
+                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -49,16 +60,40 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesEventsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForIssue(1, 42, options);
+
+                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None));
             }
         }
 
@@ -73,6 +108,17 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesEventsClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.ApiOptions);
             }
 
             [Fact]
@@ -94,16 +140,40 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesEventsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
             }
         }
 
@@ -121,12 +191,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesEventsClient(connection);
+
+                client.Get(1, 42);
+
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesEventsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
@@ -47,6 +47,29 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var result = new List<EventInfo> { new EventInfo() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesEventsClient(gitHubClient);
+
+                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                    new Response
+                    {
+                        ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
+                    }, result);
+                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var eventInfos = await client.GetAllForIssue(1, 42).ToList();
+
+                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Args.EmptyDictionary, null);
+                Assert.Equal(1, eventInfos.Count);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var result = new List<EventInfo> { new EventInfo() };
@@ -77,16 +100,52 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var result = new List<EventInfo> { new EventInfo() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesEventsClient(gitHubClient);
+                
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                    new Response
+                    {
+                        ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
+                    }, result);
+                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
+                    .Returns(Task.FromResult(response));
+
+                var eventInfos = await client.GetAllForIssue(1, 42, options).ToList();
+
+                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, eventInfos.Count);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesEventsClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
-
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1, ApiOptions.None));
             }
         }
 
@@ -112,6 +171,29 @@ namespace Octokit.Tests.Reactive
                 var issueEvents = await client.GetAllForRepository("fake", "repo").ToList();
 
                 connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.EmptyDictionary, null);
+                Assert.Equal(1, issueEvents.Count);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var result = new List<IssueEvent> { new IssueEvent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesEventsClient(gitHubClient);
+
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
+                    new Response
+                    {
+                        ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag1", new RateLimit()),
+                    }, result);
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Args.EmptyDictionary, null)
+                    .Returns(Task.FromResult(response));
+
+                var issueEvents = await client.GetAllForRepository(1).ToList();
+
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.EmptyDictionary, null);
                 Assert.Equal(1, issueEvents.Count);
             }
 
@@ -146,16 +228,52 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var result = new List<IssueEvent> { new IssueEvent() };
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesEventsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
+                    new Response
+                    {
+                        ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag1", new RateLimit()),
+                    }, result);
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
+                    .Returns(Task.FromResult(response));
+
+                var issueEvents = await client.GetAllForRepository(1, options).ToList();
+
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                Assert.Equal(1, issueEvents.Count);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesEventsClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
-
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
             }
         }
 
@@ -173,12 +291,26 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesEventsClient(gitHubClient);
+
+                client.Get(1, 42);
+
+                gitHubClient.Received().Issue.Events.Get(1, 42);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesEventsClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", 1));
                 Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
@@ -270,10 +270,10 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("", "name"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", ""));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
             }
         }
 

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -30,12 +30,35 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -54,11 +77,32 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single event
@@ -71,7 +115,20 @@ namespace Octokit
         /// <param name="number">The event id</param>
         /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         Task<IssueEvent> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single event
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#get-a-single-event
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The event id</param>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        Task<IssueEvent> Get(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -32,7 +31,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +43,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +54,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +64,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +73,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +84,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +94,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -113,7 +105,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<IssueEvent> Get(string owner, string name, int number);
@@ -126,7 +117,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<IssueEvent> Get(int repositoryId, int number);

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<IssueEvent> Get(string owner, string name, int number);
@@ -126,7 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<IssueEvent> Get(int repositoryId, int number);

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         Task<IssueEvent> Get(string owner, string name, int number);

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +43,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -59,7 +59,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +78,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -94,7 +94,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -110,7 +110,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -125,7 +125,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -143,7 +143,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -160,7 +160,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         public Task<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -177,7 +177,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        /// <returns></returns>
         public Task<IssueEvent> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -41,6 +41,20 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number)
+        {
+            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
@@ -53,6 +67,23 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<EventInfo>(ApiUrls.IssuesEvents(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets all events for the issue.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-an-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<EventInfo>(ApiUrls.IssuesEvents(repositoryId, number), options);
         }
 
         /// <summary>
@@ -78,6 +109,19 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -89,6 +133,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all events for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
+        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(repositoryId), options);
         }
 
         /// <summary>
@@ -107,6 +167,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(owner, name, number));
+        }
+
+        /// <summary>
+        /// Gets a single event
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/events/#get-a-single-event
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The event id</param>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
+        public Task<IssueEvent> Get(int repositoryId, int number)
+        {
+            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));
         }
     }
 }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{EventInfo}"/> of <see cref="EventInfo"/>s representing event information for specified number.</returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -63,7 +63,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -81,7 +81,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{IssueEvent}"/> of <see cref="IssueEvent"/>s representing issue events for specified repository.</returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IssueEvent"/> representing issue event for specified number.</returns>
         public Task<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -26,7 +26,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +42,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -59,7 +57,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +75,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -94,7 +90,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -110,7 +105,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -125,7 +119,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -143,7 +136,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -160,7 +152,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         public Task<IssueEvent> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -177,7 +168,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The event id</param>
-        /// <returns></returns>
         public Task<IssueEvent> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)IssuesEventsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IIssuesEventsClient and IObservableIssuesEventsClient).**

	  There is some divergence between XML documentation of methods in IIssuesEventsClient and IObservableIssuesEventsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IIssuesEventsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableIssuesEventsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble