### PR TITLE
Add repositoryId overloads to methods on I(Observable)IssuesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Issue> Get(string owner, string name, int number);
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Issue> Get(int repositoryId, int number);
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent();
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories();
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(ApiOptions options);
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request);
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request);
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace Octokit.Reactive
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request);
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         IObservable<Issue> Create(string owner, string name, NewIssue newIssue);
 
         /// <summary>
@@ -310,7 +310,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         IObservable<Issue> Create(int repositoryId, NewIssue newIssue);
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -345,7 +345,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         IObservable<Unit> Lock(string owner, string name, int number);
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         IObservable<Unit> Lock(int repositoryId, int number);
 
         /// <summary>
@@ -364,7 +364,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         IObservable<Unit> Unlock(string owner, string name, int number);
 
         /// <summary>
@@ -373,7 +373,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         IObservable<Unit> Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -48,7 +48,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Issue> Get(string owner, string name, int number);
@@ -61,7 +60,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Issue> Get(int repositoryId, int number);
@@ -74,7 +72,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent();
 
         /// <summary>
@@ -86,7 +83,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -97,7 +93,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
@@ -109,7 +104,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForCurrent(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -120,7 +114,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories();
 
         /// <summary>
@@ -132,7 +125,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(ApiOptions options);
 
         /// <summary>
@@ -142,7 +134,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request);
 
         /// <summary>
@@ -153,7 +144,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -163,7 +153,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -174,7 +163,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -185,7 +173,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request);
 
         /// <summary>
@@ -197,7 +184,6 @@ namespace Octokit.Reactive
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -208,7 +194,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -218,7 +203,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -230,7 +214,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -241,7 +224,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -253,7 +235,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request);
 
         /// <summary>
@@ -264,7 +245,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
@@ -277,7 +257,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -289,7 +268,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -300,7 +278,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         IObservable<Issue> Create(string owner, string name, NewIssue newIssue);
 
         /// <summary>
@@ -310,7 +287,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         IObservable<Issue> Create(int repositoryId, NewIssue newIssue);
 
         /// <summary>
@@ -323,7 +299,6 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -335,7 +310,6 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -345,7 +319,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<Unit> Lock(string owner, string name, int number);
 
         /// <summary>
@@ -354,7 +327,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<Unit> Lock(int repositoryId, int number);
 
         /// <summary>
@@ -364,7 +336,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<Unit> Unlock(string owner, string name, int number);
 
         /// <summary>
@@ -373,7 +344,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         IObservable<Unit> Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issues API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/">Issues API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableIssuesClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -50,8 +50,21 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-            Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         IObservable<Issue> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single Issue by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#get-a-single-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        IObservable<Issue> Get(int repositoryId, int number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -204,11 +217,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        IObservable<Issue> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -228,12 +262,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
         IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -251,6 +308,16 @@ namespace Octokit.Reactive
         /// issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        IObservable<Issue> Create(int repositoryId, NewIssue newIssue);
+
+        /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
@@ -258,6 +325,18 @@ namespace Octokit.Reactive
         /// </param>
         /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
         IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
+
+        /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
+        /// </param>
+        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -268,15 +347,33 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>A signal indicating completion.</returns>
         IObservable<Unit> Lock(string owner, string name, int number);
- 
-         /// <summary>
-         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
-         /// </summary>
-         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
-         /// <param name="owner">The owner of the repository</param>
-         /// <param name="name">The name of the repository</param>
-         /// <param name="number">The issue number</param>
-         /// <returns>A signal indicating completion.</returns>
-         IObservable<Unit> Unlock(string owner, string name, int number);
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal indicating completion.</returns>
+        IObservable<Unit> Lock(int repositoryId, int number);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal indicating completion.</returns>
+        IObservable<Unit> Unlock(string owner, string name, int number);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal indicating completion.</returns>
+        IObservable<Unit> Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -65,7 +65,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +81,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Issue> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -96,7 +94,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -111,7 +108,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -127,7 +123,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -144,7 +139,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -161,7 +155,6 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories()
         {
             return GetAllForOwnedAndMemberRepositories(new IssueRequest());
@@ -176,7 +169,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -191,7 +183,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -207,7 +198,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -223,7 +213,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -239,7 +228,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -256,7 +244,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -274,7 +261,6 @@ namespace Octokit.Reactive
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -292,7 +278,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -308,7 +293,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -323,7 +307,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -341,7 +324,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -358,7 +340,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -376,7 +357,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -394,7 +374,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -414,7 +393,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -431,7 +409,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         public IObservable<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -448,7 +425,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         public IObservable<Issue> Create(int repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
@@ -466,7 +442,6 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         public IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -485,7 +460,6 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         public IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
@@ -500,7 +474,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Unit> Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -515,7 +488,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Unit> Lock(int repositoryId, int number)
         {
             return _client.Lock(repositoryId, number).ToObservable();
@@ -528,7 +500,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Unit> Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -543,7 +514,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public IObservable<Unit> Unlock(int repositoryId, int number)
         {
             return _client.Unlock(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Reactive;
 using System.Reactive.Threading.Tasks;
 using Octokit.Reactive.Internal;
-using System.Reactive;
 
 namespace Octokit.Reactive
 {
@@ -72,6 +72,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Get(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets a single Issue by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#get-a-single-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        public IObservable<Issue> Get(int repositoryId, int number)
+        {
+            return _client.Get(repositoryId, number).ToObservable();
         }
 
         /// <summary>
@@ -293,6 +307,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        public IObservable<Issue> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -304,6 +331,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return GetAllForRepository(owner, name, new RepositoryIssueRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        public IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new RepositoryIssueRequest(), options);
         }
 
         /// <summary>
@@ -331,6 +374,22 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
@@ -344,6 +403,24 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Issue>(ApiUrls.Issues(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Issue>(ApiUrls.Issues(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -369,6 +446,21 @@ namespace Octokit.Reactive
         /// issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        public IObservable<Issue> Create(int repositoryId, NewIssue newIssue)
+        {
+            Ensure.ArgumentNotNull(newIssue, "newIssue");
+
+            return _client.Create(repositoryId, newIssue).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
@@ -385,6 +477,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
+        /// </param>
+        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        public IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
+        {
+            Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
+
+            return _client.Update(repositoryId, number, issueUpdate).ToObservable();
+        }
+
+        /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
@@ -393,12 +502,24 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>A signal indicating completion.</returns>
         public IObservable<Unit> Lock(string owner, string name, int number)
-         {
-             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-             Ensure.ArgumentNotNullOrEmptyString(name, "name");
- 
-             return _client.Lock(owner, name, number).ToObservable();
-         }
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return _client.Lock(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal indicating completion.</returns>
+        public IObservable<Unit> Lock(int repositoryId, int number)
+        {
+            return _client.Lock(repositoryId, number).ToObservable();
+        }
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -409,11 +530,23 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <returns>A signal indicating completion.</returns>
         public IObservable<Unit> Unlock(string owner, string name, int number)
-         {
-             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-             Ensure.ArgumentNotNullOrEmptyString(name, "name");
- 
-             return _client.Unlock(owner, name, number).ToObservable();
-         }
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return _client.Unlock(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>A signal indicating completion.</returns>
+        public IObservable<Unit> Unlock(int repositoryId, int number)
+        {
+            return _client.Unlock(repositoryId, number).ToObservable();
+        }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal containing the requested <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -127,7 +127,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -161,7 +161,7 @@ namespace Octokit.Reactive
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories()
         {
             return GetAllForOwnedAndMemberRepositories(new IssueRequest());
@@ -176,7 +176,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -191,7 +191,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -207,7 +207,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -223,7 +223,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -239,7 +239,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -256,7 +256,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -274,7 +274,7 @@ namespace Octokit.Reactive
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -292,7 +292,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -308,7 +308,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -323,7 +323,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -341,7 +341,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -358,7 +358,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -376,7 +376,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -394,7 +394,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -414,7 +414,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A signal containing one or more <see cref="Issue"/>s.</returns>
+        /// <returns></returns>
         public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -431,7 +431,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -448,7 +448,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>A signal containing the new <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Create(int repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
@@ -466,7 +466,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -485,7 +485,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>A signal containing the updated <see cref="Issue"/>.</returns>
+        /// <returns></returns>
         public IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
@@ -500,7 +500,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         public IObservable<Unit> Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -515,7 +515,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         public IObservable<Unit> Lock(int repositoryId, int number)
         {
             return _client.Lock(repositoryId, number).ToObservable();
@@ -528,7 +528,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         public IObservable<Unit> Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -543,7 +543,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>A signal indicating completion.</returns>
+        /// <returns></returns>
         public IObservable<Unit> Unlock(int repositoryId, int number)
         {
             return _client.Unlock(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -5,6 +5,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issues API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/">Issues API documentation</a> for more information.
+    /// </remarks>
     public class ObservableIssuesClient : IObservableIssuesClient
     {
         readonly IIssuesClient _client;
@@ -14,20 +20,24 @@ namespace Octokit.Reactive
         /// Client for managing assignees.
         /// </summary>
         public IObservableAssigneesClient Assignee { get; private set; }
+
         /// <summary>
         /// Client for managing comments.
         /// </summary>
         public IObservableIssueCommentsClient Comment { get; private set; }
+
         /// <summary>
         /// Client for reading various event information associated with issues/pull requests.  
         /// This is useful both for display on issue/pull request information pages and also to 
         /// determine who should be notified of comments.
         /// </summary>
         public IObservableIssuesEventsClient Events { get; private set; }
+
         /// <summary>
         /// Client for managing labels.
         /// </summary>
         public IObservableIssuesLabelsClient Labels { get; private set; }
+
         /// <summary>
         /// Client for managing milestones.
         /// </summary>

--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -42,6 +42,27 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanDeserializeIssueWithRepositoryId()
+    {
+        const string title = "a test issue";
+        const string description = "A new unassigned issue";
+        var newIssue = new NewIssue(title) { Body = description };
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+
+        Assert.True(issue.Id > 0);
+        Assert.False(issue.Locked);
+        Assert.Equal(title, issue.Title);
+        Assert.Equal(description, issue.Body);
+
+        var retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
+
+        Assert.True(retrieved.Id > 0);
+        Assert.False(retrieved.Locked);
+        Assert.Equal(title, retrieved.Title);
+        Assert.Equal(description, retrieved.Body);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsPageOfIssuesForARepository()
     {
         var options = new ApiOptions
@@ -51,6 +72,50 @@ public class IssuesClientTests : IDisposable
         };
 
         var issues = await _issuesClient.GetAllForRepository("libgit2", "libgit2sharp", options);
+
+        Assert.Equal(5, issues.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsPageOfIssuesForARepositoryWithRepositoryId()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var issues = await _issuesClient.GetAllForRepository(1415168, options);
+
+        Assert.Equal(5, issues.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsPageOfIssuesForARepositoryWithStartPage()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1, 
+            StartPage = 2
+        };
+
+        var issues = await _issuesClient.GetAllForRepository("libgit2", "libgit2sharp", options);
+
+        Assert.Equal(5, issues.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsPageOfIssuesForARepositoryWithRepositoryIdWithStartPage()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var issues = await _issuesClient.GetAllForRepository(1415168, options);
 
         Assert.Equal(5, issues.Count);
     }
@@ -86,6 +151,36 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsPageOfIssuesFromStartForARepositoryWithRepositoryId()
+    {
+        var first = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var firstPage = await _issuesClient.GetAllForRepository(1415168, first);
+
+        var second = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _issuesClient.GetAllForRepository(1415168, second);
+
+        Assert.Equal(5, firstPage.Count);
+        Assert.Equal(5, secondPage.Count);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+        Assert.NotEqual(firstPage[1].Id, secondPage[1].Id);
+        Assert.NotEqual(firstPage[2].Id, secondPage[2].Id);
+        Assert.NotEqual(firstPage[3].Id, secondPage[3].Id);
+        Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
+    }
+
+    [IntegrationTest]
     public async Task CanCreateRetrieveAndCloseIssue()
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
@@ -102,6 +197,27 @@ public class IssuesClientTests : IDisposable
         finally
         {
             var closed = _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed }).Result;
+            Assert.NotNull(closed);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task CanCreateRetrieveAndCloseIssueWithRepositoryId()
+    {
+        var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+        try
+        {
+            Assert.NotNull(issue);
+
+            var retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
+            var all = await _issuesClient.GetAllForRepository(_context.Repository.Id);
+            Assert.NotNull(retrieved);
+            Assert.True(all.Any(i => i.Number == retrieved.Number));
+        }
+        finally
+        {
+            var closed = _issuesClient.Update(_context.Repository.Id, issue.Number, new IssueUpdate { State = ItemState.Closed }).Result;
             Assert.NotNull(closed);
         }
     }
@@ -125,6 +241,24 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanLockAndUnlockIssueWithRepositoryId()
+    {
+        var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+        Assert.False(issue.Locked);
+
+        await _issuesClient.Lock(_context.Repository.Id, issue.Number);
+        var retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
+        Assert.NotNull(retrieved);
+        Assert.True(retrieved.Locked);
+
+        await _issuesClient.Unlock(_context.Repository.Id, issue.Number);
+        retrieved = await _issuesClient.Get(_context.Repository.Id, issue.Number);
+        Assert.NotNull(retrieved);
+        Assert.False(retrieved.Locked);
+    }
+
+    [IntegrationTest]
     public async Task CanListOpenIssuesWithDefaultSort()
     {
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
@@ -142,6 +276,31 @@ public class IssuesClientTests : IDisposable
             new IssueUpdate { State = ItemState.Closed });
 
         var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
+
+        Assert.Equal(3, issues.Count);
+        Assert.Equal("A test issue3", issues[0].Title);
+        Assert.Equal("A test issue2", issues[1].Title);
+        Assert.Equal("A test issue1", issues[2].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanListOpenIssuesWithDefaultSortWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+
+        await Task.Delay(1000);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+        await Task.Delay(1000);
+        await _issuesClient.Create(_context.Repository.Id, newIssue3);
+        var closed = await _issuesClient.Create(_context.Repository.Id, newIssue4);
+        await _issuesClient.Update(_context.Repository.Id, closed.Number,
+            new IssueUpdate { State = ItemState.Closed });
+
+        var issues = await _issuesClient.GetAllForRepository(_context.Repository.Id);
 
         Assert.Equal(3, issues.Count);
         Assert.Equal("A test issue3", issues[0].Title);
@@ -175,6 +334,31 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanListIssuesWithAscendingSortWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await Task.Delay(1000);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+        await Task.Delay(1000);
+        await _issuesClient.Create(_context.Repository.Id, newIssue3);
+        var closed = await _issuesClient.Create(_context.Repository.Id, newIssue4);
+        await _issuesClient.Update(_context.Repository.Id, closed.Number,
+            new IssueUpdate { State = ItemState.Closed });
+
+        var issues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { SortDirection = SortDirection.Ascending });
+
+        Assert.Equal(3, issues.Count);
+        Assert.Equal("A test issue1", issues[0].Title);
+        Assert.Equal("A test issue2", issues[1].Title);
+        Assert.Equal("A test issue3", issues[2].Title);
+    }
+
+    [IntegrationTest]
     public async Task CanListClosedIssues()
     {
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
@@ -186,6 +370,24 @@ public class IssuesClientTests : IDisposable
             new IssueUpdate { State = ItemState.Closed });
 
         var issues = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
+            new RepositoryIssueRequest { State = ItemStateFilter.Closed });
+
+        Assert.Equal(1, issues.Count);
+        Assert.Equal("A closed issue", issues[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanListClosedIssuesWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A closed issue") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+        var closed = await _issuesClient.Create(_context.Repository.Id, newIssue2);
+        await _issuesClient.Update(_context.Repository.Id, closed.Number,
+            new IssueUpdate { State = ItemState.Closed });
+
+        var issues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
             new RepositoryIssueRequest { State = ItemStateFilter.Closed });
 
         Assert.Equal(1, issues.Count);
@@ -209,6 +411,138 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanListMilestoneIssuesWithRepositoryId()
+    {
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, new NewMilestone("milestone"));
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A milestone issue") { Body = "A new unassigned issue", Milestone = milestone.Number };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+
+        var issues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Milestone = milestone.Number.ToString(CultureInfo.InvariantCulture) });
+
+        Assert.Equal(1, issues.Count);
+        Assert.Equal("A milestone issue", issues[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesWithApiOptionsWithoutStart()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        var issue1 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        var issue3 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All };
+
+        var options = new ApiOptions
+        {
+            PageSize = 4,
+            PageCount = 1
+        };
+
+        var retrieved = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, request, options);
+
+        Assert.Equal(4, retrieved.Count);
+        Assert.True(retrieved.Any(i => i.Number == issue1.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue2.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue3.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesWithApiOptionsWithoutStartWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        var issue1 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        var issue2 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        var issue3 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.Repository.Id, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All };
+
+        var options = new ApiOptions
+        {
+            PageSize = 4,
+            PageCount = 1
+        };
+
+        var retrieved = await _issuesClient.GetAllForRepository(_context.Repository.Id, request, options);
+
+        Assert.Equal(4, retrieved.Count);
+        Assert.True(retrieved.Any(i => i.Number == issue1.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue2.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue3.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesWithApiOptionsWithStart()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All, SortDirection = SortDirection.Ascending };
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 4
+        };
+
+        var retrieved = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, request, options);
+
+        Assert.Equal(1, retrieved.Count);
+        Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesWithApiOptionsWithStartWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.Repository.Id, newIssue4);
+        await _issuesClient.Update(_context.Repository.Id, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All, SortDirection = SortDirection.Ascending };
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 4
+        };
+
+        var retrieved = await _issuesClient.GetAllForRepository(_context.Repository.Id, request, options);
+
+        Assert.Equal(1, retrieved.Count);
+        Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
     public async Task CanRetrieveAllIssues()
     {
         var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
@@ -224,6 +558,69 @@ public class IssuesClientTests : IDisposable
         var request = new RepositoryIssueRequest { State = ItemStateFilter.All };
 
         var retrieved = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, request);
+
+        Assert.Equal(4, retrieved.Count);
+        Assert.True(retrieved.Any(i => i.Number == issue1.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue2.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue3.Number));
+        Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesReturnsDistinctReulstsBasedOnApiOptions()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue1);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue2);
+        await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue4);
+        await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All };
+
+        var firstOptions = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 1
+        };
+
+        var firstPage = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, request, firstOptions);
+
+        var secondOptions = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, request, secondOptions);
+
+        Assert.Equal(2, firstPage.Count);
+        Assert.Equal(2, secondPage.Count);
+        Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
+        Assert.NotEqual(firstPage[1].Number, secondPage[1].Number);
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveAllIssuesWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("A test issue1") { Body = "A new unassigned issue" };
+        var newIssue2 = new NewIssue("A test issue2") { Body = "A new unassigned issue" };
+        var newIssue3 = new NewIssue("A test issue3") { Body = "A new unassigned issue" };
+        var newIssue4 = new NewIssue("A test issue4") { Body = "A new unassigned issue" };
+        var issue1 = await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        var issue2 = await _issuesClient.Create(_context.Repository.Id, newIssue2);
+        var issue3 = await _issuesClient.Create(_context.Repository.Id, newIssue3);
+        var issue4 = await _issuesClient.Create(_context.Repository.Id, newIssue4);
+        await _issuesClient.Update(_context.Repository.Id, issue4.Number, new IssueUpdate { State = ItemState.Closed });
+
+        var request = new RepositoryIssueRequest { State = ItemStateFilter.All };
+
+        var retrieved = await _issuesClient.GetAllForRepository(_context.Repository.Id, request);
 
         Assert.Equal(4, retrieved.Count);
         Assert.True(retrieved.Any(i => i.Number == issue1.Number));
@@ -259,6 +656,32 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanFilterByAssignedWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("An assigned issue") { Body = "Assigning this to myself", Assignee = _context.RepositoryOwner };
+        var newIssue2 = new NewIssue("An unassigned issue") { Body = "A new unassigned issue" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+
+        var allIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest());
+
+        Assert.Equal(2, allIssues.Count);
+
+        var assignedIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Assignee = _context.RepositoryOwner });
+
+        Assert.Equal(1, assignedIssues.Count);
+        Assert.Equal("An assigned issue", assignedIssues[0].Title);
+
+        var unassignedIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Assignee = "none" });
+
+        Assert.Equal(1, unassignedIssues.Count);
+        Assert.Equal("An unassigned issue", unassignedIssues[0].Title);
+    }
+
+    [IntegrationTest]
     public async Task CanFilterByCreator()
     {
         var newIssue1 = new NewIssue("An issue") { Body = "words words words" };
@@ -277,6 +700,30 @@ public class IssuesClientTests : IDisposable
         Assert.Equal(2, issuesCreatedByOwner.Count);
 
         var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
+            new RepositoryIssueRequest { Creator = "shiftkey" });
+
+        Assert.Equal(0, issuesCreatedByExternalUser.Count);
+    }
+
+    [IntegrationTest]
+    public async Task CanFilterByCreatorWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("An issue") { Body = "words words words" };
+        var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+
+        var allIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest());
+
+        Assert.Equal(2, allIssues.Count);
+
+        var issuesCreatedByOwner = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Creator = _context.RepositoryOwner });
+
+        Assert.Equal(2, issuesCreatedByOwner.Count);
+
+        var issuesCreatedByExternalUser = await _issuesClient.GetAllForRepository(_context.Repository.Id,
             new RepositoryIssueRequest { Creator = "shiftkey" });
 
         Assert.Equal(0, issuesCreatedByExternalUser.Count);
@@ -307,10 +754,42 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanFilterByMentionedWithRepositoryId()
+    {
+        var newIssue1 = new NewIssue("An issue") { Body = "words words words hello there @shiftkey" };
+        var newIssue2 = new NewIssue("Another issue") { Body = "some other words" };
+        await _issuesClient.Create(_context.Repository.Id, newIssue1);
+        await _issuesClient.Create(_context.Repository.Id, newIssue2);
+
+        var allIssues = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest());
+
+        Assert.Equal(2, allIssues.Count);
+
+        var mentionsWithShiftkey = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Mentioned = "shiftkey" });
+
+        Assert.Equal(1, mentionsWithShiftkey.Count);
+
+        var mentionsWithHaacked = await _issuesClient.GetAllForRepository(_context.Repository.Id,
+            new RepositoryIssueRequest { Mentioned = "haacked" });
+
+        Assert.Equal(0, mentionsWithHaacked.Count);
+    }
+
+    [IntegrationTest]
     public async Task FilteringByInvalidAccountThrowsError()
     {
         await Assert.ThrowsAsync<ApiValidationException>(
             () => _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
+                new RepositoryIssueRequest { Assignee = "some-random-account" }));
+    }
+
+    [IntegrationTest]
+    public async Task FilteringByInvalidAccountThrowsErrorWithRepositoryId()
+    {
+        await Assert.ThrowsAsync<ApiValidationException>(
+            () => _issuesClient.GetAllForRepository(_context.Repository.Id,
                 new RepositoryIssueRequest { Assignee = "some-random-account" }));
     }
 
@@ -338,6 +817,29 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanAssignAndUnassignMilestoneWithRepositoryId()
+    {
+        var newMilestone = new NewMilestone("a milestone");
+        var milestone = await _issuesClient.Milestone.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        var newIssue1 = new NewIssue("A test issue1")
+        {
+            Body = "A new unassigned issue",
+            Milestone = milestone.Number
+        };
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue1);
+
+        Assert.NotNull(issue.Milestone);
+
+        var issueUpdate = issue.ToUpdate();
+        issueUpdate.Milestone = null;
+
+        var updatedIssue = await _issuesClient.Update(_context.Repository.Id, issue.Number, issueUpdate);
+
+        Assert.Null(updatedIssue.Milestone);
+    }
+
+    [IntegrationTest]
     public async Task DoesNotChangeLabelsByDefault()
     {
         await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
@@ -353,6 +855,26 @@ public class IssuesClientTests : IDisposable
         var issueUpdate = issue.ToUpdate();
 
         var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+
+        Assert.Equal(1, updatedIssue.Labels.Count);
+    }
+
+    [IntegrationTest]
+    public async Task DoesNotChangeLabelsByDefaultWithRepositoryId()
+    {
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
+
+        var newIssue = new NewIssue("A test issue1")
+        {
+            Body = "A new unassigned issue"
+        };
+        newIssue.Labels.Add("something");
+
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+
+        var issueUpdate = issue.ToUpdate();
+
+        var updatedIssue = await _issuesClient.Update(_context.Repository.Id, issue.Number, issueUpdate);
 
         Assert.Equal(1, updatedIssue.Labels.Count);
     }
@@ -378,6 +900,31 @@ public class IssuesClientTests : IDisposable
         issueUpdate.AddLabel("another thing");
 
         var updatedIssue = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, issueUpdate);
+
+        Assert.Equal("another thing", updatedIssue.Labels[0].Name);
+    }
+
+    [IntegrationTest]
+    public async Task CanUpdateLabelForAnIssueWithRepositoryId()
+    {
+        // create some labels
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("another thing", "0000FF"));
+
+        // setup us the issue
+        var newIssue = new NewIssue("A test issue1")
+        {
+            Body = "A new unassigned issue"
+        };
+        newIssue.Labels.Add("something");
+
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+
+        // update the issue
+        var issueUpdate = issue.ToUpdate();
+        issueUpdate.AddLabel("another thing");
+
+        var updatedIssue = await _issuesClient.Update(_context.Repository.Id, issue.Number, issueUpdate);
 
         Assert.Equal("another thing", updatedIssue.Labels[0].Name);
     }
@@ -410,6 +957,33 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanClearLabelsForAnIssueWithRepositoryId()
+    {
+        // create some labels
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("something", "FF0000"));
+        await _issuesClient.Labels.Create(_context.RepositoryOwner, _context.RepositoryName, new NewLabel("another thing", "0000FF"));
+
+        // setup us the issue
+        var newIssue = new NewIssue("A test issue1")
+        {
+            Body = "A new unassigned issue"
+        };
+        newIssue.Labels.Add("something");
+        newIssue.Labels.Add("another thing");
+
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
+        Assert.Equal(2, issue.Labels.Count);
+
+        // update the issue
+        var issueUpdate = issue.ToUpdate();
+        issueUpdate.ClearLabels();
+
+        var updatedIssue = await _issuesClient.Update(_context.Repository.Id, issue.Number, issueUpdate);
+
+        Assert.Empty(updatedIssue.Labels);
+    }
+
+    [IntegrationTest]
     public async Task CanAccessUrls()
     {
         var expectedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
@@ -420,6 +994,24 @@ public class IssuesClientTests : IDisposable
         };
 
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+        Assert.NotNull(issue.CommentsUrl);
+        Assert.Equal(new Uri(string.Format(expectedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "comments")), issue.CommentsUrl);
+        Assert.NotNull(issue.EventsUrl);
+        Assert.Equal(new Uri(string.Format(expectedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "events")), issue.EventsUrl);
+    }
+
+    [IntegrationTest]
+    public async Task CanAccessUrlsWithRepositoryId()
+    {
+        var expectedUri = "https://api.github.com/repos/{0}/{1}/issues/{2}/{3}";
+
+        var newIssue = new NewIssue("A test issue")
+        {
+            Body = "A new unassigned issue"
+        };
+
+        var issue = await _issuesClient.Create(_context.Repository.Id, newIssue);
 
         Assert.NotNull(issue.CommentsUrl);
         Assert.Equal(new Uri(string.Format(expectedUri, _context.RepositoryOwner, _context.RepositoryName, issue.Number, "comments")), issue.CommentsUrl);

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -13,14 +13,25 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.Get("fake", "repo", 42);
+                await client.Get("fake", "repo", 42);
 
                 connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                await client.Get(1, 42);
+
+                connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42"));
             }
 
             [Fact]
@@ -30,6 +41,9 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
 
@@ -47,24 +61,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForCurrent();
+                await client.GetAllForCurrent();
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "issues"),
                     Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
             }
 
             [Fact]
-            public void SendsAppropriateParameters()
+            public async Task SendsAppropriateParameters()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForCurrent(new IssueRequest { SortDirection = SortDirection.Ascending });
+                await client.GetAllForCurrent(new IssueRequest { SortDirection = SortDirection.Ascending });
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "issues"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 4
@@ -90,12 +104,12 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForOwnedAndMemberRepositories();
+                await client.GetAllForOwnedAndMemberRepositories();
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "user/issues"),
                     Arg.Any<Dictionary<string, string>>(),
@@ -106,7 +120,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForOrganizationMethod
         {
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesClient(Substitute.For<IApiConnection>());
 
@@ -131,12 +145,12 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForOrganization("fake");
+                await client.GetAllForOrganization("fake");
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/issues"),
                     Arg.Any<Dictionary<string, string>>(),
@@ -167,7 +181,7 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForRepositoryMethod
         {
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesClient(Substitute.For<IApiConnection>());
 
@@ -175,39 +189,40 @@ namespace Octokit.Tests.Clients
                 var request = new RepositoryIssueRequest();
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", options));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request, options));
-
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", options));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request, options));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", options));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, options));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request, options));
-
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", options));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request, options));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (RepositoryIssueRequest)null));
-
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request, options));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request, options));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, options));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (RepositoryIssueRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, options));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, request, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request, options));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request, options));
             }
 
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForRepository("fake", "repo");
+                await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
                     Arg.Any<Dictionary<string, string>>(),
@@ -215,12 +230,63 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void SendsAppropriateParameters()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                client.GetAllForRepository("fake", "repo", new RepositoryIssueRequest
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository("fake", "repo", options);
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"), Arg.Any<Dictionary<string, string>>(), options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    options);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParameters()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                await client.GetAllForRepository("fake", "repo", new RepositoryIssueRequest
                 {
                     SortDirection = SortDirection.Ascending
                 });
@@ -232,6 +298,80 @@ namespace Octokit.Tests.Clients
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
                     Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParametersWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                await client.GetAllForRepository(1, new RepositoryIssueRequest
+                {
+                    SortDirection = SortDirection.Ascending
+                });
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 4
+                        && d["state"] == "open"
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"
+                        && d["filter"] == "assigned"),
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParametersWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository("fake", "repo", new RepositoryIssueRequest
+                {
+                    SortDirection = SortDirection.Ascending
+                }, options);
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 4
+                        && d["state"] == "open"
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"
+                        && d["filter"] == "assigned"),
+                    options);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParametersWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, new RepositoryIssueRequest
+                {
+                    SortDirection = SortDirection.Ascending
+                }, options);
+
+                connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 4
+                        && d["state"] == "open"
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"
+                        && d["filter"] == "assigned"),
+                    options);
             }
         }
 
@@ -251,16 +391,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var newIssue = new NewIssue("some title");
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                client.Create(1, newIssue);
+
+                connection.Received().Post<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                    newIssue);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewIssue("title")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewIssue("x")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewIssue("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewIssue("x")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewIssue("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewIssue("x")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewIssue("x")));
             }
         }
 
@@ -280,16 +436,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var issueUpdate = new IssueUpdate();
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                client.Update(1, 42, issueUpdate);
+
+                connection.Received().Patch<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42"),
+                    issueUpdate);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", 1, new IssueUpdate()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 1, new IssueUpdate()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, 1, new IssueUpdate()));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 1, new IssueUpdate()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", 1, new IssueUpdate()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", 1, new IssueUpdate()));
             }
         }
 
@@ -307,14 +479,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                client.Lock(1, 42);
+
+                connection.Received().Put<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/lock"), Arg.Any<object>(), Arg.Any<string>(), Arg.Is<string>(u => u.ToString() == "application/vnd.github.the-key-preview+json"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Lock(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Lock("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Lock("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Lock("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Lock("owner", "", 1));
             }
         }
@@ -333,14 +517,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesClient(connection);
+
+                client.Unlock(1, 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/lock"), Arg.Any<object>(), Arg.Is<string>(u => u.ToString() == "application/vnd.github.the-key-preview+json"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssuesClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unlock(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Unlock("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Unlock("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Unlock("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Unlock("owner", "", 1));
             }
         }

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -5,7 +5,6 @@ using Octokit.Reactive;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -25,52 +24,235 @@ public class ObservableIssuesClientTests
         }
 
         [Fact]
-        public async Task EnsuresNonNullArguments()
+        public void GetsFromClientIssueIssueWithRepositoryId()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.Get(1, 42);
+
+            gitHubClient.Issue.Received().Get(1, 42);
+        }
+
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", 1));
+            Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, 1));
+
+            Assert.Throws<ArgumentException>(() => client.Get("owner", "", 1));
+            Assert.Throws<ArgumentException>(() => client.Get("", "name", 1));
         }
     }
 
     public class TheGetAllForRepositoryMethod
     {
         [Fact]
-        public async Task EnsuresArgumentsNotNull()
+        public void EnsuresNonNullArguments()
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
             var options = new ApiOptions();
             var request = new RepositoryIssueRequest();
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name").ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", options).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request, options).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (RepositoryIssueRequest)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null));
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name").ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", options).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request, options).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (RepositoryIssueRequest)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, request, null));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, options).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request, options).ToTask());
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", options));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", options));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", request));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", request, options));
+            Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", request, options));
+        }
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "").ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", options).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request, options).ToTask());
+        [Fact]
+        public void RequestsCorrectUrl()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (RepositoryIssueRequest)null).ToTask());
+            client.GetAllForRepository("fake", "repo");
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, options).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null).ToTask());
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
+                Arg.Any<IDictionary<string, string>>(), null);
+        }
+
+        [Fact]
+        public void RequestsCorrectUrlWithRepositoryId()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.GetAllForRepository(1);
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                Arg.Any<IDictionary<string, string>>(), null);
+        }
+
+        [Fact]
+        public void RequestsCorrectUrlWithApiOptions()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            client.GetAllForRepository("fake", "repo", options);
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"), 
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 6 
+                && d["filter"] == "assigned" 
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "desc"
+                && d["page"] == "1"
+                && d["per_page"] == "1"), null);
+        }
+
+        [Fact]
+        public void RequestsCorrectUrlWithRepositoryIdWithApiOptions()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            client.GetAllForRepository(1, options);
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 6
+                && d["filter"] == "assigned"
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "desc"
+                && d["page"] == "1"
+                && d["per_page"] == "1"), null);
+        }
+
+        [Fact]
+        public void SendsAppropriateParameters()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.GetAllForRepository("fake", "repo", new RepositoryIssueRequest
+            {
+                SortDirection = SortDirection.Ascending
+            });
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 4
+                && d["filter"] == "assigned"
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "asc"), null);
+        }
+
+        [Fact]
+        public void SendsAppropriateParametersWithRepositoryId()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.GetAllForRepository(1, new RepositoryIssueRequest
+            {
+                SortDirection = SortDirection.Ascending
+            });
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 4
+                && d["filter"] == "assigned"
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "asc"), null);
+        }
+
+        [Fact]
+        public void SendsAppropriateParametersWithApiOptions()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            client.GetAllForRepository("fake", "repo", new RepositoryIssueRequest
+            {
+                SortDirection = SortDirection.Ascending
+            }, options);
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 6
+                && d["filter"] == "assigned"
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "asc"
+                && d["page"] == "1"
+                && d["per_page"] == "1"),
+                null);
+        }
+
+        [Fact]
+        public void SendsAppropriateParametersWithRepositoryIdWithApiOptions()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            client.GetAllForRepository(1, new RepositoryIssueRequest
+            {
+                SortDirection = SortDirection.Ascending
+            }, options);
+
+            gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
+                Arg.Is<IDictionary<string, string>>(d => d.Count == 6
+                && d["filter"] == "assigned"
+                && d["state"] == "open"
+                && d["sort"] == "created"
+                && d["direction"] == "asc"
+                && d["page"] == "1"
+                && d["per_page"] == "1"),
+                null);
         }
 
         [Fact]
@@ -135,18 +317,18 @@ public class ObservableIssuesClientTests
     public class TheGetAllForOwnedAndMemberRepositoriesMethod
     {
         [Fact]
-        public async Task EnsuresNonNullArguments()
+        public void EnsuresNonNullArguments()
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.GetAllForOwnedAndMemberRepositories((ApiOptions)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.GetAllForOwnedAndMemberRepositories((IssueRequest)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.GetAllForOwnedAndMemberRepositories(null, new ApiOptions()).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.GetAllForOwnedAndMemberRepositories(new IssueRequest(), null).ToTask());
+            Assert.Throws<ArgumentNullException>(
+                () => client.GetAllForOwnedAndMemberRepositories((ApiOptions)null));
+            Assert.Throws<ArgumentNullException>(
+                () => client.GetAllForOwnedAndMemberRepositories((IssueRequest)null));
+            Assert.Throws<ArgumentNullException>(
+                () => client.GetAllForOwnedAndMemberRepositories(null, new ApiOptions()));
+            Assert.Throws<ArgumentNullException>(
+                () => client.GetAllForOwnedAndMemberRepositories(new IssueRequest(), null));
         }
 
         [Fact]
@@ -212,28 +394,28 @@ public class ObservableIssuesClientTests
     public class TheGetAllForOrganizationMethod
     {
         [Fact]
-        public async Task EnsuresArgumentsNotNull()
+        public void EnsuresNonNullArguments()
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
             var options = new ApiOptions();
             var request = new RepositoryIssueRequest();
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null, options).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null, request).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization(null, request, options).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization(null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization(null, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization(null, request));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization(null, request, options));
 
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("").ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("", options).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("", request).ToTask());
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForOrganization("", request, options).ToTask());
+            Assert.Throws<ArgumentException>(() => client.GetAllForOrganization(""));
+            Assert.Throws<ArgumentException>(() => client.GetAllForOrganization("", options));
+            Assert.Throws<ArgumentException>(() => client.GetAllForOrganization("", request));
+            Assert.Throws<ArgumentException>(() => client.GetAllForOrganization("", request, options));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization("org", (ApiOptions)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization("org", (IssueRequest)null).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization("org", (ApiOptions)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization("org", (IssueRequest)null));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization("org", null, options).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForOrganization("org", request, null).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization("org", null, options));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForOrganization("org", request, null));
         }
 
         [Fact]
@@ -299,14 +481,14 @@ public class ObservableIssuesClientTests
     public class TheGetAllForCurrentMethod
     {
         [Fact]
-        public async Task EnsuresNonNullArguments()
+        public void EnsuresNonNullArguments()
         {
             var client = new ObservableIssuesClient(Substitute.For<IGitHubClient>());
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent((ApiOptions)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent((IssueRequest)null).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null, new ApiOptions()).ToTask());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(new IssueRequest(), null).ToTask());
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent((ApiOptions)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent((IssueRequest)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent(null, new ApiOptions()));
+            Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent(new IssueRequest(), null));
         }
 
         [Fact]
@@ -383,16 +565,31 @@ public class ObservableIssuesClientTests
         }
 
         [Fact]
-        public void EnsuresArgumentsNotNull()
+        public void CreatesFromClientIssueIssueWithRepositoryId()
+        {
+            var newIssue = new NewIssue("some title");
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.Create(1, newIssue);
+
+            gitHubClient.Issue.Received().Create(1, newIssue);
+        }
+
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
-            Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewIssue("title")));
-            Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewIssue("x")));
+            Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewIssue("x")));
             Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewIssue("x")));
-            Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewIssue("x")));
             Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+            Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
+            Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewIssue("x")));
+            Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewIssue("x")));
         }
     }
 
@@ -411,16 +608,32 @@ public class ObservableIssuesClientTests
         }
 
         [Fact]
-        public void EnsuresArgumentsNotNull()
+        public void UpdatesClientIssueIssueWithRepositoryId()
+        {
+            var issueUpdate = new IssueUpdate();
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.Update(1, 42, issueUpdate);
+
+            gitHubClient.Issue.Received().Update(1, 42, issueUpdate);
+        }
+
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
             Assert.Throws<ArgumentNullException>(() => client.Update(null, "name", 42, new IssueUpdate()));
-            Assert.Throws<ArgumentException>(() => client.Update("", "name", 42, new IssueUpdate()));
             Assert.Throws<ArgumentNullException>(() => client.Update("owner", null, 42, new IssueUpdate()));
-            Assert.Throws<ArgumentException>(() => client.Update("owner", "", 42, new IssueUpdate()));
             Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
+
+            Assert.Throws<ArgumentNullException>(() => client.Update(1, 42, null));
+
+            Assert.Throws<ArgumentException>(() => client.Update("", "name", 42, new IssueUpdate()));
+            Assert.Throws<ArgumentException>(() => client.Update("owner", "", 42, new IssueUpdate()));
+            
         }
     }
 
@@ -433,18 +646,31 @@ public class ObservableIssuesClientTests
             var client = new ObservableIssuesClient(gitHubClient);
 
             client.Lock("fake", "repo", 42);
+
             gitHubClient.Issue.Received().Lock("fake", "repo", 42);
         }
 
         [Fact]
-        public void EnsuresArgumentsNotNull()
+        public void LocksIssueWithRepositoryId()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.Lock(1, 42);
+
+            gitHubClient.Issue.Received().Lock(1, 42);
+        }
+
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
             Assert.Throws<ArgumentNullException>(() => client.Lock(null, "name", 42));
-            Assert.Throws<ArgumentException>(() => client.Lock("", "name", 42));
             Assert.Throws<ArgumentNullException>(() => client.Lock("owner", null, 42));
+
+            Assert.Throws<ArgumentException>(() => client.Lock("", "name", 42));
             Assert.Throws<ArgumentException>(() => client.Lock("owner", "", 42));
         }
     }
@@ -458,18 +684,31 @@ public class ObservableIssuesClientTests
             var client = new ObservableIssuesClient(gitHubClient);
 
             client.Unlock("fake", "repo", 42);
+
             gitHubClient.Issue.Received().Unlock("fake", "repo", 42);
         }
 
         [Fact]
-        public void EnsuresArgumentsNotNull()
+        public void UnlocksIssueWithRepositoryId()
+        {
+            var gitHubClient = Substitute.For<IGitHubClient>();
+            var client = new ObservableIssuesClient(gitHubClient);
+
+            client.Unlock(1, 42);
+
+            gitHubClient.Issue.Received().Unlock(1, 42);
+        }
+
+        [Fact]
+        public void EnsuresNonNullArguments()
         {
             var gitHubClient = Substitute.For<IGitHubClient>();
             var client = new ObservableIssuesClient(gitHubClient);
 
             Assert.Throws<ArgumentNullException>(() => client.Unlock(null, "name", 42));
-            Assert.Throws<ArgumentException>(() => client.Unlock("", "name", 42));
             Assert.Throws<ArgumentNullException>(() => client.Unlock("owner", null, 42));
+
+            Assert.Throws<ArgumentException>(() => client.Unlock("", "name", 42));
             Assert.Throws<ArgumentException>(() => client.Unlock("owner", "", 42));
         }
     }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -85,7 +85,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
@@ -98,7 +97,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -110,7 +108,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories();
 
         /// <summary>
@@ -123,7 +120,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options);
 
         /// <summary>
@@ -134,7 +130,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request);
 
         /// <summary>
@@ -146,7 +141,6 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
-
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options);
 
         /// <summary>

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Issue> Get(string owner, string name, int number);
@@ -61,7 +61,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Issue> Get(int repositoryId, int number);
@@ -74,7 +74,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent();
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories();
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options);
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request);
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request);
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request);
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        /// <returns></returns>
         Task<Issue> Create(string owner, string name, NewIssue newIssue);
 
         /// <summary>
@@ -310,7 +310,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        /// <returns></returns>
         Task<Issue> Create(int repositoryId, NewIssue newIssue);
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        /// <returns></returns>
         Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        /// <returns></returns>
         Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -345,7 +345,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         Task Lock(string owner, string name, int number);
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         Task Lock(int repositoryId, int number);
 
         /// <summary>
@@ -364,7 +364,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         Task Unlock(string owner, string name, int number);
 
         /// <summary>
@@ -373,7 +373,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         Task Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -50,8 +50,21 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-            Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         Task<Issue> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single Issue by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#get-a-single-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        Task<Issue> Get(int repositoryId, int number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -204,11 +217,32 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -228,12 +262,35 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -245,6 +302,16 @@ namespace Octokit
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
         /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
         Task<Issue> Create(string owner, string name, NewIssue newIssue);
+
+        /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        Task<Issue> Create(int repositoryId, NewIssue newIssue);
 
         /// <summary>
         /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
@@ -260,6 +327,18 @@ namespace Octokit
         Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
 
         /// <summary>
+        /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#edit-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
+        /// </param>
+        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
+
+        /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
@@ -270,6 +349,15 @@ namespace Octokit
         Task Lock(string owner, string name, int number);
 
         /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        Task Lock(int repositoryId, int number);
+
+        /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
@@ -278,5 +366,14 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
         Task Unlock(string owner, string name, int number);
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        Task Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -48,7 +48,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Issue> Get(string owner, string name, int number);
@@ -61,7 +60,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Issue> Get(int repositoryId, int number);
@@ -74,7 +72,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent();
 
         /// <summary>
@@ -86,7 +83,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
@@ -97,7 +93,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request);
 
         /// <summary>
@@ -109,7 +104,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -120,7 +114,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories();
 
         /// <summary>
@@ -132,7 +125,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options);
 
         /// <summary>
@@ -142,7 +134,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request);
 
         /// <summary>
@@ -153,7 +144,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -163,7 +153,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization);
 
         /// <summary>
@@ -174,7 +163,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, ApiOptions options);
 
         /// <summary>
@@ -185,7 +173,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request);
 
         /// <summary>
@@ -197,7 +184,6 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -208,7 +194,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -218,7 +203,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -230,7 +214,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -241,7 +224,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -253,7 +235,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request);
 
         /// <summary>
@@ -264,7 +245,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
@@ -277,7 +257,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -289,7 +268,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
@@ -300,7 +278,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         Task<Issue> Create(string owner, string name, NewIssue newIssue);
 
         /// <summary>
@@ -310,7 +287,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         Task<Issue> Create(int repositoryId, NewIssue newIssue);
 
         /// <summary>
@@ -323,7 +299,6 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -335,7 +310,6 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
@@ -345,7 +319,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task Lock(string owner, string name, int number);
 
         /// <summary>
@@ -354,7 +327,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task Lock(int repositoryId, int number);
 
         /// <summary>
@@ -364,7 +336,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task Unlock(string owner, string name, int number);
 
         /// <summary>
@@ -373,7 +344,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         Task Unlock(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -28,20 +28,24 @@ namespace Octokit
         /// Client for managing assignees.
         /// </summary>
         public IAssigneesClient Assignee { get; private set; }
+
         /// <summary>
         /// Client for reading various event information associated with issues/pull requests.  
         /// This is useful both for display on issue/pull request information pages and also to 
         /// determine who should be notified of comments.
         /// </summary>
         public IIssuesEventsClient Events { get; private set; }
+
         /// <summary>
         /// Client for managing labels.
         /// </summary>
         public IIssuesLabelsClient Labels { get; private set; }
+        
         /// <summary>
         /// Client for managing milestones.
         /// </summary>
         public IMilestonesClient Milestone { get; private set; }
+        
         /// <summary>
         /// Client for managing comments.
         /// </summary>

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -60,7 +60,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +76,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task<Issue> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number));
@@ -91,7 +89,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -106,7 +103,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -122,7 +118,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -139,7 +134,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -156,7 +150,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories()
         {
             return GetAllForOwnedAndMemberRepositories(ApiOptions.None);
@@ -171,7 +164,6 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -186,7 +178,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -202,7 +193,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -218,7 +208,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -234,7 +223,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -251,7 +239,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -269,7 +256,6 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -287,7 +273,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -303,7 +288,6 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new RepositoryIssueRequest());
@@ -318,7 +302,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -336,7 +319,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -353,7 +335,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -371,7 +352,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -389,7 +369,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -409,7 +388,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -426,7 +404,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         public Task<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -443,7 +420,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns></returns>
         public Task<Issue> Create(int repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
@@ -460,7 +436,6 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -479,7 +454,6 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns></returns>
         public Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
@@ -494,7 +468,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -509,7 +482,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task Lock(int repositoryId, int number)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
@@ -522,7 +494,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -537,7 +508,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns></returns>
         public Task Unlock(int repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -60,7 +60,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number));
@@ -91,7 +91,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -106,7 +106,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -122,7 +122,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -139,7 +139,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -156,7 +156,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories()
         {
             return GetAllForOwnedAndMemberRepositories(ApiOptions.None);
@@ -171,7 +171,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -186,7 +186,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -202,7 +202,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -218,7 +218,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -234,7 +234,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -251,7 +251,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -269,7 +269,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
@@ -287,7 +287,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -303,7 +303,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new RepositoryIssueRequest());
@@ -318,7 +318,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -336,7 +336,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -353,7 +353,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -371,7 +371,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -389,7 +389,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -409,7 +409,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -426,7 +426,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -443,7 +443,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Create(int repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
@@ -460,7 +460,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -479,7 +479,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        /// <returns></returns>
         public Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
@@ -494,7 +494,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         public Task Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -509,7 +509,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         public Task Lock(int repositoryId, int number)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
@@ -522,7 +522,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         public Task Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -537,7 +537,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue number</param>
-        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        /// <returns></returns>
         public Task Unlock(int repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -40,12 +40,12 @@ namespace Octokit
         /// Client for managing labels.
         /// </summary>
         public IIssuesLabelsClient Labels { get; private set; }
-        
+
         /// <summary>
         /// Client for managing milestones.
         /// </summary>
         public IMilestonesClient Milestone { get; private set; }
-        
+
         /// <summary>
         /// Client for managing comments.
         /// </summary>
@@ -67,6 +67,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Get<Issue>(ApiUrls.Issue(owner, name, number));
+        }
+
+        /// <summary>
+        /// Gets a single Issue by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#get-a-single-issue
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing requesting the issue from the API.</returns>
+        public Task<Issue> Get(int repositoryId, int number)
+        {
+            return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number));
         }
 
         /// <summary>
@@ -276,7 +290,23 @@ namespace Octokit
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
             return GetAllForRepository(owner, name, new RepositoryIssueRequest());
+        }
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, new RepositoryIssueRequest());
         }
 
         /// <summary>
@@ -291,7 +321,27 @@ namespace Octokit
         /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
+
             return GetAllForRepository(owner, name, new RepositoryIssueRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets all open issues assigned to the authenticated user for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new RepositoryIssueRequest(), options);
         }
 
         /// <summary>
@@ -319,6 +369,22 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
@@ -332,6 +398,24 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Issue>(ApiUrls.Issues(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Gets issues for a repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of issues returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The created <see cref="Task"/> representing requesting a list of issue from the API.</returns>
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Issue>(ApiUrls.Issues(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -350,6 +434,21 @@ namespace Octokit
             Ensure.ArgumentNotNull(newIssue, "newIssue");
 
             return ApiConnection.Post<Issue>(ApiUrls.Issues(owner, name), newIssue);
+        }
+
+        /// <summary>
+        /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        /// <returns>The created <see cref="Task"/> representing the new issue from the API.</returns>
+        public Task<Issue> Create(int repositoryId, NewIssue newIssue)
+        {
+            Ensure.ArgumentNotNull(newIssue, "newIssue");
+
+            return ApiConnection.Post<Issue>(ApiUrls.Issues(repositoryId), newIssue);
         }
 
         /// <summary>
@@ -372,6 +471,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
+        /// issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/#edit-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
+        /// </param>
+        /// <returns>The created <see cref="Task"/> representing the updated issue from the API.</returns>
+        public Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
+        {
+            Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
+
+            return ApiConnection.Patch<Issue>(ApiUrls.Issue(repositoryId, number), issueUpdate);
+        }
+
+        /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
@@ -388,6 +504,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        public Task Lock(int repositoryId, int number)
+        {
+            return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
+        }
+
+        /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
@@ -401,6 +529,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Delete(ApiUrls.IssueLock(owner, name, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);
+        }
+
+        /// <summary>
+        /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns>The created <see cref="Task"/> representing accessing the API.</returns>
+        public Task Unlock(int repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)IssuesClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IIssuesClient and IObservableIssuesClient).**

	  There is some divergence between XML documentation of methods in IIssuesClient and IObservableIssuesClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IIssuesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableIssuesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
I've deleted class ObservableIssuesClientTests beacuse it is useless. All test cases are covered in non-reactive IssuesClientTests class.

/cc @shiftkey, @ryangribble