### PR TITLE
Add repositoryId overloads to methods on I(Observable)PullRequestReviewCommentsClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetComment(string owner, string name, int number);
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
@@ -18,7 +18,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +53,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -65,7 +60,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -75,7 +69,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +77,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -94,7 +86,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -103,7 +94,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -114,7 +104,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -124,7 +113,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -134,7 +122,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetComment(string owner, string name, int number);
 
         /// <summary>
@@ -143,7 +130,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
@@ -154,7 +140,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -164,7 +149,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -175,7 +159,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -185,7 +168,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -196,7 +178,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -206,7 +187,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -216,7 +196,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int number);
 
         /// <summary>
@@ -225,7 +204,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         IObservable<Unit> Delete(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
@@ -3,6 +3,12 @@ using System.Reactive;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Pull Request Review Comments API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/pulls/comments/">Review Comments API documentation</a> for more information.
+    /// </remarks>
     public interface IObservablePullRequestReviewCommentsClient
     {
         /// <summary>
@@ -19,12 +25,31 @@ namespace Octokit.Reactive
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
         IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -34,6 +59,14 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -49,11 +82,29 @@ namespace Octokit.Reactive
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -67,6 +118,16 @@ namespace Octokit.Reactive
         IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets a single pull request review comment by number.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
@@ -75,6 +136,15 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request review comment number</param>
         /// <returns>The <see cref="PullRequestReviewComment"/></returns>
         IObservable<PullRequestReviewComment> GetComment(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single pull request review comment by number.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
         /// Creates a comment on a pull request review.
@@ -88,6 +158,16 @@ namespace Octokit.Reactive
         IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
+        /// Creates a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Pull Request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
+
+        /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
@@ -97,6 +177,16 @@ namespace Octokit.Reactive
         /// <param name="comment">The comment</param>
         /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
         IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
+
+        /// <summary>
+        /// Creates a comment on a pull request review as a reply to another comment.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.
@@ -110,6 +200,16 @@ namespace Octokit.Reactive
         IObservable<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
+        /// Edits a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#edit-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <param name="comment">The edited comment</param>
+        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
+
+        /// <summary>
         /// Deletes a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
@@ -118,5 +218,14 @@ namespace Octokit.Reactive
         /// <param name="number">The pull request review comment number</param>
         /// <returns></returns>
         IObservable<Unit> Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns></returns>
+        IObservable<Unit> Delete(int repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -5,6 +5,12 @@ using Octokit.Reactive.Internal;
 
 namespace Octokit.Reactive
 {
+    /// <summary>
+    /// A client for GitHub's Pull Request Review Comments API.
+    /// </summary>
+    /// <remarks>
+    /// See the <a href="https://developer.github.com/v3/pulls/comments/">Review Comments API documentation</a> for more information.
+    /// </remarks>
     public class ObservablePullRequestReviewCommentsClient : IObservablePullRequestReviewCommentsClient
     {
         readonly IPullRequestReviewCommentsClient _client;
@@ -38,6 +44,18 @@ namespace Octokit.Reactive
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number)
+        {
+            return GetAll(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
@@ -53,6 +71,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number), options);
+        }
+
+        /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
@@ -65,6 +98,17 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAllForRepository(owner, name, new PullRequestReviewCommentRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -88,6 +132,20 @@ namespace Octokit.Reactive
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
@@ -99,6 +157,20 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(request, "request");
 
             return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -122,6 +194,23 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewCommentsRepository(repositoryId), request.ToParametersDictionary(),
+                options);
+        }
+
+        /// <summary>
         /// Gets a single pull request review comment by number.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
@@ -135,6 +224,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.GetComment(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets a single pull request review comment by number.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        public IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number)
+        {
+            return _client.GetComment(repositoryId, number).ToObservable();
         }
 
         /// <summary>
@@ -156,6 +257,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Creates a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Pull Request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        public IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            return _client.Create(repositoryId, number, comment).ToObservable();
+        }
+
+        /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
@@ -171,6 +287,21 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(comment, "comment");
 
             return _client.CreateReply(owner, name, number, comment).ToObservable();
+        }
+
+        /// <summary>
+        /// Creates a comment on a pull request review as a reply to another comment.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        public IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            return _client.CreateReply(repositoryId, number, comment).ToObservable();
         }
 
         /// <summary>
@@ -192,6 +323,21 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Edits a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#edit-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <param name="comment">The edited comment</param>
+        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        public IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            return _client.Edit(repositoryId, number, comment).ToObservable();
+        }
+
+        /// <summary>
         /// Deletes a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
@@ -205,6 +351,18 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Delete(owner, name, number).ToObservable();
+        }
+
+        /// <summary>
+        /// Deletes a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns></returns>
+        public IObservable<Unit> Delete(int repositoryId, int number)
+        {
+            return _client.Delete(repositoryId, number).ToObservable();
         }
     }
 }

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -31,7 +31,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +45,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -60,7 +58,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +74,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -91,7 +87,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -105,7 +100,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
@@ -118,7 +112,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -134,7 +127,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -149,7 +141,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -165,7 +156,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -181,7 +171,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -200,7 +189,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -217,7 +205,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -232,7 +219,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number)
         {
             return _client.GetComment(repositoryId, number).ToObservable();
@@ -246,7 +232,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -263,7 +248,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -279,7 +263,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -296,7 +279,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -312,7 +294,6 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -329,7 +310,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -344,7 +324,6 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -359,7 +338,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public IObservable<Unit> Delete(int repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -105,7 +105,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -134,7 +134,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -149,7 +149,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -165,7 +165,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -181,7 +181,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -200,7 +200,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -217,7 +217,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -232,7 +232,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number)
         {
             return _client.GetComment(repositoryId, number).ToObservable();
@@ -246,7 +246,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -263,7 +263,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -279,7 +279,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -296,7 +296,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -312,7 +312,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -329,7 +329,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
 using Octokit.Tests.Integration;
-using Xunit;
 using Octokit.Tests.Integration.Helpers;
+using Xunit;
 
 public class PullRequestReviewCommentsClientTests : IDisposable
 {
@@ -44,6 +44,21 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanCreateAndRetrieveCommentWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateCommentWithRepositoryId(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var commentFromGitHub = await _client.GetComment(_context.Repository.Id, createdComment.Id);
+
+        AssertComment(commentFromGitHub, body, position);
+    }
+
+    [IntegrationTest]
     public async Task CanEditComment()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -58,6 +73,25 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var editedComment = await _client.Edit(Helper.UserName, _context.RepositoryName, createdComment.Id, edit);
 
         var commentFromGitHub = await _client.GetComment(Helper.UserName, _context.RepositoryName, editedComment.Id);
+
+        AssertComment(commentFromGitHub, edit.Body, position);
+    }
+
+    [IntegrationTest]
+    public async Task CanEditCommentWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A new review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateCommentWithRepositoryId(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var edit = new PullRequestReviewCommentEdit("Edited Comment");
+
+        var editedComment = await _client.Edit(_context.Repository.Id, createdComment.Id, edit);
+
+        var commentFromGitHub = await _client.GetComment(_context.Repository.Id, editedComment.Id);
 
         AssertComment(commentFromGitHub, edit.Body, position);
     }
@@ -84,6 +118,27 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task TimestampsAreUpdatedWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A new review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateCommentWithRepositoryId(body, position, pullRequest.Sha, pullRequest.Number);
+
+        Assert.Equal(createdComment.UpdatedAt, createdComment.CreatedAt);
+
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        var edit = new PullRequestReviewCommentEdit("Edited Comment");
+
+        var editedComment = await _client.Edit(_context.Repository.Id, createdComment.Id, edit);
+
+        Assert.NotEqual(editedComment.UpdatedAt, editedComment.CreatedAt);
+    }
+
+    [IntegrationTest]
     public async Task CanDeleteComment()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -94,6 +149,23 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var createdComment = await CreateComment(body, position, pullRequest.Sha, pullRequest.Number);
 
         await _client.Delete(Helper.UserName, _context.RepositoryName, createdComment.Id);
+
+        Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id));
+    }
+
+    [IntegrationTest]
+    public async Task CanDeleteCommentWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "A new review comment message";
+        const int position = 1;
+
+        var createdComment = await CreateCommentWithRepositoryId(body, position, pullRequest.Sha, pullRequest.Number);
+
+        await _client.Delete(_context.Repository.Id, createdComment.Id);
+
+        Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(_context.Repository.Id, createdComment.Id));
     }
 
     [IntegrationTest]
@@ -114,6 +186,25 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanCreateReplyWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const string body = "Reply me!";
+        const int position = 1;
+
+        var createdComment = await CreateCommentWithRepositoryId(body, position, pullRequest.Sha, pullRequest.Number);
+
+        var reply = new PullRequestReviewCommentReplyCreate("Replied", createdComment.Id);
+
+        var createdReply = await _client.CreateReply(_context.Repository.Id, pullRequest.Number, reply);
+
+        var createdReplyFromGitHub = await _client.GetComment(_context.Repository.Id, createdReply.Id);
+
+        AssertComment(createdReplyFromGitHub, reply.Body, position);
+    }
+
+    [IntegrationTest]
     public async Task CanGetForPullRequest()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -129,6 +220,21 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanGetForPullRequestWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var pullRequestComments = await _client.GetAll(_context.Repository.Id, pullRequest.Number);
+
+        AssertComments(pullRequestComments, commentsToCreate, position);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithoutStart()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -137,7 +243,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
 
         await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
-        
+
         var options = new ApiOptions
         {
             PageSize = 3,
@@ -145,6 +251,27 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         };
 
         var pullRequestComments = await _client.GetAll(Helper.UserName, _context.RepositoryName, pullRequest.Number, options);
+
+        Assert.Equal(3, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithoutStartWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var pullRequestComments = await _client.GetAll(_context.Repository.Id, pullRequest.Number, options);
 
         Assert.Equal(3, pullRequestComments.Count);
     }
@@ -167,6 +294,28 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         };
 
         var pullRequestComments = await _client.GetAll(Helper.UserName, _context.RepositoryName, pullRequest.Number, options);
+
+        Assert.Equal(1, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithStartWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var pullRequestComments = await _client.GetAll(_context.Repository.Id, pullRequest.Number, options);
 
         Assert.Equal(1, pullRequestComments.Count);
     }
@@ -202,6 +351,36 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _client.GetAll(_context.Repository.Id, pullRequest.Number, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _client.GetAll(_context.Repository.Id, pullRequest.Number, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+    }
+
+    [IntegrationTest]
     public async Task CanGetForRepository()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -212,6 +391,21 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
 
         var pullRequestComments = await _client.GetAllForRepository(Helper.UserName, _context.RepositoryName);
+
+        AssertComments(pullRequestComments, commentsToCreate, position);
+    }
+
+    [IntegrationTest]
+    public async Task CanGetForRepositoryWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment One", "Comment Two" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id);
 
         AssertComments(pullRequestComments, commentsToCreate, position);
     }
@@ -238,6 +432,27 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithoutStartForRepositoryWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, options);
+
+        Assert.Equal(3, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithStartForRepository()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -255,6 +470,28 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         };
 
         var pullRequestComments = await _client.GetAllForRepository(Helper.UserName, _context.RepositoryName, options);
+
+        Assert.Equal(1, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithStartForRepositoryWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, options);
 
         Assert.Equal(1, pullRequestComments.Count);
     }
@@ -290,6 +527,36 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageForRepositoryWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _client.GetAllForRepository(_context.Repository.Id, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _client.GetAllForRepository(_context.Repository.Id, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+    }
+
+    [IntegrationTest]
     public async Task CanGetForRepositoryAscendingSort()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -307,6 +574,23 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanGetForRepositoryAscendingSortWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new[] { "Comment One", "Comment Two", "Comment Three" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Ascending };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, pullRequestReviewCommentRequest);
+
+        Assert.Equal(pullRequestComments.Select(x => x.Body), commentsToCreate);
+    }
+
+    [IntegrationTest]
     public async Task CanGetForRepositoryDescendingSort()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -319,6 +603,23 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
 
         var pullRequestComments = await _client.GetAllForRepository(Helper.UserName, _context.RepositoryName, pullRequestReviewCommentRequest);
+
+        Assert.Equal(pullRequestComments.Select(x => x.Body), commentsToCreate.Reverse());
+    }
+
+    [IntegrationTest]
+    public async Task CanGetForRepositoryDescendingSortWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new[] { "Comment One", "Comment Two", "Comment Three", "Comment Four" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, pullRequestReviewCommentRequest);
 
         Assert.Equal(pullRequestComments.Select(x => x.Body), commentsToCreate.Reverse());
     }
@@ -347,6 +648,29 @@ public class PullRequestReviewCommentsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithoutStartForRepositoryParametrizedWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 3,
+            PageCount = 1
+        };
+
+        var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, pullRequestReviewCommentRequest, options);
+
+        Assert.Equal(3, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
     public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithStartForRepositoryParametrized()
     {
         var pullRequest = await CreatePullRequest(_context);
@@ -366,6 +690,30 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
 
         var pullRequestComments = await _client.GetAllForRepository(Helper.UserName, _context.RepositoryName, pullRequestReviewCommentRequest, options);
+
+        Assert.Equal(1, pullRequestComments.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfPullRequestReviewCommentWithStartForRepositoryParametrizedWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var options = new ApiOptions
+        {
+            PageSize = 2,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
+
+        var pullRequestComments = await _client.GetAllForRepository(_context.Repository.Id, pullRequestReviewCommentRequest, options);
 
         Assert.Equal(1, pullRequestComments.Count);
     }
@@ -402,6 +750,38 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
     }
 
+    [IntegrationTest]
+    public async Task ReturnsDistinctResultsBasedOnStartPageForRepositoryParametrizedWithRepositoryId()
+    {
+        var pullRequest = await CreatePullRequest(_context);
+
+        const int position = 1;
+        var commentsToCreate = new List<string> { "Comment 1", "Comment 2", "Comment 3" };
+
+        var pullRequestReviewCommentRequest = new PullRequestReviewCommentRequest { Direction = SortDirection.Descending };
+
+        await CreateComments(commentsToCreate, position, _context.RepositoryName, pullRequest.Sha, pullRequest.Number);
+
+        var startOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1
+        };
+
+        var firstPage = await _client.GetAllForRepository(_context.Repository.Id, pullRequestReviewCommentRequest, startOptions);
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 1,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var secondPage = await _client.GetAllForRepository(Helper.UserName, _context.RepositoryName, pullRequestReviewCommentRequest, skipStartOptions);
+
+        Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
+    }
+
     public void Dispose()
     {
         _context.Dispose();
@@ -412,11 +792,27 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         return await CreateComment(body, position, _context.RepositoryName, commitId, number);
     }
 
+    async Task<PullRequestReviewComment> CreateCommentWithRepositoryId(string body, int position, string commitId, int number)
+    {
+        return await CreateComment(body, position, _context.Repository.Id, commitId, number);
+    }
+
     async Task<PullRequestReviewComment> CreateComment(string body, int position, string repoName, string pullRequestCommitId, int pullRequestNumber)
     {
         var comment = new PullRequestReviewCommentCreate(body, pullRequestCommitId, path, position);
 
         var createdComment = await _client.Create(Helper.UserName, repoName, pullRequestNumber, comment);
+
+        AssertComment(createdComment, body, position);
+
+        return createdComment;
+    }
+
+    async Task<PullRequestReviewComment> CreateComment(string body, int position, int repositoryId, string pullRequestCommitId, int pullRequestNumber)
+    {
+        var comment = new PullRequestReviewCommentCreate(body, pullRequestCommitId, path, position);
+
+        var createdComment = await _client.Create(repositoryId, pullRequestNumber, comment);
 
         AssertComment(createdComment, body, position);
 

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -95,10 +95,22 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await client.GetAll("fakeOwner", "fakeRepoName", 7);
+            await client.GetAll("owner", "name", 7);
 
             connection.Received().GetAll<PullRequestReviewComment>(
-                Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/7/comments"), Args.ApiOptions);
+                Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/comments"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            await client.GetAll(1, 7);
+
+            connection.Received().GetAll<PullRequestReviewComment>(
+                Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/7/comments"), Args.ApiOptions);
         }
 
         [Fact]
@@ -114,10 +126,29 @@ public class PullRequestReviewCommentsClientTests
                 PageSize = 1
             };
 
-            await client.GetAll("fakeOwner", "fakeRepoName", 7, options);
+            await client.GetAll("owner", "name", 7, options);
 
             connection.Received().GetAll<PullRequestReviewComment>(
-                Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/7/comments"), options);
+                Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/comments"), options);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var options = new ApiOptions
+            {
+                StartPage = 1,
+                PageCount = 1,
+                PageSize = 1
+            };
+
+            await client.GetAll(1, 7, options);
+
+            connection.Received().GetAll<PullRequestReviewComment>(
+                Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/7/comments"), options);
         }
 
         [Fact]
@@ -132,6 +163,8 @@ public class PullRequestReviewCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, 1, null));
 
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
@@ -156,9 +189,31 @@ public class PullRequestReviewCommentsClientTests
                 Sort = PullRequestReviewCommentSort.Updated
             };
 
-            await client.GetAllForRepository("fakeOwner", "fakeRepoName", request);
+            await client.GetAllForRepository("owner", "name", request);
 
-            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments"),
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments"),
+                Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var request = new PullRequestReviewCommentRequest
+            {
+                Direction = SortDirection.Descending,
+                Since = new DateTimeOffset(2013, 11, 15, 11, 43, 01, 00, new TimeSpan()),
+                Sort = PullRequestReviewCommentSort.Updated
+            };
+
+            await client.GetAllForRepository(1, request);
+
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments"),
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
@@ -185,9 +240,38 @@ public class PullRequestReviewCommentsClientTests
                 PageSize = 1
             };
 
-            await client.GetAllForRepository("fakeOwner", "fakeRepoName", request, options);
+            await client.GetAllForRepository("owner", "name", request, options);
 
-            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments"),
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments"),
+                Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), options);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var request = new PullRequestReviewCommentRequest
+            {
+                Direction = SortDirection.Descending,
+                Since = new DateTimeOffset(2013, 11, 15, 11, 43, 01, 00, new TimeSpan()),
+                Sort = PullRequestReviewCommentSort.Updated
+            };
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            await client.GetAllForRepository(1, request, options);
+
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments"),
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
@@ -200,9 +284,23 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await client.GetAllForRepository("fakeOwner", "fakeRepoName");
+            await client.GetAllForRepository("owner", "name");
 
-            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments"),
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments"),
+                Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), Args.ApiOptions);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithoutSelectedSortingArgumentsWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            await client.GetAllForRepository(1);
+
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments"),
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), Args.ApiOptions);
@@ -221,9 +319,30 @@ public class PullRequestReviewCommentsClientTests
                 PageSize = 1
             };
 
-            await client.GetAllForRepository("fakeOwner", "fakeRepoName", options);
+            await client.GetAllForRepository("owner", "name", options);
 
-            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments"),
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments"),
+                Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), options);
+        }
+
+        [Fact]
+        public async Task RequestsCorrectUrlWithoutSelectedSortingArgumentsWithApiOptionsWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                StartPage = 1,
+                PageSize = 1
+            };
+
+            await client.GetAllForRepository(1, options);
+
+            connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments"),
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"), options);
@@ -240,11 +359,22 @@ public class PullRequestReviewCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (PullRequestReviewCommentRequest)null));
 
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null));
 
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, request));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, request, null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name", request, ApiOptions.None));
@@ -270,9 +400,20 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            client.GetComment("fakeOwner", "fakeRepoName", 53);
+            client.GetComment("owner", "name", 53);
 
-            connection.Received().Get<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments/53"));
+            connection.Received().Get<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments/53"));
+        }
+
+        [Fact]
+        public void RequestsCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            client.GetComment(1, 53);
+
+            connection.Received().Get<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/53"));
         }
 
         [Fact]
@@ -281,8 +422,9 @@ public class PullRequestReviewCommentsClientTests
             var client = new PullRequestReviewCommentsClient(Substitute.For<IApiConnection>());
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, "name", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "name", 1));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment("owner", null, 1));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "name", 1));
             await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("owner", "", 1));
         }
     }
@@ -304,6 +446,20 @@ public class PullRequestReviewCommentsClientTests
         }
 
         [Fact]
+        public void PostsToCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var comment = new PullRequestReviewCommentCreate("Comment content", "qe3dsdsf6", "file.css", 7);
+
+            client.Create(1, 13, comment);
+
+            connection.Connection.Received().Post<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/13/comments"),
+                comment, null, null);
+        }
+
+        [Fact]
         public async Task EnsuresNonNullArguments()
         {
             var connection = Substitute.For<IApiConnection>();
@@ -317,10 +473,11 @@ public class PullRequestReviewCommentsClientTests
             var comment = new PullRequestReviewCommentCreate(body, commitId, path, position);
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "fakeRepoName", 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "fakeRepoName", 1, comment));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", null, 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "", 1, comment));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", "fakeRepoName", 1, null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "fakeRepoName", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "", 1, comment));
         }
     }
 
@@ -334,9 +491,23 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentReplyCreate("Comment content", 5);
 
-            client.CreateReply("fakeOwner", "fakeRepoName", 13, comment);
+            client.CreateReply("owner", "name", 13, comment);
 
-            connection.Connection.Received().Post<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/13/comments"),
+            connection.Connection.Received().Post<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/13/comments"),
+                comment, null, null);
+        }
+
+        [Fact]
+        public void PostsToCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var comment = new PullRequestReviewCommentReplyCreate("Comment content", 5);
+
+            client.CreateReply(1, 13, comment);
+
+            connection.Connection.Received().Post<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/13/comments"),
                 comment, null, null);
         }
 
@@ -351,11 +522,14 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentReplyCreate(body, inReplyTo);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(null, "fakeRepoName", 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "fakeRepoName", 1, comment));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("fakeOwner", null, 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("fakeOwner", "", 1, comment));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("fakeOwner", "fakeRepoName", 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(null, "name", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", null, 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", "name", 1, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(1, 1, null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "name", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("owner", "", 1, comment));
         }
     }
 
@@ -369,9 +543,22 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentEdit("New comment content");
 
-            await client.Edit("fakeOwner", "fakeRepoName", 13, comment);
+            await client.Edit("owner", "name", 13, comment);
 
-            connection.Received().Patch<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments/13"), comment);
+            connection.Received().Patch<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments/13"), comment);
+        }
+
+        [Fact]
+        public async Task PostsToCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            var comment = new PullRequestReviewCommentEdit("New comment content");
+
+            await client.Edit(1, 13, comment);
+
+            connection.Received().Patch<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/13"), comment);
         }
 
         [Fact]
@@ -384,11 +571,14 @@ public class PullRequestReviewCommentsClientTests
 
             var comment = new PullRequestReviewCommentEdit(body);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "fakeRepoName", 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "fakeRepoName", 1, comment));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("fakeOwner", null, 1, comment));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("fakeOwner", "", 1, comment));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("fakeOwner", null, 1, null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "name", 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, 1, comment));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", "name", 1, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(1, 1, null));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "name", 1, comment));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("owner", "", 1, comment));
         }
     }
 
@@ -400,9 +590,20 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await client.Delete("fakeOwner", "fakeRepoName", 13);
+            await client.Delete("owner", "name", 13);
 
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/comments/13"));
+            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/13"));
+        }
+
+        [Fact]
+        public async Task PostsToCorrectUrlWithRepositoryId()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new PullRequestReviewCommentsClient(connection);
+
+            await client.Delete(1, 13);
+
+            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/13"));
         }
 
         [Fact]
@@ -411,10 +612,11 @@ public class PullRequestReviewCommentsClientTests
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewCommentsClient(connection);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "fakeRepoName", 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "fakeRepoName", 1));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("fakeOwner", null, 1));
-            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("fakeOwner", "", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 1));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 1));
+
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 1));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 1));
         }
     }
 }

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -368,8 +368,8 @@ public class PullRequestReviewCommentsClientTests
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, ApiOptions.None));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, request));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, (PullRequestReviewCommentRequest)null));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, request, null));
 
@@ -592,7 +592,7 @@ public class PullRequestReviewCommentsClientTests
 
             await client.Delete("owner", "name", 13);
 
-            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/13"));
+            connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments/13"));
         }
 
         [Fact]

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -308,7 +308,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task RequestsCorrectUrlMulti()
             {
-                var firstPageUrl = new Uri("repos/fakeOwner/fakeRepoName/pulls/comments", UriKind.Relative);
+                var firstPageUrl = new Uri("repos/owner/name/pulls/comments", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
 using Octokit.Reactive;
-using System.Reactive.Threading.Tasks;
 using Xunit;
 
 namespace Octokit.Tests.Reactive
@@ -43,6 +42,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                client.GetAll(1, 1);
+
+                gitHubClient.Received().PullRequest.Comment.GetAll(1, 1);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -58,6 +68,24 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("fake", "repo", 1, options);
 
                 gitHubClient.Received().PullRequest.Comment.GetAll("fake", "repo", 1, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll(1, 1, options);
+
+                gitHubClient.Received().PullRequest.Comment.GetAll(1, 1, options);
             }
 
             [Fact]
@@ -106,7 +134,61 @@ namespace Octokit.Tests.Reactive
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                var results = await client.GetAll("fakeOwner", "fakeRepoName", 7).ToArray();
+                var results = await client.GetAll("owner", "name", 7).ToArray();
+
+                Assert.Equal(7, results.Length);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlMultiWithRepositoryId()
+            {
+                var firstPageUrl = new Uri("repositories/1/pulls/7/comments", UriKind.Relative);
+                var secondPageUrl = new Uri("https://example.com/page/2");
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
+                var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(firstPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(1),
+                        new PullRequestReviewComment(2),
+                        new PullRequestReviewComment(3)
+                    });
+                var thirdPageUrl = new Uri("https://example.com/page/3");
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
+                var secondPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(secondPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(4),
+                        new PullRequestReviewComment(5),
+                        new PullRequestReviewComment(6)
+                    }
+                );
+                var lastPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    new Response(),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(7)
+                    }
+                );
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var results = await client.GetAll(1, 7).ToArray();
 
                 Assert.Equal(7, results.Length);
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, null);
@@ -122,14 +204,14 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
-
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
 
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(1, 1, null));
+
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
                 Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));
-
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
             }
@@ -156,6 +238,24 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var request = new PullRequestReviewCommentRequest
+                {
+                    Direction = SortDirection.Descending,
+                    Since = new DateTimeOffset(2013, 11, 15, 11, 43, 01, 00, new TimeSpan()),
+                    Sort = PullRequestReviewCommentSort.Updated
+                };
+
+                client.GetAllForRepository(1, request);
+
+                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, request);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -178,6 +278,31 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo", request, options);
 
                 gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo", request, options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var request = new PullRequestReviewCommentRequest
+                {
+                    Direction = SortDirection.Descending,
+                    Since = new DateTimeOffset(2013, 11, 15, 11, 43, 01, 00, new TimeSpan()),
+                    Sort = PullRequestReviewCommentSort.Updated
+                };
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository(1, request, options);
+
+                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, request, options);
             }
 
             [Fact]
@@ -245,7 +370,90 @@ namespace Octokit.Tests.Reactive
                     Sort = PullRequestReviewCommentSort.Updated
                 };
 
-                var results = await client.GetAllForRepository("fakeOwner", "fakeRepoName", request).ToArray();
+                var results = await client.GetAllForRepository("owner", "name", request).ToArray();
+
+                Assert.Equal(8, results.Length);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl,
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlMultiWithRepositoryId()
+            {
+                var firstPageUrl = new Uri("repositories/1/pulls/comments", UriKind.Relative);
+                var secondPageUrl = new Uri("https://example.com/page/2");
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
+                var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(firstPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(1),
+                        new PullRequestReviewComment(2),
+                        new PullRequestReviewComment(3)
+                    }
+                );
+                var thirdPageUrl = new Uri("https://example.com/page/3");
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
+                var secondPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(secondPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(4),
+                        new PullRequestReviewComment(5),
+                        new PullRequestReviewComment(6)
+                    });
+                var lastPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    new Response(),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(7),
+                        new PullRequestReviewComment(8)
+                    }
+                );
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl,
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2013-11-15T11:43:01Z"
+                        && d["sort"] == "updated"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var request = new PullRequestReviewCommentRequest
+                {
+                    Direction = SortDirection.Descending,
+                    Since = new DateTimeOffset(2013, 11, 15, 11, 43, 01, 00, new TimeSpan()),
+                    Sort = PullRequestReviewCommentSort.Updated
+                };
+
+                var results = await client.GetAllForRepository(1, request).ToArray();
 
                 Assert.Equal(8, results.Length);
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl,
@@ -275,6 +483,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsCorrectUrlWithoutSelectedSortingArgumentsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                client.GetAllForRepository(1);
+
+                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1);
+            }
+
+            [Fact]
             public void RequestsCorrectUrlWithoutSelectedSortingArgumentsWithApiOptions()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
@@ -290,6 +509,24 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo", options);
 
                 gitHubClient.Received().PullRequest.Comment.GetAllForRepository("fake", "repo", options);
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithoutSelectedSortingArgumentsWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAllForRepository(1, options);
+
+                gitHubClient.Received().PullRequest.Comment.GetAllForRepository(1, options);
             }
 
             [Fact]
@@ -347,7 +584,77 @@ namespace Octokit.Tests.Reactive
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                var results = await client.GetAllForRepository("fakeOwner", "fakeRepoName").ToArray();
+                var results = await client.GetAllForRepository("owner", "name").ToArray();
+
+                Assert.Equal(8, results.Length);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl,
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null);
+                gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithoutSelectedSortingArgumentsMultiWithRepositoryId()
+            {
+                var firstPageUrl = new Uri("repositories/1/pulls/comments", UriKind.Relative);
+                var secondPageUrl = new Uri("https://example.com/page/2");
+                var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
+                var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(firstPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(1),
+                        new PullRequestReviewComment(2),
+                        new PullRequestReviewComment(3)
+                    }
+                );
+                var thirdPageUrl = new Uri("https://example.com/page/3");
+                var secondPageLinks = new Dictionary<string, Uri> { { "next", thirdPageUrl } };
+                var secondPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    CreateResponseWithApiInfo(secondPageLinks),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(4),
+                        new PullRequestReviewComment(5),
+                        new PullRequestReviewComment(6)
+                    });
+                var lastPageResponse = new ApiResponse<List<PullRequestReviewComment>>
+                (
+                    new Response(),
+                    new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment(7),
+                        new PullRequestReviewComment(8)
+                    }
+                );
+
+                var gitHubClient = Substitute.For<IGitHubClient>();
+
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl,
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
+                gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
+                        && d["direction"] == "asc"
+                        && d["sort"] == "created"), null)
+                    .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
+
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var results = await client.GetAllForRepository("owner", "name").ToArray();
 
                 Assert.Equal(8, results.Length);
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl,
@@ -369,6 +676,10 @@ namespace Octokit.Tests.Reactive
 
                 var request = new PullRequestReviewCommentRequest();
 
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (ApiOptions)null));
+
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", request));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, request));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", (PullRequestReviewCommentRequest)null));
@@ -378,6 +689,13 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request, null));
 
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (ApiOptions)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, (PullRequestReviewCommentRequest)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, request, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", request));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", "", request));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name", request, ApiOptions.None));
@@ -393,9 +711,20 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                client.GetComment("fakeOwner", "fakeRepoName", 53);
+                client.GetComment("owner", "name", 53);
 
-                gitHubClient.PullRequest.Comment.Received().GetComment("fakeOwner", "fakeRepoName", 53);
+                gitHubClient.PullRequest.Comment.Received().GetComment("owner", "name", 53);
+            }
+
+            [Fact]
+            public void GetsFromClientPullRequestCommentWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                client.GetComment(1, 53);
+
+                gitHubClient.PullRequest.Comment.Received().GetComment(1, 53);
             }
 
             [Fact]
@@ -403,12 +732,11 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservablePullRequestReviewCommentsClient(Substitute.For<IGitHubClient>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, "name", 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "name", 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment("owner", null, 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("owner", "", 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetComment(null, null, 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetComment("", "", 1).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.GetComment(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.GetComment("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.GetComment("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.GetComment("owner", "", 1));
             }
         }
 
@@ -422,9 +750,22 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentCreate("Comment content", "qe3dsdsf6", "file.css", 7);
 
-                client.Create("fakeOwner", "fakeRepoName", 13, comment);
+                client.Create("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Create("fakeOwner", "fakeRepoName", 13, comment);
+                gitHubClient.PullRequest.Comment.Received().Create("owner", "name", 13, comment);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var comment = new PullRequestReviewCommentCreate("Comment content", "qe3dsdsf6", "file.css", 7);
+
+                client.Create(1, 13, comment);
+
+                gitHubClient.PullRequest.Comment.Received().Create(1, 13, comment);
             }
 
             [Fact]
@@ -440,11 +781,14 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentCreate(body, commitId, path, position);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", 1, null).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.Create(null, "name", 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", null, 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.Create("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Create(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Create("", "name", 1, comment));
+                Assert.Throws<ArgumentException>(() => client.Create("owner", "", 1, comment));
             }
         }
 
@@ -458,9 +802,22 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentReplyCreate("Comment content", 9);
 
-                client.CreateReply("fakeOwner", "fakeRepoName", 13, comment);
+                client.CreateReply("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().CreateReply("fakeOwner", "fakeRepoName", 13, comment);
+                gitHubClient.PullRequest.Comment.Received().CreateReply("owner", "name", 13, comment);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var comment = new PullRequestReviewCommentReplyCreate("Comment content", 9);
+
+                client.CreateReply(1, 13, comment);
+
+                gitHubClient.PullRequest.Comment.Received().CreateReply(1, 13, comment);
             }
 
             [Fact]
@@ -474,11 +831,14 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentReplyCreate(body, inReplyTo);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply(null, "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("", "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", null, 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.CreateReply("owner", "", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.CreateReply("owner", "name", 1, null).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.CreateReply(null, "name", 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.CreateReply("owner", null, 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.CreateReply("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.CreateReply(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.CreateReply("", "name", 1, comment));
+                Assert.Throws<ArgumentException>(() => client.CreateReply("owner", "", 1, comment));
             }
         }
 
@@ -492,9 +852,22 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentEdit("New comment content");
 
-                client.Edit("fakeOwner", "fakeRepoName", 13, comment);
+                client.Edit("owner", "name", 13, comment);
 
-                gitHubClient.PullRequest.Comment.Received().Edit("fakeOwner", "fakeRepoName", 13, comment);
+                gitHubClient.PullRequest.Comment.Received().Edit("owner", "name", 13, comment);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                var comment = new PullRequestReviewCommentEdit("New comment content");
+
+                client.Edit(1, 13, comment);
+
+                gitHubClient.PullRequest.Comment.Received().Edit(1, 13, comment);
             }
 
             [Fact]
@@ -507,11 +880,14 @@ namespace Octokit.Tests.Reactive
 
                 var comment = new PullRequestReviewCommentEdit(body);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "name", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("owner", "", 1, comment).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", "name", 1, null).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.Edit(null, "name", 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, 1, comment));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", "name", 1, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Edit(1, 1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Edit("", "name", 1, comment));
+                Assert.Throws<ArgumentException>(() => client.Edit("owner", "", 1, comment));
             }
         }
 
@@ -523,9 +899,20 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                client.Delete("fakeOwner", "fakeRepoName", 13);
+                client.Delete("owner", "name", 13);
 
-                gitHubClient.PullRequest.Comment.Received().Delete("fakeOwner", "fakeRepoName", 13);
+                gitHubClient.PullRequest.Comment.Received().Delete("owner", "name", 13);
+            }
+
+            [Fact]
+            public void PostsToCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
+
+                client.Delete(1, 13);
+
+                gitHubClient.PullRequest.Comment.Received().Delete(1, 13);
             }
 
             [Fact]
@@ -534,10 +921,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name", 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 1).ToTask());
-                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", "", 1).ToTask());
+                Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, 1));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", "", 1));
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -91,7 +91,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task RequestsCorrectUrlMulti()
             {
-                var firstPageUrl = new Uri("repos/fakeOwner/fakeRepoName/pulls/7/comments", UriKind.Relative);
+                var firstPageUrl = new Uri("repos/owner/name/pulls/7/comments", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>
@@ -532,7 +532,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task RequestsCorrectUrlWithoutSelectedSortingArgumentsMulti()
             {
-                var firstPageUrl = new Uri("repos/fakeOwner/fakeRepoName/pulls/comments", UriKind.Relative);
+                var firstPageUrl = new Uri("repos/owner/name/pulls/comments", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
                 var firstPageResponse = new ApiResponse<List<PullRequestReviewComment>>
@@ -654,7 +654,7 @@ namespace Octokit.Tests.Reactive
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
 
-                var results = await client.GetAllForRepository("owner", "name").ToArray();
+                var results = await client.GetAllForRepository(1).ToArray();
 
                 Assert.Equal(8, results.Length);
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(firstPageUrl,

--- a/Octokit/Clients/IPullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentsClient.cs
@@ -25,12 +25,31 @@ namespace Octokit
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number);
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options);
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -40,6 +59,14 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -55,11 +82,29 @@ namespace Octokit
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -73,6 +118,16 @@ namespace Octokit
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets a single pull request review comment by number.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
@@ -81,6 +136,15 @@ namespace Octokit
         /// <param name="number">The pull request review comment number</param>
         /// <returns>The <see cref="PullRequestReviewComment"/></returns>
         Task<PullRequestReviewComment> GetComment(string owner, string name, int number);
+
+        /// <summary>
+        /// Gets a single pull request review comment by number.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        Task<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
         /// Creates a comment on a pull request review.
@@ -94,6 +158,16 @@ namespace Octokit
         Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
+        /// Creates a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Pull Request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
+
+        /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
@@ -103,6 +177,16 @@ namespace Octokit
         /// <param name="comment">The comment</param>
         /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
         Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
+
+        /// <summary>
+        /// Creates a comment on a pull request review as a reply to another comment.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.
@@ -116,6 +200,16 @@ namespace Octokit
         Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
+        /// Edits a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#edit-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <param name="comment">The edited comment</param>
+        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
+
+        /// <summary>
         /// Deletes a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
@@ -124,5 +218,14 @@ namespace Octokit
         /// <param name="number">The pull request review comment number</param>
         /// <returns></returns>
         Task Delete(string owner, string name, int number);
+
+        /// <summary>
+        /// Deletes a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns></returns>
+        Task Delete(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> GetComment(string owner, string name, int number);
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>

--- a/Octokit/Clients/IPullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentsClient.cs
@@ -18,7 +18,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number);
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
@@ -48,7 +45,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options);
 
         /// <summary>
@@ -57,7 +53,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -65,7 +60,6 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId);
 
         /// <summary>
@@ -75,7 +69,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options);
 
         /// <summary>
@@ -84,7 +77,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options);
 
         /// <summary>
@@ -94,7 +86,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -103,7 +94,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
@@ -114,7 +104,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -124,7 +113,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
@@ -134,7 +122,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> GetComment(string owner, string name, int number);
 
         /// <summary>
@@ -143,7 +130,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> GetComment(int repositoryId, int number);
 
         /// <summary>
@@ -154,7 +140,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -164,7 +149,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
@@ -175,7 +159,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -185,7 +168,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
@@ -196,7 +178,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -206,7 +187,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
@@ -216,7 +196,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         Task Delete(string owner, string name, int number);
 
         /// <summary>
@@ -225,7 +204,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         Task Delete(int repositoryId, int number);
     }
 }

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -24,7 +24,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -39,7 +38,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -53,7 +51,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +67,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +80,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -98,7 +93,6 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
@@ -111,7 +105,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -127,7 +120,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -142,7 +134,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -158,7 +149,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -174,7 +164,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -192,7 +181,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -208,7 +196,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public Task<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -223,7 +210,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public Task<PullRequestReviewComment> GetComment(int repositoryId, int number)
         {
             return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number));
@@ -237,7 +223,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public async Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -262,7 +247,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public async Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -286,7 +270,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public async Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -311,7 +294,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns></returns>
         public async Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -335,7 +317,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         public Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -352,7 +333,6 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns></returns>
         public Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -367,7 +347,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -382,7 +361,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns></returns>
         public Task Delete(int repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.PullRequestReviewComment(repositoryId, number));

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -39,7 +39,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -70,7 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -84,7 +84,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -98,7 +98,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
@@ -111,7 +111,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -127,7 +127,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -158,7 +158,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -174,7 +174,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -192,7 +192,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        /// <returns></returns>
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
@@ -208,7 +208,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public Task<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -223,7 +223,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public Task<PullRequestReviewComment> GetComment(int repositoryId, int number)
         {
             return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number));
@@ -237,7 +237,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public async Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -262,7 +262,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public async Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -286,7 +286,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public async Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -311,7 +311,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public async Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
@@ -335,7 +335,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -352,7 +352,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        /// <returns></returns>
         public Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -37,6 +37,18 @@ namespace Octokit
         /// Gets review comments for a specified pull request.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number)
+        {
+            return GetAll(repositoryId, number, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
@@ -52,6 +64,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets review comments for a specified pull request.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified pull request</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number), options);
+        }
+
+        /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
@@ -64,6 +91,17 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAllForRepository(owner, name, new PullRequestReviewCommentRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId)
+        {
+            return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -87,6 +125,20 @@ namespace Octokit
         /// Gets a list of the pull request review comments in a specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
@@ -98,6 +150,20 @@ namespace Octokit
             Ensure.ArgumentNotNull(request, "request");
 
             return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
         }
 
         /// <summary>
@@ -120,6 +186,22 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a list of the pull request review comments in a specified repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The list of <see cref="PullRequestReviewComment"/>s for the specified repository</returns>
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<PullRequestReviewComment>(ApiUrls.PullRequestReviewCommentsRepository(repositoryId), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
         /// Gets a single pull request review comment by number.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
@@ -133,6 +215,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(owner, name, number));
+        }
+
+        /// <summary>
+        /// Gets a single pull request review comment by number.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns>The <see cref="PullRequestReviewComment"/></returns>
+        public Task<PullRequestReviewComment> GetComment(int repositoryId, int number)
+        {
+            return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number));
         }
 
         /// <summary>
@@ -151,6 +245,29 @@ namespace Octokit
             Ensure.ArgumentNotNull(comment, "comment");
 
             var endpoint = ApiUrls.PullRequestReviewComments(owner, name, number);
+            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(endpoint, comment, null, null).ConfigureAwait(false);
+
+            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
+            }
+
+            return response.Body;
+        }
+
+        /// <summary>
+        /// Creates a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The Pull Request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        public async Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            var endpoint = ApiUrls.PullRequestReviewComments(repositoryId, number);
             var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(endpoint, comment, null, null).ConfigureAwait(false);
 
             if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
@@ -188,6 +305,29 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Creates a comment on a pull request review as a reply to another comment.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#create-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request number</param>
+        /// <param name="comment">The comment</param>
+        /// <returns>The created <see cref="PullRequestReviewComment"/></returns>
+        public async Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            var endpoint = ApiUrls.PullRequestReviewComments(repositoryId, number);
+            var response = await ApiConnection.Connection.Post<PullRequestReviewComment>(endpoint, comment, null, null).ConfigureAwait(false);
+
+            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
+            }
+
+            return response.Body;
+        }
+
+        /// <summary>
         /// Edits a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#edit-a-comment</remarks>
@@ -206,6 +346,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Edits a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#edit-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <param name="comment">The edited comment</param>
+        /// <returns>The edited <see cref="PullRequestReviewComment"/></returns>
+        public Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
+        {
+            Ensure.ArgumentNotNull(comment, "comment");
+
+            return ApiConnection.Patch<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number), comment);
+        }
+
+        /// <summary>
         /// Deletes a comment on a pull request review.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
@@ -219,6 +374,18 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Delete(ApiUrls.PullRequestReviewComment(owner, name, number));
+        }
+
+        /// <summary>
+        /// Deletes a comment on a pull request review.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="number">The pull request review comment number</param>
+        /// <returns></returns>
+        public Task Delete(int repositoryId, int number)
+        {
+            return ApiConnection.Delete(ApiUrls.PullRequestReviewComment(repositoryId, number));
         }
     }
 }


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)PullRequestReviewCommentsClient to get access by repository id.

- [x] **Add overloads to IPullRequestReviewCommentsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservablePullRequestReviewCommentsClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.