### PR TITLE
Add repositoryId overloads to methods on I(Observable)NotificationsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -16,7 +16,7 @@ namespace Octokit.Reactive
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent();
 
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(ApiOptions options);
 
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(NotificationsRequest request);
 
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
 
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns>A <see cref="Notification"/> for the given Id.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Notification> Get(int id);
 
@@ -197,7 +197,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns>A <see cref="ThreadSubscription"/> for the chosen thread.</returns>
+        /// <returns></returns>
         IObservable<ThreadSubscription> GetThreadSubscription(int id);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -16,7 +16,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent();
 
@@ -25,7 +24,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(ApiOptions options);
 
@@ -35,7 +33,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -43,7 +40,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -53,7 +49,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -62,7 +57,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -70,7 +64,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(NotificationsRequest request);
 
@@ -80,7 +73,6 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
 
@@ -91,7 +83,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request);
 
         /// <summary>
@@ -100,7 +91,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request);
 
         /// <summary>
@@ -111,7 +101,6 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -121,14 +110,12 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsRead();
 
         /// <summary>
@@ -136,7 +123,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsRead(MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -145,7 +131,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsReadForRepository(string owner, string name);
 
         /// <summary>
@@ -153,7 +138,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsReadForRepository(int repositoryId);
 
         /// <summary>
@@ -163,7 +147,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -172,7 +155,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -180,7 +162,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Notification> Get(int id);
 
@@ -189,7 +170,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        /// <returns></returns>
         IObservable<Unit> MarkAsRead(int id);
 
         /// <summary>
@@ -197,7 +177,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns></returns>
         IObservable<ThreadSubscription> GetThreadSubscription(int id);
 
         /// <summary>
@@ -206,7 +185,6 @@ namespace Octokit.Reactive
         /// <param name="id">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        /// <returns></returns>
         IObservable<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription);
 
         /// <summary>
@@ -214,7 +192,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        /// <returns></returns>
         IObservable<Unit> DeleteThreadSubscription(int id);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Notifications API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Activity Notifications API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableNotificationsClient
     {
         /// <summary>
@@ -35,12 +41,29 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
@@ -74,6 +97,15 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
@@ -81,6 +113,16 @@ namespace Octokit.Reactive
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
@@ -109,12 +151,29 @@ namespace Octokit.Reactive
         /// <summary>
         /// Marks the notifications for a given repository as read.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        IObservable<Unit> MarkAsReadForRepository(int repositoryId);
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
         IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -5,6 +5,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Activity Notifications API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Activity Notifications API documentation</a> for more information.
+    /// </remarks>
     public class ObservableNotificationsClient : IObservableNotificationsClient
     {
         readonly IConnection _connection;
@@ -59,6 +65,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
@@ -71,6 +88,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(repositoryId), options);
         }
 
         /// <summary>
@@ -121,6 +152,20 @@ namespace Octokit.Reactive
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
@@ -135,6 +180,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Notification>(ApiUrls.Notifications(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -178,6 +239,17 @@ namespace Octokit.Reactive
         /// <summary>
         /// Marks the notifications for a given repository as read.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        public IObservable<Unit> MarkAsReadForRepository(int repositoryId)
+        {
+            return _notificationsClient.MarkAsReadForRepository(repositoryId).ToObservable();
+        }
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
@@ -190,6 +262,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
 
             return _notificationsClient.MarkAsReadForRepository(owner, name, markAsReadRequest).ToObservable();
+        }
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        public IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
+        {
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
+
+            return _notificationsClient.MarkAsReadForRepository(repositoryId, markAsReadRequest).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -39,7 +39,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IObservable{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -109,7 +109,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -123,7 +123,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -139,7 +139,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -155,7 +155,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -171,7 +171,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -189,7 +189,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -283,7 +283,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns>A <see cref="Notification"/> for the given Id.</returns>
+        /// <returns></returns>
         public IObservable<Notification> Get(int id)
         {
             return _notificationsClient.Get(id).ToObservable();
@@ -305,7 +305,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns>A <see cref="ThreadSubscription"/> for the chosen thread.</returns>
+        /// <returns></returns>
         public IObservable<ThreadSubscription> GetThreadSubscription(int id)
         {
             return _notificationsClient.GetThreadSubscription(id).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -28,7 +28,6 @@ namespace Octokit.Reactive
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -39,7 +38,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -53,7 +51,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -67,7 +64,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -80,7 +76,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -96,7 +91,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -109,7 +103,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -123,7 +116,6 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -139,7 +131,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -155,7 +146,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -171,7 +161,6 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -189,7 +178,6 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -202,7 +190,6 @@ namespace Octokit.Reactive
         /// Marks all notifications as read.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsRead()
         {
             return _notificationsClient.MarkAsRead().ToObservable();
@@ -213,7 +200,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
@@ -227,7 +213,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsReadForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -241,7 +226,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsReadForRepository(int repositoryId)
         {
             return _notificationsClient.MarkAsReadForRepository(repositoryId).ToObservable();
@@ -254,7 +238,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -270,7 +253,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
@@ -283,7 +265,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns></returns>
         public IObservable<Notification> Get(int id)
         {
             return _notificationsClient.Get(id).ToObservable();
@@ -294,7 +275,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        /// <returns></returns>
         public IObservable<Unit> MarkAsRead(int id)
         {
             return _notificationsClient.MarkAsRead(id).ToObservable();
@@ -305,7 +285,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns></returns>
         public IObservable<ThreadSubscription> GetThreadSubscription(int id)
         {
             return _notificationsClient.GetThreadSubscription(id).ToObservable();
@@ -317,7 +296,6 @@ namespace Octokit.Reactive
         /// <param name="id">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        /// <returns></returns>
         public IObservable<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription)
         {
             Ensure.ArgumentNotNull(threadSubscription, "threadSubscription");
@@ -330,7 +308,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        /// <returns></returns>
         public IObservable<Unit> DeleteThreadSubscription(int id)
         {
             return _notificationsClient.DeleteThreadSubscription(id).ToObservable();

--- a/Octokit.Tests/Clients/NotificationsClientTests.cs
+++ b/Octokit.Tests/Clients/NotificationsClientTests.cs
@@ -254,7 +254,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (NotificationsRequest)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest(), ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new NotificationsRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new NotificationsRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));

--- a/Octokit.Tests/Clients/NotificationsClientTests.cs
+++ b/Octokit.Tests/Clients/NotificationsClientTests.cs
@@ -13,27 +13,26 @@ namespace Octokit.Tests.Clients
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                Assert.Throws<ArgumentNullException>(
-                    () => new NotificationsClient(null));
+                Assert.Throws<ArgumentNullException>(() => new NotificationsClient(null));
             }
         }
 
         public class TheGetAllForCurrentMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var endpoint = new Uri("notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
                 var client = new NotificationsClient(connection);
 
-                client.GetAllForCurrent();
+                await client.GetAllForCurrent();
 
                 connection.Received().GetAll<Notification>(endpoint, Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlApiOptions()
+            public async Task RequestsCorrectUrlApiOptions()
             {
                 var endpoint = new Uri("notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -46,13 +45,13 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllForCurrent(options);
+                await client.GetAllForCurrent(options);
 
                 connection.Received().GetAll<Notification>(endpoint, options);
             }
 
             [Fact]
-            public void RequestsCorrectUrlNotificationRequest()
+            public async Task RequestsCorrectUrlNotificationRequest()
             {
                 var endpoint = new Uri("notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -60,14 +59,14 @@ namespace Octokit.Tests.Clients
 
                 var notificationsRequest = new NotificationsRequest { All = true };
 
-                client.GetAllForCurrent(notificationsRequest);
+                await client.GetAllForCurrent(notificationsRequest);
 
                 connection.Received().GetAll<Notification>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2
-                                                                                                              && d["all"] == "true" && d["participating"] == "false"), Args.ApiOptions);
+                    && d["all"] == "true" && d["participating"] == "false"), Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            public async Task RequestsCorrectUrlNotificationRequestWithApiOptions()
             {
                 var endpoint = new Uri("notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -82,10 +81,10 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllForCurrent(notificationsRequest, options);
+                await client.GetAllForCurrent(notificationsRequest, options);
 
                 connection.Received().GetAll<Notification>(endpoint, Arg.Is<IDictionary<string, string>>(d => d.Count == 2
-                                                                                                              && d["all"] == "true" && d["participating"] == "false"), options);
+                    && d["all"] == "true" && d["participating"] == "false"), options);
             }
 
             [Fact]
@@ -101,19 +100,31 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForRepository
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
                 var client = new NotificationsClient(connection);
 
-                client.GetAllForRepository("banana", "split");
+                await client.GetAllForRepository("banana", "split");
 
                 connection.Received().GetAll<Notification>(endpoint, Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<Notification>(endpoint, Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -126,13 +137,32 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllForRepository("banana", "split", options);
+                await client.GetAllForRepository("banana", "split", options);
 
                 connection.Received().GetAll<Notification>(endpoint, options);
             }
 
             [Fact]
-            public void RequestsCorrectUrlNotificationRequest()
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<Notification>(endpoint, options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlNotificationRequest()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -140,15 +170,31 @@ namespace Octokit.Tests.Clients
 
                 var notificationsRequest = new NotificationsRequest { All = true };
 
-                client.GetAllForRepository("banana", "split", notificationsRequest);
+                await client.GetAllForRepository("banana", "split", notificationsRequest);
 
                 connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
-                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"), 
-                        Args.ApiOptions);
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    Args.ApiOptions);
             }
 
             [Fact]
-            public void RequestsCorrectUrlNotificationRequestWithApiOptions()
+            public async Task RequestsCorrectUrlNotificationRequestWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                await client.GetAllForRepository(1, notificationsRequest);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlNotificationRequestWithApiOptions()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
                 var connection = Substitute.For<IApiConnection>();
@@ -163,11 +209,34 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                client.GetAllForRepository("banana", "split", notificationsRequest, options);
+                await client.GetAllForRepository("banana", "split", notificationsRequest, options);
 
                 connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
-                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"), 
-                        options);
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    options);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlNotificationRequestWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, notificationsRequest, options);
+
+                connection.Received().GetAll<Notification>(endpoint, Arg.Is<Dictionary<string, string>>(
+                        d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    options);
             }
 
             [Fact]
@@ -183,6 +252,15 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (NotificationsRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new NotificationsRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new NotificationsRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (NotificationsRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, new NotificationsRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
@@ -190,6 +268,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest(), ApiOptions.None));
             }
         }
 
@@ -223,6 +303,18 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                client.MarkAsReadForRepository(1);
+
+                connection.Received().Put(endpoint);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlParameterized()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
@@ -237,6 +329,20 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlParameterizedWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IApiConnection>();
+                var client = new NotificationsClient(connection);
+
+                var markAsReadRequest = new MarkAsReadRequest();
+
+                client.MarkAsReadForRepository(1, markAsReadRequest);
+
+                connection.Received().Put<object>(endpoint, markAsReadRequest);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new NotificationsClient(Substitute.For<IApiConnection>());
@@ -246,6 +352,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name", new MarkAsReadRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null, new MarkAsReadRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.MarkAsReadForRepository(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.MarkAsReadForRepository("owner", ""));

--- a/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableNotificationsClientTests.cs
@@ -120,6 +120,19 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.GetAllForRepository(1);
+
+                connection.Received().Get<List<Notification>>(endpoint, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
@@ -140,6 +153,26 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository(1, options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlNotificationRequest()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
@@ -150,6 +183,23 @@ namespace Octokit.Tests.Reactive
                 var notificationsRequest = new NotificationsRequest { All = true };
 
                 client.GetAllForRepository("banana", "split", notificationsRequest);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(
+                    d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
+                    null);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                client.GetAllForRepository(1, notificationsRequest);
 
                 connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(
                     d => d.Count == 2 && d["all"] == "true" && d["participating"] == "false"),
@@ -182,6 +232,31 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlNotificationRequestWithApiOptionsWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var notificationsRequest = new NotificationsRequest { All = true };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository(1, notificationsRequest, options);
+
+                connection.Received().Get<List<Notification>>(endpoint, Arg.Is<Dictionary<string, string>>(
+                    d => d.Count == 4 && d["all"] == "true" && d["participating"] == "false"
+                         && d["page"] == "1" && d["per_page"] == "1"),
+                    null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
@@ -194,6 +269,15 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (NotificationsRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new NotificationsRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new NotificationsRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new NotificationsRequest(), null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (NotificationsRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, new NotificationsRequest(), null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
@@ -201,6 +285,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new NotificationsRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new NotificationsRequest(), ApiOptions.None));
             }
         }
 
@@ -236,6 +322,19 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                client.MarkAsReadForRepository(1);
+
+                connection.Received().Put(endpoint);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlParameterized()
             {
                 var endpoint = new Uri("repos/banana/split/notifications", UriKind.Relative);
@@ -251,6 +350,21 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlParameterizedWithRepositoryId()
+            {
+                var endpoint = new Uri("repositories/1/notifications", UriKind.Relative);
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableNotificationsClient(gitHubClient);
+
+                var markAsReadRequest = new MarkAsReadRequest();
+
+                client.MarkAsReadForRepository(1, markAsReadRequest);
+
+                connection.Received().Put<object>(endpoint, markAsReadRequest);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableNotificationsClient(Substitute.For<IGitHubClient>());
@@ -260,6 +374,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository(null, "name", new MarkAsReadRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", null, new MarkAsReadRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.MarkAsReadForRepository(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.MarkAsReadForRepository("owner", ""));

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -60,12 +60,29 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -80,6 +97,15 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
@@ -87,6 +113,16 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
@@ -115,12 +151,29 @@ namespace Octokit
         /// <summary>
         /// Marks the notifications for a given repository as read.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        Task MarkAsReadForRepository(int repositoryId);
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
         /// <returns></returns>
         Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -16,7 +16,6 @@ namespace Octokit
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent();
 
@@ -25,7 +24,6 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options);
 
@@ -34,7 +32,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request);
 
@@ -44,7 +41,6 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
 
@@ -54,7 +50,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -62,7 +57,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -72,7 +66,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -81,7 +74,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -91,7 +83,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request);
 
         /// <summary>
@@ -100,7 +91,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request);
 
         /// <summary>
@@ -111,7 +101,6 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -121,14 +110,12 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         Task MarkAsRead();
 
         /// <summary>
@@ -136,7 +123,6 @@ namespace Octokit
         /// </summary>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         Task MarkAsRead(MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -145,7 +131,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         Task MarkAsReadForRepository(string owner, string name);
 
         /// <summary>
@@ -153,7 +138,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         Task MarkAsReadForRepository(int repositoryId);
 
         /// <summary>
@@ -163,7 +147,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -172,7 +155,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
@@ -180,7 +162,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Notification> Get(int id);
 
@@ -189,7 +170,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        /// <returns></returns>
         Task MarkAsRead(int id);
 
         /// <summary>
@@ -197,7 +177,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns></returns>
         Task<ThreadSubscription> GetThreadSubscription(int id);
 
         /// <summary>
@@ -206,7 +185,6 @@ namespace Octokit
         /// <param name="id">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        /// <returns></returns>
         Task<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription);
 
         /// <summary>
@@ -214,7 +192,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        /// <returns></returns>
         Task DeleteThreadSubscription(int id);
     }
 }

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -16,7 +16,7 @@ namespace Octokit
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent();
 
@@ -25,7 +25,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options);
 
@@ -34,7 +34,7 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request);
 
@@ -44,7 +44,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options);
 
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns>A <see cref="Notification"/> for the given Id.</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         Task<Notification> Get(int id);
 
@@ -197,7 +197,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns>A <see cref="ThreadSubscription"/> for the chosen thread.</returns>
+        /// <returns></returns>
         Task<ThreadSubscription> GetThreadSubscription(int id);
 
         /// <summary>

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -23,7 +23,6 @@ namespace Octokit
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -34,7 +33,6 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -47,7 +45,6 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -61,7 +58,6 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -76,7 +72,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -90,7 +85,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -103,7 +97,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -119,7 +112,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -134,7 +126,6 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +141,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -166,7 +156,6 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -184,7 +173,6 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -197,7 +185,6 @@ namespace Octokit
         /// Marks all notifications as read.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         public Task MarkAsRead()
         {
             return ApiConnection.Put(ApiUrls.Notifications());
@@ -208,7 +195,6 @@ namespace Octokit
         /// </summary>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
-        /// <returns></returns>
         public Task MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
@@ -222,7 +208,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public Task MarkAsReadForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -236,7 +221,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public Task MarkAsReadForRepository(int repositoryId)
         {
             return ApiConnection.Put(ApiUrls.Notifications(repositoryId));
@@ -249,7 +233,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -265,7 +248,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        /// <returns></returns>
         public Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
@@ -278,7 +260,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns></returns>
         public Task<Notification> Get(int id)
         {
             return ApiConnection.Get<Notification>(ApiUrls.Notification(id));
@@ -289,7 +270,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
-        /// <returns></returns>
         public Task MarkAsRead(int id)
         {
             return ApiConnection.Patch(ApiUrls.Notification(id));
@@ -300,7 +280,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns></returns>
         public Task<ThreadSubscription> GetThreadSubscription(int id)
         {
             return ApiConnection.Get<ThreadSubscription>(ApiUrls.NotificationSubscription(id));
@@ -312,7 +291,6 @@ namespace Octokit
         /// <param name="id">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
-        /// <returns></returns>
         public Task<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription)
         {
             Ensure.ArgumentNotNull(threadSubscription, "threadSubscription");
@@ -325,7 +303,6 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
-        /// <returns></returns>
         public Task DeleteThreadSubscription(int id)
         {
             return ApiConnection.Delete(ApiUrls.NotificationSubscription(id));

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -34,7 +34,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -47,7 +47,7 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -61,7 +61,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -76,7 +76,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -90,7 +90,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -103,7 +103,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -119,7 +119,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -134,7 +134,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +150,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -166,7 +166,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -184,7 +184,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -278,7 +278,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
-        /// <returns>A <see cref="Notification"/> for the given Id.</returns>
+        /// <returns></returns>
         public Task<Notification> Get(int id)
         {
             return ApiConnection.Get<Notification>(ApiUrls.Notification(id));
@@ -300,7 +300,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
-        /// <returns>A <see cref="ThreadSubscription"/> for the chosen thread.</returns>
+        /// <returns></returns>
         public Task<ThreadSubscription> GetThreadSubscription(int id)
         {
             return ApiConnection.Get<ThreadSubscription>(ApiUrls.NotificationSubscription(id));

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -88,6 +88,17 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
@@ -100,6 +111,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(repositoryId), options);
         }
 
         /// <summary>
@@ -122,6 +147,20 @@ namespace Octokit
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
@@ -136,6 +175,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(owner, name), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository.</param>
+        /// <param name="request">Specifies the parameters to filter notifications by</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <returns>A <see cref="IReadOnlyPagedCollection{Notification}"/> of <see cref="Notification"/>.</returns>
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Notification>(ApiUrls.Notifications(repositoryId), request.ToParametersDictionary(), options);
         }
 
         /// <summary>
@@ -179,6 +234,17 @@ namespace Octokit
         /// <summary>
         /// Marks the notifications for a given repository as read.
         /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        public Task MarkAsReadForRepository(int repositoryId)
+        {
+            return ApiConnection.Put(ApiUrls.Notifications(repositoryId));
+        }
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
@@ -188,9 +254,23 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(markAsReadRequest, "markAsRead");
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
 
             return ApiConnection.Put<object>(ApiUrls.Notifications(owner, name), markAsReadRequest);
+        }
+
+        /// <summary>
+        /// Marks the notifications for a given repository as read.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
+        /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        /// <returns></returns>
+        public Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
+        {
+            Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
+
+            return ApiConnection.Put<object>(ApiUrls.Notifications(repositoryId), markAsReadRequest);
         }
 
         /// <summary>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)NotificationsClient to get access by repository id.

- [x] **Add overloads to INotificationsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableNotificationsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] ~~**Add integration tests.**~~

	  I've skipped this item becuase of #1333