### PR TITLE
Add repositoryId overloads to methods on I(Observable)PullRequestsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -3,6 +3,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Pull Requests API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Pull Requests API documentation</a> for more information.
+    /// </remarks>
     public interface IObservablePullRequestsClient
     {
         /// <summary>
@@ -16,10 +22,26 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The number of the pull request</param>
         /// <returns>A <see cref="PullRequest"/> result</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         IObservable<PullRequest> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single Pull Request by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the pull request</param>
+        /// <returns>A <see cref="PullRequest"/> result</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        IObservable<PullRequest> Get(int repositoryId, int number);
 
         /// <summary>
         /// Gets all open pull requests for the repository.
@@ -38,11 +60,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A collection of <see cref="PullRequest"/> results</returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -62,12 +105,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A collection of <see cref="PullRequest"/> results</returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a pull request for the specified repository.
@@ -78,6 +144,15 @@ namespace Octokit.Reactive
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
         /// <returns>A created <see cref="PullRequest"/> result</returns>
         IObservable<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
+
+        /// <summary>
+        /// Creates a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
         /// Update a pull request for the specified repository.
@@ -92,6 +167,17 @@ namespace Octokit.Reactive
         IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
+        /// Update a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
+        /// </param>
+        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+
+        /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
@@ -101,6 +187,16 @@ namespace Octokit.Reactive
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>A <see cref="PullRequestMerge"/> result</returns>
         IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
+
+        /// <summary>
+        /// Merge a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Gets the pull request merge status.
@@ -113,6 +209,15 @@ namespace Octokit.Reactive
         IObservable<bool> Merged(string owner, string name, int number);
 
         /// <summary>
+        /// Gets the pull request merge status.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        IObservable<bool> Merged(int repositoryId, int number);
+
+        /// <summary>
         /// Gets the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
@@ -123,6 +228,15 @@ namespace Octokit.Reactive
         IObservable<PullRequestCommit> Commits(string owner, string name, int number);
 
         /// <summary>
+        /// Gets the list of commits on a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        IObservable<PullRequestCommit> Commits(int repositoryId, int number);
+
+        /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
@@ -131,5 +245,14 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request number</param>
         /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
         IObservable<PullRequestFile> Files(string owner, string name, int number);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        IObservable<PullRequestFile> Files(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<PullRequest> Get(string owner, string name, int number);
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<PullRequest> Get(int repositoryId, int number);
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request);
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        /// <returns></returns>
         IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        /// <returns></returns>
         IObservable<bool> Merged(string owner, string name, int number);
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        /// <returns></returns>
         IObservable<bool> Merged(int repositoryId, int number);
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequestCommit> Commits(string owner, string name, int number);
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequestCommit> Commits(int repositoryId, int number);
 
         /// <summary>
@@ -243,7 +243,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequestFile> Files(string owner, string name, int number);
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        /// <returns></returns>
         IObservable<PullRequestFile> Files(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -25,7 +25,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<PullRequest> Get(string owner, string name, int number);
@@ -38,7 +37,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         IObservable<PullRequest> Get(int repositoryId, int number);
@@ -51,7 +49,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -61,7 +58,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -73,7 +69,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +79,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -96,7 +90,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request);
 
         /// <summary>
@@ -107,7 +100,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request);
 
         /// <summary>
@@ -120,7 +112,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -132,7 +123,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -142,7 +132,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         IObservable<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -151,7 +140,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -163,7 +151,6 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -174,7 +161,6 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -185,7 +171,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -195,7 +180,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -205,7 +189,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<bool> Merged(string owner, string name, int number);
 
         /// <summary>
@@ -214,7 +197,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<bool> Merged(int repositoryId, int number);
 
         /// <summary>
@@ -224,7 +206,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestCommit> Commits(string owner, string name, int number);
 
         /// <summary>
@@ -233,7 +214,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestCommit> Commits(int repositoryId, int number);
 
         /// <summary>
@@ -243,7 +223,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestFile> Files(string owner, string name, int number);
 
         /// <summary>
@@ -252,7 +231,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestFile> Files(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -4,6 +4,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Pull Requests API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Pull Requests API documentation</a> for more information.
+    /// </remarks>
     public class ObservablePullRequestsClient : IObservablePullRequestsClient
     {
         readonly IPullRequestsClient _client;
@@ -39,6 +45,20 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single Pull Request by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The number of the pull request</param>
+        /// <returns>A <see cref="PullRequest"/> result</returns>
+        public IObservable<PullRequest> Get(int repositoryId, int number)
+        {
+            return _client.Get(repositoryId, number).ToObservable();
+        }
+
+        /// <summary>
         /// Gets all open pull requests for the repository.
         /// </summary>
         /// <remarks>
@@ -61,6 +81,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -72,6 +105,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(repositoryId), options);
         }
 
         /// <summary>
@@ -99,6 +148,22 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
@@ -112,6 +177,25 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(owner, name),
+                request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PullRequest>(ApiUrls.PullRequests(repositoryId),
                 request.ToParametersDictionary(), options);
         }
 
@@ -130,6 +214,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
 
             return _client.Create(owner, name, newPullRequest).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        public IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
+        {
+            Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
+
+            return _client.Create(repositoryId, newPullRequest).ToObservable();
         }
 
         /// <summary>
@@ -152,6 +250,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Update a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
+        /// </param>
+        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        public IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        {
+            Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
+
+            return _client.Update(repositoryId, number, pullRequestUpdate).ToObservable();
+        }
+
+        /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
@@ -167,6 +281,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
 
             return _client.Merge(owner, name, number, mergePullRequest).ToObservable();
+        }
+
+        /// <summary>
+        /// Merge a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        public IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
+        {
+            Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
+
+            return _client.Merge(repositoryId, number, mergePullRequest).ToObservable();
         }
 
         /// <summary>
@@ -186,6 +315,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets the pull request merge status.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        public IObservable<bool> Merged(int repositoryId, int number)
+        {
+            return _client.Merged(repositoryId, number).ToObservable();
+        }
+
+        /// <summary>
         /// Gets the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
@@ -202,6 +343,18 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets the list of commits on a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        public IObservable<PullRequestCommit> Commits(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
+        }
+
+        /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
@@ -215,6 +368,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number));
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        public IObservable<PullRequestFile> Files(int repositoryId, int number)
+        {
+            return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -35,7 +35,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns></returns>
         public IObservable<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -52,7 +51,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns></returns>
         public IObservable<PullRequest> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -66,7 +64,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +79,6 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -97,7 +93,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -115,7 +110,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -132,7 +126,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +143,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -168,7 +160,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -189,7 +180,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -206,7 +196,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         public IObservable<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -222,7 +211,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         public IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
@@ -239,7 +227,6 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         public IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -257,7 +244,6 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         public IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
@@ -273,7 +259,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         public IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -290,7 +275,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         public IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
@@ -305,7 +289,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -320,7 +303,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<bool> Merged(int repositoryId, int number)
         {
             return _client.Merged(repositoryId, number).ToObservable();
@@ -333,7 +315,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestCommit> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -348,7 +329,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestCommit> Commits(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
@@ -361,7 +341,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestFile> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -376,7 +355,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestFile> Files(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Get(int repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
@@ -66,7 +66,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -97,7 +97,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -132,7 +132,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -150,7 +150,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -168,7 +168,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -189,7 +189,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A collection of <see cref="PullRequest"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -206,7 +206,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -222,7 +222,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A created <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
@@ -239,7 +239,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -257,7 +257,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
@@ -273,7 +273,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -290,7 +290,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>A <see cref="PullRequestMerge"/> result</returns>
+        /// <returns></returns>
         public IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
@@ -305,7 +305,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        /// <returns></returns>
         public IObservable<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -320,7 +320,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="bool"/> result - true if the pull request has been merged, false otherwise</returns>
+        /// <returns></returns>
         public IObservable<bool> Merged(int repositoryId, int number)
         {
             return _client.Merged(repositoryId, number).ToObservable();
@@ -333,7 +333,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequestCommit> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -348,7 +348,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestCommit"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequestCommit> Commits(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
@@ -361,7 +361,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequestFile> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -376,7 +376,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A collection of <see cref="PullRequestFile"/> results</returns>
+        /// <returns></returns>
         public IObservable<PullRequestFile> Files(int repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
-using Xunit;
 using Octokit.Tests.Integration.Helpers;
+using Xunit;
 
 public class PullRequestsClientTests : IDisposable
 {
@@ -38,6 +38,16 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanCreateWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(_context.Repository.Id, newPullRequest);
+        Assert.Equal("a pull request", result.Title);
+    }
+
+    [IntegrationTest]
     public async Task CanGetForRepository()
     {
         await CreateTheWorld();
@@ -46,6 +56,20 @@ public class PullRequestsClientTests : IDisposable
         var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
         var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetForRepositoryWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -72,6 +96,26 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithoutStartWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfPullRequestsWithStart()
     {
         await CreateTheWorld();
@@ -89,6 +133,29 @@ public class PullRequestsClientTests : IDisposable
         };
 
         var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithStartWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 1
+        };
+
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, options);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -125,6 +192,36 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsDistinctPullRequestsBasedOnStartPageWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _fixture.GetAllForRepository(_context.Repository.Id, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _fixture.GetAllForRepository(_context.Repository.Id, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Title, secondPage[0].Title);
+    }
+
+    [IntegrationTest]
     public async Task CanGetOpenPullRequest()
     {
         await CreateTheWorld();
@@ -134,6 +231,21 @@ public class PullRequestsClientTests : IDisposable
 
         var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
         var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetOpenPullRequestWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -155,6 +267,27 @@ public class PullRequestsClientTests : IDisposable
 
         var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
         var pullRequests = await _fixture.GetAllForRepository(Helper.UserName, _context.RepositoryName, openPullRequests, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithoutStartParameterizedWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests, options);
 
         Assert.Equal(1, pullRequests.Count);
         Assert.Equal(result.Title, pullRequests[0].Title);
@@ -185,6 +318,30 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestsWithStartParameterizedWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var options = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 1
+        };
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests, options);
+
+        Assert.Equal(1, pullRequests.Count);
+        Assert.Equal(result.Title, pullRequests[0].Title);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsDistinctPullRequestsBasedOnStartPageParameterized()
     {
         await CreateTheWorld();
@@ -201,7 +358,7 @@ public class PullRequestsClientTests : IDisposable
             PageSize = 1,
             PageCount = 1
         };
-        
+
         var firstPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, openPullRequests, startOptions);
 
         var skipStartOptions = new ApiOptions
@@ -212,6 +369,38 @@ public class PullRequestsClientTests : IDisposable
         };
 
         var secondPage = await _fixture.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName, openPullRequests, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Title, secondPage[0].Title);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctPullRequestsBasedOnStartPageParameterizedWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest1 = new NewPullRequest("a pull request 1", branchName, "master");
+        var newPullRequest2 = new NewPullRequest("a pull request 2", otherBranchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest1);
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest2);
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Open };
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests, skipStartOptions);
 
         Assert.NotEqual(firstPage[0].Title, secondPage[0].Title);
     }
@@ -231,6 +420,20 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task IgnoresOpenPullRequestWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var openPullRequests = new PullRequestRequest { State = ItemStateFilter.Closed };
+        var pullRequests = await _fixture.GetAllForRepository(_context.Repository.Id, openPullRequests);
+
+        Assert.Empty(pullRequests);
+    }
+
+    [IntegrationTest]
     public async Task CanUpdate()
     {
         await CreateTheWorld();
@@ -240,6 +443,21 @@ public class PullRequestsClientTests : IDisposable
 
         var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body" };
         var result = await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
+
+        Assert.Equal(updatePullRequest.Title, result.Title);
+        Assert.Equal(updatePullRequest.Body, result.Body);
+    }
+
+    [IntegrationTest]
+    public async Task CanUpdateWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body" };
+        var result = await _fixture.Update(_context.Repository.Id, pullRequest.Number, updatePullRequest);
 
         Assert.Equal(updatePullRequest.Title, result.Title);
         Assert.Equal(updatePullRequest.Body, result.Body);
@@ -333,6 +551,19 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task IsNotMergedInitiallyWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var result = await _fixture.Merged(_context.Repository.Id, pullRequest.Number);
+
+        Assert.False(result);
+    }
+
+    [IntegrationTest]
     public async Task CanBeMerged()
     {
         await CreateTheWorld();
@@ -342,6 +573,20 @@ public class PullRequestsClientTests : IDisposable
 
         var merge = new MergePullRequest { CommitMessage = "thing the thing" };
         var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
+
+        Assert.True(result.Merged);
+    }
+
+    [IntegrationTest]
+    public async Task CanBeMergedWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var merge = new MergePullRequest { CommitMessage = "thing the thing" };
+        var result = await _fixture.Merge(_context.Repository.Id, pullRequest.Number, merge);
 
         Assert.True(result.Merged);
     }
@@ -359,6 +604,7 @@ public class PullRequestsClientTests : IDisposable
 
         Assert.True(result.Merged);
     }
+
     [IntegrationTest]
     public async Task CanBeMergedWithShaSpecified()
     {
@@ -384,14 +630,12 @@ public class PullRequestsClientTests : IDisposable
         var merge = new MergePullRequest { CommitMessage = "fake commit message", CommitTitle = "fake title", Squash = true };
         var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
         var commit = await _github.Repository.Commit.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
-        var message = commit.Commit.Message;
+
         Assert.True(result.Merged);
         Assert.Equal("fake title\n\nfake commit message", commit.Commit.Message);
-
     }
 
     [IntegrationTest]
-
     public async Task CannotBeMergedDueMismatchConflict()
     {
         await CreateTheWorld();
@@ -462,6 +706,20 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanBrowseCommitsWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var result = await _fixture.Commits(_context.Repository.Id, pullRequest.Number);
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal("this is the commit to merge into the pull request", result[0].Commit.Message);
+    }
+
+    [IntegrationTest]
     public async Task CanGetCommitsAndCommentCount()
     {
         await CreateTheWorld();
@@ -494,6 +752,38 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanGetCommitsAndCommentCountWithRepositoryId()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        // create new commit for branch
+
+        const string commitMessage = "Another commit in branch";
+
+        var branch = await _github.Git.Reference.Get(Helper.UserName, _context.RepositoryName, "heads/" + branchName);
+
+        var newTree = await CreateTree(new Dictionary<string, string> { { "README.md", "Hello World!" } });
+        var newCommit = await CreateCommit(commitMessage, newTree.Sha, branch.Object.Sha);
+        await _github.Git.Reference.Update(Helper.UserName, _context.RepositoryName, "heads/" + branchName, new ReferenceUpdate(newCommit.Sha));
+
+        await _repositoryCommentsClient.Create(Helper.UserName, _context.RepositoryName, newCommit.Sha, new NewCommitComment("I am a nice comment") { Path = "README.md", Position = 1 });
+
+        // don't try this at home
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        var result = await _fixture.Commits(_context.Repository.Id, pullRequest.Number);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("this is the commit to merge into the pull request", result[0].Commit.Message);
+        Assert.Equal(0, result[0].Commit.CommentCount);
+        Assert.Equal(commitMessage, result[1].Commit.Message);
+        Assert.Equal(1, result[1].Commit.CommentCount);
+    }
+
+    [IntegrationTest]
     public async Task CanBrowseFiles()
     {
         var expectedFiles = new List<PullRequestFile>
@@ -505,6 +795,30 @@ public class PullRequestsClientTests : IDisposable
         };
 
         var result = await _fixture.Files("octokit", "octokit.net", 288);
+
+        Assert.Equal(4, result.Count);
+        Assert.True(expectedFiles.All(expectedFile => result.Any(file => file.FileName.Equals(expectedFile.FileName))));
+        foreach (var file in result)
+        {
+            var expectedFile = expectedFiles.Find(prf => file.FileName.Equals(prf.FileName));
+            Assert.Equal(expectedFile.Changes, file.Changes);
+            Assert.Equal(expectedFile.Additions, file.Additions);
+            Assert.Equal(expectedFile.Deletions, file.Deletions);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task CanBrowseFilesWithRepositoryId()
+    {
+        var expectedFiles = new List<PullRequestFile>
+        {
+            new PullRequestFile(null, "Octokit.Tests.Integration/Clients/ReferencesClientTests.cs", null, 8, 3, 11, null, null, null, null),
+            new PullRequestFile(null, "Octokit/Clients/ApiPagination.cs", null, 21, 6, 27, null, null, null, null),
+            new PullRequestFile(null, "Octokit/Helpers/IApiPagination.cs", null, 1, 1, 2, null, null, null, null),
+            new PullRequestFile(null, "Octokit/Http/ApiConnection.cs", null, 1, 1, 2, null, null, null, null)
+        };
+
+        var result = await _fixture.Files(7528679, 288);
 
         Assert.Equal(4, result.Count);
         Assert.True(expectedFiles.All(expectedFile => result.Any(file => file.FileName.Equals(expectedFile.FileName))));

--- a/Octokit.Tests/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestsClientTests.cs
@@ -11,14 +11,25 @@ namespace Octokit.Tests.Clients
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                client.Get("fake", "repo", 42);
+                await client.Get("fake", "repo", 42);
 
                 connection.Received().Get<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.Get(1, 42);
+
+                connection.Received().Get<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42"));
             }
 
             [Fact]
@@ -28,8 +39,9 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
 
@@ -44,6 +56,18 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForRepository("fake", "repo");
 
                 connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
+                    Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.GetAllForRepository(1);
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls"),
                     Arg.Any<Dictionary<string, string>>(), Args.ApiOptions);
             }
 
@@ -67,6 +91,25 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, options);
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls"),
+                    Arg.Any<Dictionary<string, string>>(), options);
+            }
+
+            [Fact]
             public async Task SendsAppropriateParameters()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -75,6 +118,23 @@ namespace Octokit.Tests.Clients
                 await client.GetAllForRepository("fake", "repo", new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" });
 
                 connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
+                        && d["head"] == "user:ref-head"
+                        && d["state"] == "open"
+                        && d["base"] == "fake_base_branch"
+                        && d["sort"] == "created"
+                        && d["direction"] == "desc"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task SendsAppropriateParametersWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.GetAllForRepository(1, new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" });
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["head"] == "user:ref-head"
                         && d["state"] == "open"
@@ -108,6 +168,30 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task SendsAppropriateParametersWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    StartPage = 1,
+                    PageCount = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllForRepository(1, new PullRequestRequest { Head = "user:ref-head", Base = "fake_base_branch" }, options);
+
+                connection.Received().GetAll<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
+                        && d["head"] == "user:ref-head"
+                        && d["state"] == "open"
+                        && d["base"] == "fake_base_branch"
+                        && d["sort"] == "created"
+                        && d["direction"] == "desc"), options);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new PullRequestsClient(Substitute.For<IApiConnection>());
@@ -127,6 +211,11 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, new PullRequestRequest(), ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", new PullRequestRequest(), null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (PullRequestRequest)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, new PullRequestRequest(), null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));
@@ -158,21 +247,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task PostsToCorrectUrlWithRepositoryId()
+            {
+                var newPullRequest = new NewPullRequest("some title", "branch:name", "branch:name");
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.Create(1, newPullRequest);
+
+                connection.Received().Post<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls"),
+                    newPullRequest);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
             }
         }
 
@@ -192,21 +292,32 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task PostsToCorrectUrlWithRepositoryId()
+            {
+                var pullRequestUpdate = new PullRequestUpdate();
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.Update(1, 42, pullRequestUpdate);
+
+                connection.Received().Patch<PullRequest>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42"),
+                    pullRequestUpdate);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentException>(() =>
-                    client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Create("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", new NewPullRequest("title", "ref", "ref2")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", new NewPullRequest("title", "ref", "ref2")));
             }
         }
 
@@ -222,21 +333,36 @@ namespace Octokit.Tests.Clients
                 client.Merge("fake", "repo", 42, mergePullRequest);
 
                 connection.Received().Put<PullRequestMerge>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/42/merge"),
-                    mergePullRequest,null, "application/vnd.github.polaris-preview+json");
+                    mergePullRequest, null, "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void PutsToCorrectUrlWithRepositoryId()
+            {
+                var mergePullRequest = new MergePullRequest { CommitMessage = "fake commit message" };
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                client.Merge(1, 42, mergePullRequest);
+
+                connection.Received().Put<PullRequestMerge>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/merge"),
+                    mergePullRequest, null, "application/vnd.github.polaris-preview+json");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge(null, "name", 42, new MergePullRequest { CommitMessage = "message" }));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge("owner", null, 42, new MergePullRequest { CommitMessage = "message" }));
-                await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                    client.Merge("owner", "name", 42, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merge(null, "name", 42, new MergePullRequest { CommitMessage = "message" }));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merge("owner", null, 42, new MergePullRequest { CommitMessage = "message" }));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merge("owner", "name", 42, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merge(1, 42, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merge("", "name", 42, new MergePullRequest { CommitMessage = "message" }));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merge("owner", "", 42, new MergePullRequest { CommitMessage = "message" }));
             }
         }
 
@@ -257,15 +383,30 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var conn = Substitute.For<IConnection>();
+                var connection = Substitute.For<IApiConnection>();
+                connection.Connection.Returns(conn);
+
+                var client = new PullRequestsClient(connection);
+
+                client.Merged(1, 42);
+
+                conn.Received().Get<object>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/merge"), null, null);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Merged(null, "", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Merged("owner", "", 1));
             }
         }
 
@@ -284,15 +425,28 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.Commits(1, 42);
+
+                connection.Received()
+                    .GetAll<PullRequestCommit>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/commits"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits("owner", null, 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Commits(null, "", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", null, 1));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Commits("owner", "", 1));
             }
         }
 
@@ -311,13 +465,26 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public async Task EnsuresArgumentsNotNull()
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new PullRequestsClient(connection);
+
+                await client.Files(1, 42);
+
+                connection.Received()
+                    .GetAll<PullRequestFile>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/42/files"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files(null, "name", 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Files("owner", null, 1));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Files("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Files("owner", "", 1));
             }

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -23,7 +23,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<PullRequest> Get(string owner, string name, int number);
@@ -34,7 +33,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<PullRequest> Get(int repositoryId, int number);
@@ -47,7 +45,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -57,7 +54,6 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -69,7 +65,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -80,7 +75,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -92,7 +86,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request);
 
         /// <summary>
@@ -103,7 +96,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request);
 
         /// <summary>
@@ -116,7 +108,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -128,7 +119,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -138,7 +128,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -147,7 +136,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -159,7 +147,6 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -170,7 +157,6 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -181,7 +167,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -191,7 +176,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -201,7 +185,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<bool> Merged(string owner, string name, int number);
 
         /// <summary>
@@ -210,7 +193,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<bool> Merged(int repositoryId, int number);
 
         /// <summary>
@@ -220,7 +202,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number);
 
         /// <summary>
@@ -229,7 +210,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number);
 
         /// <summary>
@@ -239,7 +219,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number);
 
         /// <summary>
@@ -248,7 +227,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -4,6 +4,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Pull Requests API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Pull Requests API documentation</a> for more information.
+    /// </remarks>
     public interface IPullRequestsClient
     {
         /// <summary>
@@ -19,8 +25,19 @@ namespace Octokit
         /// </remarks>
         /// <returns>A <see cref="PullRequest"/> result</returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
-        Justification = "Method makes a network request")]
+             Justification = "Method makes a network request")]
         Task<PullRequest> Get(string owner, string name, int number);
+
+        /// <summary>
+        /// Get a pull request by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
+        /// </remarks>
+        /// <returns>A <see cref="PullRequest"/> result</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
+             Justification = "Method makes a network request")]
+        Task<PullRequest> Get(int repositoryId, int number);
 
         /// <summary>
         /// Get all open pull requests for the repository.
@@ -39,11 +56,32 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId);
+
+        /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -63,12 +101,35 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Create a pull request for the specified repository.
@@ -79,6 +140,15 @@ namespace Octokit
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
         /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
         Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
+
+        /// <summary>
+        /// Create a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
         /// Create a pull request for the specified repository. 
@@ -93,6 +163,17 @@ namespace Octokit
         Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
+        /// Create a pull request for the specified repository. 
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
+        /// </param>
+        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+
+        /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
@@ -102,6 +183,16 @@ namespace Octokit
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
         /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
         Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
+
+        /// <summary>
+        /// Merge a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Get the pull request merge status.
@@ -114,6 +205,15 @@ namespace Octokit
         Task<bool> Merged(string owner, string name, int number);
 
         /// <summary>
+        /// Get the pull request merge status.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>True if the operation has been merged, false otherwise</returns>
+        Task<bool> Merged(int repositoryId, int number);
+
+        /// <summary>
         /// Get the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
@@ -124,6 +224,15 @@ namespace Octokit
         Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number);
 
         /// <summary>
+        /// Get the list of commits on a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number);
+
+        /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
@@ -132,5 +241,14 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
         Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number);
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<PullRequest> Get(string owner, string name, int number);
@@ -34,7 +34,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<PullRequest> Get(int repositoryId, int number);
@@ -47,7 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request);
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        /// <returns></returns>
         Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        /// <returns></returns>
         Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        /// <returns></returns>
         Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        /// <returns></returns>
         Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>True if the operation has been merged, false otherwise</returns>
+        /// <returns></returns>
         Task<bool> Merged(string owner, string name, int number);
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>True if the operation has been merged, false otherwise</returns>
+        /// <returns></returns>
         Task<bool> Merged(int repositoryId, int number);
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number);
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number);
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number);
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -4,6 +4,12 @@ using System.Threading.Tasks;
 
 namespace Octokit
 {
+    /// <summary>
+    /// A client for GitHub's Pull Requests API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="http://developer.github.com/v3/activity/notifications/">Pull Requests API documentation</a> for more information.
+    /// </remarks>
     public class PullRequestsClient : ApiClient, IPullRequestsClient
     {
         public PullRequestsClient(IApiConnection apiConnection) : base(apiConnection)
@@ -32,6 +38,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get a pull request by number.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
+        /// </remarks>
+        /// <returns>A <see cref="PullRequest"/> result</returns>
+        public Task<PullRequest> Get(int repositoryId, int number)
+        {
+            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number));
+        }
+
+        /// <summary>
         /// Get all open pull requests for the repository.
         /// </summary>
         /// <remarks>
@@ -54,6 +72,19 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, new PullRequestRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -65,6 +96,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return GetAllForRepository(owner, name, new PullRequestRequest(), options);
+        }
+
+        /// <summary>
+        /// Get all open pull requests for the repository.
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new PullRequestRequest(), options);
         }
 
         /// <summary>
@@ -92,6 +139,22 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
@@ -105,6 +168,25 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<PullRequest>(ApiUrls.PullRequests(owner, name),
+                request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
+        /// Query pull requests for the repository based on criteria
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/pulls/#list-pull-requests
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PullRequest>(ApiUrls.PullRequests(repositoryId),
                 request.ToParametersDictionary(), options);
         }
 
@@ -123,6 +205,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
 
             return ApiConnection.Post<PullRequest>(ApiUrls.PullRequests(owner, name), newPullRequest);
+        }
+
+        /// <summary>
+        /// Create a pull request for the specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        public Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
+        {
+            Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
+
+            return ApiConnection.Post<PullRequest>(ApiUrls.PullRequests(repositoryId), newPullRequest);
         }
 
         /// <summary>
@@ -145,6 +241,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Create a pull request for the specified repository. 
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The PullRequest number</param>
+        /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
+        /// </param>
+        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        public Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        {
+            Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
+
+            return ApiConnection.Patch<PullRequest>(ApiUrls.PullRequest(repositoryId, number), pullRequestUpdate);
+        }
+
+        /// <summary>
         /// Merge a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
@@ -162,7 +274,41 @@ namespace Octokit
             try
             {
                 var endpoint = ApiUrls.MergePullRequest(owner, name, number);
-                return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest,null, 
+                return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest, null,
+                    AcceptHeaders.SquashCommitPreview).ConfigureAwait(false);
+            }
+            catch (ApiException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.MethodNotAllowed)
+                {
+                    throw new PullRequestNotMergeableException(ex.HttpResponse);
+                }
+
+                if (ex.StatusCode == HttpStatusCode.Conflict)
+                {
+                    throw new PullRequestMismatchException(ex.HttpResponse);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Merge a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#merge-a-pull-request-merge-buttontrade</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        public async Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
+        {
+            Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
+
+            try
+            {
+                var endpoint = ApiUrls.MergePullRequest(repositoryId, number);
+                return await ApiConnection.Put<PullRequestMerge>(endpoint, mergePullRequest, null,
                     AcceptHeaders.SquashCommitPreview).ConfigureAwait(false);
             }
             catch (ApiException ex)
@@ -207,6 +353,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get the pull request merge status.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>True if the operation has been merged, false otherwise</returns>
+        public async Task<bool> Merged(int repositoryId, int number)
+        {
+            try
+            {
+                var endpoint = ApiUrls.MergePullRequest(repositoryId, number);
+                var response = await Connection.Get<object>(endpoint, null, null).ConfigureAwait(false);
+                return response.HttpResponse.IsTrue();
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Get the list of commits on a pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
@@ -223,6 +390,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Get the list of commits on a pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        public Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
+        }
+
+        /// <summary>
         /// Get the list of files on a pull request.
         /// </summary>
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
@@ -236,6 +415,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(owner, name, number));
+        }
+
+        /// <summary>
+        /// Get the list of files on a pull request.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        public Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number)
+        {
+            return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
         }
     }
 }

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -28,7 +28,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns></returns>
         public Task<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +42,6 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns></returns>
         public Task<PullRequest> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number));
@@ -57,7 +55,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -73,7 +70,6 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestRequest(), ApiOptions.None);
@@ -88,7 +84,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -106,7 +101,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -123,7 +117,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -141,7 +134,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -159,7 +151,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -180,7 +171,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -197,7 +187,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         public Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -213,7 +202,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns></returns>
         public Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
@@ -230,7 +218,6 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -248,7 +235,6 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns></returns>
         public Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
@@ -264,7 +250,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -300,7 +285,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns></returns>
         public async Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
@@ -334,7 +318,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public async Task<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -358,7 +341,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public async Task<bool> Merged(int repositoryId, int number)
         {
             try
@@ -380,7 +362,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -395,7 +376,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
@@ -408,7 +388,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -423,7 +402,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public Task<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -43,7 +43,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        /// <returns>A <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public Task<PullRequest> Get(int repositoryId, int number)
         {
             return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number));
@@ -57,7 +57,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -73,7 +73,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestRequest(), ApiOptions.None);
@@ -88,7 +88,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -106,7 +106,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which are currently open</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -123,7 +123,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -141,7 +141,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -159,7 +159,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -180,7 +180,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequest}"/> of <see cref="PullRequest"/>s which match the criteria</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -197,7 +197,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        /// <returns></returns>
         public Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -213,7 +213,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        /// <returns>A <see cref="PullRequest"/> result which was created on the server</returns>
+        /// <returns></returns>
         public Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
@@ -230,7 +230,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -248,7 +248,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        /// <returns>An updated <see cref="PullRequest"/> result</returns>
+        /// <returns></returns>
         public Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
@@ -264,7 +264,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        /// <returns></returns>
         public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -300,7 +300,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        /// <returns>An <see cref="PullRequestMerge"/> result which indicates the merge result</returns>
+        /// <returns></returns>
         public async Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
@@ -334,7 +334,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>True if the operation has been merged, false otherwise</returns>
+        /// <returns></returns>
         public async Task<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -358,7 +358,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>True if the operation has been merged, false otherwise</returns>
+        /// <returns></returns>
         public async Task<bool> Merged(int repositoryId, int number)
         {
             try
@@ -380,7 +380,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -395,7 +395,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestCommit}"/> of <see cref="Commit"/>s which are part of this pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
@@ -408,7 +408,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -423,7 +423,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>A <see cref="IReadOnlyList{PullRequestFile}"/> which are part of this pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)PullRequestsClient to get access by repository id.

- [x] **Add overloads to IPullRequestsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservablePullRequestsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.