### PR TITLE
Add repositoryId overloads to methods on I(Observable)IssueReactionsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableIssueReactionsClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -22,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -11,6 +11,25 @@ namespace Octokit.Reactive
     public interface IObservableIssueReactionsClient
     {
         /// <summary>
+        /// List reactions for a specified Issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        IObservable<Reaction> GetAll(string owner, string name, int number);
+        
+        /// <summary>
+        /// List reactions for a specified Issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        IObservable<Reaction> GetAll(int repositoryId, int number);
+
+        /// <summary>
         /// Creates a reaction for a specified Issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
@@ -22,13 +41,13 @@ namespace Octokit.Reactive
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
-        /// List reactions for a specified Issue.
+        /// Creates a reaction for a specified Issue.
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
-        IObservable<Reaction> GetAll(string owner, string name, int number);
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -17,16 +17,16 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
-        
+
         /// <summary>
         /// List reactions for a specified Issue.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -17,7 +17,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -37,7 +35,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -47,7 +44,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -24,6 +24,34 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// List reactions for a specified Issue
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        public IObservable<Reaction> GetAll(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(owner, name, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// List reactions for a specified Issue.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
@@ -42,19 +70,16 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// List reactions for a specified Issue
+        /// Creates a reaction for a specified Issue.
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
-        public IObservable<Reaction> GetAll(string owner, string name, int number)
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>
+        /// <param name="reaction">The reaction to create </param>
+        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(owner, name, number), null, AcceptHeaders.ReactionsPreview);
+            return _client.Create(repositoryId, number, reaction).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -79,6 +79,8 @@ namespace Octokit.Reactive
         /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
             return _client.Create(repositoryId, number, reaction).ToObservable();
         }
     }

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -1,6 +1,6 @@
-﻿using Octokit.Reactive.Internal;
-using System;
+﻿using System;
 using System.Reactive.Threading.Tasks;
+using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -59,7 +59,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -30,7 +30,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +44,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -59,7 +57,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -76,7 +73,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -4,6 +4,12 @@ using System.Reactive.Threading.Tasks;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class ObservableIssueReactionsClient : IObservableIssueReactionsClient
     {
         readonly IIssueReactionsClient _client;
@@ -25,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>An <see cref="IObservable{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -59,7 +59,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        /// <returns>An <see cref="IObservable{T}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
@@ -1,8 +1,8 @@
-﻿using Octokit;
+﻿using System;
+using System.Threading.Tasks;
+using Octokit;
 using Octokit.Tests.Integration;
 using Octokit.Tests.Integration.Helpers;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 public class IssueReactionsClientTests
@@ -16,9 +16,47 @@ public class IssueReactionsClientTests
         public TheCreateReactionMethod()
         {
             _github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
             _issuesClient = _github.Issue;
+
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _context = _github.CreateRepositoryContext(new NewRepository(repoName)).Result;
+        }
+
+        [IntegrationTest]
+        public async Task CanListReactions()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueReaction = await _github.Reaction.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new NewReaction(ReactionType.Heart));
+
+            var issueReactions = await _github.Reaction.Issue.GetAll(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+
+            Assert.NotEmpty(issueReactions);
+
+            Assert.Equal(issueReaction.Id, issueReactions[0].Id);
+            Assert.Equal(issueReaction.Content, issueReactions[0].Content);
+        }
+
+        [IntegrationTest]
+        public async Task CanListReactionsWithRepositoryId()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueReaction = await _github.Reaction.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new NewReaction(ReactionType.Heart));
+
+            var issueReactions = await _github.Reaction.Issue.GetAll(_context.Repository.Id, issue.Number);
+
+            Assert.NotEmpty(issueReactions);
+
+            Assert.Equal(issueReaction.Id, issueReactions[0].Id);
+            Assert.Equal(issueReaction.Content, issueReactions[0].Content);
         }
 
         [IntegrationTest]
@@ -40,10 +78,28 @@ public class IssueReactionsClientTests
             Assert.Equal(issue.User.Id, issueReaction.User.Id);
         }
 
+        [IntegrationTest]
+        public async Task CanCreateReactionWithRepositoryId()
+        {
+            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
+
+            Assert.NotNull(issue);
+
+            var issueReaction = await _github.Reaction.Issue.Create(_context.Repository.Id, issue.Number, new NewReaction(ReactionType.Heart));
+
+            Assert.NotNull(issueReaction);
+
+            Assert.IsType<Reaction>(issueReaction);
+
+            Assert.Equal(ReactionType.Heart, issueReaction.Content);
+
+            Assert.Equal(issue.User.Id, issueReaction.User.Id);
+        }
+
         public void Dispose()
         {
             _context.Dispose();
         }
     }
 }
-

--- a/Octokit.Tests/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueReactionsClientTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueReactionsClientTests.cs
@@ -22,24 +22,35 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new IssueReactionsClient(connection);
 
-                client.Issue.GetAll("fake", "repo", 42);
+                await client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueReactionsClient(connection);
+
+                await client.GetAll(1, 42);
+
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReactionsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.GetAll(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.GetAll("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.GetAll("owner", "", 1));
             }
         }
 
@@ -51,11 +62,40 @@ namespace Octokit.Tests.Clients
                 NewReaction newReaction = new NewReaction(ReactionType.Heart);
 
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new IssueReactionsClient(connection);
 
-                client.Issue.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
 
                 connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                NewReaction newReaction = new NewReaction(ReactionType.Heart);
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueReactionsClient(connection);
+
+                client.Create(1, 1, newReaction);
+
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReactionsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Issue.Create(1, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Issue.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit.Tests/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueReactionsClientTests.cs
@@ -1,6 +1,6 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients

--- a/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
@@ -18,33 +18,37 @@ namespace Octokit.Tests.Reactive
 
         public class TheGetAllMethod
         {
-            private readonly IGitHubClient _githubClient;
-            private readonly IObservableReactionsClient _client;
-            private const string owner = "owner";
-            private const string name = "name";
-
-            public TheGetAllMethod()
-            {
-                _githubClient = Substitute.For<IGitHubClient>();
-                _client = new ObservableReactionsClient(_githubClient);
-            }
-
             [Fact]
             public void RequestsCorrectUrl()
             {
-                _client.Issue.GetAll("fake", "repo", 42);
-                _githubClient.Received().Reaction.Issue.GetAll("fake", "repo", 42);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueReactionsClient(gitHubClient);
+
+                client.GetAll("fake", "repo", 42);
+                gitHubClient.Received().Reaction.Issue.GetAll("fake", "repo", 42);
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueReactionsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => _client.Issue.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.Issue.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.Issue.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.Issue.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.Issue.Create("owner", "name", 1, null));
+                client.GetAll(1, 42);
+                gitHubClient.Received().Reaction.Issue.GetAll(1, 42);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -58,7 +62,36 @@ namespace Octokit.Tests.Reactive
                 var newReaction = new NewReaction(ReactionType.Confused);
 
                 client.Issue.Create("fake", "repo", 1, newReaction);
+
                 githubClient.Received().Reaction.Issue.Create("fake", "repo", 1, newReaction);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReactionsClient(githubClient);
+                var newReaction = new NewReaction(ReactionType.Confused);
+
+                client.Issue.Create(1, 1, newReaction);
+
+                githubClient.Received().Reaction.Issue.Create(1, 1, newReaction);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
@@ -1,6 +1,6 @@
-﻿using NSubstitute;
+﻿using System;
+using NSubstitute;
 using Octokit.Reactive;
-using System;
 using Xunit;
 
 namespace Octokit.Tests.Reactive

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -22,6 +22,15 @@ namespace Octokit
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
+        /// Get all reactions for a specified Issue
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
+
+        /// <summary>
         /// Creates a reaction for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
@@ -31,5 +40,15 @@ namespace Octokit
         /// <param name="reaction">The reaction to create</param>
         /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
+
+        /// <summary>
+        /// Creates a reaction for a specified Issue
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -18,7 +18,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IIssueReactionsClient
     {
         /// <summary>
@@ -12,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -23,7 +29,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -38,7 +38,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
@@ -52,7 +52,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -1,9 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class IssueReactionsClient : ApiClient, IIssueReactionsClient
     {
         public IssueReactionsClient(IApiConnection apiConnection)
@@ -14,12 +19,12 @@ namespace Octokit
         /// <summary>
         /// Creates a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#create-reactions-for-an-issue</remarks>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -36,7 +41,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{T}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -17,6 +17,34 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get all reactions for a specified Issue
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(owner, name, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// Get all reactions for a specified Issue
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>        
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Issue
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
@@ -35,19 +63,18 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Get all reactions for a specified Issue
+        /// Creates a reaction for a specified Issue
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified issue.</returns>
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-an-issue</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified issue.</returns>
+        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(reaction, "reaction");
 
-            return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(owner, name, number), AcceptHeaders.ReactionsPreview);
+            return ApiConnection.Post<Reaction>(ApiUrls.IssueReactions(repositoryId, number), reaction, AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -23,7 +23,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -38,7 +37,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
@@ -52,7 +50,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +66,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -331,6 +331,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for the reaction of a specified issue.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <returns></returns>
+        public static Uri IssueReactions(int repositoryId, int number)
+        {
+            return "repositories/{0}/issues/{1}/reactions".FormatUri(repositoryId, number);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for the comments for all issues in a specific repo.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)IssueReactionsClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IIssueReactionsClient and IObservableIssueReactionsClient).**

	  There is some divergence between XML documentation of methods in IIssueReactionsClient and IObservableIssueReactionsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IIssueReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableIssueReactionsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
I've deleted class ObservableIssueReactionsClientTests beacuse it is useless. All test cases are covered in non-reactive IssueReactionsClientTests class.

/cc @shiftkey, @ryangribble