### PR TITLE
Add repositoryId overloads to methods on I(Observable)StarredClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -78,36 +78,24 @@ namespace Octokit.Reactive
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user
-        /// </returns>
         IObservable<Repository> GetAllForCurrent();
         
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user
-        /// </returns>
         IObservable<Repository> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForCurrentWithTimestamps();
         
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(ApiOptions options);
 
         /// <summary>
@@ -115,10 +103,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters
-        /// </returns>
         IObservable<Repository> GetAllForCurrent(StarredRequest request);
 
         /// <summary>
@@ -127,10 +111,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters
-        /// </returns>
         IObservable<Repository> GetAllForCurrent(StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -138,10 +118,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(StarredRequest request);
 
         /// <summary>
@@ -150,10 +126,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -176,9 +148,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user);
 
         /// <summary>
@@ -187,9 +156,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, ApiOptions options);
 
         /// <summary>
@@ -215,10 +181,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, StarredRequest request);
 
         /// <summary>
@@ -228,10 +190,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -22,12 +22,29 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
+        IObservable<User> GetAllStargazers(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
         /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         IObservable<User> GetAllStargazers(string owner, string name, ApiOptions options);
+        
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
+        IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -37,6 +54,14 @@ namespace Octokit.Reactive
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name);
+        
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -47,6 +72,15 @@ namespace Octokit.Reactive
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user

--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -16,7 +16,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         IObservable<User> GetAllStargazers(string owner, string name);
 
         /// <summary>
@@ -24,7 +23,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         IObservable<User> GetAllStargazers(int repositoryId);
 
         /// <summary>
@@ -34,7 +32,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         IObservable<User> GetAllStargazers(string owner, string name, ApiOptions options);
         
         /// <summary>
@@ -43,7 +40,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -52,7 +48,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name);
         
         /// <summary>
@@ -60,7 +55,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId);
 
         /// <summary>
@@ -70,7 +64,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -79,7 +72,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -169,7 +161,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         IObservable<Repository> GetAllForUser(string user);
 
         /// <summary>
@@ -178,7 +169,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         IObservable<Repository> GetAllForUser(string user, ApiOptions options);
 
         /// <summary>
@@ -208,7 +198,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         IObservable<Repository> GetAllForUser(string user, StarredRequest request);
 
         /// <summary>
@@ -218,7 +207,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         IObservable<Repository> GetAllForUser(string user, StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -252,7 +240,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         IObservable<bool> CheckStarred(string owner, string name);
 
         /// <summary>
@@ -260,7 +247,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
         IObservable<bool> StarRepo(string owner, string name);
 
         /// <summary>
@@ -268,7 +254,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         IObservable<bool> RemoveStarFromRepo(string owner, string name);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -2,6 +2,12 @@
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Starring API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/starring/">Activity Starring API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableStarredClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Starring API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/starring/">Activity Starring API documentation</a> for more information.
+    /// </remarks>
     public class ObservableStarredClient : IObservableStarredClient
     {
         private readonly IStarredClient _client;

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -29,7 +29,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         public IObservable<User> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +42,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         public IObservable<User> GetAllStargazers(int repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
@@ -56,7 +54,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         public IObservable<User> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -72,7 +69,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
         public IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -86,7 +82,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -100,7 +95,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId)
         {
             return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
@@ -113,7 +107,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public IObservable<UserStar> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -129,7 +122,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -264,7 +256,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         public IObservable<Repository> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -278,7 +269,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         public IObservable<Repository> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -325,7 +315,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public IObservable<Repository> GetAllForUser(string user, StarredRequest request)
         {
@@ -342,7 +331,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>A <see cref="IObservable{Repository}"/> starred by the specified user</returns>
         public IObservable<Repository> GetAllForUser(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -397,7 +385,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         public IObservable<bool> CheckStarred(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -411,7 +398,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
         public IObservable<bool> StarRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -425,7 +411,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         public IObservable<bool> RemoveStarFromRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -41,6 +41,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
+        public IObservable<User> GetAllStargazers(int repositoryId)
+        {
+            return GetAllStargazers(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -53,6 +64,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<User>(ApiUrls.Stargazers(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
+        /// <returns>A <see cref="IObservable{User}"/> of <see cref="User"/>s starring the passed repository</returns>
+        public IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.Stargazers(repositoryId), options);
         }
 
         /// <summary>
@@ -73,6 +98,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId)
+        {
+            return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -85,6 +121,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<UserStar>(ApiUrls.Stargazers(owner, name), null, AcceptHeaders.StarCreationTimestamps, options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<UserStar>(ApiUrls.Stargazers(repositoryId), null, AcceptHeaders.StarCreationTimestamps, options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -133,9 +133,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user
-        /// </returns>
         public IObservable<Repository> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -145,9 +142,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user
-        /// </returns>
         public IObservable<Repository> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -159,9 +153,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForCurrentWithTimestamps()
         {
             return GetAllForCurrentWithTimestamps(ApiOptions.None);
@@ -171,9 +162,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -186,10 +174,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public IObservable<Repository> GetAllForCurrent(StarredRequest request)
         {
@@ -204,10 +188,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        /// <returns>
-        /// A <see cref="IObservable{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters
-        /// </returns>
         public IObservable<Repository> GetAllForCurrent(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -221,10 +201,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(StarredRequest request)
         {
@@ -239,10 +215,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -282,9 +254,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -298,9 +267,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -346,10 +312,6 @@ namespace Octokit.Reactive
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, StarredRequest request)
         {
@@ -366,10 +328,6 @@ namespace Octokit.Reactive
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IObservable{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         public IObservable<RepositoryStar> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit.Tests/Clients/StarredClientTests.cs
+++ b/Octokit.Tests/Clients/StarredClientTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using Octokit.Internal;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
+using Octokit.Internal;
 using Xunit;
 
 namespace Octokit.Tests.Clients
@@ -15,8 +15,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                Assert.Throws<ArgumentNullException>(
-                    () => new StarredClient(null));
+                Assert.Throws<ArgumentNullException>(() => new StarredClient(null));
             }
         }
 
@@ -153,7 +152,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForCurrentWithTimestamps(request, options);
 
-                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"), 
+                connection.Received().GetAll<RepositoryStar>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["direction"] == "asc"),
                     "application/vnd.github.v3.star+json", options);
             }
 
@@ -346,19 +345,31 @@ namespace Octokit.Tests.Clients
         public class TheGetAllStargazersForRepoMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
                 var client = new StarredClient(connection);
 
-                client.GetAllStargazers("fight", "club");
+                await client.GetAllStargazers("fight", "club");
 
                 connection.Received().GetAll<User>(endpoint, Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new StarredClient(connection);
+
+                await client.GetAllStargazers(1);
+
+                connection.Received().GetAll<User>(endpoint, Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -371,27 +382,15 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllStargazers("fight", "club", options);
+                await client.GetAllStargazers("fight", "club", options);
 
                 connection.Received().GetAll<User>(endpoint, options);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithTimestamps()
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
             {
-                var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
-                var connection = Substitute.For<IApiConnection>();
-                var client = new StarredClient(connection);
-
-                client.GetAllStargazersWithTimestamps("fight", "club");
-
-                connection.Received().GetAll<UserStar>(endpoint, null, "application/vnd.github.v3.star+json", Args.ApiOptions);
-            }
-
-            [Fact]
-            public void RequestsCorrectUrlWithTimestampsWithApiOptions()
-            {
-                var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
                 var client = new StarredClient(connection);
 
@@ -402,7 +401,69 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllStargazersWithTimestamps("fight", "club", options);
+                await client.GetAllStargazers(1, options);
+
+                connection.Received().GetAll<User>(endpoint, options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithTimestamps()
+            {
+                var endpoint = new Uri("repos/fake/repo/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new StarredClient(connection);
+
+                await client.GetAllStargazersWithTimestamps("fake", "repo");
+
+                connection.Received().GetAll<UserStar>(endpoint, null, "application/vnd.github.v3.star+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithTimestampsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new StarredClient(connection);
+
+                await client.GetAllStargazersWithTimestamps(1);
+
+                connection.Received().GetAll<UserStar>(endpoint, null, "application/vnd.github.v3.star+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithTimestampsWithApiOptions()
+            {
+                var endpoint = new Uri("repos/fake/repo/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new StarredClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllStargazersWithTimestamps("fake", "repo", options);
+
+                connection.Received().GetAll<UserStar>(endpoint, null, "application/vnd.github.v3.star+json", options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithTimestampsWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new StarredClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllStargazersWithTimestamps(1, options);
 
                 connection.Received().GetAll<UserStar>(endpoint, null, "application/vnd.github.v3.star+json", options);
             }
@@ -422,6 +483,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps(null, "club", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", "club", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazers(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers("", "club"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllStargazers("fight", ""));

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -36,6 +36,20 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableStarredClient(gitHubClient);
+
+                client.GetAllStargazers(1);
+
+                connection.Received().Get<List<User>>(endpoint, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
@@ -57,6 +71,27 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableStarredClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllStargazers(1, options);
+
+                connection.Received().Get<List<User>>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithTimestamps()
             {
                 var endpoint = new Uri("repos/fight/club/stargazers", UriKind.Relative);
@@ -66,6 +101,20 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableStarredClient(gitHubClient);
 
                 client.GetAllStargazersWithTimestamps("fight", "club");
+
+                connection.Received().Get<List<UserStar>>(endpoint, Args.EmptyDictionary, "application/vnd.github.v3.star+json");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithTimestampsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableStarredClient(gitHubClient);
+
+                client.GetAllStargazersWithTimestamps(1);
 
                 connection.Received().Get<List<UserStar>>(endpoint, Args.EmptyDictionary, "application/vnd.github.v3.star+json");
             }
@@ -92,6 +141,27 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithTimestampsWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/stargazers", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Returns(connection);
+                var client = new ObservableStarredClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllStargazersWithTimestamps(1, options);
+
+                connection.Received().Get<List<UserStar>>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.v3.star+json");
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var client = new ObservableStarredClient(Substitute.For<IGitHubClient>());
@@ -106,6 +176,9 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps(null, "club", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", "club", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllStargazers(1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllStargazers("", "club"));
                 Assert.Throws<ArgumentException>(() => client.GetAllStargazers("fight", ""));

--- a/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableStarredClientTests.cs
@@ -177,7 +177,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps("fight", "club", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllStargazers(1, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllStargazers(1, null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllStargazersWithTimestamps(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllStargazers("", "club"));

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -23,12 +23,29 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -42,12 +59,29 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user.
@@ -227,7 +261,7 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <c>bool</c> representing the success of the operation</returns>
         Task<bool> CheckStarred(string owner, string name);
-
+        
         /// <summary>
         /// Stars a repository for the authenticated user.
         /// </summary>
@@ -235,7 +269,7 @@ namespace Octokit
         /// <param name="name">The name of the repository to star</param>
         /// <returns>A <c>bool</c> representing the success of starring</returns>
         Task<bool> StarRepo(string owner, string name);
-
+        
         /// <summary>
         /// Unstars a repository for the authenticated user.
         /// </summary>

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -17,7 +17,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name);
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options);
 
         /// <summary>

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -79,9 +79,6 @@ namespace Octokit
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent();
 
         /// <summary>
@@ -89,18 +86,12 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps();
 
         /// <summary>
@@ -108,9 +99,6 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(ApiOptions options);
 
         /// <summary>
@@ -118,10 +106,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request);
 
         /// <summary>
@@ -130,10 +114,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -141,10 +121,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request);
 
         /// <summary>
@@ -153,10 +129,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -164,9 +136,6 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user);
 
         /// <summary>
@@ -175,9 +144,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
-        /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options);
 
         /// <summary>
@@ -185,9 +151,6 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user);
 
         /// <summary>
@@ -196,9 +159,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options);
 
         /// <summary>
@@ -224,10 +184,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request);
 
         /// <summary>
@@ -237,10 +193,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options);
 
         /// <summary>

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -17,7 +17,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent();
 
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options);
 
@@ -73,7 +73,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps();
 
@@ -83,7 +83,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(ApiOptions options);
 
@@ -93,7 +93,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request);
@@ -105,7 +105,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request, ApiOptions options);
@@ -116,7 +116,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request);
@@ -128,7 +128,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options);
@@ -139,7 +139,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) starred by the specified user.
+        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user);
 
@@ -150,7 +150,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) starred by the specified user.
+        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
         /// </returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options);
 
@@ -160,7 +160,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user);
 
@@ -171,7 +171,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options);
 
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> starred by the specified user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request);
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> starred by the specified user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request);
@@ -214,7 +214,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options);

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -17,7 +17,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name);
 
         /// <summary>
@@ -25,7 +24,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId);
 
         /// <summary>
@@ -35,7 +33,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -44,7 +41,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -53,7 +49,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name);
 
         /// <summary>
@@ -61,7 +56,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId);
 
         /// <summary>
@@ -71,7 +65,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -80,7 +73,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -215,7 +207,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request);
 
         /// <summary>
@@ -225,7 +216,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options);
 
         /// <summary>
@@ -259,7 +249,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         Task<bool> CheckStarred(string owner, string name);
         
         /// <summary>
@@ -267,7 +256,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
         Task<bool> StarRepo(string owner, string name);
         
         /// <summary>
@@ -275,7 +263,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         Task<bool> RemoveStarFromRepo(string owner, string name);
     }
 }

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +40,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -26,7 +26,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -40,7 +39,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
@@ -53,7 +51,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -69,7 +66,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -83,7 +79,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -97,7 +92,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId)
         {
             return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
@@ -110,7 +104,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -126,7 +119,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -330,7 +322,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request)
         {
@@ -347,7 +338,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -402,7 +392,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         public async Task<bool> CheckStarred(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -424,7 +413,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
-        /// <returns>A <c>bool</c> representing the success of starring</returns>
         public async Task<bool> StarRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -446,7 +434,6 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
-        /// <returns>A <c>bool</c> representing the success of the operation</returns>
         public async Task<bool> RemoveStarFromRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -38,6 +38,17 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId)
+        {
+            return GetAllStargazers(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -50,6 +61,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<User>(ApiUrls.Stargazers(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<User>(ApiUrls.Stargazers(repositoryId), options);
         }
 
         /// <summary>
@@ -70,6 +95,17 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId)
+        {
+            return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -82,6 +118,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<UserStar>(ApiUrls.Stargazers(owner, name), null, AcceptHeaders.StarCreationTimestamps, options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<UserStar>(ApiUrls.Stargazers(repositoryId), null, AcceptHeaders.StarCreationTimestamps, options);
         }
 
         /// <summary>

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +42,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
+        /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s starring the passed repository.</returns>
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -74,7 +74,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
+        /// <returns>A <see cref="IReadOnlyList{UserStar}"/> of <see cref="User"/>s starring the passed repository with star creation timestamps.</returns>
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -89,7 +89,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
         /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
@@ -102,7 +102,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
         /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
@@ -116,7 +116,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps()
         {
@@ -129,7 +129,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(ApiOptions options)
         {
@@ -144,7 +144,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
@@ -163,7 +163,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters.
         /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request, ApiOptions options)
@@ -180,7 +180,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
@@ -199,7 +199,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options)
@@ -216,7 +216,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) starred by the specified user.
+        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
         /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user)
         {
@@ -232,7 +232,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) starred by the specified user.
+        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
         /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options)
         {
@@ -248,7 +248,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user)
         {
@@ -264,7 +264,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
+        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options)
         {
@@ -280,7 +280,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> starred by the specified user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request)
         {
@@ -297,7 +297,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> starred by the specified user.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> starred by the specified user.</returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -314,7 +314,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
@@ -334,7 +334,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>
-        /// A <see cref="IReadOnlyPagedCollection{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
+        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
         /// sorted according to the passed request parameters and with star creation timestamps.
         /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options)

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -130,9 +130,6 @@ namespace Octokit
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
-        /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -143,9 +140,6 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user.
-        /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -157,9 +151,6 @@ namespace Octokit
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps()
         {
             return GetAllForCurrentWithTimestamps(ApiOptions.None);
@@ -170,9 +161,6 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current authenticated user with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -185,10 +173,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters.
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
             Justification = "But i think i do need star-specific request parameters")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request)
@@ -204,10 +188,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters.
-        /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -221,10 +201,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
             Justification = "But i think i do need star-specific request parameters")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request)
@@ -240,10 +216,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the current user,
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -257,9 +229,6 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
-        /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -273,9 +242,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{Repository}"/>(ies) starred by the specified user.
-        /// </returns>
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -289,9 +255,6 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -305,9 +268,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/>(ies) starred by the specified user with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
@@ -353,10 +313,6 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request)
         {
@@ -373,10 +329,6 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>
-        /// A <see cref="IReadOnlyList{RepoStar}"/> of <see cref="Repository"/>(ies) starred by the specified user, 
-        /// sorted according to the passed request parameters and with star creation timestamps.
-        /// </returns>
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)StarredClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IStarredClient and IObservableStarredClient).**

	  There is some divergence between XML documentation of methods in IStarredClient and IObservableStarredClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IStarredClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableStarredClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.