### PR TITLE
lock to an earlier version of mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 4.2.3
 
 sudo: false  # use the new container-based Travis infrastructure
 os:


### PR DESCRIPTION
Travis is currently in an interesting spot where `latest` means it'll use Mono **4.4.0** when building and testing on OS X, and **4.2.3** when building and testing on Linux.

Unfortunately this means the OS X builds are exhibiting some strange behaviour:

 - a [wall of Chinese text](https://twitter.com/shiftkey/status/742500043769274369) in the `BuildMono` step
 - `* Assertion at metadata.c:3643, condition 'ptr' not met` when running the PCL tests

Example build output: https://travis-ci.org/octokit/octokit.net/jobs/137385011

I found the flag to force a specific version of Mono for both platforms, and that seems to do the trick here.

@dampir @ErikSchierboom @shaggygi @alfhenrik @maddin2016 I think you're all encountering this on your PRs, feel free to merge `master` or cherry-pick this commit into your branch after I confirm this resolves the issue.