### PR TITLE
Add repositoryId overloads to methods on I(Observable)IssuesLabelsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -21,7 +21,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -32,7 +31,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +43,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +54,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +64,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +73,6 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +84,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +94,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -113,7 +105,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForMilestone(string owner, string name, int number);
 
         /// <summary>
@@ -124,7 +115,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForMilestone(int repositoryId, int number);
 
         /// <summary>
@@ -137,7 +127,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -149,7 +138,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -161,7 +149,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Label> Get(string owner, string name, string labelName);
@@ -174,7 +161,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Label> Get(int repositoryId, string labelName);
@@ -188,7 +174,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, string labelName);
 
         /// <summary>
@@ -199,7 +184,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(int repositoryId, string labelName);
 
         /// <summary>
@@ -211,7 +195,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         IObservable<Label> Create(string owner, string name, NewLabel newLabel);
 
         /// <summary>
@@ -222,7 +205,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         IObservable<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
@@ -235,7 +217,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -247,7 +228,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -260,7 +240,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
@@ -272,7 +251,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
@@ -285,7 +263,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         IObservable<Unit> RemoveFromIssue(string owner, string name, int number, string labelName);
 
         /// <summary>
@@ -297,7 +274,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName);
 
         /// <summary>
@@ -310,7 +286,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
@@ -322,7 +297,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
@@ -334,7 +308,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number);
 
         /// <summary>
@@ -345,7 +318,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Label> Get(string owner, string name, string labelName);
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<Label> Get(int repositoryId, string labelName);
@@ -211,7 +211,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         IObservable<Label> Create(string owner, string name, NewLabel newLabel);
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         IObservable<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -4,6 +4,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Labels API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/labels/">Issue Labels API documentation</a> for more information.
+    /// </remarks>
     public interface IObservableIssuesLabelsClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -24,12 +24,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForIssue(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of labels</returns>
         IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -48,11 +71,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of labels</returns>
         IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -72,12 +116,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <returns></returns>
+        IObservable<Label> GetAllForMilestone(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -90,8 +157,21 @@ namespace Octokit.Reactive
         /// <param name="labelName">The name of the label</param>
         /// <returns>The label</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         IObservable<Label> Get(string owner, string name, string labelName);
+
+        /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        IObservable<Label> Get(int repositoryId, string labelName);
 
         /// <summary>
         /// Deletes a label.
@@ -106,6 +186,17 @@ namespace Octokit.Reactive
         IObservable<Unit> Delete(string owner, string name, string labelName);
 
         /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, string labelName);
+
+        /// <summary>
         /// Creates a label.
         /// </summary>
         /// <remarks>
@@ -116,6 +207,17 @@ namespace Octokit.Reactive
         /// <param name="newLabel">The data for the label to be created</param>
         /// <returns>The created label</returns>
         IObservable<Label> Create(string owner, string name, NewLabel newLabel);
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        IObservable<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
         /// Updates a label.
@@ -131,6 +233,18 @@ namespace Octokit.Reactive
         IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
+
+        /// <summary>
         /// Adds a label to an issue
         /// </summary>
         /// <remarks>
@@ -142,6 +256,18 @@ namespace Octokit.Reactive
         /// <param name="labels">The names of the labels to add</param>
         /// <returns></returns>
         IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -157,6 +283,18 @@ namespace Octokit.Reactive
         IObservable<Unit> RemoveFromIssue(string owner, string name, int number, string labelName);
 
         /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labelName">The name of the label to remove</param>
+        /// <returns></returns>
+        IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName);
+
+        /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
         /// </summary>
         /// <remarks>
@@ -170,6 +308,18 @@ namespace Octokit.Reactive
         IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
+
+        /// <summary>
         /// Removes all labels from an issue
         /// </summary>
         /// <remarks>
@@ -180,5 +330,16 @@ namespace Octokit.Reactive
         /// <param name="number">The number of the issue</param>
         /// <returns></returns>
         IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -43,6 +43,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForIssue(int repositoryId, int number)
+        {
+            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
@@ -55,6 +69,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.IssueLabels(repositoryId, number), options);
         }
 
         /// <summary>
@@ -80,6 +111,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -91,6 +135,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Label>(ApiUrls.Labels(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.Labels(repositoryId), options);
         }
 
         /// <summary>
@@ -117,6 +177,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <returns></returns>
+        public IObservable<Label> GetAllForMilestone(int repositoryId, int number)
+        {
+            return GetAllForMilestone(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
@@ -129,6 +203,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Label>(ApiUrls.MilestoneLabels(repositoryId, number), options);
         }
 
         /// <summary>
@@ -151,6 +242,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        public IObservable<Label> Get(int repositoryId, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.Get(repositoryId, labelName).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a label.
         /// </summary>
         /// <remarks>
@@ -170,6 +277,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.Delete(repositoryId, labelName).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a label.
         /// </summary>
         /// <remarks>
@@ -186,6 +309,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(newLabel, "newLabel");
 
             return _client.Create(owner, name, newLabel).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        public IObservable<Label> Create(int repositoryId, NewLabel newLabel)
+        {
+            Ensure.ArgumentNotNull(newLabel, "newLabel");
+
+            return _client.Create(repositoryId, newLabel).ToObservable();
         }
 
         /// <summary>
@@ -210,6 +349,24 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        public IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
+        {
+            Ensure.ArgumentNotNull(labelName, "labelName");
+            Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
+
+            return _client.Update(repositoryId, labelName, labelUpdate).ToObservable();
+        }
+
+        /// <summary>
         /// Adds a label to an issue
         /// </summary>
         /// <remarks>
@@ -231,6 +388,22 @@ namespace Octokit.Reactive
                 .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages
         }
 
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        public IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels)
+        {
+            return _client.AddToIssue(repositoryId, number, labels)
+                .ToObservable()
+                .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages
+        }
 
         /// <summary>
         /// Removes a label from an issue
@@ -250,6 +423,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
             return _client.RemoveFromIssue(owner, name, number, labelName).ToObservable();
+        }
+
+        /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labelName">The name of the label to remove</param>
+        /// <returns></returns>
+        public IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return _client.RemoveFromIssue(repositoryId, number, labelName).ToObservable();
         }
 
         /// <summary>
@@ -275,6 +465,25 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        public IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
+        {
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return _client.ReplaceAllForIssue(repositoryId, number, labels)
+                .ToObservable()
+                .SelectMany(x => x);  // HACK: PUT is not compatible with GetAndFlattenPages
+        }
+
+        /// <summary>
         /// Removes all labels from an issue
         /// </summary>
         /// <remarks>
@@ -290,6 +499,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.RemoveAllFromIssue(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        public IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number)
+        {
+            return _client.RemoveAllFromIssue(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -348,7 +348,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(labelName, "labelName");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
             Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
 
             return _client.Update(owner, name, labelName, labelUpdate).ToObservable();
@@ -366,7 +366,7 @@ namespace Octokit.Reactive
         /// <returns>The updated label</returns>
         public IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
         {
-            Ensure.ArgumentNotNull(labelName, "labelName");
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
             Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
 
             return _client.Update(repositoryId, labelName, labelUpdate).ToObservable();
@@ -406,6 +406,8 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels)
         {
+            Ensure.ArgumentNotNull(labels, "labels");
+
             return _client.AddToIssue(repositoryId, number, labels)
                 .ToObservable()
                 .SelectMany(x => x); // HACK: POST is not compatible with GetAndFlattenPages

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -34,7 +34,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,7 +50,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -67,7 +65,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -86,7 +83,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -102,7 +98,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +113,6 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -133,7 +127,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -151,7 +144,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -168,7 +160,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForMilestone(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -185,7 +176,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForMilestone(int repositoryId, int number)
         {
             return GetAllForMilestone(repositoryId, number, ApiOptions.None);
@@ -201,7 +191,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -220,7 +209,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -237,7 +225,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public IObservable<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -255,7 +242,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public IObservable<Label> Get(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -272,7 +258,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -290,7 +275,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -307,7 +291,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         public IObservable<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -325,7 +308,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         public IObservable<Label> Create(int repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
@@ -343,7 +325,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         public IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -363,7 +344,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         public IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -382,7 +362,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         public IObservable<Label> AddToIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -403,7 +382,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         public IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
@@ -423,7 +401,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         public IObservable<Unit> RemoveFromIssue(string owner, string name, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -442,7 +419,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         public IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -460,7 +436,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         public IObservable<Label> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -481,7 +456,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         public IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
@@ -500,7 +474,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public IObservable<Unit> RemoveAllFromIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -517,7 +490,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number)
         {
             return _client.RemoveAllFromIssue(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -6,6 +6,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Issue Labels API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/labels/">Issue Labels API documentation</a> for more information.
+    /// </remarks>
     public class ObservableIssuesLabelsClient : IObservableIssuesLabelsClient
     {
         readonly IIssuesLabelsClient _client;

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -102,7 +102,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -133,7 +133,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -151,7 +151,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -237,7 +237,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         public IObservable<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -255,7 +255,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         public IObservable<Label> Get(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -307,7 +307,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         public IObservable<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -325,7 +325,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         public IObservable<Label> Create(int repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
@@ -343,7 +343,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         public IObservable<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -363,7 +363,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         public IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");

--- a/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesLabelsClientTests.cs
@@ -32,6 +32,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                await client.GetAllForIssue(1, 42);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -50,6 +61,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForIssue(1, 42, options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -59,6 +88,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
@@ -81,6 +112,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -99,6 +141,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -108,6 +168,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
@@ -130,6 +192,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                await client.GetAllForMilestone(1, 42);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42/labels"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -148,6 +221,24 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForMilestone(1, 42, options);
+
+                connection.Received().GetAll<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42/labels"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -157,6 +248,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForMilestone(1, 42, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("", "name", 42));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42));
@@ -179,6 +272,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                await client.Get(1, "label");
+
+                connection.Received().Get<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels/label"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -187,9 +291,13 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, "label"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", "name", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", "label"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", "label"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get(1, ""));
             }
         }
 
@@ -209,6 +317,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.AddToIssue(1, 42, labels);
+
+                connection.Received().Post<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), Arg.Any<string[]>());
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -216,6 +335,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue(null, "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", null, 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddToIssue(1, 42, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.AddToIssue("", "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.AddToIssue("owner", "", 42, labels));
@@ -236,6 +357,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void DeleteCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.RemoveFromIssue(1, 42, "label");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels/label"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -244,9 +376,13 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", null, 42, "label"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue("owner", "name", 42, null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveFromIssue(1, 42, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("", "name", 42, "label"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("owner", "", 42, "label"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue("owner", "name", 42, ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveFromIssue(1, 42, ""));
             }
         }
 
@@ -266,6 +402,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void PutsToCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.ReplaceAllForIssue(1, 42, labels);
+
+                connection.Received().Put<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), Arg.Any<string[]>());
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -273,6 +420,8 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue(null, "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", null, 42, labels));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAllForIssue(1, 42, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.ReplaceAllForIssue("", "name", 42, labels));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.ReplaceAllForIssue("owner", "", 42, labels));
@@ -293,6 +442,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void DeletesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.RemoveAllFromIssue(1, 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
@@ -302,6 +462,144 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAllFromIssue("", "name", 42));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAllFromIssue("owner", "", 42));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void DeletesCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.Delete("fake", "repo", "labelName");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels/labelName"));
+            }
+
+            [Fact]
+            public void DeletesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                client.Delete(1, "labelName");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels/labelName"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", "labelName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, "labelName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", "labelName"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", "labelName"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "name", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete(1, ""));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void CreatesCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                client.Create("fake", "repo", newLabel);
+
+                connection.Received().Post<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels"), newLabel);
+            }
+
+            [Fact]
+            public void CreatesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                client.Create(1, newLabel);
+
+                connection.Received().Post<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels"), newLabel);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", newLabel));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, newLabel));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", newLabel));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", newLabel));
+            }
+        }
+
+        public class TheUpdateMethod
+        {
+            [Fact]
+            public void UpdatesCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+                
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                client.Update("fake", "repo", "labelName", labelUpdate);
+
+                connection.Received().Post<Label>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/labels/labelName"), labelUpdate);
+            }
+
+            [Fact]
+            public void UpdatesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssuesLabelsClient(connection);
+
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                client.Update(1, "labelName", labelUpdate);
+
+                connection.Received().Post<Label>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels/labelName"), labelUpdate);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new IssuesLabelsClient(Substitute.For<IApiConnection>());
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(null, "name", "labelName", labelUpdate));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", null, "labelName", labelUpdate));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", null, labelUpdate));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update("owner", "name", "labelName", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, null, labelUpdate));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, "labelName", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("", "name", "labelName", labelUpdate));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "", "labelName", labelUpdate));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update("owner", "name", "", labelUpdate));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Update(1, "", labelUpdate));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
@@ -34,6 +34,18 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForIssue(1, 42);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IConnection>();
@@ -53,6 +65,25 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForIssue(1, 42, options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -62,6 +93,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));
@@ -85,6 +118,18 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForRepository(1);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IConnection>();
@@ -104,6 +149,25 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForRepository(1, options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -113,6 +177,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));
@@ -136,6 +202,18 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.GetAllForMilestone(1, 42);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42/labels"), Args.EmptyDictionary, null);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IConnection>();
@@ -155,6 +233,25 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllForMilestone(1, 42, options);
+
+                connection.Received().Get<List<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/milestones/42/labels"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -164,6 +261,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone(null, "name", 42, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone("owner", null, 42, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForMilestone(1, 42, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("", "name", 42));
                 Assert.Throws<ArgumentException>(() => client.GetAllForMilestone("owner", "", 42));
@@ -186,6 +285,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.Get(1, "label");
+
+                gitHubClient.Issue.Labels.Received().Get(1, "label");
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -194,9 +304,13 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, "label"));
                 Assert.Throws<ArgumentNullException>(() => client.Get("owner", "name", null));
 
+                Assert.Throws<ArgumentNullException>(() => client.Get(1, null));
+
                 Assert.Throws<ArgumentException>(() => client.Get("", "name", "label"));
                 Assert.Throws<ArgumentException>(() => client.Get("owner", "", "label"));
                 Assert.Throws<ArgumentException>(() => client.Get("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Get(1, ""));
             }
         }
 
@@ -216,6 +330,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.AddToIssue(1, 42, labels);
+
+                gitHubClient.Issue.Labels.Received().AddToIssue(1, 42, labels);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -223,6 +348,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.AddToIssue(null, "name", 42, labels));
                 Assert.Throws<ArgumentNullException>(() => client.AddToIssue("owner", null, 42, labels));
                 Assert.Throws<ArgumentNullException>(() => client.AddToIssue("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.AddToIssue(1, 42, null));
 
                 Assert.Throws<ArgumentException>(() => client.AddToIssue("", "name", 42, labels));
                 Assert.Throws<ArgumentException>(() => client.AddToIssue("owner", "", 42, labels));
@@ -244,6 +371,18 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void DeleteCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.RemoveFromIssue(1, 42, "label");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels/label"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -252,9 +391,13 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue("owner", null, 42, "label"));
                 Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue("owner", "name", 42, null));
 
+                Assert.Throws<ArgumentNullException>(() => client.RemoveFromIssue(1, 42, null));
+
                 Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("", "name", 42, "label"));
                 Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("owner", "", 42, "label"));
                 Assert.Throws<ArgumentException>(() => client.RemoveFromIssue("owner", "name", 42, ""));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveFromIssue(1, 42, ""));
             }
         }
 
@@ -274,6 +417,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void PutsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.ReplaceAllForIssue(1, 42, labels);
+
+                gitHubClient.Issue.Labels.Received().ReplaceAllForIssue(1, 42, labels);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -281,6 +435,8 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue(null, "name", 42, labels));
                 Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", null, 42, labels));
                 Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue("owner", "name", 42, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.ReplaceAllForIssue(1, 42, null));
 
                 Assert.Throws<ArgumentException>(() => client.ReplaceAllForIssue("", "name", 42, labels));
                 Assert.Throws<ArgumentException>(() => client.ReplaceAllForIssue("owner", "", 42, labels));
@@ -302,6 +458,18 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void DeletesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.RemoveAllFromIssue(1, 42);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
@@ -311,6 +479,144 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => client.RemoveAllFromIssue("", "name", 42));
                 Assert.Throws<ArgumentException>(() => client.RemoveAllFromIssue("owner", "", 42));
+            }
+        }
+
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public void DeletesCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.Delete("fake", "repo", "labelName");
+
+                gitHubClient.Received().Issue.Labels.Delete("fake", "repo", "labelName");
+            }
+
+            [Fact]
+            public void DeletesCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                client.Delete(1, "labelName");
+
+                gitHubClient.Received().Issue.Labels.Delete(1, "labelName");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", "labelName"));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, "labelName"));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name", "labelName"));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "", "labelName"));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "name", ""));
+
+                Assert.Throws<ArgumentException>(() => client.Delete(1, ""));
+            }
+        }
+
+        public class TheCreateMethod
+        {
+            [Fact]
+            public void CreatesCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                client.Create("fake", "repo", newLabel);
+
+                gitHubClient.Received().Issue.Labels.Create("fake", "repo", newLabel);
+            }
+
+            [Fact]
+            public void CreatesCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                client.Create(1, newLabel);
+
+                gitHubClient.Received().Issue.Labels.Create(1, newLabel);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+                var newLabel = new NewLabel("labelName", "FF0000");
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", newLabel));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, newLabel));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", null));
+                
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, null));
+                
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", newLabel));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", newLabel));
+            }
+        }
+
+        public class TheUpdateMethod
+        {
+            [Fact]
+            public void UpdatesCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                client.Update("fake", "repo", "labelName", labelUpdate);
+
+                gitHubClient.Received().Issue.Labels.Update("fake", "repo", "labelName", labelUpdate);
+            }
+
+            [Fact]
+            public void UpdatesCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssuesLabelsClient(gitHubClient);
+
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                client.Update(1, "labelName", labelUpdate);
+
+                gitHubClient.Received().Issue.Labels.Update(1, "labelName", labelUpdate);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableIssuesLabelsClient(Substitute.For<IGitHubClient>());
+                var labelUpdate = new LabelUpdate("name", "FF0000");
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(null, "name", "labelName", labelUpdate));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", null, "labelName", labelUpdate));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", null, labelUpdate));
+                Assert.Throws<ArgumentNullException>(() => client.Update("owner", "name", "labelName", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Update(1, null, labelUpdate));
+                Assert.Throws<ArgumentNullException>(() => client.Update(1, "labelName", null));
+
+                Assert.Throws<ArgumentException>(() => client.Update("", "name", "labelName", labelUpdate));
+                Assert.Throws<ArgumentException>(() => client.Update("owner", "", "labelName", labelUpdate));
+                Assert.Throws<ArgumentException>(() => client.Update("owner", "name", "", labelUpdate));
+
+                Assert.Throws<ArgumentException>(() => client.Update(1, "", labelUpdate));
             }
         }
     }

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -21,7 +21,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
         
         /// <summary>
@@ -32,7 +31,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +43,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +54,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +64,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +73,6 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +84,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +94,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -113,7 +105,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number);
 
         /// <summary>
@@ -124,7 +115,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number);
 
         /// <summary>
@@ -137,7 +127,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -149,7 +138,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -161,7 +149,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         Task<Label> Get(string owner, string name, string labelName);
@@ -174,7 +161,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         Task<Label> Get(int repositoryId, string labelName);
@@ -188,7 +174,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         Task Delete(string owner, string name, string labelName);
 
         /// <summary>
@@ -199,7 +184,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         Task Delete(int repositoryId, string labelName);
 
         /// <summary>
@@ -211,7 +195,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         Task<Label> Create(string owner, string name, NewLabel newLabel);
 
         /// <summary>
@@ -222,7 +205,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         Task<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
@@ -235,7 +217,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -247,7 +228,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -260,7 +240,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
@@ -272,7 +251,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
@@ -285,7 +263,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         Task RemoveFromIssue(string owner, string name, int number, string labelName);
 
         /// <summary>
@@ -297,7 +274,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         Task RemoveFromIssue(int repositoryId, int number, string labelName);
 
         /// <summary>
@@ -310,7 +286,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
@@ -322,7 +297,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
@@ -334,7 +308,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         Task RemoveAllFromIssue(string owner, string name, int number);
 
         /// <summary>
@@ -345,7 +318,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         Task RemoveAllFromIssue(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -4,6 +4,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Issue Labels API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/labels/">Issue Labels API documentation</a> for more information.
+    /// </remarks>
     public interface IIssuesLabelsClient
     {
         /// <summary>

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -17,6 +17,17 @@ namespace Octokit
         /// <param name="number">The number of the issue</param>
         /// <returns>The list of labels</returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
+        
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -30,6 +41,18 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of labels</returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -48,11 +71,32 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of labels</returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -72,12 +116,35 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -94,6 +161,19 @@ namespace Octokit
         Task<Label> Get(string owner, string name, string labelName);
 
         /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+        Justification = "Method makes a network request")]
+        Task<Label> Get(int repositoryId, string labelName);
+
+        /// <summary>
         /// Deletes a label.
         /// </summary>
         /// <remarks>
@@ -106,6 +186,17 @@ namespace Octokit
         Task Delete(string owner, string name, string labelName);
 
         /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        Task Delete(int repositoryId, string labelName);
+
+        /// <summary>
         /// Creates a label.
         /// </summary>
         /// <remarks>
@@ -116,6 +207,17 @@ namespace Octokit
         /// <param name="newLabel">The data for the label to be created</param>
         /// <returns>The created label</returns>
         Task<Label> Create(string owner, string name, NewLabel newLabel);
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        Task<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
         /// Updates a label.
@@ -131,6 +233,18 @@ namespace Octokit
         Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
+
+        /// <summary>
         /// Adds a label to an issue
         /// </summary>
         /// <remarks>
@@ -142,6 +256,18 @@ namespace Octokit
         /// <param name="labels">The names of the labels to add</param>
         /// <returns></returns>
         Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels);
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -157,6 +283,18 @@ namespace Octokit
         Task RemoveFromIssue(string owner, string name, int number, string labelName);
 
         /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labelName">The name of the label to remove</param>
+        /// <returns></returns>
+        Task RemoveFromIssue(int repositoryId, int number, string labelName);
+
+        /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
         /// </summary>
         /// <remarks>
@@ -170,6 +308,18 @@ namespace Octokit
         Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels);
 
         /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
+
+        /// <summary>
         /// Removes all labels from an issue
         /// </summary>
         /// <remarks>
@@ -180,5 +330,16 @@ namespace Octokit
         /// <param name="number">The number of the issue</param>
         /// <returns></returns>
         Task RemoveAllFromIssue(string owner, string name, int number);
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        Task RemoveAllFromIssue(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number);
         
         /// <summary>
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number);
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         Task<Label> Get(string owner, string name, string labelName);
@@ -174,7 +174,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
         Task<Label> Get(int repositoryId, string labelName);
@@ -211,7 +211,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         Task<Label> Create(string owner, string name, NewLabel newLabel);
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         Task<Label> Create(int repositoryId, NewLabel newLabel);
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +42,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -93,7 +93,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -109,7 +109,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -142,7 +142,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of labels</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -228,7 +228,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         public Task<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -246,7 +246,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns>The label</returns>
+        /// <returns></returns>
         public Task<Label> Get(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -298,7 +298,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         public Task<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -316,7 +316,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns>The created label</returns>
+        /// <returns></returns>
         public Task<Label> Create(int repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
@@ -334,7 +334,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         public Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -354,7 +354,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns>The updated label</returns>
+        /// <returns></returns>
         public Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -25,7 +25,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -42,7 +41,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -58,7 +56,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +74,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -93,7 +89,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -109,7 +104,6 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -124,7 +118,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -142,7 +135,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -159,7 +151,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -176,7 +167,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number)
         {
             return GetAllForMilestone(repositoryId, number, ApiOptions.None);
@@ -192,7 +182,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -211,7 +200,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -228,7 +216,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public Task<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -246,7 +233,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public Task<Label> Get(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -263,7 +249,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public Task Delete(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -281,7 +266,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        /// <returns></returns>
         public Task Delete(int repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -298,7 +282,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         public Task<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -316,7 +299,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        /// <returns></returns>
         public Task<Label> Create(int repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
@@ -334,7 +316,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         public Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -354,7 +335,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        /// <returns></returns>
         public Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -373,7 +353,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -392,7 +371,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
@@ -410,7 +388,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         public Task RemoveFromIssue(string owner, string name, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -429,7 +406,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        /// <returns></returns>
         public Task RemoveFromIssue(int repositoryId, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
@@ -447,7 +423,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -466,7 +441,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
@@ -483,7 +457,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public Task RemoveAllFromIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -500,7 +473,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the issue</param>
-        /// <returns></returns>
         public Task RemoveAllFromIssue(int repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, number));

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -34,6 +34,20 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number)
+        {
+            return GetAllForIssue(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
@@ -46,6 +60,23 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the issue.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-labels-on-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Label>(ApiUrls.IssueLabels(repositoryId, number), options);
         }
 
         /// <summary>
@@ -71,6 +102,19 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -82,6 +126,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Label>(ApiUrls.Labels(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all  labels for the repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of labels</returns>
+        public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Label>(ApiUrls.Labels(repositoryId), options);
         }
 
         /// <summary>
@@ -108,6 +168,20 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number)
+        {
+            return GetAllForMilestone(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
@@ -120,6 +194,23 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(owner, name, number), options);
+        }
+
+        /// <summary>
+        /// Gets labels for every issue in a milestone
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the milestone</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Label>(ApiUrls.MilestoneLabels(repositoryId, number), options);
         }
 
         /// <summary>
@@ -142,6 +233,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a single Label by name.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#get-a-single-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns>The label</returns>
+        public Task<Label> Get(int repositoryId, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return ApiConnection.Get<Label>(ApiUrls.Label(repositoryId, labelName));
+        }
+
+        /// <summary>
         /// Deletes a label.
         /// </summary>
         /// <remarks>
@@ -161,6 +268,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Deletes a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#delete-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return ApiConnection.Delete(ApiUrls.Label(repositoryId, labelName));
+        }
+
+        /// <summary>
         /// Creates a label.
         /// </summary>
         /// <remarks>
@@ -177,6 +300,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(newLabel, "newLabel");
 
             return ApiConnection.Post<Label>(ApiUrls.Labels(owner, name), newLabel);
+        }
+
+        /// <summary>
+        /// Creates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#create-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newLabel">The data for the label to be created</param>
+        /// <returns>The created label</returns>
+        public Task<Label> Create(int repositoryId, NewLabel newLabel)
+        {
+            Ensure.ArgumentNotNull(newLabel, "newLabel");
+
+            return ApiConnection.Post<Label>(ApiUrls.Labels(repositoryId), newLabel);
         }
 
         /// <summary>
@@ -201,6 +340,24 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Updates a label.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#update-a-label">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="labelName">The name of the label</param>
+        /// <param name="labelUpdate">The data for the label to be updated</param>
+        /// <returns>The updated label</returns>
+        public Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+            Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
+
+            return ApiConnection.Post<Label>(ApiUrls.Label(repositoryId, labelName), labelUpdate);
+        }
+
+        /// <summary>
         /// Adds a label to an issue
         /// </summary>
         /// <remarks>
@@ -218,6 +375,23 @@ namespace Octokit
             Ensure.ArgumentNotNull(labels, "labels");
 
             return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(owner, name, number), labels);
+        }
+
+        /// <summary>
+        /// Adds a label to an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#add-labels-to-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to add</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels)
+        {
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return ApiConnection.Post<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, number), labels);
         }
 
         /// <summary>
@@ -241,6 +415,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Removes a label from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labelName">The name of the label to remove</param>
+        /// <returns></returns>
+        public Task RemoveFromIssue(int repositoryId, int number, string labelName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
+
+            return ApiConnection.Delete(ApiUrls.IssueLabel(repositoryId, number, labelName));
+        }
+
+        /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
         /// </summary>
         /// <remarks>
@@ -261,6 +452,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Replaces all labels on the specified issues with the provided labels
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <param name="labels">The names of the labels to set</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
+        {
+            Ensure.ArgumentNotNull(labels, "labels");
+
+            return ApiConnection.Put<IReadOnlyList<Label>>(ApiUrls.IssueLabels(repositoryId, number), labels);
+        }
+
+        /// <summary>
         /// Removes all labels from an issue
         /// </summary>
         /// <remarks>
@@ -276,6 +484,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Delete(ApiUrls.IssueLabels(owner, name, number));
+        }
+
+        /// <summary>
+        /// Removes all labels from an issue
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the issue</param>
+        /// <returns></returns>
+        public Task RemoveAllFromIssue(int repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, number));
         }
     }
 }

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -3,6 +3,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Issue Labels API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/issues/labels/">Issue Labels API documentation</a> for more information.
+    /// </remarks>
     public class IssuesLabelsClient : ApiClient, IIssuesLabelsClient
     {
         public IssuesLabelsClient(IApiConnection apiConnection)


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)IssuesLabelsClient to get access by repository id.

- [x] **Add overloads to IIssuesLabelsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableIssuesLabelsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.