### PR TITLE
Add repositoryId overloads to methods on I(Observable)CommitCommentReactionsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -22,6 +22,16 @@ namespace Octokit.Reactive
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
+        /// Creates a reaction for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+
+        /// <summary>
         /// List reactions for a specified Commit Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
@@ -30,5 +40,14 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>        
         /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
+        
+        /// <summary>
+        /// List reactions for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableCommitCommentReactionsClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -22,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class ObservableCommitCommentReactionsClient : IObservableCommitCommentReactionsClient
     {
         readonly ICommitCommentReactionsClient _client;
@@ -25,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -42,6 +42,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a reaction for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return _client.Create(repositoryId, number, reaction).ToObservable();
+        }
+
+        /// <summary>
         /// List reactions for a specified Commit Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
@@ -55,6 +70,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.CommitCommentReactions(owner, name, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// List reactions for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);

--- a/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -64,8 +63,9 @@ public class CommitCommentReactionsClientTests
 
             Assert.NotEmpty(reactions);
 
-            var @default = reactions.FirstOrDefault(r => r.Id == reaction.Id);
-            Assert.NotNull(@default);
+            Assert.Equal(reaction.Id, reactions[0].Id);
+
+            Assert.Equal(reaction.Content, reactions[0].Content);
         }
 
         [IntegrationTest]
@@ -87,8 +87,9 @@ public class CommitCommentReactionsClientTests
 
             Assert.NotEmpty(reactions);
 
-            var @default = reactions.FirstOrDefault(r => r.Id == reaction.Id);
-            Assert.NotNull(@default);
+            Assert.Equal(reaction.Id, reactions[0].Id);
+
+            Assert.Equal(reaction.Content, reactions[0].Content);
         }
 
         [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
@@ -1,8 +1,9 @@
-﻿using Octokit;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit;
 using Octokit.Tests.Integration;
 using Octokit.Tests.Integration.Helpers;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 public class CommitCommentReactionsClientTests
@@ -45,6 +46,52 @@ public class CommitCommentReactionsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanListReactions()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var newReaction = new NewReaction(ReactionType.Confused);
+            var reaction = await _github.Reaction.CommitComment.Create(_context.RepositoryOwner, _context.RepositoryName, result.Id, newReaction);
+
+            var reactions = await _github.Reaction.CommitComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, result.Id);
+
+            Assert.NotEmpty(reactions);
+
+            var @default = reactions.FirstOrDefault(r => r.Id == reaction.Id);
+            Assert.NotNull(@default);
+        }
+
+        [IntegrationTest]
+        public async Task CanListReactionsWithRepositoryId()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var newReaction = new NewReaction(ReactionType.Confused);
+            var reaction = await _github.Reaction.CommitComment.Create(_context.Repository.Id, result.Id, newReaction);
+
+            var reactions = await _github.Reaction.CommitComment.GetAll(_context.Repository.Id, result.Id);
+
+            Assert.NotEmpty(reactions);
+
+            var @default = reactions.FirstOrDefault(r => r.Id == reaction.Id);
+            Assert.NotNull(@default);
+        }
+
+        [IntegrationTest]
         public async Task CanCreateReaction()
         {
             var commit = await SetupCommitForRepository(_github);
@@ -58,6 +105,28 @@ public class CommitCommentReactionsClientTests
 
             var newReaction = new NewReaction(ReactionType.Confused);
             var reaction = await _github.Reaction.CommitComment.Create(_context.RepositoryOwner, _context.RepositoryName, result.Id, newReaction);
+
+            Assert.IsType<Reaction>(reaction);
+
+            Assert.Equal(ReactionType.Confused, reaction.Content);
+
+            Assert.Equal(result.User.Id, reaction.User.Id);
+        }
+
+        [IntegrationTest]
+        public async Task CanCreateReactionWithRepositoryId()
+        {
+            var commit = await SetupCommitForRepository(_github);
+
+            var comment = new NewCommitComment("test");
+
+            var result = await _github.Repository.Comment.Create(_context.RepositoryOwner, _context.RepositoryName,
+                commit.Sha, comment);
+
+            Assert.NotNull(result);
+
+            var newReaction = new NewReaction(ReactionType.Confused);
+            var reaction = await _github.Reaction.CommitComment.Create(_context.Repository.Id, result.Id, newReaction);
 
             Assert.IsType<Reaction>(reaction);
 

--- a/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
@@ -24,7 +24,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitCommentReactionsClient(connection);
 
-                client.GetAll("fake", "repo", 42);
+                await client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new CommitCommentReactionsClient(connection);
 
-                client.GetAll(1, 42);
+                await client.GetAll(1, 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }

--- a/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
@@ -22,9 +22,9 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                client.CommitComment.GetAll("fake", "repo", 42);
+                client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
@@ -33,9 +33,9 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                client.CommitComment.GetAll(1, 42);
+                client.GetAll(1, 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
@@ -44,13 +44,13 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNotNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.GetAll(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.GetAll("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CommitComment.GetAll("", "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CommitComment.GetAll("owner", "", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -62,9 +62,9 @@ namespace Octokit.Tests.Clients
                 NewReaction newReaction = new NewReaction(ReactionType.Heart);
 
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                client.CommitComment.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
 
                 connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
             }
@@ -75,9 +75,9 @@ namespace Octokit.Tests.Clients
                 NewReaction newReaction = new NewReaction(ReactionType.Heart);
 
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                client.CommitComment.Create(1, 1, newReaction);
+                client.Create(1, 1, newReaction);
 
                 connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
             }
@@ -86,16 +86,16 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNotNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new CommitCommentReactionsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.Create("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CommitComment.Create(1, 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, 1, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CommitComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CommitComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableCommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitCommentReactionsClientTests.cs
@@ -22,9 +22,9 @@ namespace Octokit.Tests.Reactive
             public void RequestsCorrectUrl()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(gitHubClient);
+                var client = new ObservableCommitCommentReactionsClient(gitHubClient);
 
-                client.CommitComment.GetAll("fake", "repo", 42);
+                client.GetAll("fake", "repo", 42);
 
                 gitHubClient.Received().Reaction.CommitComment.GetAll("fake", "repo", 42);
             }
@@ -33,9 +33,9 @@ namespace Octokit.Tests.Reactive
             public void RequestsCorrectUrlWithRepositoryId()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(gitHubClient);
+                var client = new ObservableCommitCommentReactionsClient(gitHubClient);
 
-                client.CommitComment.GetAll(1, 42);
+                client.GetAll(1, 42);
 
                 gitHubClient.Received().Reaction.CommitComment.GetAll(1, 42);
             }
@@ -44,13 +44,13 @@ namespace Octokit.Tests.Reactive
             public void EnsuresNotNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(gitHubClient);
+                var client = new ObservableCommitCommentReactionsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.GetAll(null, "name", 1));
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.GetAll("owner", null, 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
 
-                Assert.Throws<ArgumentException>(() => client.CommitComment.GetAll("", "name", 1));
-                Assert.Throws<ArgumentException>(() => client.CommitComment.GetAll("owner", "", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -60,10 +60,10 @@ namespace Octokit.Tests.Reactive
             public void RequestsCorrectUrl()
             {
                 var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(githubClient);
+                var client = new ObservableCommitCommentReactionsClient(githubClient);
                 var newReaction = new NewReaction(ReactionType.Confused);
 
-                client.CommitComment.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
 
                 githubClient.Received().Reaction.CommitComment.Create("fake", "repo", 1, newReaction);
             }
@@ -72,10 +72,10 @@ namespace Octokit.Tests.Reactive
             public void RequestsCorrectUrlWithRepositoryId()
             {
                 var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(githubClient);
+                var client = new ObservableCommitCommentReactionsClient(githubClient);
                 var newReaction = new NewReaction(ReactionType.Confused);
 
-                client.CommitComment.Create(1, 1, newReaction);
+                client.Create(1, 1, newReaction);
 
                 githubClient.Received().Reaction.CommitComment.Create(1, 1, newReaction);
             }
@@ -84,16 +84,16 @@ namespace Octokit.Tests.Reactive
             public void EnsuresNotNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(gitHubClient);
+                var client = new ObservableCommitCommentReactionsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create("owner", "name", 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
 
-                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create(1, 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, 1, null));
 
-                Assert.Throws<ArgumentException>(() => client.CommitComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => client.CommitComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableCommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCommitCommentReactionsClientTests.cs
@@ -18,33 +18,39 @@ namespace Octokit.Tests.Reactive
 
         public class TheGetAllMethod
         {
-            private readonly IGitHubClient _githubClient;
-            private readonly IObservableReactionsClient _client;
-            private const string owner = "owner";
-            private const string name = "name";
-
-            public TheGetAllMethod()
-            {
-                _githubClient = Substitute.For<IGitHubClient>();
-                _client = new ObservableReactionsClient(_githubClient);
-            }
-
             [Fact]
             public void RequestsCorrectUrl()
             {
-                _client.CommitComment.GetAll("fake", "repo", 42);
-                _githubClient.Received().Reaction.CommitComment.GetAll("fake", "repo", 42);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(gitHubClient);
+
+                client.CommitComment.GetAll("fake", "repo", 42);
+
+                gitHubClient.Received().Reaction.CommitComment.GetAll("fake", "repo", 42);
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => _client.CommitComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.CommitComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.CommitComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.CommitComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.CommitComment.Create("owner", "name", 1, null));
+                client.CommitComment.GetAll(1, 42);
+
+                gitHubClient.Received().Reaction.CommitComment.GetAll(1, 42);
+            }
+
+            [Fact]
+            public void EnsuresNotNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.GetAll(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.GetAll("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.CommitComment.GetAll("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.CommitComment.GetAll("owner", "", 1));
             }
         }
 
@@ -58,7 +64,36 @@ namespace Octokit.Tests.Reactive
                 var newReaction = new NewReaction(ReactionType.Confused);
 
                 client.CommitComment.Create("fake", "repo", 1, newReaction);
+
                 githubClient.Received().Reaction.CommitComment.Create("fake", "repo", 1, newReaction);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(githubClient);
+                var newReaction = new NewReaction(ReactionType.Confused);
+
+                client.CommitComment.Create(1, 1, newReaction);
+
+                githubClient.Received().Reaction.CommitComment.Create(1, 1, newReaction);
+            }
+
+            [Fact]
+            public void EnsuresNotNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.CommitComment.Create(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.CommitComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentException>(() => client.CommitComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class CommitCommentReactionsClient : ApiClient, ICommitCommentReactionsClient
     {
         public CommitCommentReactionsClient(IApiConnection apiConnection)
@@ -18,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -35,7 +41,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -56,7 +56,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +71,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -35,6 +35,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a reaction for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return ApiConnection.Post<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), reaction, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Get all reactions for a specified Commit Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
@@ -48,6 +63,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.GetAll<Reaction>(ApiUrls.CommitCommentReactions(owner, name, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// Get all reactions for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface ICommitCommentReactionsClient
     {
         /// <summary>
@@ -13,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -23,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -23,6 +23,16 @@ namespace Octokit
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
+        /// Creates a reaction for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+
+        /// <summary>
         /// Get all reactions for a specified Commit Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
@@ -31,5 +41,14 @@ namespace Octokit
         /// <param name="number">The comment id</param>        
         /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
+
+        /// <summary>
+        /// Get all reactions for a specified Commit Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing all reactions for specified comment id.</returns>
+        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -425,6 +425,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for the reaction of a specified commit comment.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment number</param>
+        /// <returns></returns>
+        public static Uri CommitCommentReactions(int repositoryId, int number)
+        {
+            return "repositories/{0}/comments/{2}/reactions".FormatUri(repositoryId, number);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns all of the assignees to which issues may be assigned.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -432,7 +432,7 @@ namespace Octokit
         /// <returns></returns>
         public static Uri CommitCommentReactions(int repositoryId, int number)
         {
-            return "repositories/{0}/comments/{2}/reactions".FormatUri(repositoryId, number);
+            return "repositories/{0}/comments/{1}/reactions".FormatUri(repositoryId, number);
         }
 
         /// <summary>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)CommitCommentReactionsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of ICommitCommentReactionsClient and IObservableCommitCommentReactionsClient).**

	  There is some divergence between XML documentation of methods in ICommitCommentReactionsClient and IObservableCommitCommentReactionsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to ICommitCommentReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableCommitCommentReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
I've deleted class ObservableCommitCommentReactionsClientTests beacuse it is useless. All test cases are covered in non-reactive CommitCommentReactionsClientTests class.

/cc @shiftkey, @ryangribble