### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepoCollaboratorsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -92,7 +92,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">Username of the prospective collaborator</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         IObservable<Unit> Add(string owner, string name, string user);
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">Username of the prospective collaborator</param>
+        /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         IObservable<Unit> Delete(string owner, string name, string user);

--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -20,7 +20,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<User> GetAll(string owner, string name);
 
         /// <summary>
@@ -31,7 +30,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<User> GetAll(int repositoryId);
 
         /// <summary>
@@ -44,7 +42,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<User> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -56,7 +53,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<User> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -69,7 +65,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
@@ -81,7 +76,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<bool> IsCollaborator(int repositoryId, string user);
 
         /// <summary>
@@ -94,7 +88,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<Unit> Add(string owner, string name, string user);
 
         /// <summary>
@@ -106,7 +99,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<Unit> Add(int repositoryId, string user);
 
         /// <summary>
@@ -119,7 +111,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, string user);
 
         /// <summary>
@@ -131,7 +122,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         IObservable<Unit> Delete(int repositoryId, string user);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -29,12 +29,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        IObservable<User> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         IObservable<User> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        IObservable<User> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repository.
@@ -50,6 +73,18 @@ namespace Octokit.Reactive
         IObservable<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
+        /// Checks if a user is a collaborator on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the prospective collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        IObservable<bool> IsCollaborator(int repositoryId, string user);
+
+        /// <summary>
         /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
@@ -63,6 +98,18 @@ namespace Octokit.Reactive
         IObservable<Unit> Add(string owner, string name, string user);
 
         /// <summary>
+        /// Adds a new collaborator to the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the new collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        IObservable<Unit> Add(int repositoryId, string user);
+
+        /// <summary>
         /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
@@ -74,5 +121,17 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         IObservable<Unit> Delete(string owner, string name, string user);
+
+        /// <summary>
+        /// Deletes a collaborator from the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the removed collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        IObservable<Unit> Delete(int repositoryId, string user);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -3,50 +3,76 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Collaborators on a Repository.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/collaborators/">Collaborators API documentation</a> for more details.
+    /// </remarks>
     public interface IObservableRepoCollaboratorsClient
     {
         /// <summary>
-        /// Gets all the available collaborators on this repo.
+        /// Gets all the collaborators on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
-        IObservable<User> GetAll(string owner, string repo);
+        /// <param name="name">The name of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        IObservable<User> GetAll(string owner, string name);
 
         /// <summary>
-        /// Gets all the available collaborators on this repo.
+        /// Gets all the collaborators on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
-        IObservable<User> GetAll(string owner, string repo, ApiOptions options);
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        IObservable<User> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
-        /// Checks to see if a user is an assignee for a repository.
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        IObservable<bool> IsCollaborator(string owner, string repo, string user);
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        IObservable<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
-        /// Adds a user as a collaborator to a repository.
+        /// Adds a new collaborator to the repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        IObservable<Unit> Add(string owner, string repo, string user);
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        IObservable<Unit> Add(string owner, string name, string user);
 
         /// <summary>
-        /// Removes a user as a collaborator for a repository.
+        /// Deletes a collaborator from the repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string repo, string user);
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        IObservable<Unit> Delete(string owner, string name, string user);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -52,6 +52,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        public IObservable<User> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -64,6 +78,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
             
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        public IObservable<User> GetAll(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(repositoryId), options);
         }
 
         /// <summary>
@@ -87,6 +118,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Checks if a user is a collaborator on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the prospective collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        public IObservable<bool> IsCollaborator(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            return _client.IsCollaborator(repositoryId, user).ToObservable();
+        }
+
+        /// <summary>
         /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
@@ -107,6 +155,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Adds a new collaborator to the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the new collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        public IObservable<Unit> Add(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            return _client.Add(repositoryId, user).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
@@ -124,6 +189,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
             return _client.Delete(owner, name, user).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a collaborator from the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">Username of the removed collaborator</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        public IObservable<Unit> Delete(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            return _client.Delete(repositoryId, user).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -37,7 +37,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<User> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -54,7 +53,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<User> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -70,7 +68,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<User> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -89,7 +86,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<User> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -107,7 +103,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<bool> IsCollaborator(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -126,7 +121,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<bool> IsCollaborator(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -144,7 +138,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<Unit> Add(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -163,7 +156,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<Unit> Add(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -181,7 +173,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<Unit> Delete(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -200,7 +191,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public IObservable<Unit> Delete(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -142,7 +142,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">Username of the prospective collaborator</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         public IObservable<Unit> Add(string owner, string name, string user)
@@ -179,7 +179,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">Username of the prospective collaborator</param>
+        /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         public IObservable<Unit> Delete(string owner, string name, string user)
@@ -198,7 +198,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">Username of the removed collaborator</param>
+        /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Unit"/></returns>
         public IObservable<Unit> Delete(int repositoryId, string user)

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -79,6 +79,10 @@ namespace Octokit.Reactive
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
         public IObservable<bool> IsCollaborator(string owner, string name, string user)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
             return _client.IsCollaborator(owner, name, user).ToObservable();
         }
 
@@ -95,6 +99,10 @@ namespace Octokit.Reactive
         /// <returns><see cref="Unit"/></returns>
         public IObservable<Unit> Add(string owner, string name, string user)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
             return _client.Add(owner, name, user).ToObservable();
         }
 
@@ -111,6 +119,10 @@ namespace Octokit.Reactive
         /// <returns><see cref="Unit"/></returns>
         public IObservable<Unit> Delete(string owner, string name, string user)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
             return _client.Delete(owner, name, user).ToObservable();
         }
     }

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -5,11 +5,21 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Collaborators on a Repository.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/repos/collaborators/">Collaborators API documentation</a> for more details.
+    /// </remarks>
     public class ObservableRepoCollaboratorsClient : IObservableRepoCollaboratorsClient
     {
         readonly IRepoCollaboratorsClient _client;
         readonly IConnection _connection;
 
+        /// <summary>
+        /// Initializes a new GitHub Repo Collaborators API client.
+        /// </summary>
+        /// <param name="client">An IGitHubClient client.</param>
         public ObservableRepoCollaboratorsClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");
@@ -19,69 +29,89 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all the available collaborators on this repo.
+        /// Gets all the collaborators on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
-        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
-        public IObservable<User> GetAll(string owner, string repo)
+        /// <param name="name">The name of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        public IObservable<User> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repo, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
-        /// Gets all the available collaborators on this repo.
+        /// Gets all the collaborators on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="User"/>s for the specified repository.</returns>
-        public IObservable<User> GetAll(string owner, string repo, ApiOptions options)
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s for the specified repository.</returns>
+        public IObservable<User> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
             
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(owner, repo), options);
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.RepoCollaborators(owner, name), options);
         }
 
         /// <summary>
-        /// Checks to see if a user is an assignee for a repository.
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        public IObservable<bool> IsCollaborator(string owner, string repo, string user)
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        public IObservable<bool> IsCollaborator(string owner, string name, string user)
         {
-            return _client.IsCollaborator(owner, repo, user).ToObservable();
+            return _client.IsCollaborator(owner, name, user).ToObservable();
         }
 
         /// <summary>
-        /// Adds a user as a collaborator to a repository.
+        /// Adds a new collaborator to the repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        public IObservable<Unit> Add(string owner, string repo, string user)
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        public IObservable<Unit> Add(string owner, string name, string user)
         {
-            return _client.Add(owner, repo, user).ToObservable();
+            return _client.Add(owner, name, user).ToObservable();
         }
 
         /// <summary>
-        /// Removes a user as a collaborator for a repository.
+        /// Deletes a collaborator from the repository.
         /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
-        /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string repo, string user)
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Unit"/></returns>
+        public IObservable<Unit> Delete(string owner, string name, string user)
         {
-            return _client.Delete(owner, repo, user).ToObservable();
+            return _client.Delete(owner, name, user).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
@@ -30,25 +30,6 @@ public class RepositoryCollaboratorClientTests
         }
 
         [IntegrationTest]
-        public async Task ReturnsAllCollaboratorsWithRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add a collaborator
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var collaborators = await fixture.GetAll(context.Repository.Id);
-                Assert.NotNull(collaborators);
-                Assert.Equal(2, collaborators.Count);
-            }
-        }
-
-        [IntegrationTest]
         public async Task ReturnsCorrectCountOfCollaboratorsWithoutStart()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -68,31 +49,6 @@ public class RepositoryCollaboratorClientTests
                 };
 
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
-                Assert.NotNull(collaborators);
-                Assert.Equal(1, collaborators.Count);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task ReturnsCorrectCountOfCollaboratorsWithoutStartAndRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add some collaborators
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1
-                };
-
-                var collaborators = await fixture.GetAll(context.Repository.Id, options);
                 Assert.NotNull(collaborators);
                 Assert.Equal(1, collaborators.Count);
             }
@@ -119,32 +75,6 @@ public class RepositoryCollaboratorClientTests
                 };
 
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
-                Assert.NotNull(collaborators);
-                Assert.Equal(1, collaborators.Count);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task ReturnsCorrectCountOfCollaboratorsWithStartAndRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add some collaborators
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var options = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var collaborators = await fixture.GetAll(context.Repository.Id, options);
                 Assert.NotNull(collaborators);
                 Assert.Equal(1, collaborators.Count);
             }
@@ -183,40 +113,6 @@ public class RepositoryCollaboratorClientTests
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             }
         }
-
-        [IntegrationTest]
-        public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add some collaborators
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var startOptions = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1
-                };
-
-                var firstPage = await fixture.GetAll(context.Repository.Id, startOptions);
-
-                var skipStartOptions = new ApiOptions
-                {
-                    PageSize = 1,
-                    PageCount = 1,
-                    StartPage = 2
-                };
-
-                var secondPage = await fixture.GetAll(context.Repository.Id, skipStartOptions);
-
-                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
-            }
-        }
     }
 
     public class TheIsCollaboratorMethod
@@ -232,77 +128,11 @@ public class RepositoryCollaboratorClientTests
                 var fixture = github.Repository.Collaborator;
 
                 // add a collaborator
-                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+                fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
 
                 var isCollab = await fixture.IsCollaborator(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
 
                 Assert.True(isCollab);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task ReturnsTrueIfUserIsCollaboratorWithRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add a collaborator
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var isCollab = await fixture.IsCollaborator(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                Assert.True(isCollab);
-            }
-        }
-    }
-
-    public class TheDeleteMethod
-    {
-        [IntegrationTest]
-        public async Task CheckDeleteMethod()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add a collaborator
-                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
-
-                // and remove
-                await fixture.Delete(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
-
-                var isCollab = await fixture.IsCollaborator(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
-
-                Assert.False(isCollab);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task CheckDeleteMethodWithRepositoryId()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
-            {
-                var fixture = github.Repository.Collaborator;
-
-                // add a collaborator
-                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                // and remove
-                await fixture.Delete(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                var isCollab = await fixture.IsCollaborator(context.Repository.Id, "m-zuber-octokit-integration-tests");
-
-                Assert.False(isCollab);
             }
         }
     }

--- a/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
@@ -30,6 +30,25 @@ public class RepositoryCollaboratorClientTests
         }
 
         [IntegrationTest]
+        public async Task ReturnsAllCollaboratorsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add a collaborator
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var collaborators = await fixture.GetAll(context.Repository.Id);
+                Assert.NotNull(collaborators);
+                Assert.Equal(2, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
         public async Task ReturnsCorrectCountOfCollaboratorsWithoutStart()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -49,6 +68,31 @@ public class RepositoryCollaboratorClientTests
                 };
 
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithoutStartAndRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var collaborators = await fixture.GetAll(context.Repository.Id, options);
                 Assert.NotNull(collaborators);
                 Assert.Equal(1, collaborators.Count);
             }
@@ -75,6 +119,32 @@ public class RepositoryCollaboratorClientTests
                 };
 
                 var collaborators = await fixture.GetAll(context.RepositoryOwner, context.RepositoryName, options);
+                Assert.NotNull(collaborators);
+                Assert.Equal(1, collaborators.Count);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfCollaboratorsWithStartAndRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var collaborators = await fixture.GetAll(context.Repository.Id, options);
                 Assert.NotNull(collaborators);
                 Assert.Equal(1, collaborators.Count);
             }
@@ -113,6 +183,40 @@ public class RepositoryCollaboratorClientTests
                 Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             }
         }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add some collaborators
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var firstPage = await fixture.GetAll(context.Repository.Id, startOptions);
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var secondPage = await fixture.GetAll(context.Repository.Id, skipStartOptions);
+
+                Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+            }
+        }
     }
 
     public class TheIsCollaboratorMethod
@@ -128,11 +232,77 @@ public class RepositoryCollaboratorClientTests
                 var fixture = github.Repository.Collaborator;
 
                 // add a collaborator
-                fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
 
                 var isCollab = await fixture.IsCollaborator(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
 
                 Assert.True(isCollab);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsTrueIfUserIsCollaboratorWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add a collaborator
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var isCollab = await fixture.IsCollaborator(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                Assert.True(isCollab);
+            }
+        }
+    }
+
+    public class TheDeleteMethod
+    {
+        [IntegrationTest]
+        public async Task CheckDeleteMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add a collaborator
+                await fixture.Add(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                // and remove
+                await fixture.Delete(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                var isCollab = await fixture.IsCollaborator(context.RepositoryOwner, context.RepositoryName, "m-zuber-octokit-integration-tests");
+
+                Assert.False(isCollab);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CheckDeleteMethodWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+
+                // add a collaborator
+                await fixture.Add(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                // and remove
+                await fixture.Delete(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                var isCollab = await fixture.IsCollaborator(context.Repository.Id, "m-zuber-octokit-integration-tests");
+
+                Assert.False(isCollab);
             }
         }
     }

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -32,7 +32,8 @@ namespace Octokit.Tests.Clients
                 var client = new RepoCollaboratorsClient(connection);
 
                 client.GetAll("owner", "test");
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), null, "application/vnd.github.ironman-preview+json", Args.ApiOptions);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), Args.ApiOptions);
             }
 
             [Fact]
@@ -42,6 +43,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepoCollaboratorsClient(connection);
 
                 client.GetAll(1);
+
                 connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators"), Args.ApiOptions);
             }
 
@@ -61,7 +63,7 @@ namespace Octokit.Tests.Clients
                 client.GetAll("owner", "test", options);
 
                 connection.Received()
-                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), null, "application/vnd.github.ironman-preview+json", options);
+                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators"), options);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -36,6 +36,16 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                client.GetAll(1);
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators"), Args.ApiOptions);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -55,6 +65,25 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptionsAndRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(1, options);
+
+                connection.Received()
+                    .GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
@@ -67,6 +96,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "test", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "test", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
             }
         }
 
@@ -91,6 +122,25 @@ namespace Octokit.Tests.Clients
                 Assert.Equal(expected, result);
             }
 
+            [Theory]
+            [InlineData(HttpStatusCode.NoContent, true)]
+            [InlineData(HttpStatusCode.NotFound, false)]
+            public async Task RequestsCorrectValueForStatusCodeWithRepositoryId(HttpStatusCode status, bool expected)
+            {
+                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                    new ApiResponse<object>(new Response(status, null, new Dictionary<string, string>(), "application/json")));
+                var connection = Substitute.For<IConnection>();
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1"),
+                    null, null).Returns(response);
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Connection.Returns(connection);
+                var client = new RepoCollaboratorsClient(apiConnection);
+
+                var result = await client.IsCollaborator(1, "user1");
+
+                Assert.Equal(expected, result);
+            }
+
             [Fact]
             public async Task ThrowsExceptionForInvalidStatusCode()
             {
@@ -101,9 +151,24 @@ namespace Octokit.Tests.Clients
                     null, null).Returns(response);
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Connection.Returns(connection);
-                var client = new AssigneesClient(apiConnection);
+                var client = new RepoCollaboratorsClient(apiConnection);
 
-                await Assert.ThrowsAsync<ApiException>(() => client.CheckAssignee("foo", "bar", "cody"));
+                await Assert.ThrowsAsync<ApiException>(() => client.IsCollaborator("foo", "bar", "cody"));
+            }
+
+            [Fact]
+            public async Task ThrowsExceptionForInvalidStatusCodeWithRepositoryId()
+            {
+                var response = Task.Factory.StartNew<IApiResponse<object>>(() =>
+                    new ApiResponse<object>(new Response(HttpStatusCode.Conflict, null, new Dictionary<string, string>(), "application/json")));
+                var connection = Substitute.For<IConnection>();
+                connection.Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/assignees/cody"),
+                    null, null).Returns(response);
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Connection.Returns(connection);
+                var client = new RepoCollaboratorsClient(apiConnection);
+
+                await Assert.ThrowsAsync<ApiException>(() => client.IsCollaborator(1, "cody"));
             }
 
             [Fact]
@@ -112,11 +177,14 @@ namespace Octokit.Tests.Clients
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator(null, "test", "user1"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator("owner", null, "user1"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("owner", "", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator("owner", "test", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsCollaborator("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsCollaborator(1, ""));
             }
         }
 
@@ -133,16 +201,29 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                client.Add(1, "user1");
+                connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add(null, "test", "user1"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Add("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add("owner", null, "user1"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Add("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add("owner", "", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add("owner", "test", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Add("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Add(1, ""));
             }
         }
 
@@ -159,16 +240,29 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                client.Delete(1, "user1");
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "test", "user1"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "test", "user1"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, "user1"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(1, null));
+                
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "test", "user1"));;
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", "user1"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "test", ""));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", "test", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete(1, ""));
             }
         }
     }

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -101,7 +101,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetMethod
+        public class TheIsCollaboratorMethod
         {
             [Theory]
             [InlineData(HttpStatusCode.NoContent, true)]

--- a/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
@@ -11,12 +11,22 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableRepoCollaboratorsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableRepoCollaboratorsClient(null));
+            }
+        }
+
         public class TheGetAllMethod
         {
             private readonly IGitHubClient _githubClient;
             private readonly IObservableRepoCollaboratorsClient _client;
             private const string owner = "owner";
             private const string name = "name";
+            private const int repositoryId = 1;
 
             public TheGetAllMethod()
             {
@@ -30,6 +40,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(null, name));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, null));
                 Assert.Throws<ArgumentNullException>(() => _client.GetAll(owner, name, null));
+                Assert.Throws<ArgumentNullException>(() => _client.GetAll(repositoryId, null));
             }
 
             [Fact]
@@ -54,6 +65,18 @@ namespace Octokit.Tests.Reactive
                 var expectedUrl = string.Format("repos/{0}/{1}/collaborators", owner, name);
 
                 _client.GetAll(owner, name);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
+                        Arg.Any<string>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var expectedUrl = string.Format("repositories/{0}/collaborators", repositoryId);
+
+                _client.GetAll(repositoryId);
                 _githubClient.Connection.Received(1)
                     .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0), 
@@ -103,6 +126,129 @@ namespace Octokit.Tests.Reactive
                         Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
                         null);
             }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsAndRepositoryId()
+            {
+                var expectedUrl = string.Format("repositories/{0}/collaborators", repositoryId);
+
+                // all properties are setted => only 2 options (StartPage, PageSize) in dictionary
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                _client.GetAll(repositoryId, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 2),
+                        null);
+
+                // StartPage is setted => only 1 option (StartPage) in dictionary
+                options = new ApiOptions
+                {
+                    StartPage = 1
+                };
+
+                _client.GetAll(repositoryId, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 1),
+                        null);
+
+                // PageCount is setted => none of options in dictionary
+                options = new ApiOptions
+                {
+                    PageCount = 1
+                };
+
+                _client.GetAll(repositoryId, options);
+                _githubClient.Connection.Received(1)
+                    .Get<List<User>>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
+                        Arg.Is<IDictionary<string, string>>(dictionary => dictionary.Count == 0),
+                        null);
+            }
+        }
+
+        public class TheIsCollaboratorMethod
+        {
+            private readonly IGitHubClient _githubClient;
+            private IObservableRepoCollaboratorsClient _client;
+
+            public TheIsCollaboratorMethod()
+            {
+                _githubClient = Substitute.For<IGitHubClient>();
+            }
+
+            private void SetupWithoutNonReactiveClient()
+            {
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            private void SetupWithNonReactiveClient()
+            {
+                var deploymentsClient = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
+                _githubClient.Repository.Collaborator.Returns(deploymentsClient);
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentNullException>(() => _client.IsCollaborator(null, "repo", "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.IsCollaborator("owner", null, "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.IsCollaborator("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => _client.IsCollaborator(1, null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => _client.IsCollaborator("", "repo", "user"));
+                Assert.Throws<ArgumentException>(() => _client.IsCollaborator("owner", "", "user"));
+                Assert.Throws<ArgumentException>(() => _client.IsCollaborator(1, ""));
+            }
+
+            [Fact]
+            public async Task EnsuresNonWhitespaceArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.IsCollaborator(whitespace, "repo", "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.IsCollaborator("owner", whitespace, "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.IsCollaborator(1, whitespace));
+            }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClient()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.IsCollaborator(1, "user");
+
+                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(1),
+                    Arg.Is("user"));
+            }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClientWithRepositoryId()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.IsCollaborator(1, "user");
+
+                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(1),
+                    Arg.Is("user"));
+            }
         }
 
         public class TheAddMethod
@@ -135,6 +281,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => _client.Add(null, "repo", "user"));
                 Assert.Throws<ArgumentNullException>(() => _client.Add("owner", null, "user"));
                 Assert.Throws<ArgumentNullException>(() => _client.Add("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => _client.Add(1, null));
             }
 
             [Fact]
@@ -144,6 +291,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => _client.Add("", "repo", "user"));
                 Assert.Throws<ArgumentException>(() => _client.Add("owner", "", "user"));
+                Assert.Throws<ArgumentException>(() => _client.Add(1, ""));
             }
 
             [Fact]
@@ -155,6 +303,8 @@ namespace Octokit.Tests.Reactive
                     async whitespace => await _client.Add(whitespace, "repo", "user"));
                 await AssertEx.ThrowsWhenGivenWhitespaceArgument(
                     async whitespace => await _client.Add("owner", whitespace, "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Add(1, whitespace));
             }
 
             [Fact]
@@ -168,14 +318,96 @@ namespace Octokit.Tests.Reactive
                     Arg.Is("repo"),
                     Arg.Is("user"));
             }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClientWithRepositoryId()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.Add(1, "user");
+
+                _githubClient.Repository.Collaborator.Received(1).Add(Arg.Is(1),
+                    Arg.Is("user"));
+            }
         }
 
-        public class TheCtor
+        public class TheDeleteMethod
         {
+            private readonly IGitHubClient _githubClient;
+            private IObservableRepoCollaboratorsClient _client;
+
+            public TheDeleteMethod()
+            {
+                _githubClient = Substitute.For<IGitHubClient>();
+            }
+
+            private void SetupWithoutNonReactiveClient()
+            {
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
+            private void SetupWithNonReactiveClient()
+            {
+                var deploymentsClient = new RepoCollaboratorsClient(Substitute.For<IApiConnection>());
+                _githubClient.Repository.Collaborator.Returns(deploymentsClient);
+                _client = new ObservableRepoCollaboratorsClient(_githubClient);
+            }
+
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                Assert.Throws<ArgumentNullException>(() => new ObservableRepoCollaboratorsClient(null));
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentNullException>(() => _client.Delete(null, "repo", "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.Delete("owner", null, "user"));
+                Assert.Throws<ArgumentNullException>(() => _client.Delete("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => _client.Delete(1, null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                Assert.Throws<ArgumentException>(() => _client.Delete("", "repo", "user"));
+                Assert.Throws<ArgumentException>(() => _client.Delete("owner", "", "user"));
+                Assert.Throws<ArgumentException>(() => _client.Delete(1, ""));
+            }
+
+            [Fact]
+            public async Task EnsuresNonWhitespaceArguments()
+            {
+                SetupWithNonReactiveClient();
+
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Delete(whitespace, "repo", "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Delete("owner", whitespace, "user"));
+                await AssertEx.ThrowsWhenGivenWhitespaceArgument(
+                    async whitespace => await _client.Delete(1, whitespace));
+            }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClient()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.Delete("owner", "repo", "user");
+
+                _githubClient.Repository.Collaborator.Received(1).Delete(Arg.Is("owner"),
+                    Arg.Is("repo"),
+                    Arg.Is("user"));
+            }
+
+            [Fact]
+            public void CallsCreateOnRegularDeploymentsClientWithRepositoryId()
+            {
+                SetupWithoutNonReactiveClient();
+
+                _client.Delete(1, "user");
+
+                _githubClient.Repository.Collaborator.Received(1).Delete(Arg.Is(1),
+                    Arg.Is("user"));
             }
         }
     }

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -31,12 +31,35 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        Task<IReadOnlyList<User>> GetAll(int repositoryId);
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repo
@@ -52,6 +75,18 @@ namespace Octokit
         Task<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
+        /// Checks if a user is a collaborator on a repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        Task<bool> IsCollaborator(int repositoryId, string user);
+
+        /// <summary>
         /// Adds a new collaborator to the repo
         /// </summary>
         /// <remarks>
@@ -65,6 +100,18 @@ namespace Octokit
         Task Add(string owner, string name, string user);
 
         /// <summary>
+        /// Adds a new collaborator to the repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Task"/></returns>
+        Task Add(int repositoryId, string user);
+
+        /// <summary>
         /// Deletes a collaborator from the repo
         /// </summary>
         /// <remarks>
@@ -76,5 +123,17 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         Task Delete(string owner, string name, string user);
+
+        /// <summary>
+        /// Deletes a collaborator from the repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Task"/></returns>
+        Task Delete(int repositoryId, string user);
     }
 }

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string name);
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         Task<IReadOnlyList<User>> GetAll(int repositoryId);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -58,80 +58,80 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
-        /// Checks if a user is a collaborator on a repo
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
         Task<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
-        /// Checks if a user is a collaborator on a repo
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
         Task<bool> IsCollaborator(int repositoryId, string user);
 
         /// <summary>
-        /// Adds a new collaborator to the repo
+        /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         Task Add(string owner, string name, string user);
 
         /// <summary>
-        /// Adds a new collaborator to the repo
+        /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         Task Add(int repositoryId, string user);
 
         /// <summary>
-        /// Deletes a collaborator from the repo
+        /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         Task Delete(string owner, string name, string user);
 
         /// <summary>
-        /// Deletes a collaborator from the repo
+        /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         Task Delete(int repositoryId, string user);

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -1,6 +1,6 @@
 #if NET_45
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 #endif
 
 namespace Octokit
@@ -20,10 +20,10 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
-        Task<IReadOnlyList<User>> GetAll(string owner, string repo);
+        Task<IReadOnlyList<User>> GetAll(string owner, string name);
 
         /// <summary>
         /// Gets all the collaborators on a repository.
@@ -32,11 +32,11 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
-        Task<IReadOnlyList<User>> GetAll(string owner, string repo, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repo
@@ -44,9 +44,12 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
-        Task<bool> IsCollaborator(string owner, string repo, string user);
+        Task<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
         /// Adds a new collaborator to the repo
@@ -54,9 +57,12 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
-        Task Add(string owner, string repo, string user);
+        Task Add(string owner, string name, string user);
 
         /// <summary>
         /// Deletes a collaborator from the repo
@@ -64,8 +70,11 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
-        Task Delete(string owner, string repo, string user);
+        Task Delete(string owner, string name, string user);
     }
 }

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -22,7 +22,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string name);
 
         /// <summary>
@@ -33,7 +32,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAll(int repositoryId);
 
         /// <summary>
@@ -46,7 +44,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -58,7 +55,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -71,7 +67,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<bool> IsCollaborator(string owner, string name, string user);
 
         /// <summary>
@@ -83,7 +78,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task<bool> IsCollaborator(int repositoryId, string user);
 
         /// <summary>
@@ -96,7 +90,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task Add(string owner, string name, string user);
 
         /// <summary>
@@ -108,7 +101,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task Add(int repositoryId, string user);
 
         /// <summary>
@@ -121,7 +113,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task Delete(string owner, string name, string user);
 
         /// <summary>
@@ -133,7 +124,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         Task Delete(int repositoryId, string user);
     }
 }

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -31,7 +31,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +47,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -64,7 +62,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -83,7 +80,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -101,7 +97,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public async Task<bool> IsCollaborator(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -128,7 +123,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public async Task<bool> IsCollaborator(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -154,7 +148,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task Add(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -173,7 +166,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task Add(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -191,7 +183,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task Delete(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -210,7 +201,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns></returns>
         public Task Delete(int repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -86,6 +86,8 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options)
         {
+            Ensure.ArgumentNotNull(options, "options");
+
             return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(repositoryId), options);
         }
 

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -29,15 +29,15 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
-        public Task<IReadOnlyList<User>> GetAll(string owner, string repo)
+        public Task<IReadOnlyList<User>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAll(owner, repo, ApiOptions.None);
+            return GetAll(owner, name, ApiOptions.None);
         }
 
         /// <summary>
@@ -47,17 +47,17 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
-        public Task<IReadOnlyList<User>> GetAll(string owner, string repo, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, repo), null, AcceptHeaders.OrganizationPermissionsPreview, options);
+            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, name), options);
         }
 
         /// <summary>
@@ -66,17 +66,20 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
-        public async Task<bool> IsCollaborator(string owner, string repo, string user)
+        public async Task<bool> IsCollaborator(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             
             try
             {
-                var response = await Connection.Get<object>(ApiUrls.RepoCollaborator(owner, repo, user), null, null).ConfigureAwait(false);
+                var response = await Connection.Get<object>(ApiUrls.RepoCollaborator(owner, name, user), null, null).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
             catch (NotFoundException)
@@ -91,15 +94,18 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
-        public Task Add(string owner, string repo, string user)
+        public Task Add(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             
-            return ApiConnection.Put(ApiUrls.RepoCollaborator(owner, repo, user));
+            return ApiConnection.Put(ApiUrls.RepoCollaborator(owner, name, user));
         }
 
         /// <summary>
@@ -108,15 +114,18 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="user">The name of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
-        public Task Delete(string owner, string repo, string user)
+        public Task Delete(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repo, "repo");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             
-            return ApiConnection.Delete(ApiUrls.RepoCollaborator(owner, repo, user));
+            return ApiConnection.Delete(ApiUrls.RepoCollaborator(owner, name, user));
         }
     }
 }

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -1,6 +1,6 @@
 ﻿#if NET_45
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 #endif
 
 namespace Octokit
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<User>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -48,7 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<User>> GetAll(int repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -83,21 +83,21 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s for the specified repository.</returns>
         public Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options)
         {
             return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(repositoryId), options);
         }
 
         /// <summary>
-        /// Checks if a user is a collaborator on a repo
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
         public async Task<bool> IsCollaborator(string owner, string name, string user)
@@ -118,13 +118,13 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Checks if a user is a collaborator on a repo
+        /// Checks if a user is a collaborator on a repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
         public async Task<bool> IsCollaborator(int repositoryId, string user)
@@ -143,14 +143,14 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Adds a new collaborator to the repo
+        /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Add(string owner, string name, string user)
@@ -163,13 +163,13 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Adds a new collaborator to the repo
+        /// Adds a new collaborator to the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Add(int repositoryId, string user)
@@ -180,14 +180,14 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Deletes a collaborator from the repo
+        /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Delete(string owner, string name, string user)
@@ -200,13 +200,13 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Deletes a collaborator from the repo
+        /// Deletes a collaborator from the repository.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">The name of the user</param>
+        /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Delete(int repositoryId, string user)

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -189,7 +189,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="user">Username of the removed collaborator</param>
+        /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Delete(string owner, string name, string user)
@@ -208,7 +208,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
-        /// <param name="user">Username of the removed collaborator</param>
+        /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns><see cref="Task"/></returns>
         public Task Delete(int repositoryId, string user)

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -46,6 +46,20 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        public Task<IReadOnlyList<User>> GetAll(int repositoryId)
+        {
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -58,6 +72,21 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the collaborators on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#list">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>.</returns>
+        public Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options)
+        {
+            return ApiConnection.GetAll<User>(ApiUrls.RepoCollaborators(repositoryId), options);
         }
 
         /// <summary>
@@ -89,6 +118,31 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Checks if a user is a collaborator on a repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="bool"/>True if user is a collaborator else false</returns>
+        public async Task<bool> IsCollaborator(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            try
+            {
+                var response = await Connection.Get<object>(ApiUrls.RepoCollaborator(repositoryId, user), null, null).ConfigureAwait(false);
+                return response.HttpResponse.IsTrue();
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Adds a new collaborator to the repo
         /// </summary>
         /// <remarks>
@@ -109,6 +163,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Adds a new collaborator to the repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Task"/></returns>
+        public Task Add(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            return ApiConnection.Put(ApiUrls.RepoCollaborator(repositoryId, user));
+        }
+
+        /// <summary>
         /// Deletes a collaborator from the repo
         /// </summary>
         /// <remarks>
@@ -126,6 +197,23 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             
             return ApiConnection.Delete(ApiUrls.RepoCollaborator(owner, name, user));
+        }
+
+        /// <summary>
+        /// Deletes a collaborator from the repo
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/collaborators/#remove-collaborator">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns><see cref="Task"/></returns>
+        public Task Delete(int repositoryId, string user)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(user, "user");
+
+            return ApiConnection.Delete(ApiUrls.RepoCollaborator(repositoryId, user));
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1408,7 +1408,7 @@ namespace Octokit
         /// <returns>The <see cref="Uri"/> to check user is collaborator</returns>
         public static Uri RepoCollaborator(int repositoryId, string user)
         {
-            return "repositories/{0}/collaborators/{2}".FormatUri(repositoryId, user);
+            return "repositories/{0}/collaborators/{1}".FormatUri(repositoryId, user);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1401,6 +1401,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> to check user is collaborator
+        /// </summary>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="user">The name of the user</param>
+        /// <returns>The <see cref="Uri"/> to check user is collaborator</returns>
+        public static Uri RepoCollaborator(int repositoryId, string user)
+        {
+            return "repositories/{0}/collaborators/{2}".FormatUri(repositoryId, user);
+        }
+
+        /// <summary>
         /// returns the <see cref="Uri"/> for branches
         /// </summary>
         /// <param name="owner">owner of repo</param>


### PR DESCRIPTION
_This PR created instead of #1305 (I've renamed branch :smile: )_

As part of my work on #1120 I've added new overloads on I(Observable)RepoCollaboratorsClient to get access by repository id.

- [x] **Rename parameter "repo" to "name" (in order to deliver more consistency into the codebase).**

	 I've found out that there is the pair (owner, name) is used to identify repository. But some clients use pair (owner, repo) and it's some type of inconsistency.
	  So I've decided to fix these cases during my work on #1120.
- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IRepoCollaboratorsClient and IObservableRepoCollaboratorsClient).**

	  There is some divergence between XML documentation of methods in IRepoCollaboratorsClient and IObservableRepoCollaboratorsClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IRepoCollaboratorsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepoCollaboratorsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.

/cc @shiftkey, @ryangribble