### PR TITLE
Add repositoryId overloads to methods on I(Observable)MilestonesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -22,6 +22,17 @@ namespace Octokit.Reactive
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         IObservable<Milestone> Get(string owner, string name, int number);
+        
+        /// <summary>
+        /// Gets a single Milestone by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+        /// </remarks>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+        Justification = "Method makes a network request")]
+        IObservable<Milestone> Get(int repositoryId, int number);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -33,6 +44,16 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
         IObservable<Milestone> GetAllForRepository(string owner, string name);
+        
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(int repositoryId);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -52,11 +73,33 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
         IObservable<Milestone> GetAllForRepository(string owner, string name, MilestoneRequest request);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -72,6 +115,18 @@ namespace Octokit.Reactive
         IObservable<Milestone> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options);
+
+        /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a
         /// Milestone.
         /// </summary>
@@ -81,6 +136,16 @@ namespace Octokit.Reactive
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
         IObservable<Milestone> Create(string owner, string name, NewMilestone newMilestone);
+
+        /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#create-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
+        /// <returns></returns>
+        IObservable<Milestone> Create(int repositoryId, NewMilestone newMilestone);
 
         /// <summary>
         /// Updates a milestone for the specified repository. Any user with pull access to a repository can create a
@@ -96,6 +161,18 @@ namespace Octokit.Reactive
         IObservable<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
+        /// Updates a milestone for the specified repository. Any user with pull access to a repository can create a
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
+        /// </param>
+        /// <returns></returns>
+        IObservable<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate);
+
+        /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
         /// Milestone.
         /// </summary>
@@ -105,5 +182,15 @@ namespace Octokit.Reactive
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The milestone number</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Milestones API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/milestones/">Issue Milestones API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableMilestonesClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -40,6 +40,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single Milestone by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+        /// </remarks>
+        /// <returns></returns>
+        public IObservable<Milestone> Get(int repositoryId, int number)
+        {
+            return _client.Get(repositoryId, number).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all open milestones for the repository.
         /// </summary>
         /// <remarks>
@@ -54,6 +66,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAllForRepository(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
         }
 
         /// <summary>
@@ -81,6 +106,22 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(repositoryId), options);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
@@ -92,6 +133,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(request, "request");
 
             return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -117,6 +174,25 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Milestone>(ApiUrls.Milestones(repositoryId),
+                request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a
         /// Milestone.
         /// </summary>
@@ -132,6 +208,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(newMilestone, "newMilestone");
 
             return _client.Create(owner, name, newMilestone).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#create-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
+        /// <returns></returns>
+        public IObservable<Milestone> Create(int repositoryId, NewMilestone newMilestone)
+        {
+            Ensure.ArgumentNotNull(newMilestone, "newMilestone");
+
+            return _client.Create(repositoryId, newMilestone).ToObservable();
         }
 
         /// <summary>
@@ -155,6 +246,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Updates a milestone for the specified repository. Any user with pull access to a repository can create a
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
+        /// </param>
+        /// <returns></returns>
+        public IObservable<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        {
+            Ensure.ArgumentNotNull(milestoneUpdate, "milestoneUpdate");
+
+            return _client.Update(repositoryId, number, milestoneUpdate).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
         /// Milestone.
         /// </summary>
@@ -169,6 +277,19 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Delete(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The milestone number</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, int number)
+        {
+            return _client.Delete(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -5,6 +5,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Milestones API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/milestones/">Issue Milestones API documentation</a> for more information.
+    /// </remarks>
     public class ObservableMilestonesClient : IObservableMilestonesClient
     {
         readonly IMilestonesClient _client;

--- a/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MilestonesClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
@@ -34,9 +33,88 @@ public class MilestonesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanRetrieveOneMilestoneWithRepositoryId()
+    {
+        var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
+        var created = await _milestonesClient.Create(_context.Repository.Id, newMilestone);
+
+        var result = await _milestonesClient.Get(_context.Repository.Id, created.Number);
+
+        Assert.Equal("a milestone", result.Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanDeleteOneMilestone()
+    {
+        var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
+        var created = await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        var result1 = await _milestonesClient.Get(_context.RepositoryOwner, _context.RepositoryName, created.Number);
+        Assert.Equal("a milestone", result1.Title);
+
+        await _milestonesClient.Delete(_context.RepositoryOwner, _context.RepositoryName, created.Number);
+
+        var result2 = await _milestonesClient.Get(_context.RepositoryOwner, _context.RepositoryName, created.Number);
+        Assert.Null(result2);
+    }
+
+    [IntegrationTest]
+    public async Task CanDeleteOneMilestoneWithRepositoryId()
+    {
+        var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
+        var created = await _milestonesClient.Create(_context.Repository.Id, newMilestone);
+
+        var result1 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
+        Assert.Equal("a milestone", result1.Title);
+
+        await _milestonesClient.Delete(_context.Repository.Id, created.Number);
+
+        var result2 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
+        Assert.Null(result2);
+    }
+
+    [IntegrationTest]
+    public async Task CanUpdateOneMilestone()
+    {
+        var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
+        var created = await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newMilestone);
+
+        var result1 = await _milestonesClient.Get(_context.RepositoryOwner, _context.RepositoryName, created.Number);
+        Assert.Equal("a milestone", result1.Title);
+
+        await _milestonesClient.Update(_context.RepositoryOwner, _context.RepositoryName, created.Number, new MilestoneUpdate { Title = "New title" });
+
+        var result2 = await _milestonesClient.Get(_context.RepositoryOwner, _context.RepositoryName, created.Number);
+        Assert.Equal("New title", result2.Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanUpdateOneMilestoneWithRepositoryId()
+    {
+        var newMilestone = new NewMilestone("a milestone") { DueOn = DateTime.Now };
+        var created = await _milestonesClient.Create(_context.Repository.Id, newMilestone);
+
+        var result1 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
+        Assert.Equal("a milestone", result1.Title);
+
+        await _milestonesClient.Update(_context.Repository.Id, created.Number, new MilestoneUpdate {Title = "New title"});
+
+        var result2 = await _milestonesClient.Get(_context.Repository.Id, created.Number);
+        Assert.Equal("New title", result2.Title);
+    }
+
+    [IntegrationTest]
     public async Task CanListEmptyMilestones()
     {
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
+
+        Assert.Empty(milestones);
+    }
+
+    [IntegrationTest]
+    public async Task CanListEmptyMilestonesWithRepositoryId()
+    {
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id);
 
         Assert.Empty(milestones);
     }
@@ -52,6 +130,24 @@ public class MilestonesClientTests : IDisposable
         await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
 
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
+
+        Assert.Equal(2, milestones.Count);
+        Assert.Equal("milestone 1", milestones[0].Title);
+        Assert.Equal("milestone 2", milestones[1].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanListMilestonesWithDefaultSortByDueDateAscWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.Repository.Id, milestone1);
+        await _milestonesClient.Create(_context.Repository.Id, milestone2);
+        await _milestonesClient.Create(_context.Repository.Id, milestone3);
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id);
+
         Assert.Equal(2, milestones.Count);
         Assert.Equal("milestone 1", milestones[0].Title);
         Assert.Equal("milestone 2", milestones[1].Title);
@@ -69,6 +165,25 @@ public class MilestonesClientTests : IDisposable
 
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
             new MilestoneRequest { SortDirection = SortDirection.Descending });
+
+        Assert.Equal(2, milestones.Count);
+        Assert.Equal("milestone 2", milestones[0].Title);
+        Assert.Equal("milestone 1", milestones[1].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanListMilestonesWithSortByDueDateDescWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.Repository.Id, milestone1);
+        await _milestonesClient.Create(_context.Repository.Id, milestone2);
+        await _milestonesClient.Create(_context.Repository.Id, milestone3);
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id,
+            new MilestoneRequest { SortDirection = SortDirection.Descending });
+
         Assert.Equal(2, milestones.Count);
         Assert.Equal("milestone 2", milestones[0].Title);
         Assert.Equal("milestone 1", milestones[1].Title);
@@ -92,22 +207,20 @@ public class MilestonesClientTests : IDisposable
     }
 
     [IntegrationTest]
-    public async Task CanRetrieveClosedIssues()
+    public async Task CanListClosedMilestonesWithRepositoryId()
     {
-        var newIssue = new NewIssue("A test issue") { Body = "A new unassigned issue" };
-        var issue1 = await _github.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        var issue2 = await _github.Issue.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-        await _github.Issue.Update(_context.RepositoryOwner, _context.RepositoryName, issue1.Number,
-        new IssueUpdate { State = ItemState.Closed });
-        await _github.Issue.Update(_context.RepositoryOwner, _context.RepositoryName, issue2.Number,
-        new IssueUpdate { State = ItemState.Closed });
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.Repository.Id, milestone1);
+        await _milestonesClient.Create(_context.Repository.Id, milestone2);
+        await _milestonesClient.Create(_context.Repository.Id, milestone3);
 
-        var retrieved = await _github.Issue.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName,
-            new RepositoryIssueRequest { State = ItemStateFilter.Closed });
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id,
+            new MilestoneRequest { State = ItemStateFilter.Closed });
 
-        Assert.True(retrieved.Count >= 2);
-        Assert.True(retrieved.Any(i => i.Number == issue1.Number));
-        Assert.True(retrieved.Any(i => i.Number == issue2.Number));
+        Assert.Equal(1, milestones.Count);
+        Assert.Equal("milestone 3", milestones[0].Title);
     }
 
     [IntegrationTest]
@@ -132,6 +245,27 @@ public class MilestonesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithoutStartWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3) };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id, options);
+
+        Assert.Equal(3, milestones.Count);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfMilestonesWithStart()
     {
         var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
@@ -149,6 +283,28 @@ public class MilestonesClientTests : IDisposable
         };
 
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, options);
+
+        Assert.Equal(1, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithStartWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3) };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id, options);
 
         Assert.Equal(1, milestones.Count);
     }
@@ -184,6 +340,36 @@ public class MilestonesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1) };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _milestonesClient.GetAllForRepository(_context.Repository.Id, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _milestonesClient.GetAllForRepository(_context.Repository.Id, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfMilestonesWithoutStartParametrized()
     {
         var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
@@ -202,6 +388,29 @@ public class MilestonesClientTests : IDisposable
         };
 
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
+
+        Assert.Equal(3, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithoutStartParametrizedWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        var milestone4 = new NewMilestone("milestone 4") { DueOn = DateTime.Now.AddDays(4), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone4);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
 
         Assert.Equal(3, milestones.Count);
     }
@@ -226,6 +435,30 @@ public class MilestonesClientTests : IDisposable
         };
 
         var milestones = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
+
+        Assert.Equal(1, milestones.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfMilestonesWithStartParametrizedWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        var milestone4 = new NewMilestone("milestone 4") { DueOn = DateTime.Now.AddDays(4), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone4);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var milestones = await _milestonesClient.GetAllForRepository(_context.Repository.Id, new MilestoneRequest { State = ItemStateFilter.Closed }, options);
 
         Assert.Equal(1, milestones.Count);
     }
@@ -258,6 +491,38 @@ public class MilestonesClientTests : IDisposable
         };
         
         var secondPage = await _milestonesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, milestoneRequest, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageParametrizedWithRepositoryId()
+    {
+        var milestone1 = new NewMilestone("milestone 1") { DueOn = DateTime.Now };
+        var milestone2 = new NewMilestone("milestone 2") { DueOn = DateTime.Now.AddDays(1), State = ItemState.Closed };
+        var milestone3 = new NewMilestone("milestone 3") { DueOn = DateTime.Now.AddDays(3), State = ItemState.Closed };
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone1);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone2);
+        await _milestonesClient.Create(_context.RepositoryOwner, _context.RepositoryName, milestone3);
+
+        var milestoneRequest = new MilestoneRequest { State = ItemStateFilter.Closed };
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _milestonesClient.GetAllForRepository(_context.Repository.Id, milestoneRequest, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+        
+        var secondPage = await _milestonesClient.GetAllForRepository(_context.Repository.Id, milestoneRequest, skipStartOptions);
 
         Assert.NotEqual(firstPage[0].Number, secondPage[0].Number);
     }

--- a/Octokit.Tests/Clients/MilestonesClientTests.cs
+++ b/Octokit.Tests/Clients/MilestonesClientTests.cs
@@ -22,14 +22,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                client.Get(1, 42);
+
+                connection.Received().Get<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new MilestonesClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
 
@@ -44,6 +56,18 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones"),
+                    Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones"),
                     Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
             }
 
@@ -67,6 +91,25 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones"),
+                    Arg.Any<Dictionary<string, string>>(), options);
+            }
+
+            [Fact]
             public void SendsAppropriateParameters()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -75,6 +118,21 @@ namespace Octokit.Tests.Clients
                 client.GetAllForRepository("fake", "repo", new MilestoneRequest { SortDirection = SortDirection.Descending });
 
                 connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/milestones"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["state"] == "open"
+                        && d["sort"] == "due_date"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public void SendsAppropriateParametersWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                client.GetAllForRepository(1, new MilestoneRequest { SortDirection = SortDirection.Descending });
+
+                connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["state"] == "open"
@@ -104,6 +162,28 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void SendsAppropriateParametersWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository(1, new MilestoneRequest { SortDirection = SortDirection.Descending }, options);
+
+                connection.Received().GetAll<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["state"] == "open"
+                        && d["sort"] == "due_date"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new MilestonesClient(Substitute.For<IApiConnection>());
@@ -111,30 +191,35 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (MilestoneRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, new MilestoneRequest(), null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
             }
         }
 
@@ -154,16 +239,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var newMilestone = new NewMilestone("some title");
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                client.Create(1, newMilestone);
+
+                connection.Received().Post<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones"),
+                    newMilestone);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new MilestonesClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewMilestone("title")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewMilestone("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewMilestone("x")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
             }
         }
 
@@ -183,16 +284,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var milestoneUpdate = new MilestoneUpdate();
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                client.Update(1, 42, milestoneUpdate);
+
+                connection.Received().Patch<Milestone>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42"),
+                    milestoneUpdate);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new MilestonesClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewMilestone("title")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewMilestone("x")));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
             }
         }
 
@@ -210,14 +327,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new MilestonesClient(connection);
+
+                client.Delete(1, 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new MilestonesClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 42));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 42));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 42));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 42));
             }
         }

--- a/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMilestonesClientTests.cs
@@ -26,12 +26,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void GetsFromClientIssueMilestoneWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                client.Get(1, 42);
+
+                gitHubClient.Issue.Milestone.Received().Get(1, 42);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableMilestonesClient(Substitute.For<IGitHubClient>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1).ToTask());
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1).ToTask());
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1).ToTask());
             }
@@ -48,6 +60,17 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo");
 
                 gitHubClient.Received().Issue.Milestone.GetAllForRepository("fake", "repo");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                client.GetAllForRepository(1);
+
+                gitHubClient.Received().Issue.Milestone.GetAllForRepository(1);
             }
 
             [Fact]
@@ -69,6 +92,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository(1, options);
+
+                gitHubClient.Received().Issue.Milestone.GetAllForRepository(1, options);
+            }
+
+            [Fact]
             public void SendsAppropriateParameters()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -78,6 +119,18 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo", milestoneRequest);
 
                 gitHubClient.Received().Issue.Milestone.GetAllForRepository("fake", "repo", milestoneRequest, Args.ApiOptions);
+            }
+
+            [Fact]
+            public void SendsAppropriateParametersWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                var milestoneRequest = new MilestoneRequest { SortDirection = SortDirection.Descending };
+                client.GetAllForRepository(1, milestoneRequest);
+
+                gitHubClient.Received().Issue.Milestone.GetAllForRepository(1, milestoneRequest, Args.ApiOptions);
             }
 
             [Fact]
@@ -100,37 +153,61 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void SendsAppropriateParametersWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                var milestoneRequest = new MilestoneRequest { SortDirection = SortDirection.Descending };
+                client.GetAllForRepository(1, milestoneRequest, options);
+
+                gitHubClient.Received().Issue.Milestone.GetAllForRepository(1, milestoneRequest, options);
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var client = new ObservableMilestonesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest()));
-
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest()));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (MilestoneRequest)null));
+                
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new MilestoneRequest(), null));
+                
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (MilestoneRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, new MilestoneRequest(), null));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest()));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest()));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", new MilestoneRequest(), ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", new MilestoneRequest(), ApiOptions.None));
             }
 
             [Fact]
@@ -168,7 +245,7 @@ namespace Octokit.Tests.Reactive
                     {
                         new Milestone(7)
                     }
-               );
+                );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<Milestone>>(firstPageUrl, Args.EmptyDictionary, null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
@@ -224,10 +301,10 @@ namespace Octokit.Tests.Reactive
                 );
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 gitHubClient.Connection.Get<List<Milestone>>(Arg.Is(firstPageUrl),
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
-                        && d["direction"] == "desc"
-                        && d["state"] == "open"
-                        && d["sort"] == "due_date"), null)
+                        Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                            && d["direction"] == "desc"
+                            && d["state"] == "open"
+                            && d["sort"] == "due_date"), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => firstPageResponse));
                 gitHubClient.Connection.Get<List<Milestone>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
@@ -239,7 +316,7 @@ namespace Octokit.Tests.Reactive
                         && d["state"] == "open"
                         && d["sort"] == "due_date"), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Milestone>>>(() => lastPageResponse));
-                
+
                 var client = new ObservableMilestonesClient(gitHubClient);
 
                 var results = await client.GetAllForRepository("fake", "repo", new MilestoneRequest { SortDirection = SortDirection.Descending }).ToArray();
@@ -266,16 +343,31 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void CreatesFromClientIssueMilestoneWithRepositoryId()
+            {
+                var newMilestone = new NewMilestone("some title");
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                client.Create(1, newMilestone);
+
+                gitHubClient.Issue.Milestone.Received().Create(1, newMilestone);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableMilestonesClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewMilestone("title")));
-                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", new NewMilestone("x")));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, new NewMilestone("x")));
-                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
                 Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", new NewMilestone("x")));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", new NewMilestone("x")));
             }
         }
 
@@ -294,16 +386,31 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void UpdatesClientIssueMilestoneWithRepositoryId()
+            {
+                var milestoneUpdate = new MilestoneUpdate();
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                client.Update(1, 42, milestoneUpdate);
+
+                gitHubClient.Issue.Milestone.Received().Update(1, 42, milestoneUpdate);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableMilestonesClient(gitHubClient);
 
                 Assert.Throws<ArgumentNullException>(() => client.Update(null, "name", 42, new MilestoneUpdate()));
-                Assert.Throws<ArgumentException>(() => client.Update("", "name", 42, new MilestoneUpdate()));
                 Assert.Throws<ArgumentNullException>(() => client.Update("owner", null, 42, new MilestoneUpdate()));
-                Assert.Throws<ArgumentException>(() => client.Update("owner", "", 42, new MilestoneUpdate()));
                 Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(1, 42, null));
+
+                Assert.Throws<ArgumentException>(() => client.Update("", "name", 42, new MilestoneUpdate()));
+                Assert.Throws<ArgumentException>(() => client.Update("owner", "", 42, new MilestoneUpdate()));
             }
         }
 
@@ -321,14 +428,26 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void EnsuresArgumentsNotNull()
+            public void DeletesFromClientIssueMilestoneWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableMilestonesClient(gitHubClient);
+
+                client.Delete(1, 42);
+
+                gitHubClient.Issue.Milestone.Received().Delete(1, 42);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableMilestonesClient(gitHubClient);
 
                 Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", 42));
-                Assert.Throws<ArgumentException>(() => client.Delete("", "name", 42));
                 Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, 42));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name", 42));
                 Assert.Throws<ArgumentException>(() => client.Delete("owner", "", 42));
             }
         }

--- a/Octokit/Clients/IMilestonesClient.cs
+++ b/Octokit/Clients/IMilestonesClient.cs
@@ -20,8 +20,19 @@ namespace Octokit
         /// </remarks>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         Task<Milestone> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single Milestone by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+        /// </remarks>
+        /// <returns></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        Task<Milestone> Get(int repositoryId, int number);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -33,6 +44,16 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
         Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -52,11 +73,33 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
         Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -70,6 +113,18 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -86,6 +141,16 @@ namespace Octokit
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
         /// Milestone.
         /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#create-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
+        /// <returns></returns>
+        Task<Milestone> Create(int repositoryId, NewMilestone newMilestone);
+
+        /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -94,6 +159,18 @@ namespace Octokit
         /// </param>
         /// <returns></returns>
         Task<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate);
+
+        /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
+        /// </param>
+        /// <returns></returns>
+        Task<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -105,5 +182,15 @@ namespace Octokit
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
         Task Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The milestone number</param>
+        /// <returns></returns>
+        Task Delete(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -35,6 +35,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a single Milestone by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
+        /// </remarks>
+        /// <returns></returns>
+        public Task<Milestone> Get(int repositoryId, int number)
+        {
+            return ApiConnection.Get<Milestone>(ApiUrls.Milestone(repositoryId, number));
+        }
+
+        /// <summary>
         /// Gets all open milestones for the repository.
         /// </summary>
         /// <remarks>
@@ -49,6 +61,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             
             return GetAllForRepository(owner, name, new MilestoneRequest());
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, new MilestoneRequest());
         }
 
         /// <summary>
@@ -76,6 +101,22 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new MilestoneRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
@@ -87,6 +128,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, "request");
 
             return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -112,6 +169,25 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all open milestones for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of Milestones returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Milestone>(ApiUrls.Milestones(repositoryId),
+                request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
         /// Milestone.
         /// </summary>
@@ -127,6 +203,21 @@ namespace Octokit
             Ensure.ArgumentNotNull(newMilestone, "newMilestone");
 
             return ApiConnection.Post<Milestone>(ApiUrls.Milestones(owner, name), newMilestone);
+        }
+
+        /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#create-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
+        /// <returns></returns>
+        public Task<Milestone> Create(int repositoryId, NewMilestone newMilestone)
+        {
+            Ensure.ArgumentNotNull(newMilestone, "newMilestone");
+
+            return ApiConnection.Post<Milestone>(ApiUrls.Milestones(repositoryId), newMilestone);
         }
 
         /// <summary>
@@ -150,6 +241,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#update-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Milestone number</param>
+        /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
+        /// </param>
+        /// <returns></returns>
+        public Task<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        {
+            Ensure.ArgumentNotNull(milestoneUpdate, "milestoneUpdate");
+
+            return ApiConnection.Patch<Milestone>(ApiUrls.Milestone(repositoryId, number), milestoneUpdate);
+        }
+
+        /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
         /// Milestone.
         /// </summary>
@@ -164,6 +272,19 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Delete(ApiUrls.Milestone(owner, name, number));
+        }
+
+        /// <summary>
+        /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
+        /// Milestone.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/milestones/#delete-a-milestone</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The milestone number</param>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.Milestone(repositoryId, number));
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)MilestonesClient to get access by repository id.

- [x] **Add overloads to IMilestonesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableMilestonesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.