### PR TITLE
Add repositoryId overloads to methods on I(Observable)IssueCommentReactionsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -22,6 +22,16 @@ namespace Octokit.Reactive
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
+        /// Creates a reaction for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+
+        /// <summary>
         /// List reactions for a specified Issue Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
@@ -30,5 +40,14 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>        
         /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
+
+        /// <summary>
+        /// List reactions for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableIssueCommentReactionsClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -22,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -28,7 +27,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -47,7 +44,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -1,10 +1,15 @@
-﻿using Octokit.Reactive.Internal;
-using System;
-using System.Reactive.Linq;
+﻿using System;
 using System.Reactive.Threading.Tasks;
+using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class ObservableIssueCommentReactionsClient : IObservableIssueCommentReactionsClient
     {
         readonly IIssueCommentReactionsClient _client;
@@ -26,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -42,6 +42,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a reaction for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return _client.Create(repositoryId, number, reaction).ToObservable();
+        }
+
+        /// <summary>
         /// List reactions for a specified Issue Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
@@ -55,6 +70,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(owner, name, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// List reactions for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -31,7 +31,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +47,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -63,7 +61,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +75,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>A <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of < see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);

--- a/Octokit.Tests.Integration/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentReactionsClientTests.cs
@@ -1,8 +1,8 @@
-﻿using Octokit;
+﻿using System;
+using System.Threading.Tasks;
+using Octokit;
 using Octokit.Tests.Integration;
 using Octokit.Tests.Integration.Helpers;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 public class IssueCommentReactionsClientTests
@@ -22,6 +22,52 @@ public class IssueCommentReactionsClientTests
         }
 
         [IntegrationTest]
+        public async Task CanListReactions()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueComment = await _issuesClient.Comment.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, "A test comment");
+
+            Assert.NotNull(issueComment);
+
+            var issueCommentReaction = await _github.Reaction.IssueComment.Create(_context.RepositoryOwner, _context.RepositoryName, issueComment.Id, new NewReaction(ReactionType.Heart));
+
+            var reactions = await _github.Reaction.IssueComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, issueComment.Id);
+
+            Assert.NotEmpty(reactions);
+
+            Assert.Equal(reactions[0].Id, issueCommentReaction.Id);
+
+            Assert.Equal(reactions[0].Content, issueCommentReaction.Content);
+        }
+
+        [IntegrationTest]
+        public async Task CanListReactionsWithRepositoryId()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueComment = await _issuesClient.Comment.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, "A test comment");
+
+            Assert.NotNull(issueComment);
+
+            var issueCommentReaction = await _github.Reaction.IssueComment.Create(_context.Repository.Id, issueComment.Id, new NewReaction(ReactionType.Heart));
+
+            var reactions = await _github.Reaction.IssueComment.GetAll(_context.Repository.Id, issueComment.Id);
+
+            Assert.NotEmpty(reactions);
+
+            Assert.Equal(reactions[0].Id, issueCommentReaction.Id);
+
+            Assert.Equal(reactions[0].Content, issueCommentReaction.Content);
+        }
+
+        [IntegrationTest]
         public async Task CanCreateReaction()
         {
             var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
@@ -34,6 +80,29 @@ public class IssueCommentReactionsClientTests
             Assert.NotNull(issueComment);
 
             var issueCommentReaction = await _github.Reaction.IssueComment.Create(_context.RepositoryOwner, _context.RepositoryName, issueComment.Id, new NewReaction(ReactionType.Heart));
+
+            Assert.NotNull(issueCommentReaction);
+
+            Assert.IsType<Reaction>(issueCommentReaction);
+
+            Assert.Equal(ReactionType.Heart, issueCommentReaction.Content);
+
+            Assert.Equal(issueComment.User.Id, issueCommentReaction.User.Id);
+        }
+
+        [IntegrationTest]
+        public async Task CanCreateReactionWithRepositoryId()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueComment = await _issuesClient.Comment.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, "A test comment");
+
+            Assert.NotNull(issueComment);
+
+            var issueCommentReaction = await _github.Reaction.IssueComment.Create(_context.Repository.Id, issueComment.Id, new NewReaction(ReactionType.Heart));
 
             Assert.NotNull(issueCommentReaction);
 

--- a/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
@@ -24,7 +24,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueCommentReactionsClient(connection);
 
-                client.GetAll("fake", "repo", 42);
+                await client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new IssueCommentReactionsClient(connection);
 
-                client.GetAll(1, 42);
+                await client.GetAll(1, 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }

--- a/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
@@ -1,6 +1,6 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -22,24 +22,35 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new IssueCommentReactionsClient(connection);
 
-                client.IssueComment.GetAll("fake", "repo", 42);
+                client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new IssueCommentReactionsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IssueComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.IssueComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IssueComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.IssueComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IssueComment.Create("owner", "name", 1, null));
+                client.GetAll(1, 42);
+
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentReactionsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -51,11 +62,40 @@ namespace Octokit.Tests.Clients
                 NewReaction newReaction = new NewReaction(ReactionType.Heart);
 
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new IssueCommentReactionsClient(connection);
 
-                client.IssueComment.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
 
                 connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                NewReaction newReaction = new NewReaction(ReactionType.Heart);
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentReactionsClient(connection);
+
+                client.Create(1, 1, newReaction);
+
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentReactionsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -23,6 +23,16 @@ namespace Octokit
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
+        /// Creates a reaction for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+
+        /// <summary>
         /// Get all reactions for a specified Issue Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
@@ -31,5 +41,14 @@ namespace Octokit
         /// <param name="number">The comment id</param>        
         /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
+        
+        /// <summary>
+        /// Get all reactions for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -19,7 +19,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -29,7 +28,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -39,7 +37,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IIssueCommentReactionsClient
     {
         /// <summary>
@@ -13,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -23,7 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -1,9 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class IssueCommentReactionsClient : ApiClient, IIssueCommentReactionsClient
     {
         public IssueCommentReactionsClient(IApiConnection apiConnection)
@@ -19,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -36,7 +41,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -24,7 +24,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +40,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -56,7 +54,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +68,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created reaction for specified comment id.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
@@ -56,7 +56,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -71,7 +71,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -35,6 +35,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a reaction for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Reaction"/> representing created reaction for specified comment id.</returns>
+        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return ApiConnection.Post<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), reaction, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Get all reactions for a specified Issue Comment
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
@@ -48,6 +63,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(owner, name, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// Get all reactions for a specified Issue Comment
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="IReadOnlyList{Reaction}"/> of <see cref="Reaction"/>s representing reactions for specified comment id.</returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -378,6 +378,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for the reaction of a specified issue comment.
+        /// </summary>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment number</param>
+        /// <returns></returns>
+        public static Uri IssueCommentReactions(int repositoryId, int number)
+        {
+            return "repositories/{0}/issues/comments/{1}/reactions".FormatUri(repositoryId, number);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for the specified comment.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)IssueCommentReactionsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IIssueCommentReactionsClient and IObservableIssueCommentReactionsClient).**

	  There is some divergence between XML documentation of methods in IIssueCommentReactionsClient and IObservableIssueCommentReactionsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IIssueCommentReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableIssueCommentReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
I've deleted class ObservableIssueCommentReactionsClientTests beacuse it is useless. All test cases are covered in non-reactive IssueCommentReactionsClientTests class.

/cc @shiftkey, @ryangribble