### PR TITLE
Add repositoryId overloads to methods on I(Observable)PullRequestReviewCommentReactionsClient 

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -11,6 +11,16 @@ namespace Octokit.Reactive
     public interface IObservablePullRequestReviewCommentReactionsClient
     {
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns></returns>
+        IObservable<Reaction> GetAll(string owner, string name, int number);
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -20,15 +30,5 @@ namespace Octokit.Reactive
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
-
-        /// <summary>
-        /// Get all reactions for a specified Pull Request Review Comment.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
-        /// <returns></returns>
-        IObservable<Reaction> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -21,6 +21,15 @@ namespace Octokit.Reactive
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        IObservable<Reaction> GetAll(int repositoryId, int number);
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -30,5 +39,15 @@ namespace Octokit.Reactive
         /// <param name="reaction">The reaction to create</param>
         /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
+
+        /// <summary>
+        /// Creates a reaction for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -1,8 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IObservablePullRequestReviewCommentReactionsClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -17,7 +17,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,7 +25,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -37,7 +35,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -47,7 +44,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -17,7 +17,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         IObservable<Reaction> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -1,10 +1,15 @@
-﻿using Octokit.Reactive.Internal;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Reactive.Threading.Tasks;
+using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class ObservablePullRequestReviewCommentReactionsClient : IObservablePullRequestReviewCommentReactionsClient
     {
         readonly IPullRequestReviewCommentReactionsClient _client;

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -59,7 +59,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -24,6 +24,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns></returns>
+        public IObservable<Reaction> GetAll(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -39,22 +55,6 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(reaction, "reaction");
 
             return _client.Create(owner, name, number, reaction).ToObservable();
-        }
-
-        /// <summary>
-        /// Get all reactions for a specified Pull Request Review Comment.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
-        /// <returns></returns>
-        public IObservable<Reaction> GetAll(string owner, string name, int number)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), null, AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -30,7 +30,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -45,7 +44,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public IObservable<Reaction> GetAll(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -59,7 +57,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -76,7 +73,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -40,6 +40,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -55,6 +67,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(reaction, "reaction");
 
             return _client.Create(owner, name, number, reaction).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a reaction for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>An <see cref="IObservable{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return _client.Create(repositoryId, number, reaction).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentReactionsClientTests.cs
@@ -1,8 +1,8 @@
-﻿using Octokit;
+﻿using System;
+using System.Threading.Tasks;
+using Octokit;
 using Octokit.Tests.Integration;
 using Octokit.Tests.Integration.Helpers;
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 public class PullRequestReviewCommentReactionsClientTests : IDisposable
@@ -27,6 +27,52 @@ public class PullRequestReviewCommentReactionsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanListReactions()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateComment(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var commentFromGitHub = await _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id);
+
+        AssertComment(commentFromGitHub, body, position);
+
+        var reaction = await _github.Reaction.PullRequestReviewComment.Create(_context.RepositoryOwner, _context.RepositoryName, commentFromGitHub.Id, new NewReaction(ReactionType.Heart));
+
+        var reactions = await _github.Reaction.PullRequestReviewComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, commentFromGitHub.Id);
+
+        Assert.NotEmpty(reactions);
+        Assert.Equal(reaction.Id, reactions[0].Id);
+        Assert.Equal(reaction.Content, reactions[0].Content);
+    }
+
+    [IntegrationTest]
+    public async Task CanListReactionsWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateComment(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var commentFromGitHub = await _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id);
+
+        AssertComment(commentFromGitHub, body, position);
+
+        var reaction = await _github.Reaction.PullRequestReviewComment.Create(_context.Repository.Id, commentFromGitHub.Id, new NewReaction(ReactionType.Heart));
+
+        var reactions = await _github.Reaction.PullRequestReviewComment.GetAll(_context.Repository.Id, commentFromGitHub.Id);
+
+        Assert.NotEmpty(reactions);
+        Assert.Equal(reaction.Id, reactions[0].Id);
+        Assert.Equal(reaction.Content, reactions[0].Content);
+    }
+
+    [IntegrationTest]
     public async Task CanCreateReaction()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -41,6 +87,31 @@ public class PullRequestReviewCommentReactionsClientTests : IDisposable
         AssertComment(commentFromGitHub, body, position);
 
         var pullRequestReviewCommentReaction = await _github.Reaction.PullRequestReviewComment.Create(_context.RepositoryOwner, _context.RepositoryName, commentFromGitHub.Id, new NewReaction(ReactionType.Heart));
+
+        Assert.NotNull(pullRequestReviewCommentReaction);
+
+        Assert.IsType<Reaction>(pullRequestReviewCommentReaction);
+
+        Assert.Equal(ReactionType.Heart, pullRequestReviewCommentReaction.Content);
+
+        Assert.Equal(commentFromGitHub.User.Id, pullRequestReviewCommentReaction.User.Id);
+    }
+
+    [IntegrationTest]
+    public async Task CanCreateReactionWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateComment(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var commentFromGitHub = await _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id);
+
+        AssertComment(commentFromGitHub, body, position);
+
+        var pullRequestReviewCommentReaction = await _github.Reaction.PullRequestReviewComment.Create(_context.Repository.Id, commentFromGitHub.Id, new NewReaction(ReactionType.Heart));
 
         Assert.NotNull(pullRequestReviewCommentReaction);
 
@@ -154,4 +225,3 @@ public class PullRequestReviewCommentReactionsClientTests : IDisposable
         public string Sha { get; set; }
     }
 }
-

--- a/Octokit.Tests/Clients/PullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentReactionsClientTests.cs
@@ -1,6 +1,6 @@
-﻿using NSubstitute;
-using System;
+﻿using System;
 using System.Threading.Tasks;
+using NSubstitute;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -22,24 +22,35 @@ namespace Octokit.Tests.Clients
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new PullRequestReviewCommentReactionsClient(connection);
 
-                client.PullRequestReviewComment.GetAll("fake", "repo", 42);
+                await client.GetAll("fake", "repo", 42);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new PullRequestReviewCommentReactionsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.PullRequestReviewComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.PullRequestReviewComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.PullRequestReviewComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.PullRequestReviewComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.PullRequestReviewComment.Create("owner", "name", 1, null));
+                await client.GetAll(1, 42);
+
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/42/reactions"), "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestReviewCommentReactionsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -51,11 +62,40 @@ namespace Octokit.Tests.Clients
                 NewReaction newReaction = new NewReaction(ReactionType.Heart);
 
                 var connection = Substitute.For<IApiConnection>();
-                var client = new ReactionsClient(connection);
+                var client = new PullRequestReviewCommentReactionsClient(connection);
 
-                client.PullRequestReviewComment.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/1/reactions"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                NewReaction newReaction = new NewReaction(ReactionType.Heart);
+
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestReviewCommentReactionsClient(connection);
+
+                client.Create(1, 1, newReaction);
+
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestReviewCommentReactionsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, 1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentReactionsClientTests.cs
@@ -1,13 +1,12 @@
-﻿using NSubstitute;
+﻿using System;
+using NSubstitute;
 using Octokit.Reactive;
-using System;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
 {
     public class ObservablePullRequestReviewCommentReactionsClientTests
     {
-
         public class TheCtor
         {
             [Fact]
@@ -19,33 +18,39 @@ namespace Octokit.Tests.Reactive
 
         public class TheGetAllMethod
         {
-            private readonly IGitHubClient _githubClient;
-            private readonly IObservableReactionsClient _client;
-            private const string owner = "owner";
-            private const string name = "name";
-
-            public TheGetAllMethod()
-            {
-                _githubClient = Substitute.For<IGitHubClient>();
-                _client = new ObservableReactionsClient(_githubClient);
-            }
-
             [Fact]
             public void RequestsCorrectUrl()
             {
-                _client.PullRequestReviewComment.GetAll("fake", "repo", 42);
-                _githubClient.Received().Reaction.PullRequestReviewComment.GetAll("fake", "repo", 42);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
+
+                client.GetAll("fake", "repo", 42);
+
+                gitHubClient.Received().Reaction.PullRequestReviewComment.GetAll("fake", "repo", 42);
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
             {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => _client.PullRequestReviewComment.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.PullRequestReviewComment.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.PullRequestReviewComment.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentException>(() => _client.PullRequestReviewComment.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
-                Assert.Throws<ArgumentNullException>(() => _client.PullRequestReviewComment.Create("owner", "name", 1, null));
+                client.GetAll(1, 42);
+
+                gitHubClient.Received().Reaction.PullRequestReviewComment.GetAll(1, 42);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));
             }
         }
 
@@ -54,12 +59,41 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public void RequestsCorrectUrl()
             {
-                var githubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservableReactionsClient(githubClient);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
                 var newReaction = new NewReaction(ReactionType.Confused);
 
-                client.PullRequestReviewComment.Create("fake", "repo", 1, newReaction);
-                githubClient.Received().Reaction.PullRequestReviewComment.Create("fake", "repo", 1, newReaction);
+                client.Create("fake", "repo", 1, newReaction);
+
+                gitHubClient.Received().Reaction.PullRequestReviewComment.Create("fake", "repo", 1, newReaction);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
+                var newReaction = new NewReaction(ReactionType.Confused);
+
+                client.Create(1, 1, newReaction);
+
+                gitHubClient.Received().Reaction.PullRequestReviewComment.Create(1, 1, newReaction);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentReactionsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", 1, new NewReaction(ReactionType.Heart)));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", 1, new NewReaction(ReactionType.Heart)));
             }
         }
     }

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -20,6 +20,15 @@ namespace Octokit
         /// <param name="number">The comment id</param>        
         /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
+        
+        /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
 
         /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
@@ -31,5 +40,15 @@ namespace Octokit
         /// <param name="reaction">The reaction to create</param>
         /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
+
+        /// <summary>
+        /// Creates a reaction for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -3,8 +3,24 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public interface IPullRequestReviewCommentReactionsClient
     {
+        /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns></returns>
+        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
+
         /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
@@ -15,15 +31,5 @@ namespace Octokit
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
-
-        /// <summary>
-        /// Get all reactions for a specified Pull Request Review Comment.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
-        /// <returns></returns>
-        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -18,7 +18,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
         
         /// <summary>
@@ -27,7 +26,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(string owner, string name, int number, NewReaction reaction);
 
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -17,6 +17,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -32,22 +48,6 @@ namespace Octokit
             Ensure.ArgumentNotNull(reaction, "reaction");
 
             return ApiConnection.Post<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), reaction, AcceptHeaders.ReactionsPreview);
-        }
-
-        /// <summary>
-        /// Get all reactions for a specified Pull Request Review Comment.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
-        /// <returns></returns>
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -33,6 +33,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get all reactions for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>        
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
@@ -48,6 +60,21 @@ namespace Octokit
             Ensure.ArgumentNotNull(reaction, "reaction");
 
             return ApiConnection.Post<Reaction>(ApiUrls.PullRequestReviewCommentReaction(owner, name, number), reaction, AcceptHeaders.ReactionsPreview);
+        }
+
+        /// <summary>
+        /// Creates a reaction for a specified Pull Request Review Comment.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment id</param>
+        /// <param name="reaction">The reaction to create</param>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        {
+            Ensure.ArgumentNotNull(reaction, "reaction");
+
+            return ApiConnection.Post<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), reaction, AcceptHeaders.ReactionsPreview);
         }
     }
 }

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -1,9 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Reactions API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/reactions/">Reactions API documentation</a> for more information.
+    /// </remarks>
     public class PullRequestReviewCommentReactionsClient : ApiClient, IPullRequestReviewCommentReactionsClient
     {
         public PullRequestReviewCommentReactionsClient(IApiConnection apiConnection)

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -23,7 +23,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -38,7 +37,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), AcceptHeaders.ReactionsPreview);
@@ -52,7 +50,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +66,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -38,7 +38,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>        
-        /// <returns>A <see cref="Task{T}"/> of <see cref="IReadOnlyList{Reactions}"/> representing <see cref="Reaction"/>s for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), AcceptHeaders.ReactionsPreview);
@@ -52,7 +52,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        /// <returns>A <see cref="Task{Reaction}"/> representing created <see cref="Reaction"/> for a specified pull request review comment.</returns>
+        /// <returns></returns>
         public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1220,6 +1220,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for the reaction of a specified pull request review comment.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The comment number</param>
+        /// <returns></returns>
+        public static Uri PullRequestReviewCommentReaction(int repositoryId, int number)
+        {
+            return "repositories/{0}/pulls/comments/{1}/reactions".FormatUri(repositoryId, number);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for the pull request review comments on a specified repository.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)PullRequestReviewCommentReactionsClient  to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IPullRequestReviewCommentReactionsClient  and IObservablePullRequestReviewCommentReactionsClient ).**

	  There is some divergence between XML documentation of methods in IPullRequestReviewCommentReactionsClient  and IObservablePullRequestReviewCommentReactionsClient . So I've decided 
	  to sync XML documentation of these classes during my work on #1120.

- [x] **Add overloads to IPullRequestReviewCommentReactionsClient .**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservablePullRequestReviewCommentReactionsClient .**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
I've deleted class ObservablePullRequestReviewCommentReactionsClient Tests beacuse it is useless. All test cases are covered in non-reactive PullRequestReviewCommentReactionsClient Tests class.

/cc @shiftkey, @ryangribble