### PR TITLE
Add repositoryId overloads to methods on I(Observable)EventsClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:

--- a/Octokit.Reactive/Clients/IObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEventsClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Events API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/events/">Activity Events API documentation</a> for more information
+    /// </remarks>
     public interface IObservableEventsClient
     {
         /// <summary>
@@ -41,11 +47,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -64,11 +91,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllIssuesForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit.Reactive/Clients/IObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEventsClient.cs
@@ -16,7 +16,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Activity> GetAll();
 
@@ -27,7 +26,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>        
         IObservable<Activity> GetAll(ApiOptions options);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -60,7 +56,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -71,7 +66,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -82,7 +76,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllIssuesForRepository(string owner, string name);
 
         /// <summary>
@@ -92,7 +85,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllIssuesForRepository(int repositoryId);
 
         /// <summary>
@@ -104,7 +96,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -115,7 +106,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -126,7 +116,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         IObservable<Activity> GetAllForRepositoryNetwork(string owner, string name);
 
         /// <summary>
@@ -138,7 +127,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         IObservable<Activity> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -148,7 +136,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         IObservable<Activity> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -159,7 +146,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         IObservable<Activity> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -169,7 +155,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         IObservable<Activity> GetAllUserReceived(string user);
 
         /// <summary>
@@ -180,7 +165,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         IObservable<Activity> GetAllUserReceived(string user, ApiOptions options);
 
         /// <summary>
@@ -190,7 +174,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         IObservable<Activity> GetAllUserReceivedPublic(string user);
 
         /// <summary>
@@ -201,7 +184,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         IObservable<Activity> GetAllUserReceivedPublic(string user, ApiOptions options);
 
         /// <summary>
@@ -211,7 +193,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         IObservable<Activity> GetAllUserPerformed(string user);
 
         /// <summary>
@@ -222,7 +203,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         IObservable<Activity> GetAllUserPerformed(string user, ApiOptions options);
 
         /// <summary>
@@ -232,7 +212,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         IObservable<Activity> GetAllUserPerformedPublic(string user);
 
         /// <summary>
@@ -243,7 +222,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         IObservable<Activity> GetAllUserPerformedPublic(string user, ApiOptions options);
 
         /// <summary>
@@ -254,7 +232,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         IObservable<Activity> GetAllForAnOrganization(string user, string organization);
 
         /// <summary>
@@ -266,7 +243,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         IObservable<Activity> GetAllForAnOrganization(string user, string organization, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -3,6 +3,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Events API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/events/">Activity Events API documentation</a> for more information
+    /// </remarks>
     public class ObservableEventsClient : IObservableEventsClient
     {
         readonly IConnection _connection;
@@ -64,6 +70,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -75,6 +94,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.Events(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.Events(repositoryId), options);
         }
 
         /// <summary>
@@ -95,6 +130,19 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllIssuesForRepository(int repositoryId)
+        {
+            return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
         /// Gets all the events for a given repository
         /// </summary>
         /// <remarks>
@@ -111,6 +159,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.IssuesEvents(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Activity>(ApiUrls.IssuesEvents(repositoryId), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -26,7 +26,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>
         public IObservable<Activity> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -39,7 +38,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>        
         public IObservable<Activity> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -55,7 +53,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +68,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -86,7 +82,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -104,7 +99,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -120,7 +114,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -136,7 +129,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllIssuesForRepository(int repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
@@ -151,7 +143,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -169,7 +160,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -185,7 +175,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         public IObservable<Activity> GetAllForRepositoryNetwork(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -203,7 +192,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         public IObservable<Activity> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -220,7 +208,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         public IObservable<Activity> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -236,7 +223,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         public IObservable<Activity> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -252,7 +238,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public IObservable<Activity> GetAllUserReceived(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -268,7 +253,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public IObservable<Activity> GetAllUserReceived(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -284,7 +268,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public IObservable<Activity> GetAllUserReceivedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -300,7 +283,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public IObservable<Activity> GetAllUserReceivedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -316,7 +298,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         public IObservable<Activity> GetAllUserPerformed(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -332,7 +313,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         public IObservable<Activity> GetAllUserPerformed(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -348,7 +328,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         public IObservable<Activity> GetAllUserPerformedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -364,7 +343,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         public IObservable<Activity> GetAllUserPerformedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -381,7 +359,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         public IObservable<Activity> GetAllForAnOrganization(string user, string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -399,7 +376,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         public IObservable<Activity> GetAllForAnOrganization(string user, string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit.Tests.Integration/Clients/EventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/EventsClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,7 +14,282 @@ namespace Octokit.Tests.Integration.Clients
             {
                 var github = Helper.GetAuthenticatedClient();
                 var events = await github.Activity.Events.GetAllUserPerformed("shiftkey");
+
                 Assert.NotEmpty(events);
+            }
+        }
+
+        public class TheGetAllForRepositoryMethod
+        {
+            [IntegrationTest]
+            public async Task CanListEvents()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                var events = await github.Activity.Events.GetAllForRepository("octokit", "octokit.net");
+
+                Assert.NotEmpty(events);
+            }
+
+            [IntegrationTest]
+            public async Task CanListEventsWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                var events = await github.Activity.Events.GetAllForRepository(7528679);
+
+                Assert.NotEmpty(events);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfEventsWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllForRepository("octokit", "octokit.net", options);
+
+                Assert.Equal(3, eventInfos.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfEventsWithoutStartWitRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllForRepository(7528679, options);
+
+                Assert.Equal(3, eventInfos.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfEventsWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllForRepository("octokit", "octokit.net", options);
+
+                Assert.Equal(2, eventInfos.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfEventsWithStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllForRepository(7528679, options);
+
+                Assert.Equal(2, eventInfos.Count);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctEventsBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                 
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Activity.Events.GetAllForRepository("octokit", "octokit.net", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Activity.Events.GetAllForRepository("octokit", "octokit.net", skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsDistinctEventsBasedOnStartPageWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                 
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Activity.Events.GetAllForRepository(7528679, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Activity.Events.GetAllForRepository(7528679, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+        }
+
+        public class TheGetAllIssuesForRepositoryMethod
+        {
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task CanListIssues()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                var issues = await github.Activity.Events.GetAllIssuesForRepository("octokit", "octokit.net");
+
+                Assert.NotEmpty(issues);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task CanListIssuesWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+                var issues = await github.Activity.Events.GetAllIssuesForRepository(7528679);
+
+                Assert.NotEmpty(issues);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsCorrectCountOfEventsWithoutStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllIssuesForRepository("octokit", "octokit.net", options);
+
+                Assert.Equal(3, eventInfos.Count);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsCorrectCountOfEventsWithoutStartWitRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 3,
+                    PageCount = 1
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllIssuesForRepository(7528679, options);
+
+                Assert.Equal(3, eventInfos.Count);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsCorrectCountOfEventsWithStart()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllIssuesForRepository("octokit", "octokit.net", options);
+
+                Assert.Equal(2, eventInfos.Count);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsCorrectCountOfEventsWithStartWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var options = new ApiOptions
+                {
+                    PageSize = 2,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var eventInfos = await github.Activity.Events.GetAllIssuesForRepository(7528679, options);
+
+                Assert.Equal(2, eventInfos.Count);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsDistinctEventsBasedOnStartPage()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Activity.Events.GetAllIssuesForRepository("octokit", "octokit.net", startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Activity.Events.GetAllIssuesForRepository("octokit", "octokit.net", skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+
+            [IntegrationTest(Skip = "Fails because of SimpleJsonSerializer, see https://github.com/octokit/octokit.net/issues/1374 for details.")]
+            public async Task ReturnsDistinctEventsBasedOnStartPageWithRepositoryId()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await github.Activity.Events.GetAllIssuesForRepository(7528679, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await github.Activity.Events.GetAllIssuesForRepository(7528679, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             }
         }
 

--- a/Octokit.Tests/Clients/EventsClientTests.cs
+++ b/Octokit.Tests/Clients/EventsClientTests.cs
@@ -25,17 +25,18 @@ namespace Octokit.Tests.Clients
         public class TheGetAllMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAll();
+                await client.GetAll();
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "events"), Args.ApiOptions);
             }
+
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -47,7 +48,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
                 
-                client.GetAll(options);
+                await client.GetAll(options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "events"), options);
             }
@@ -65,17 +66,29 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForRepositoryMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllForRepository("fake", "repo");
+                await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/events"), Args.ApiOptions);
             }
+
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/events"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -87,24 +100,46 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-
-                client.GetAllForRepository("fake", "repo", options);
+                await client.GetAllForRepository("fake", "repo", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/events"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name",null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "",ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
             }
         }
@@ -112,17 +147,29 @@ namespace Octokit.Tests.Clients
         public class TheGetAllIssuesForRepositoryMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllIssuesForRepository("fake", "repo");
+                await client.GetAllIssuesForRepository("fake", "repo");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
             }
+
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                await client.GetAllIssuesForRepository(1);
+
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -134,23 +181,45 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-
-                client.GetAllIssuesForRepository("fake", "repo", options);
+                await client.GetAllIssuesForRepository("fake", "repo", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new EventsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAllIssuesForRepository(1, options);
+
+                connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name", ApiOptions.None));
             }
@@ -159,18 +228,18 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForRepositoryNetworkMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllForRepositoryNetwork("fake", "repo");
+                await client.GetAllForRepositoryNetwork("fake", "repo");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "networks/fake/repo/events"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -182,22 +251,26 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllForRepositoryNetwork("fake", "repo", options);
+                await client.GetAllForRepositoryNetwork("fake", "repo", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "networks/fake/repo/events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork(null, "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("", "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork("owner", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("owner", ""));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepositoryNetwork("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("owner", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepositoryNetwork("", "name", ApiOptions.None));
             }
@@ -206,18 +279,18 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForOrganizationMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllForOrganization("fake");
+                await client.GetAllForOrganization("fake");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/events"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -229,20 +302,21 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllForOrganization("fake", options);
+                await client.GetAllForOrganization("fake", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization("fake", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("", ApiOptions.None));
             }
         }
@@ -250,18 +324,18 @@ namespace Octokit.Tests.Clients
         public class TheGetUserReceivedMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllUserReceived("fake");
+                await client.GetAllUserReceived("fake");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/received_events"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -273,20 +347,21 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllUserReceived("fake", options);
+                await client.GetAllUserReceived("fake", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/received_events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceived(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceived(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceived("fake", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceived(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceived("", ApiOptions.None));
             }
         }
@@ -294,18 +369,18 @@ namespace Octokit.Tests.Clients
         public class TheGetUserReceivedPublicMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllUserReceivedPublic("fake");
+                await client.GetAllUserReceivedPublic("fake");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/received_events/public"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -317,20 +392,21 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllUserReceivedPublic("fake", options);
+                await client.GetAllUserReceivedPublic("fake", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/received_events/public"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceivedPublic(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceivedPublic(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserReceivedPublic("fake", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceivedPublic(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserReceivedPublic("", ApiOptions.None));
             }
         }
@@ -338,18 +414,18 @@ namespace Octokit.Tests.Clients
         public class TheGetUserPerformedMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllUserPerformed("fake");
+                await client.GetAllUserPerformed("fake");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -361,20 +437,21 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllUserPerformed("fake", options);
+                await client.GetAllUserPerformed("fake", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformed(null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformed(""));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformed("fake", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformed(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformed("", ApiOptions.None));
             }
         }
@@ -382,18 +459,18 @@ namespace Octokit.Tests.Clients
         public class TheGetUserPerformedPublicMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllUserPerformedPublic("fake");
+                await client.GetAllUserPerformedPublic("fake");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events/public"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -405,39 +482,40 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllUserPerformedPublic("fake", options);
+                await client.GetAllUserPerformedPublic("fake", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events/public"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformedPublic(null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformedPublic("fake", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformedPublic(""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllUserPerformedPublic("fake",null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformedPublic("",ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllUserPerformedPublic("", ApiOptions.None));
             }
         }
 
         public class TheGetForAnOrganizationMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
-                client.GetAllForAnOrganization("fake", "org");
+                await client.GetAllForAnOrganization("fake", "org");
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events/orgs/org"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
@@ -449,22 +527,25 @@ namespace Octokit.Tests.Clients
                     StartPage = 1
                 };
 
-                client.GetAllForAnOrganization("fake", "org", options);
+                await client.GetAllForAnOrganization("fake", "org", options);
 
                 connection.Received().GetAll<Activity>(Arg.Is<Uri>(u => u.ToString() == "users/fake/events/orgs/org"), options);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new EventsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization(null, "org"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("", "org"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization("fake", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("fake", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization(null, "org", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization("fake", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForAnOrganization("fake", "org", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("", "org"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("fake", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("fake", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForAnOrganization("", "org", ApiOptions.None));
             }

--- a/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableEventsClientTests.cs
@@ -32,6 +32,33 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("events", UriKind.Relative), Args.EmptyDictionary, null);
             }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(options);
+
+                gitHubClient.Connection.Received().Get<List<Activity>>(new Uri("events", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null));
+            }
         }
 
         public class TheGetAllForRepositoryMethod
@@ -44,19 +71,78 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative),
+                    Args.EmptyDictionary, null);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
+                client.GetAllForRepository(1);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative), 
+                    Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository("fake", "repo", options);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/events", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                var apiOptions = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository(1, apiOptions);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/events", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
             }
         }
 
@@ -70,19 +156,78 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllIssuesForRepository("fake", "repo");
 
-                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                    Args.EmptyDictionary, null);
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("", "name").ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllIssuesForRepository("owner", "").ToTask());
+                client.GetAllIssuesForRepository(1);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                    Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllIssuesForRepository("fake", "repo", options);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repos/fake/repo/issues/events", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllIssuesForRepository(1, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Activity>>(new Uri("repositories/1/issues/events", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableEventsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllIssuesForRepository(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllIssuesForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllIssuesForRepository("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllIssuesForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllIssuesForRepository("owner", "", ApiOptions.None));
             }
         }
 
@@ -100,7 +245,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -126,7 +271,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -150,7 +295,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -174,7 +319,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -198,7 +343,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -222,7 +367,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);
@@ -246,7 +391,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableEventsClient(gitHubClient);

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -61,7 +61,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAllForRepository(owner,name,ApiOptions.None);
+            return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
@@ -83,6 +96,21 @@ namespace Octokit
             return ApiConnection.GetAll<Activity>(ApiUrls.Events(owner, name), options);
         }
 
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Activity>(ApiUrls.Events(repositoryId), options);
+        }
 
         /// <summary>
         /// Gets all the event issues for a given repository
@@ -99,6 +127,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAllIssuesForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId)
+        {
+            return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
@@ -121,6 +162,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Activity>(ApiUrls.IssuesEvents(repositoryId), options);
+        }
+
+        /// <summary>
         /// Gets all the events for a given repository network
         /// </summary>
         /// <remarks>
@@ -134,7 +191,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAllForRepositoryNetwork(owner,name,ApiOptions.None);
+            return GetAllForRepositoryNetwork(owner, name, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -26,7 +26,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>
         public Task<IReadOnlyList<Activity>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -55,7 +54,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +69,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -86,7 +83,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -104,7 +100,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -120,7 +115,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -136,7 +130,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
@@ -151,7 +144,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -169,7 +161,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -185,7 +176,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -203,7 +193,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -220,7 +209,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -236,7 +224,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -252,7 +239,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserReceived(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -268,7 +254,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserReceived(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -284,7 +269,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -300,7 +284,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -316,7 +299,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -332,7 +314,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -348,7 +329,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -364,7 +344,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         public Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -381,7 +360,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -399,7 +377,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         public Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -17,7 +17,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Activity>> GetAll();
 
@@ -39,7 +38,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -49,7 +47,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -61,7 +58,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -72,7 +68,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -83,7 +78,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name);
 
         /// <summary>
@@ -93,7 +87,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId);
 
         /// <summary>
@@ -105,7 +98,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -116,7 +108,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -127,7 +118,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name);
 
         /// <summary>
@@ -139,7 +129,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options);
         
         /// <summary>
@@ -149,7 +138,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -160,7 +148,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s for the particular organization.</returns>
         Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -170,7 +157,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserReceived(string user);
 
         /// <summary>
@@ -181,7 +167,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserReceived(string user, ApiOptions options);
 
         /// <summary>
@@ -191,7 +176,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user);
 
         /// <summary>
@@ -202,7 +186,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has received.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user, ApiOptions options);
 
         /// <summary>
@@ -212,7 +195,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user);
 
         /// <summary>
@@ -223,7 +205,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the <see cref="Activity"/>s that a particular user has performed.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user, ApiOptions options);
 
         /// <summary>
@@ -233,7 +214,6 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user);
 
         /// <summary>
@@ -244,7 +224,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that a particular user has performed.</returns>
         Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user, ApiOptions options);
 
         /// <summary>
@@ -255,7 +234,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization);
 
         /// <summary>
@@ -267,7 +245,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s that are associated with an organization.</returns>
         Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization, ApiOptions options);
     }
 }

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -48,11 +48,32 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -71,11 +92,32 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
         Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the issue events for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All the <see cref="Activity"/>s for the particular repository.</returns>
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network
@@ -98,8 +140,8 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All the <see cref="Activity"/>s for the particular repository network.</returns>
-        Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name,ApiOptions options);
-
+        Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options);
+        
         /// <summary>
         /// Gets all the events for a given organization
         /// </summary>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)EventsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IEventsClient and IObservableEventsClient).**

	  There is some divergence between XML documentation of methods in IEventsClient and IObservableEventsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IEventsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableEventsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
Also I've found bug in deserialization, see #1374 for details. I skipped failed new integration tests because of this.

/cc @shiftkey, @ryangribble