### PR TITLE
Add repositoryId overloads to methods on I(Observable)ReferencesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -25,6 +25,19 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
         IObservable<Reference> Get(string owner, string name, string reference);
+        
+        /// <summary>
+        /// Gets a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+            Justification = "Method makes a network request")]
+        IObservable<Reference> Get(int repositoryId, string reference);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -36,6 +49,16 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
         IObservable<Reference> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -50,6 +73,17 @@ namespace Octokit.Reactive
         IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace);
 
         /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAllForSubNamespace(int repositoryId, string subNamespace);
+
+        /// <summary>
         /// Creates a reference for a given repository
         /// </summary>
         /// <remarks>
@@ -60,6 +94,17 @@ namespace Octokit.Reactive
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
         IObservable<Reference> Create(string owner, string name, NewReference reference);
+
+        /// <summary>
+        /// Creates a reference for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#create-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference to create</param>
+        /// <returns></returns>
+        IObservable<Reference> Create(int repositoryId, NewReference reference);
 
         /// <summary>
         /// Updates a reference for a given repository by reference name
@@ -75,6 +120,18 @@ namespace Octokit.Reactive
         IObservable<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
+        /// Updates a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#update-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <param name="referenceUpdate">The updated reference data</param>
+        /// <returns></returns>
+        IObservable<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate);
+
+        /// <summary>
         /// Deletes a reference for a given repository by reference name
         /// </summary>
         /// <remarks>
@@ -85,5 +142,16 @@ namespace Octokit.Reactive
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, string reference);
+
+        /// <summary>
+        /// Deletes a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#delete-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's References API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/refs/">References API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableReferencesClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -5,6 +5,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's References API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/git/refs/">References API documentation</a> for more information.
+    /// </remarks>
     public class ObservableReferencesClient : IObservableReferencesClient
     {
         readonly IReferencesClient _reference;

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -44,6 +44,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        public IObservable<Reference> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _reference.Get(repositoryId, reference).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all references for a given repository
         /// </summary>
         /// <remarks>
@@ -58,6 +74,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name));
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAll(int repositoryId)
+        {
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId));
         }
 
         /// <summary>
@@ -80,6 +109,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAllForSubNamespace(int repositoryId, string subNamespace)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+        }
+
+        /// <summary>
         /// Creates a reference for a given repository
         /// </summary>
         /// <remarks>
@@ -96,6 +141,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(reference, "reference");
 
             return _reference.Create(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a reference for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#create-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference to create</param>
+        /// <returns></returns>
+        public IObservable<Reference> Create(int repositoryId, NewReference reference)
+        {
+            Ensure.ArgumentNotNull(reference, "reference");
+
+            return _reference.Create(repositoryId, reference).ToObservable();
         }
 
         /// <summary>
@@ -120,6 +181,24 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Updates a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#update-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <param name="referenceUpdate">The updated reference data</param>
+        /// <returns></returns>
+        public IObservable<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(referenceUpdate, "update");
+
+            return _reference.Update(repositoryId, reference, referenceUpdate).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a reference for a given repository by reference name
         /// </summary>
         /// <remarks>
@@ -136,6 +215,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return _reference.Delete(owner, name, reference).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#delete-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return _reference.Delete(repositoryId, reference).ToObservable();
         }
     }
 }

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -26,9 +26,14 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(1, ""));
             }
 
             [Fact]
@@ -41,6 +46,17 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
             }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Get(1, "heads/develop");
+
+                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
+            }
         }
 
         public class TheGetAllMethod
@@ -52,6 +68,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
             }
@@ -66,6 +83,17 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"));
             }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.GetAll(1);
+
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"));
+            }
         }
 
         public class TheGetAllForSubNamespaceMethod
@@ -77,8 +105,15 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace(1, ""));
             }
 
             [Fact]
@@ -90,6 +125,17 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForSubNamespace("owner", "repo", "heads");
 
                 connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.GetAllForSubNamespace(1, "heads");
+
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"));
             }
         }
 
@@ -103,6 +149,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewReference("heads/develop", "sha")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewReference("heads/develop", "sha")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewReference("heads/develop", "sha")));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewReference("heads/develop", "sha")));
             }
@@ -118,6 +167,18 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Post<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"), newReference);
             }
+
+            [Fact]
+            public async Task PostsToCorrectUrlWithRepositoryId()
+            {
+                var newReference = new NewReference("heads/develop", "sha");
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Create(1, newReference);
+
+                connection.Received().Post<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"), newReference);
+            }
         }
 
         public class TheUpdateMethod
@@ -131,9 +192,15 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, "heads/develop", new ReferenceUpdate("sha")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", null, new ReferenceUpdate("sha")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", "heads/develop", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, null, new ReferenceUpdate("sha")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, "heads/develop", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", "heads/develop", new ReferenceUpdate("sha")));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", "heads/develop", new ReferenceUpdate("sha")));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "name", "", new ReferenceUpdate("sha")));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update(1, "", new ReferenceUpdate("sha")));
             }
 
             [Fact]
@@ -147,6 +214,18 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Patch<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"), referenceUpdate);
             }
+
+            [Fact]
+            public async Task PostsToCorrectUrlWithRepositoryId()
+            {
+                var referenceUpdate = new ReferenceUpdate("sha");
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Update(1, "heads/develop", referenceUpdate);
+
+                connection.Received().Patch<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"), referenceUpdate);
+            }
         }
 
         public class TheDeleteMethod
@@ -159,9 +238,14 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", "heads/develop"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete(1, ""));
             }
 
             [Fact]
@@ -173,6 +257,17 @@ namespace Octokit.Tests.Clients
                 await client.Delete("owner", "repo", "heads/develop");
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Delete(1, "heads/develop");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
             }
         }
     }

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Reactive\ObservableIssuesLabelsClientTests.cs" />
     <Compile Include="Reactive\ObservablePullRequestReviewCommentReactionsClientTests.cs" />
     <Compile Include="Reactive\ObservableReactionsClientTests.cs" />
+    <Compile Include="Reactive\ObservableReferencesClientTests.cs" />
     <Compile Include="Reactive\ObservableRepoCollaboratorsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentsClientTests.cs" />
     <Compile Include="Reactive\ObservableDeploymentStatusClientTests.cs" />

--- a/Octokit.Tests/Reactive/ObservableReferencesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReferencesClientTests.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using NSubstitute;
+using Octokit.Reactive;
+using Xunit;
+
+namespace Octokit.Tests.Reactive
+{
+    public class ObservableReferencesClientTests
+    {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableReferencesClient(null));
+            }
+        }
+
+        public class TheGetMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", "heads/develop"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "heads/develop"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", "heads/develop"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", "heads/develop"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Get(1, ""));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Get("owner", "repo", "heads/develop");
+
+                gitHubClient.Received().Git.Reference.Get("owner", "repo", "heads/develop");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Get(1, "heads/develop");
+
+                gitHubClient.Received().Git.Reference.Get(1, "heads/develop");
+            }
+        }
+
+        public class TheGetAllMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAll("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAll("owner", ""));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.GetAll("owner", "repo");
+
+                gitHubClient.Received().Git.Reference.GetAll("owner", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.GetAll(1);
+
+                gitHubClient.Received().Git.Reference.GetAll(1);
+            }
+        }
+
+        public class TheGetAllForSubNamespaceMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForSubNamespace(1, ""));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.GetAllForSubNamespace("owner", "repo", "heads");
+
+                gitHubClient.Received().Git.Reference.GetAllForSubNamespace("owner", "repo", "heads");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.GetAllForSubNamespace(1, "heads");
+
+                gitHubClient.Received().Git.Reference.GetAllForSubNamespace(1, "heads");
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewReference("heads/develop", "sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewReference("heads/develop", "sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewReference("heads/develop", "sha")));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewReference("heads/develop", "sha")));
+            }
+
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var newReference = new NewReference("heads/develop", "sha");
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Create("owner", "repo", newReference);
+
+                gitHubClient.Received().Git.Reference.Create("owner", "repo", newReference);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var newReference = new NewReference("heads/develop", "sha");
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Create(1, newReference);
+
+                gitHubClient.Received().Git.Reference.Create(1, newReference);
+            }
+        }
+
+        public class TheUpdateMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(null, "name", "heads/develop", new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", null, "heads/develop", new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", null, new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", "heads/develop", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(1, null, new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentNullException>(() => client.Update(1, "heads/develop", null));
+
+                Assert.Throws<ArgumentException>(() => client.Update("", "name", "heads/develop", new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentException>(() => client.Update("owner", "", "heads/develop", new ReferenceUpdate("sha")));
+                Assert.Throws<ArgumentException>(() => client.Update("owner", "name", "", new ReferenceUpdate("sha")));
+
+                Assert.Throws<ArgumentException>(() => client.Update(1, "", new ReferenceUpdate("sha")));
+            }
+
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var referenceUpdate = new ReferenceUpdate("sha");
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Update("owner", "repo", "heads/develop", referenceUpdate);
+
+                gitHubClient.Received().Git.Reference.Update("owner", "repo", "heads/develop", referenceUpdate);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var referenceUpdate = new ReferenceUpdate("sha");
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Update(1, "heads/develop", referenceUpdate);
+
+                gitHubClient.Received().Git.Reference.Update(1, "heads/develop", referenceUpdate);
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableReferencesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", "heads/develop"));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, "heads/develop"));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name", "heads/develop"));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "", "heads/develop"));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Delete(1, ""));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Delete("owner", "repo", "heads/develop");
+
+                gitHubClient.Received().Git.Reference.Delete("owner", "repo", "heads/develop");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReferencesClient(gitHubClient);
+
+                client.Delete(1, "heads/develop");
+
+                gitHubClient.Received().Git.Reference.Delete(1, "heads/develop");
+            }
+        }
+    }
+}

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -23,8 +23,21 @@ namespace Octokit
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-            Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         Task<Reference> Get(string owner, string name, string reference);
+
+        /// <summary>
+        /// Gets a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        Task<Reference> Get(int repositoryId, string reference);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -36,6 +49,16 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
         Task<IReadOnlyList<Reference>> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAll(int repositoryId);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -50,6 +73,17 @@ namespace Octokit
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace);
 
         /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(int repositoryId, string subNamespace);
+
+        /// <summary>
         /// Creates a reference for a given repository
         /// </summary>
         /// <remarks>
@@ -60,6 +94,17 @@ namespace Octokit
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
         Task<Reference> Create(string owner, string name, NewReference reference);
+
+        /// <summary>
+        /// Creates a reference for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#create-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference to create</param>
+        /// <returns></returns>
+        Task<Reference> Create(int repositoryId, NewReference reference);
 
         /// <summary>
         /// Updates a reference for a given repository by reference name
@@ -75,6 +120,18 @@ namespace Octokit
         Task<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
+        /// Updates a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#update-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <param name="referenceUpdate">The updated reference data</param>
+        /// <returns></returns>
+        Task<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate);
+
+        /// <summary>
         /// Deletes a reference for a given repository by reference name
         /// </summary>
         /// <remarks>
@@ -85,5 +142,16 @@ namespace Octokit
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
         Task Delete(string owner, string name, string reference);
+
+        /// <summary>
+        /// Deletes a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#delete-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        Task Delete(int repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -40,6 +40,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        public Task<Reference> Get(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Get<Reference>(ApiUrls.Reference(repositoryId, reference));
+        }
+
+        /// <summary>
         /// Gets all references for a given repository
         /// </summary>
         /// <remarks>
@@ -54,6 +70,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name));
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAll(int repositoryId)
+        {
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId));
         }
 
         /// <summary>
@@ -78,6 +107,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(int repositoryId, string subNamespace)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+
+            // TODO: Handle 404 when subNamespace cannot be found
+
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+        }
+
+        /// <summary>
         /// Creates a reference for a given repository
         /// </summary>
         /// <remarks>
@@ -94,6 +141,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(reference, "reference");
 
             return ApiConnection.Post<Reference>(ApiUrls.Reference(owner, name), reference);
+        }
+
+        /// <summary>
+        /// Creates a reference for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#create-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The reference to create</param>
+        /// <returns></returns>
+        public Task<Reference> Create(int repositoryId, NewReference reference)
+        {
+            Ensure.ArgumentNotNull(reference, "reference");
+
+            return ApiConnection.Post<Reference>(ApiUrls.Reference(repositoryId), reference);
         }
 
         /// <summary>
@@ -118,6 +181,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Updates a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#update-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <param name="referenceUpdate">The updated reference data</param>
+        /// <returns></returns>
+        public Task<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+            Ensure.ArgumentNotNull(referenceUpdate, "update");
+
+            return ApiConnection.Patch<Reference>(ApiUrls.Reference(repositoryId, reference), referenceUpdate);
+        }
+
+        /// <summary>
         /// Deletes a reference for a given repository by reference name
         /// </summary>
         /// <remarks>
@@ -134,6 +215,22 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
             return ApiConnection.Delete(ApiUrls.Reference(owner, name, reference));
+        }
+
+        /// <summary>
+        /// Deletes a reference for a given repository by reference name
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#delete-a-reference
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="reference">The name of the reference</param>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
+
+            return ApiConnection.Delete(ApiUrls.Reference(repositoryId, reference));
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)ReferencesClient to get access by repository id.

- [x] **Update XML documentation of interface methods of clients (also synchronize XML docs of IReferencesClient and IObservableReferencesClient).**

	  There is some divergence between XML documentation of methods in IReferencesClient and IObservableReferencesClient. So I've decided 
	  to sync XML documentation of these classes during my work on #1120.
- [x] **Add overloads to IReferencesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableReferencesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.