### PR TITLE
Add repositoryId overloads to methods on I(Observable)RepositoriesClient

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -526,19 +526,19 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
+        /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        IObservable<Branch> EditBranch(string owner, string name, string branchName, BranchUpdate update);
+        IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
+        /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        IObservable<Branch> EditBranch(int repositoryId, string branchName, BranchUpdate update);
+        IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repo Collaborators.

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -526,19 +526,19 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="branch">The name of the branch</param>
+        /// <param name="branchName">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
+        IObservable<Branch> EditBranch(string owner, string name, string branchName, BranchUpdate update);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <param name="branch">The name of the branch</param>
+        /// <param name="branchName">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
+        IObservable<Branch> EditBranch(int repositoryId, string branchName, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repo Collaborators.

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -31,6 +31,14 @@ namespace Octokit.Reactive
         IObservable<Unit> Delete(string owner, string name);
 
         /// <summary>
+        /// Deletes a repository for the specified owner and name.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.</remarks>
+        /// <returns>An <see cref="IObservable{Unit}"/> for the operation</returns>
+        IObservable<Unit> Delete(int repositoryId);
+
+        /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -38,6 +46,14 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="Repository"/></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
         IObservable<Repository> Get(string owner, string name);
+
+        /// <summary>
+        /// Retrieves the <see cref="Repository"/> for the specified owner and name.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="Repository"/></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        IObservable<Repository> Get(int repositoryId);
 
         /// <summary>
         /// Retrieves every public <see cref="Repository"/>.
@@ -234,12 +250,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        IObservable<Branch> GetAllBranches(int repositoryId);
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         IObservable<Branch> GetAllBranches(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        IObservable<Branch> GetAllBranches(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -258,11 +297,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All contributors of the repository.</returns>
+        IObservable<RepositoryContributor> GetAllContributors(int repositoryId);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
         IObservable<RepositoryContributor> GetAllContributors(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -276,6 +336,16 @@ namespace Octokit.Reactive
         /// <returns>All contributors of the repository.</returns>
         IObservable<RepositoryContributor> GetAllContributors(string owner, string name, bool includeAnonymous);
 
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <returns>All contributors of the repository.</returns>
+        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -291,6 +361,18 @@ namespace Octokit.Reactive
         IObservable<RepositoryContributor> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options);
 
         /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options);
+
+        /// <summary>
         /// Gets all languages for the specified repository.
         /// </summary>
         /// <remarks>
@@ -300,6 +382,16 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
         IObservable<RepositoryLanguage> GetAllLanguages(string owner, string name);
+
+        /// <summary>
+        /// Gets all languages for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-languages">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        IObservable<RepositoryLanguage> GetAllLanguages(int repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -318,11 +410,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        IObservable<Team> GetAllTeams(int repositoryId);
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
         IObservable<Team> GetAllTeams(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        IObservable<Team> GetAllTeams(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -341,11 +454,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All of the repositories tags.</returns>
+        IObservable<RepositoryTag> GetAllTags(int repositoryId);
+
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
         IObservable<RepositoryTag> GetAllTags(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All of the repositories tags.</returns>
+        IObservable<RepositoryTag> GetAllTags(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -354,10 +488,21 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
-        IObservable<Branch> GetBranch(string owner, string repositoryName, string branchName);
+        IObservable<Branch> GetBranch(string owner, string name, string branchName);
+
+        /// <summary>
+        /// Gets the specified branch.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
+        IObservable<Branch> GetBranch(int repositoryId, string branchName);
 
         /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
@@ -369,6 +514,14 @@ namespace Octokit.Reactive
         IObservable<Repository> Edit(string owner, string name, RepositoryUpdate update);
 
         /// <summary>
+        /// Updates the specified repository with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="update">New values to update the repository with</param>
+        /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        IObservable<Repository> Edit(int repositoryId, RepositoryUpdate update);
+
+        /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -377,6 +530,15 @@ namespace Octokit.Reactive
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
+
+        /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repo Collaborators.
@@ -401,7 +563,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/commits/">Commits API documentation</a> for more details
         ///</remarks>
-        [System.Obsolete("Commit information is now available under the Commit property. This will be removed in a future update.")]
+        [Obsolete("Commit information is now available under the Commit property. This will be removed in a future update.")]
         IObservableRepositoryCommitsClient Commits { get; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -795,32 +795,32 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
+        /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public IObservable<Branch> EditBranch(string owner, string name, string branchName, BranchUpdate update)
+        public IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
 
-            return _client.EditBranch(owner, name, branchName, update).ToObservable();
+            return _client.EditBranch(owner, name, branch, update).ToObservable();
         }
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <param name="branchName">The name of the branch</param>
+        /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public IObservable<Branch> EditBranch(int repositoryId, string branchName, BranchUpdate update)
+        public IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
         {
-            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
 
-            return _client.EditBranch(repositoryId, branchName, update).ToObservable();
+            return _client.EditBranch(repositoryId, branch, update).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -90,6 +90,17 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Deletes a repository for the specified owner and name.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <remarks>Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.</remarks>
+        /// <returns>An <see cref="IObservable{Unit}"/> for the operation</returns>
+        public IObservable<Unit> Delete(int repositoryId)
+        {
+            return _client.Delete(repositoryId).ToObservable();
+        }
+
+        /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -101,6 +112,16 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return _client.Get(owner, name).ToObservable();
+        }
+
+        /// <summary>
+        /// Retrieves the <see cref="Repository"/> for the specified owner and name.
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>A <see cref="Repository"/></returns>
+        public IObservable<Repository> Get(int repositoryId)
+        {
+            return _client.Get(repositoryId).ToObservable();
         }
 
         /// <summary>
@@ -350,6 +371,20 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        public IObservable<Branch> GetAllBranches(int repositoryId)
+        {
+            return GetAllBranches(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -362,6 +397,23 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Branch>(ApiUrls.RepoBranches(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        public IObservable<Branch> GetAllBranches(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Branch>(ApiUrls.RepoBranches(repositoryId), options);
         }
 
         /// <summary>
@@ -380,7 +432,20 @@ namespace Octokit.Reactive
 
             return GetAllContributors(owner, name, ApiOptions.None);
         }
-        
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All contributors of the repository.</returns>
+        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId)
+        {
+            return GetAllContributors(repositoryId, ApiOptions.None);
+        }
+
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
@@ -401,6 +466,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllContributors(repositoryId, false, ApiOptions.None);
+        }
+
+        /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
         /// </summary>
         /// <remarks>
@@ -418,6 +499,20 @@ namespace Octokit.Reactive
             return GetAllContributors(owner, name, false, ApiOptions.None);
         }
 
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <returns>All contributors of the repository.</returns>
+        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous)
+        {
+            return GetAllContributors(repositoryId, false, ApiOptions.None);
+        }
+
         public IObservable<RepositoryContributor> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -425,6 +520,28 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             var endpoint = ApiUrls.RepositoryContributors(owner, name);
+            var parameters = new Dictionary<string, string>();
+            if (includeAnonymous)
+                parameters.Add("anon", "1");
+
+            return _connection.GetAndFlattenAllPages<RepositoryContributor>(endpoint, parameters);
+        }
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            var endpoint = ApiUrls.RepositoryContributors(repositoryId);
             var parameters = new Dictionary<string, string>();
             if (includeAnonymous)
                 parameters.Add("anon", "1");
@@ -453,6 +570,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all languages for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-languages">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        public IObservable<RepositoryLanguage> GetAllLanguages(int repositoryId)
+        {
+            var endpoint = ApiUrls.RepositoryLanguages(repositoryId);
+            return _connection
+                .GetAndFlattenAllPages<Tuple<string, long>>(endpoint)
+                .Select(t => new RepositoryLanguage(t.Item1, t.Item2));
+        }
+
+        /// <summary>
         /// Gets all teams for the specified repository.
         /// </summary>
         /// <remarks>
@@ -475,6 +608,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        public IObservable<Team> GetAllTeams(int repositoryId)
+        {
+            return GetAllTeams(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -486,6 +632,22 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(options, "options");
 
             return _connection.GetAndFlattenAllPages<Team>(ApiUrls.RepositoryTeams(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        public IObservable<Team> GetAllTeams(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Team>(ApiUrls.RepositoryTeams(repositoryId), options);
         }
 
         /// <summary>
@@ -511,6 +673,19 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All of the repositories tags.</returns>
+        public IObservable<RepositoryTag> GetAllTags(int repositoryId)
+        {
+            return GetAllTags(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -525,18 +700,48 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All of the repositories tags.</returns>
+        public IObservable<RepositoryTag> GetAllTags(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<RepositoryTag>(ApiUrls.RepositoryTags(repositoryId), options);
+        }
+
+        /// <summary>
         /// Gets the specified branch.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
-        public IObservable<Branch> GetBranch(string owner, string repositoryName, string branchName)
+        public IObservable<Branch> GetBranch(string owner, string name, string branchName)
         {
-            return _client.GetBranch(owner, repositoryName, branchName).ToObservable();
+            return _client.GetBranch(owner, name, branchName).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets the specified branch.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
+        public IObservable<Branch> GetBranch(int repositoryId, string branchName)
+        {
+            return _client.GetBranch(repositoryId, branchName).ToObservable();
         }
 
         /// <summary>
@@ -552,6 +757,17 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Updates the specified repository with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="update">New values to update the repository with</param>
+        /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        public IObservable<Repository> Edit(int repositoryId, RepositoryUpdate update)
+        {
+            return _client.Edit(repositoryId, update).ToObservable();
+        }
+
+        /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -562,6 +778,18 @@ namespace Octokit.Reactive
         public IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
         {
             return _client.EditBranch(owner, name, branch, update).ToObservable();
+        }
+
+        /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
+        {
+            return _client.EditBranch(repositoryId, branch, update).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -462,7 +462,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return GetAllContributors(owner, name, false, ApiOptions.None);
+            return GetAllContributors(owner, name, false, options);
         }
 
         /// <summary>
@@ -478,7 +478,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return GetAllContributors(repositoryId, false, ApiOptions.None);
+            return GetAllContributors(repositoryId, false, options);
         }
 
         /// <summary>
@@ -496,7 +496,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAllContributors(owner, name, false, ApiOptions.None);
+            return GetAllContributors(owner, name, includeAnonymous, ApiOptions.None);
         }
 
         /// <summary>
@@ -510,9 +510,20 @@ namespace Octokit.Reactive
         /// <returns>All contributors of the repository.</returns>
         public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous)
         {
-            return GetAllContributors(repositoryId, false, ApiOptions.None);
+            return GetAllContributors(repositoryId, includeAnonymous, ApiOptions.None);
         }
 
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
         public IObservable<RepositoryContributor> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -524,7 +535,7 @@ namespace Octokit.Reactive
             if (includeAnonymous)
                 parameters.Add("anon", "1");
 
-            return _connection.GetAndFlattenAllPages<RepositoryContributor>(endpoint, parameters);
+            return _connection.GetAndFlattenAllPages<RepositoryContributor>(endpoint, parameters, options);
         }
 
         /// <summary>
@@ -546,7 +557,7 @@ namespace Octokit.Reactive
             if (includeAnonymous)
                 parameters.Add("anon", "1");
 
-            return _connection.GetAndFlattenAllPages<RepositoryContributor>(endpoint, parameters);
+            return _connection.GetAndFlattenAllPages<RepositoryContributor>(endpoint, parameters, options);
         }
 
         /// <summary>
@@ -727,6 +738,10 @@ namespace Octokit.Reactive
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
         public IObservable<Branch> GetBranch(string owner, string name, string branchName)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+
             return _client.GetBranch(owner, name, branchName).ToObservable();
         }
 
@@ -741,6 +756,8 @@ namespace Octokit.Reactive
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
         public IObservable<Branch> GetBranch(int repositoryId, string branchName)
         {
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+
             return _client.GetBranch(repositoryId, branchName).ToObservable();
         }
 
@@ -753,6 +770,10 @@ namespace Octokit.Reactive
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
         public IObservable<Repository> Edit(string owner, string name, RepositoryUpdate update)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(update, "update");
+
             return _client.Edit(owner, name, update).ToObservable();
         }
 
@@ -764,6 +785,8 @@ namespace Octokit.Reactive
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
         public IObservable<Repository> Edit(int repositoryId, RepositoryUpdate update)
         {
+            Ensure.ArgumentNotNull(update, "update");
+
             return _client.Edit(repositoryId, update).ToObservable();
         }
 
@@ -772,24 +795,32 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="branch">The name of the branch</param>
+        /// <param name="branchName">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
+        public IObservable<Branch> EditBranch(string owner, string name, string branchName, BranchUpdate update)
         {
-            return _client.EditBranch(owner, name, branch, update).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+            Ensure.ArgumentNotNull(update, "update");
+
+            return _client.EditBranch(owner, name, branchName, update).ToObservable();
         }
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="repositoryId">The ID of the repository</param>
-        /// <param name="branch">The name of the branch</param>
+        /// <param name="branchName">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
-        public IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
+        public IObservable<Branch> EditBranch(int repositoryId, string branchName, BranchUpdate update)
         {
-            return _client.EditBranch(repositoryId, branch, update).ToObservable();
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+            Ensure.ArgumentNotNull(update, "update");
+
+            return _client.EditBranch(repositoryId, branchName, update).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -347,6 +347,20 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task UpdatesNameWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
+            var update = new RepositoryUpdate { Name = updatedName };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
+
+            Assert.Equal(update.Name, _repository.Name);
+        }
+
+        [IntegrationTest]
         public async Task UpdatesDescription()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -360,6 +374,19 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task UpdatesDescriptionWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, Description = "Updated description" };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
+
+            Assert.Equal("Updated description", _repository.Description);
+        }
+
+        [IntegrationTest]
         public async Task UpdatesHomepage()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -368,6 +395,19 @@ public class RepositoriesClientTests
             var update = new RepositoryUpdate { Name = repoName, Homepage = "http://aUrl.to/nowhere" };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
+
+            Assert.Equal("http://aUrl.to/nowhere", _repository.Homepage);
+        }
+
+        [IntegrationTest]
+        public async Task UpdatesHomepageWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, Homepage = "http://aUrl.to/nowhere" };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
 
             Assert.Equal("http://aUrl.to/nowhere", _repository.Homepage);
         }
@@ -392,6 +432,26 @@ public class RepositoriesClientTests
             Assert.Equal(true, _repository.Private);
         }
 
+        [PaidAccountTest]
+        public async Task UpdatesPrivateWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var userDetails = await github.User.Current();
+            if (userDetails.Plan.PrivateRepos == 0)
+            {
+                throw new Exception("Test cannot complete, account is on free plan");
+            }
+
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, Private = true };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
+
+            Assert.Equal(true, _repository.Private);
+        }
+
         [IntegrationTest]
         public async Task UpdatesHasDownloads()
         {
@@ -401,6 +461,19 @@ public class RepositoriesClientTests
             var update = new RepositoryUpdate { Name = repoName, HasDownloads = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
+
+            Assert.Equal(false, _repository.HasDownloads);
+        }
+
+        [IntegrationTest]
+        public async Task UpdatesHasDownloadsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, HasDownloads = false };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
 
             Assert.Equal(false, _repository.HasDownloads);
         }
@@ -419,6 +492,19 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task UpdatesHasIssuesWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, HasIssues = false };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
+
+            Assert.Equal(false, _repository.HasIssues);
+        }
+
+        [IntegrationTest]
         public async Task UpdatesHasWiki()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -427,6 +513,19 @@ public class RepositoriesClientTests
             var update = new RepositoryUpdate { Name = repoName, HasWiki = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
+
+            Assert.Equal(false, _repository.HasWiki);
+        }
+
+        [IntegrationTest]
+        public async Task UpdatesHasWikiWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+            _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
+            var update = new RepositoryUpdate { Name = repoName, HasWiki = false };
+
+            _repository = await github.Repository.Edit(_repository.Id, update);
 
             Assert.Equal(false, _repository.HasWiki);
         }
@@ -450,6 +549,18 @@ public class RepositoriesClientTests
 
             await github.Repository.Delete(Helper.UserName, repoName);
         }
+
+        [IntegrationTest]
+        public async Task DeletesRepositoryWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repoName = Helper.MakeNameWithTimestamp("repo-to-delete");
+
+            var repository = await github.Repository.Create(new NewRepository(repoName));
+
+            await github.Repository.Delete(repository.Id);
+        }
     }
 
     public class TheGetMethod
@@ -460,6 +571,19 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
 
             var repository = await github.Repository.Get("haacked", "seegit");
+
+            Assert.Equal("https://github.com/Haacked/SeeGit.git", repository.CloneUrl);
+            Assert.False(repository.Private);
+            Assert.False(repository.Fork);
+            Assert.Equal(AccountType.User, repository.Owner.Type);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsSpecifiedRepositoryWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repository = await github.Repository.Get(3622414);
 
             Assert.Equal("https://github.com/Haacked/SeeGit.git", repository.CloneUrl);
             Assert.False(repository.Private);
@@ -481,11 +605,35 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task ReturnsOrganizationRepositoryWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repository = await github.Repository.Get(7528679);
+
+            Assert.Equal("https://github.com/octokit/octokit.net.git", repository.CloneUrl);
+            Assert.False(repository.Private);
+            Assert.False(repository.Fork);
+            Assert.Equal(AccountType.Organization, repository.Owner.Type);
+        }
+
+        [IntegrationTest]
         public async Task ReturnsForkedRepository()
         {
             var github = Helper.GetAuthenticatedClient();
 
             var repository = await github.Repository.Get("haacked", "libgit2sharp");
+
+            Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
+            Assert.True(repository.Fork);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsForkedRepositoryWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var repository = await github.Repository.Get(4550038);
 
             Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
             Assert.True(repository.Fork);
@@ -639,6 +787,82 @@ public class RepositoriesClientTests
         }
 
         [IntegrationTest]
+        public async Task GetsContributorsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var contributors = await github.Repository.GetAllContributors(7528679);
+
+            Assert.True(contributors.Any(c => c.Login == "pmacn"));
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var contributors = await github.Repository.GetAllContributors("octokit", "octokit.net", options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithoutStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var contributors = await github.Repository.GetAllContributors(7528679, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var contributors = await github.Repository.GetAllContributors("octokit", "octokit.net", options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var contributors = await github.Repository.GetAllContributors(7528679, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
         public async Task GetsPagesOfContributors()
         {
             var github = Helper.GetAuthenticatedClient();
@@ -670,22 +894,9 @@ public class RepositoriesClientTests
             Assert.NotEqual(firstPage[3].Login, secondPage[3].Login);
             Assert.NotEqual(firstPage[4].Login, secondPage[4].Login);
         }
-    }
-
-    public class TheGetAllForCurrentMethod
-    {
-        [IntegrationTest]
-        public async Task CanRetrieveResults()
-        {
-            var github = Helper.GetAuthenticatedClient();
-
-            var repositories = await github.Repository.GetAllForCurrent();
-
-            Assert.NotEmpty(repositories);
-        }
 
         [IntegrationTest]
-        public async Task GetsPagesOfRepositories()
+        public async Task GetsPagesOfContributorsWithRepositoryId()
         {
             var github = Helper.GetAuthenticatedClient();
 
@@ -696,7 +907,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var firstPage = await github.Repository.GetAllForCurrent(firstPageOptions);
+            var firstPage = await github.Repository.GetAllContributors(7528679, firstPageOptions);
 
             var secondPageOptions = new ApiOptions
             {
@@ -705,7 +916,205 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var secondPage = await github.Repository.GetAllForCurrent(secondPageOptions);
+            var secondPage = await github.Repository.GetAllContributors(7528679, secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Login, secondPage[0].Login);
+            Assert.NotEqual(firstPage[1].Login, secondPage[1].Login);
+            Assert.NotEqual(firstPage[2].Login, secondPage[2].Login);
+            Assert.NotEqual(firstPage[3].Login, secondPage[3].Login);
+            Assert.NotEqual(firstPage[4].Login, secondPage[4].Login);
+        }
+
+        [IntegrationTest]
+        public async Task GetsContributorsIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var contributors = await github.Repository.GetAllContributors("ruby", "ruby", true);
+
+            Assert.True(contributors.Any(c => c.Type == "Anonymous"));
+        }
+
+        [IntegrationTest]
+        public async Task GetsContributorsIncludeAnonymousWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var contributors = await github.Repository.GetAllContributors(538746, true);
+
+            Assert.True(contributors.Any(c => c.Type == "Anonymous"));
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithoutStartIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var contributors = await github.Repository.GetAllContributors("ruby", "ruby", true, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithoutStartWithRepositoryIdIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var contributors = await github.Repository.GetAllContributors(538746, true, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithStartIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var contributors = await github.Repository.GetAllContributors("ruby", "ruby", true, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfContributorsWithStartWithRepositoryIdIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var contributors = await github.Repository.GetAllContributors(538746, true, options);
+
+            Assert.Equal(5, contributors.Count);
+        }
+
+        [IntegrationTest]
+        public async Task GetsPagesOfContributorsIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Repository.GetAllContributors("ruby", "ruby",  true, firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 2,
+                PageCount = 1
+            };
+
+            var secondPage = await github.Repository.GetAllContributors("ruby", "ruby", true, secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Login, secondPage[0].Login);
+            Assert.NotEqual(firstPage[1].Login, secondPage[1].Login);
+            Assert.NotEqual(firstPage[2].Login, secondPage[2].Login);
+            Assert.NotEqual(firstPage[3].Login, secondPage[3].Login);
+            Assert.NotEqual(firstPage[4].Login, secondPage[4].Login);
+        }
+
+        [IntegrationTest]
+        public async Task GetsPagesOfContributorsWithRepositoryIdIncludeAnonymous()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Repository.GetAllContributors(538746, true, firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 2,
+                PageCount = 1
+            };
+
+            var secondPage = await github.Repository.GetAllContributors(538746, true, secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Login, secondPage[0].Login);
+            Assert.NotEqual(firstPage[1].Login, secondPage[1].Login);
+            Assert.NotEqual(firstPage[2].Login, secondPage[2].Login);
+            Assert.NotEqual(firstPage[3].Login, secondPage[3].Login);
+            Assert.NotEqual(firstPage[4].Login, secondPage[4].Login);
+        }
+    }
+
+    public class TheGetAllForCurrentMethod
+    {
+        [IntegrationTest]
+        public async Task CanRetrieveResults()
+        {
+            var gitHubClient = Helper.GetAuthenticatedClient();
+
+            var repositories = await gitHubClient.Repository.GetAllForCurrent();
+
+            Assert.NotEmpty(repositories);
+        }
+
+        [IntegrationTest]
+        public async Task GetsPagesOfRepositories()
+        {
+            var gitHubClient = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await gitHubClient.Repository.GetAllForCurrent(firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 2,
+                PageCount = 1
+            };
+
+            var secondPage = await gitHubClient.Repository.GetAllForCurrent(secondPageOptions);
 
             Assert.Equal(5, firstPage.Count);
             Assert.Equal(5, secondPage.Count);
@@ -773,6 +1182,17 @@ public class RepositoriesClientTests
             Assert.NotEmpty(languages);
             Assert.True(languages.Any(l => l.Name == "C#"));
         }
+
+        [IntegrationTest]
+        public async Task GetsLanguagesWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var languages = await github.Repository.GetAllLanguages(7528679);
+
+            Assert.NotEmpty(languages);
+            Assert.True(languages.Any(l => l.Name == "C#"));
+        }
     }
 
     public class TheGetAllTagsMethod
@@ -787,6 +1207,81 @@ public class RepositoriesClientTests
             Assert.True(tags.Any(t => t.Name == "v0.1.0"));
         }
 
+        [IntegrationTest]
+        public async Task GetsTagsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var tags = await github.Repository.GetAllTags(7528679);
+
+            Assert.True(tags.Any(t => t.Name == "v0.1.0"));
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfTagsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var tags = await github.Repository.GetAllTags("octokit", "octokit.net", options);
+
+            Assert.Equal(5, tags.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfTagsWithoutStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var tags = await github.Repository.GetAllTags(7528679, options);
+
+            Assert.Equal(5, tags.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfTagsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var tags = await github.Repository.GetAllTags("octokit", "octokit.net", options);
+
+            Assert.Equal(5, tags.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfTagsWithStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var tags = await github.Repository.GetAllTags(7528679, options);
+
+            Assert.Equal(5, tags.Count);
+        }
 
         [IntegrationTest]
         public async Task GetsPagesOfTags()
@@ -821,6 +1316,38 @@ public class RepositoriesClientTests
             Assert.NotEqual(firstPage[4].Name, secondPage[4].Name);
         }
 
+        [IntegrationTest]
+        public async Task GetsPagesOfTagsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Repository.GetAllTags(7528679, firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 2,
+                PageCount = 1
+            };
+
+            var secondPage = await github.Repository.GetAllTags(7528679, secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Name, secondPage[0].Name);
+            Assert.NotEqual(firstPage[1].Name, secondPage[1].Name);
+            Assert.NotEqual(firstPage[2].Name, secondPage[2].Name);
+            Assert.NotEqual(firstPage[3].Name, secondPage[3].Name);
+            Assert.NotEqual(firstPage[4].Name, secondPage[4].Name);
+        }
     }
 
     public class TheGetAllBranchesMethod
@@ -833,6 +1360,82 @@ public class RepositoriesClientTests
             var branches = await github.Repository.GetAllBranches("octokit", "octokit.net");
 
             Assert.NotEmpty(branches);
+        }
+
+        [IntegrationTest]
+        public async Task GetsAllBranchesWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var branches = await github.Repository.GetAllBranches(7528679);
+
+            Assert.NotEmpty(branches);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfBranchesWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var branches = await github.Repository.GetAllBranches("octokit", "octokit.net", options);
+
+            Assert.Equal(5, branches.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfBranchesWithoutStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var branches = await github.Repository.GetAllBranches(7528679, options);
+
+            Assert.Equal(5, branches.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfBranchesWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var branches = await github.Repository.GetAllBranches("octokit", "octokit.net", options);
+
+            Assert.Equal(5, branches.Count);
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfBranchesWithStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var branches = await github.Repository.GetAllBranches(7528679, options);
+
+            Assert.Equal(5, branches.Count);
         }
 
         [IntegrationTest]
@@ -867,6 +1470,39 @@ public class RepositoriesClientTests
             Assert.NotEqual(firstPage[3].Name, secondPage[3].Name);
             Assert.NotEqual(firstPage[4].Name, secondPage[4].Name);
         }
+
+        [IntegrationTest]
+        public async Task GetsPagesOfBranchesWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Repository.GetAllBranches(7528679, firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 2,
+                PageCount = 1
+            };
+
+            var secondPage = await github.Repository.GetAllBranches(7528679, secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Name, secondPage[0].Name);
+            Assert.NotEqual(firstPage[1].Name, secondPage[1].Name);
+            Assert.NotEqual(firstPage[2].Name, secondPage[2].Name);
+            Assert.NotEqual(firstPage[3].Name, secondPage[3].Name);
+            Assert.NotEqual(firstPage[4].Name, secondPage[4].Name);
+        }
     }
 
     public class TheGetBranchMethod
@@ -877,6 +1513,17 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
 
             var branch = await github.Repository.GetBranch("octokit", "octokit.net", "master");
+
+            Assert.NotNull(branch);
+            Assert.Equal("master", branch.Name);
+        }
+
+        [IntegrationTest]
+        public async Task GetsABranchWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var branch = await github.Repository.GetBranch(7528679, "master");
 
             Assert.NotNull(branch);
             Assert.Equal("master", branch.Name);
@@ -893,6 +1540,82 @@ public class RepositoriesClientTests
             var branches = await github.Repository.GetAllTeams("octokit", "octokit.net");
 
             Assert.NotEmpty(branches);
+        }
+
+        [IntegrationTest(Skip="Test requires administration rights to access this endpoint")]
+        public async Task GetsAllTeamsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var branches = await github.Repository.GetAllTeams(7528679);
+
+            Assert.NotEmpty(branches);
+        }
+
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
+        public async Task ReturnsCorrectCountOfTeamsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var teams = await github.Repository.GetAllTeams("octokit", "octokit.net", options);
+
+            Assert.Equal(5, teams.Count);
+        }
+
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
+        public async Task ReturnsCorrectCountOfTeamsWithoutStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1
+            };
+
+            var teams = await github.Repository.GetAllTeams(7528679, options);
+
+            Assert.Equal(5, teams.Count);
+        }
+
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
+        public async Task ReturnsCorrectCountOfTeamsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var teams = await github.Repository.GetAllTeams("octokit", "octokit.net", options);
+
+            Assert.Equal(5, teams.Count);
+        }
+
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
+        public async Task ReturnsCorrectCountOfTeamsWithStartWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageSize = 5,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var teams = await github.Repository.GetAllTeams(7528679, options);
+
+            Assert.Equal(5, teams.Count);
         }
 
         [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
@@ -917,6 +1640,39 @@ public class RepositoriesClientTests
             };
 
             var secondPage = await github.Repository.GetAllTeams("octokit", "octokit.net", secondPageOptions);
+
+            Assert.Equal(5, firstPage.Count);
+            Assert.Equal(5, secondPage.Count);
+
+            Assert.NotEqual(firstPage[0].Name, secondPage[0].Name);
+            Assert.NotEqual(firstPage[1].Name, secondPage[1].Name);
+            Assert.NotEqual(firstPage[2].Name, secondPage[2].Name);
+            Assert.NotEqual(firstPage[3].Name, secondPage[3].Name);
+            Assert.NotEqual(firstPage[4].Name, secondPage[4].Name);
+        }
+
+        [IntegrationTest(Skip = "Test requires administration rights to access this endpoint")]
+        public async Task GetsPagesOfBranchesWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var firstPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Repository.GetAllTeams(7528679, firstPageOptions);
+
+            var secondPageOptions = new ApiOptions
+            {
+                PageSize = 5,
+                StartPage = 1,
+                PageCount = 1
+            };
+
+            var secondPage = await github.Repository.GetAllTeams(7528679, secondPageOptions);
 
             Assert.Equal(5, firstPage.Count);
             Assert.Equal(5, secondPage.Count);

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -214,37 +214,62 @@ namespace Octokit.Tests.Clients
         public class TheDeleteMethod
         {
             [Fact]
-            public async Task EnsuresNonNullArguments()
-            {
-                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "aRepoName"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("anOwner", null));
-            }
-
-            [Fact]
             public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.Delete("theOwner", "theRepoName");
+                await client.Delete("owner", "name");
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/theOwner/theRepoName"));
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.Delete(1);
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoriesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("owner", ""));
             }
         }
 
         public class TheGetMethod
         {
             [Fact]
-            public void RequestsCorrectUrl()
+            public async Task RequestsCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.Get("fake", "repo");
+                await client.Get("owner", "name");
 
-                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo"));
+                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.Get(1);
+
+                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1"));
             }
 
             [Fact]
@@ -254,46 +279,48 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", ""));
             }
         }
 
         public class TheGetAllPublicMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsRepositories()
+            public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllPublic();
+                await client.GetAllPublic();
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories"));
             }
         }
 
-
         public class TheGetAllPublicSinceMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllPublic(new PublicRepositoryRequest(364));
+                await client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));
             }
 
             [Fact]
-            public void SendsTheCorrectParameter()
+            public async Task SendsTheCorrectParameter()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllPublic(new PublicRepositoryRequest(364));
+                await client.GetAllPublic(new PublicRepositoryRequest(364));
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));
@@ -303,19 +330,19 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForCurrentMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrlAndReturnsRepositories()
+            public async Task RequestsTheCorrectUrlAndReturnsRepositories()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllForCurrent();
+                await client.GetAllForCurrent();
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Args.ApiOptions);
             }
 
             [Fact]
-            public void CanFilterByType()
+            public async Task CanFilterByType()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -325,7 +352,7 @@ namespace Octokit.Tests.Clients
                     Type = RepositoryType.All
                 };
 
-                client.GetAllForCurrent(request);
+                await client.GetAllForCurrent(request);
 
                 connection.Received()
                     .GetAll<Repository>(
@@ -335,7 +362,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void CanFilterBySort()
+            public async Task CanFilterBySort()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -346,7 +373,7 @@ namespace Octokit.Tests.Clients
                     Sort = RepositorySort.FullName
                 };
 
-                client.GetAllForCurrent(request);
+                await client.GetAllForCurrent(request);
 
                 connection.Received()
                     .GetAll<Repository>(
@@ -357,7 +384,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void CanFilterBySortDirection()
+            public async Task CanFilterBySortDirection()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -369,7 +396,7 @@ namespace Octokit.Tests.Clients
                     Direction = SortDirection.Ascending
                 };
 
-                client.GetAllForCurrent(request);
+                await client.GetAllForCurrent(request);
 
                 connection.Received()
                     .GetAll<Repository>(
@@ -380,7 +407,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void CanFilterByVisibility()
+            public async Task CanFilterByVisibility()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -389,7 +416,8 @@ namespace Octokit.Tests.Clients
                 {
                     Visibility = RepositoryVisibility.Private
                 };
-                client.GetAllForCurrent(request);
+
+                await client.GetAllForCurrent(request);
 
                 connection.Received()
                     .GetAll<Repository>(
@@ -400,7 +428,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void CanFilterByAffiliation()
+            public async Task CanFilterByAffiliation()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -411,7 +439,7 @@ namespace Octokit.Tests.Clients
                     Sort = RepositorySort.FullName
                 };
 
-                client.GetAllForCurrent(request);
+                await client.GetAllForCurrent(request);
 
                 connection.Received()
                     .GetAll<Repository>(
@@ -454,12 +482,12 @@ namespace Octokit.Tests.Clients
         public class TheGetAllForOrgMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllForOrg("orgname");
+                await client.GetAllForOrg("orgname");
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "orgs/orgname/repos"), Args.ApiOptions);
@@ -482,73 +510,244 @@ namespace Octokit.Tests.Clients
         public class TheGetAllBranchesMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllBranches("owner", "name");
+                await client.GetAllBranches("owner", "name");
 
                 connection.Received()
                     .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"), null, "application/vnd.github.loki-preview+json", Args.ApiOptions);
             }
 
             [Fact]
-            public async Task EnsuresArguments()
+            public async Task RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllBranches(1);
+
+                connection.Received()
+                    .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches"), null, "application/vnd.github.loki-preview+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllBranches("owner", "name", options);
+
+                connection.Received()
+                    .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"), null, "application/vnd.github.loki-preview+json", options);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllBranches(1, options);
+
+                connection.Received()
+                    .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches"), null, "application/vnd.github.loki-preview+json", options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "repo"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "repo"));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
             }
         }
 
         public class TheGetAllContributorsMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllContributors("owner", "name");
+                await client.GetAllContributors("owner", "name");
 
                 connection.Received()
                     .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Any<IDictionary<string, string>>(), Args.ApiOptions);
             }
 
             [Fact]
-            public async Task EnsuresArguments()
+            public async Task RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllContributors(1);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Any<IDictionary<string, string>>(), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllContributors("owner", "name", options);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Any<IDictionary<string, string>>(), options);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllContributors(1, options);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Any<IDictionary<string, string>>(), options);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlIncludeAnonymous()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllContributors("owner", "name", true);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryIdIncludeAnonymous()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllContributors(1, true);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptionsIncludeAnonymous()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllContributors("owner", "name", true, options);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), options);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryIdWithApiOptionsIncludeAnonymous()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllContributors(1, true, options);
+
+                connection.Received()
+                    .GetAll<RepositoryContributor>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), options);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(null, "repo"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(null, "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", "repo", null));
-
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("", "repo", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("owner", "", ApiOptions.None));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(null, "repo", false, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", null, false, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", "repo", false, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("", "repo", false, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("owner", "", false, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(1, false, null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors(null, "repo"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllContributors("owner", null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("", "repo"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("", "repo", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("", "repo", false, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContributors("owner", "", false, ApiOptions.None));
             }
         }
 
         public class TheGetAllLanguagesMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -560,12 +759,25 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                client.GetAllLanguages(1);
+
+                connection.Received()
+                    .Get<Dictionary<string, long>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/languages"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllLanguages(null, "repo"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllLanguages("owner", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllLanguages("", "repo"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllLanguages("owner", ""));
             }
@@ -574,17 +786,73 @@ namespace Octokit.Tests.Clients
         public class TheGetAllTeamsMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllTeams("owner", "name");
+                await client.GetAllTeams("owner", "name");
 
                 connection.Received()
                     .GetAll<Team>(
                         Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/teams"),
                         Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllTeams(1);
+
+                connection.Received()
+                    .GetAll<Team>(
+                        Arg.Is<Uri>(u => u.ToString() == "repositories/1/teams"),
+                        Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllTeams("owner", "name", options);
+
+                connection.Received()
+                    .GetAll<Team>(
+                        Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/teams"),
+                        options);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllTeams(1, options);
+
+                connection.Received()
+                    .GetAll<Team>(
+                        Arg.Is<Uri>(u => u.ToString() == "repositories/1/teams"),
+                        options);
             }
 
             [Fact]
@@ -594,14 +862,14 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams(null, "repo"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams("owner", null));
-
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams(null, "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams("owner", "repo", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTeams(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTeams("", "repo"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTeams("owner", ""));
-
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTeams("", "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTeams("owner", "", ApiOptions.None));
             }
@@ -610,15 +878,65 @@ namespace Octokit.Tests.Clients
         public class TheGetAllTagsMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetAllTags("owner", "name");
+                await client.GetAllTags("owner", "name");
 
                 connection.Received()
                     .GetAll<RepositoryTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/tags"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetAllTags(1);
+
+                connection.Received()
+                    .GetAll<RepositoryTag>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/tags"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllTags("owner", "name", options);
+
+                connection.Received()
+                    .GetAll<RepositoryTag>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/tags"), options);
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                await client.GetAllTags(1, options);
+
+                connection.Received()
+                    .GetAll<RepositoryTag>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/tags"), options);
             }
 
             [Fact]
@@ -628,14 +946,14 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags(null, "repo"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags("owner", null));
-                
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags(null, "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags("owner", "repo", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllTags(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTags("", "repo"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTags("owner", ""));
-
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTags("", "repo", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllTags("owner", "", ApiOptions.None));
             }
@@ -644,15 +962,27 @@ namespace Octokit.Tests.Clients
         public class TheGetBranchMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                client.GetBranch("owner", "repo", "branch");
+                await client.GetBranch("owner", "repo", "branch");
 
                 connection.Received()
                     .Get<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch"), null, "application/vnd.github.loki-preview+json");
+            }
+
+            [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+
+                await client.GetBranch(1, "branch");
+
+                connection.Received()
+                    .Get<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch"), null, "application/vnd.github.loki-preview+json");
             }
 
             [Fact]
@@ -663,6 +993,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetBranch(null, "repo", "branch"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetBranch("owner", null, "branch"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetBranch("owner", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetBranch(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetBranch("", "repo", "branch"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetBranch("owner", "", "branch"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetBranch("owner", "repo", ""));
@@ -685,6 +1018,19 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void PatchesCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var update = new RepositoryUpdate();
+
+                client.Edit(1, update);
+
+                connection.Received()
+                    .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1"), Arg.Any<RepositoryUpdate>());
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
@@ -693,6 +1039,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "repo", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(1, null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("", "repo", update));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Edit("owner", "", update));
             }
@@ -719,7 +1068,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
 
@@ -763,7 +1112,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -792,7 +1141,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);
@@ -807,7 +1156,7 @@ namespace Octokit.Tests.Clients
         public class TheEditBranchMethod
         {
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
@@ -821,6 +1170,20 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var update = new BranchUpdate();
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.EditBranch(1, "branch", update);
+
+                connection.Received()
+                    .Patch<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch"), Arg.Any<BranchUpdate>(), previewAcceptsHeader);
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
@@ -830,9 +1193,15 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", null, "branch", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", "repo", null, update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch("owner", "repo", "branch", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch(1, null, update));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.EditBranch(1, "branch", null));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("", "repo", "branch", update));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("owner", "", "branch", update));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch("owner", "repo", "", update));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.EditBranch(1, "", update));
             }
         }
 
@@ -859,7 +1228,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryCommitsClient(connection);

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -21,8 +21,67 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheDeleteMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                await client.Delete("owner", "name");
+
+                gitHubClient.Received().Repository.Delete("owner", "name");
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                await client.Delete(1);
+
+                gitHubClient.Received().Repository.Delete(1);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.Delete("", "name"));
+                Assert.Throws<ArgumentException>(() => client.Delete("owner", ""));
+            }
+        }
+
         public class TheGetMethod
         {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                await client.Get("owner", "name");
+
+                gitHubClient.Received().Repository.Get("owner", "name");
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                await client.Get(1);
+
+                gitHubClient.Repository.Get(1);
+            }
+
             // This isn't really a test specific to this method. This is just as good a place as any to test
             // that our API methods returns the right kind of observables.
             [Fact]
@@ -47,6 +106,44 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Same(repository, result);
                 Assert.Same(repository, result2);
+            }
+
+            // This isn't really a test specific to this method. This is just as good a place as any to test
+            // that our API methods returns the right kind of observables.
+            [Fact]
+            public async Task IsALukeWarmObservableWithRepositoryId()
+            {
+                var repository = new Repository();
+                var response = Task.Factory.StartNew<IApiResponse<Repository>>(() =>
+                    new ApiResponse<Repository>(new Response(), repository));
+                var connection = Substitute.For<IConnection>();
+                connection.Get<Repository>(Args.Uri, null, null).Returns(response);
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var observable = client.Get(1);
+
+                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+
+                var result = await observable;
+                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                var result2 = await observable;
+                // TODO: If we change this to a warm observable, we'll need to change this to Received(2)
+                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+
+                Assert.Same(repository, result);
+                Assert.Same(repository, result2);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null));
+
+                Assert.Throws<ArgumentException>(() => client.Get("", "name"));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", ""));
             }
         }
 
@@ -85,7 +182,7 @@ namespace Octokit.Tests.Reactive
                     });
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string,string>>(), null)
+                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => firstPageResponse));
                 gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => secondPageResponse));
@@ -133,7 +230,6 @@ namespace Octokit.Tests.Reactive
                 var thirdPageLinks = new Dictionary<string, Uri> { { "next", fourthPageUrl } };
                 var thirdPageResponse = new ApiResponse<List<Repository>>
                 (
-
                     CreateResponseWithApiInfo(thirdPageLinks),
                     new List<Repository>
                     {
@@ -227,33 +323,92 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllBranchesMethod
         {
             [Fact]
-            public void EnsuresArguments()
+            public void RequestsTheCorrectUrl()
             {
-                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
-
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "repo"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null));
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "repo"));
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", ""));
-            }
-
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoriesClient(github);
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
                 var expected = new Uri("repos/owner/repo/branches", UriKind.Relative);
 
                 client.GetAllBranches("owner", "repo");
 
-                github.Connection.Received(1).Get<List<Branch>>(expected, Args.EmptyDictionary, null);
+                gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/branches", UriKind.Relative);
+
+                client.GetAllBranches(1);
+
+                gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Args.EmptyDictionary, null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/name/branches", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllBranches("owner", "name", options);
+
+                gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/branches", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllBranches(1, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
             }
         }
 
         public class TheGetCommitMethod
         {
             [Fact]
-            public void EnsuresArguments()
+            public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
 
@@ -292,7 +447,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public void RequestsTheCorrectUrl()
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
@@ -307,36 +462,193 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllContributorsMethod
         {
             [Fact]
-            public void EnsuresArguments()
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/contributors", UriKind.Relative);
+
+                client.GetAllContributors("owner", "repo");
+
+                gitHubClient.Connection.Received(1)
+                    .Get<List<RepositoryContributor>>(expected,
+                        Args.EmptyDictionary,
+                        null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/contributors", UriKind.Relative);
+
+                client.GetAllContributors(1);
+
+                gitHubClient.Connection.Received(1)
+                    .Get<List<RepositoryContributor>>(expected,
+                        Args.EmptyDictionary,
+                        null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/contributors", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllContributors("owner", "repo", options);
+
+                gitHubClient.Connection.Received(1)
+                    .Get<List<RepositoryContributor>>(expected,
+                        Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"),
+                        null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptionsWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/contributors", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllContributors(1, options);
+
+                gitHubClient.Connection.Received(1)
+                    .Get<List<RepositoryContributor>>(expected,
+                        Arg.Is<IDictionary<string, string>>(d => d.Count == 2),
+                        null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlIncludeAnonymous()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                client.GetAllContributors("owner", "name", true);
+
+                gitHubClient.Connection.Received()
+                    .Get<List<RepositoryContributor>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdIncludeAnonymous()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                client.GetAllContributors(1, true);
+
+                gitHubClient.Connection.Received()
+                    .Get<List<RepositoryContributor>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Is<IDictionary<string, string>>(d => d["anon"] == "1"), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptionsIncludeAnonymous()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllContributors("owner", "name", true, options);
+
+                gitHubClient.Connection.Received()
+                    .Get<List<RepositoryContributor>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/contributors"), Arg.Is<IDictionary<string, string>>(d => d.Count == 3 && d["anon"] == "1" && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdWithApiOptionsIncludeAnonymous()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllContributors(1, true, options);
+
+                gitHubClient.Connection.Received()
+                    .Get<List<RepositoryContributor>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/contributors"), Arg.Is<IDictionary<string, string>>(d => d.Count == 3 && d["anon"] == "1" && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContributors(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllContributors("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors(null, "repo", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors(null, "repo", false, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors("owner", null, false, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors("owner", "repo", false, null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllContributors(1, false, null));
+
                 Assert.Throws<ArgumentException>(() => client.GetAllContributors("", "repo"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContributors("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllContributors("", "repo", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContributors("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContributors("", "repo", false, ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllContributors("owner", "", false, ApiOptions.None));
             }
-
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoriesClient(github);
-                var expected = new Uri("repos/owner/repo/contributors", UriKind.Relative);
-
-                client.GetAllContributors("owner", "repo");
-
-                github.Connection.Received(1)
-                    .Get<List<RepositoryContributor>>(expected,
-                                          Arg.Any<IDictionary<string, string>>(),
-                                          Arg.Any<string>());
-            }
-
-            // TODO: Needs test for 'includeAnonymous'
         }
 
         public class TheGetAllLanguagesMethod
         {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/languages", UriKind.Relative);
+
+                client.GetAllLanguages("owner", "repo");
+
+                gitHubClient.Connection.Received(1).GetResponse<List<Tuple<string, long>>>(expected);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/languages", UriKind.Relative);
+
+                client.GetAllLanguages(1);
+
+                gitHubClient.Connection.Received(1).GetResponse<List<Tuple<string, long>>>(expected);
+            }
+
             [Fact]
             public void EnsuresNonNullArguments()
             {
@@ -344,97 +656,192 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllLanguages(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllLanguages("owner", null));
+                
                 Assert.Throws<ArgumentException>(() => client.GetAllLanguages("", "repo"));
                 Assert.Throws<ArgumentException>(() => client.GetAllLanguages("owner", ""));
-            }
-
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoriesClient(github);
-                var expected = new Uri("repos/owner/repo/languages", UriKind.Relative);
-
-                client.GetAllLanguages("owner", "repo");
-
-                github.Connection.Received(1).GetResponse<List<Tuple<string, long>>>(expected);
             }
         }
 
         public class TheGetAllTeamsMethod
         {
             [Fact]
-            public void EnsuresArguments()
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/teams", UriKind.Relative);
+
+                client.GetAllTeams("owner", "repo");
+
+                gitHubClient.Connection.Received(1).Get<List<Team>>(expected,
+                    Arg.Any<IDictionary<string, string>>(),
+                    Arg.Any<string>());
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/teams", UriKind.Relative);
+
+                client.GetAllTeams(1);
+
+                gitHubClient.Connection.Received(1).Get<List<Team>>(expected,
+                    Arg.Any<IDictionary<string, string>>(),
+                    Arg.Any<string>());
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/teams", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllTeams("owner", "repo", options);
+
+                gitHubClient.Connection.Received(1).Get<List<Team>>(expected,
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"),
+                    Arg.Any<string>());
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/teams", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllTeams(1, options);
+
+                gitHubClient.Connection.Received(1).Get<List<Team>>(expected,
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"),
+                    Arg.Any<string>());
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllTeams(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllTeams("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTeams(null, "repo", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTeams("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTeams("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTeams(1, null));
+
                 Assert.Throws<ArgumentException>(() => client.GetAllTeams("", "repo"));
                 Assert.Throws<ArgumentException>(() => client.GetAllTeams("owner", ""));
-            }
-
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoriesClient(github);
-                var expected = new Uri("repos/owner/repo/teams", UriKind.Relative);
-
-                client.GetAllTeams("owner", "repo");
-
-                github.Connection.Received(1).Get<List<Team>>(expected,
-                    Arg.Any<IDictionary<string, string>>(),
-                    Arg.Any<string>());
+                Assert.Throws<ArgumentException>(() => client.GetAllTeams("", "repo", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllTeams("owner", "", ApiOptions.None));
             }
         }
 
         public class TheGetAllTagsMethod
         {
             [Fact]
-            public void EnsuresArguments()
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/tags", UriKind.Relative);
+
+                client.GetAllTags("owner", "repo");
+
+                gitHubClient.Connection.Received(1).Get<List<RepositoryTag>>(expected, Arg.Any<IDictionary<string, string>>(), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/tags", UriKind.Relative);
+
+                client.GetAllTags(1);
+
+                gitHubClient.Connection.Received(1).Get<List<RepositoryTag>>(expected, Arg.Any<IDictionary<string, string>>(), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repos/owner/repo/tags", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllTags("owner", "repo", options);
+
+                gitHubClient.Connection.Received(1).Get<List<RepositoryTag>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var expected = new Uri("repositories/1/tags", UriKind.Relative);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    StartPage = 1,
+                    PageSize = 1
+                };
+
+                client.GetAllTags(1, options);
+
+                gitHubClient.Connection.Received(1).Get<List<RepositoryTag>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllTags(null, "repo"));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllTags("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTags(null, "repo", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTags("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTags("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllTags(1, null));
+
                 Assert.Throws<ArgumentException>(() => client.GetAllTags("", "repo"));
                 Assert.Throws<ArgumentException>(() => client.GetAllTags("owner", ""));
-            }
-
-            [Fact]
-            public void GetsCorrectUrl()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var client = new ObservableRepositoriesClient(github);
-                var expected = new Uri("repos/owner/repo/tags", UriKind.Relative);
-
-                client.GetAllTags("owner", "repo");
-
-                github.Connection.Received(1).Get<List<RepositoryTag>>(expected, Arg.Any<IDictionary<string,string>>(), null);
+                Assert.Throws<ArgumentException>(() => client.GetAllTags("", "repo", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllTags("owner", "", ApiOptions.None));
             }
         }
 
         public class TheGetBranchMethod
         {
             [Fact]
-            public async Task EnsuresArguments()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var nonreactiveClient = new RepositoriesClient(Substitute.For<IApiConnection>());
-                github.Repository.Returns(nonreactiveClient);
-                var client = new ObservableRepositoriesClient(github);
-
-                Assert.Throws<ArgumentNullException>(() => client.GetBranch(null, "repo", "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetBranch("owner", null, "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetBranch("owner", "repo", null));
-                Assert.Throws<ArgumentException>(() => client.GetBranch("", "repo", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetBranch("owner", "", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetBranch("owner", "repo", ""));
-            }
-
-            [Fact]
-            public void CallsIntoClient()
+            public void RequestsTheCorrectUrl()
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
@@ -443,28 +850,41 @@ namespace Octokit.Tests.Reactive
 
                 github.Repository.Received(1).GetBranch("owner", "repo", "branch");
             }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(github);
+
+                client.GetBranch(1, "branch");
+
+                github.Repository.Received(1).GetBranch(1, "branch");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetBranch(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetBranch("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetBranch("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetBranch(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetBranch("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetBranch("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetBranch("owner", "repo", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetBranch(1, ""));
+            }
         }
 
         public class TheEditMethod
         {
             [Fact]
-            public async Task EnsuresArguments()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var nonreactiveClient = new RepositoriesClient(Substitute.For<IApiConnection>());
-                github.Repository.Returns(nonreactiveClient);
-                var client = new ObservableRepositoriesClient(github);
-                var update = new RepositoryUpdate();
-
-                Assert.Throws<ArgumentNullException>(() => client.Edit(null, "repo", update));
-                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, update));
-                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", "repo", null));
-                Assert.Throws<ArgumentException>(() => client.Edit("", "repo", update));
-                Assert.Throws<ArgumentException>(() => client.Edit("owner", "", update));
-            }
-
-            [Fact]
-            public void CallsIntoClient()
+            public void PatchsTheCorrectUrl()
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
@@ -474,30 +894,40 @@ namespace Octokit.Tests.Reactive
 
                 github.Repository.Received(1).Edit("owner", "repo", update);
             }
+
+            [Fact]
+            public void PatchsTheCorrectUrlWithRepositoryId()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(github);
+                var update = new RepositoryUpdate();
+
+                client.Edit(1, update);
+
+                github.Repository.Received(1).Edit(1, update);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+                var update = new RepositoryUpdate();
+
+                Assert.Throws<ArgumentNullException>(() => client.Edit(null, "repo", update));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, update));
+                Assert.Throws<ArgumentNullException>(() => client.Edit("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.Edit(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.Edit("", "repo", update));
+                Assert.Throws<ArgumentException>(() => client.Edit("owner", "", update));
+            }
         }
 
         public class TheEditBranchMethod
         {
             [Fact]
-            public async Task EnsuresArguments()
-            {
-                var github = Substitute.For<IGitHubClient>();
-                var nonreactiveClient = new RepositoriesClient(Substitute.For<IApiConnection>());
-                github.Repository.Returns(nonreactiveClient);
-                var client = new ObservableRepositoriesClient(github);
-                var update = new BranchUpdate();
-
-                Assert.Throws<ArgumentNullException>(() => client.EditBranch(null, "repo", "branch", update));
-                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", null, "branch", update));
-                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", null, update));
-                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", "branch", null));
-                Assert.Throws<ArgumentException>(() => client.EditBranch("", "repo", "branch", update));
-                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "", "branch", update));
-                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "repo", "", update));
-            }
-
-            [Fact]
-            public void CallsIntoClient()
+            public void PatchsTheCorrectUrl()
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
@@ -506,6 +936,39 @@ namespace Octokit.Tests.Reactive
                 client.EditBranch("owner", "repo", "branch", update);
 
                 github.Repository.Received(1).EditBranch("owner", "repo", "branch", update);
+            }
+
+            [Fact]
+            public void PatchsTheCorrectUrlWithRepositoryId()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(github);
+                var update = new BranchUpdate();
+
+                client.EditBranch(1, "branch", update);
+
+                github.Repository.Received(1).EditBranch(1, "branch", update);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
+                var update = new BranchUpdate();
+
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch(null, "repo", "branch", update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", null, "branch", update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", null, update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch("owner", "repo", "branch", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch(1, null, update));
+                Assert.Throws<ArgumentNullException>(() => client.EditBranch(1, "branch", null));
+
+                Assert.Throws<ArgumentException>(() => client.EditBranch("", "repo", "branch", update));
+                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "", "branch", update));
+                Assert.Throws<ArgumentException>(() => client.EditBranch("owner", "repo", "", update));
+
+                Assert.Throws<ArgumentException>(() => client.EditBranch(1, "", update));
             }
         }
 

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using System;
 #if NET_45
 using System.Collections.Generic;
 #endif
@@ -92,6 +92,17 @@ namespace Octokit
         Task Delete(string owner, string name);
 
         /// <summary>
+        /// Deletes the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#delete-a-repository">API documentation</a> for more information.
+        /// Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        Task Delete(int repositoryId);
+
+        /// <summary>
         /// Gets the specified repository.
         /// </summary>
         /// <remarks>
@@ -105,6 +116,18 @@ namespace Octokit
         Task<Repository> Get(string owner, string name);
 
         /// <summary>
+        /// Gets the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Repository"/></returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
+        Task<Repository> Get(int repositoryId);
+
+        /// <summary>
         /// Gets all public repositories.
         /// </summary>
         /// <remarks>
@@ -115,9 +138,8 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
-            Justification = "Makes a network request")]
+             Justification = "Makes a network request")]
         Task<IReadOnlyList<Repository>> GetAllPublic();
-
 
         /// <summary>
         /// Gets all public repositories since the integer ID of the last Repository that you've seen.
@@ -143,7 +165,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
-            Justification = "Makes a network request")]
+             Justification = "Makes a network request")]
         Task<IReadOnlyList<Repository>> GetAllForCurrent();
 
         /// <summary>
@@ -170,7 +192,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         Task<IReadOnlyList<Repository>> GetAllForCurrent(RepositoryRequest request);
-        
+
         /// <summary>
         /// Gets all repositories owned by the current user.
         /// </summary>
@@ -349,12 +371,35 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId);
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -373,11 +418,32 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All contributors of the repository.</returns>
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
         Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -397,12 +463,35 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <returns>All contributors of the repository.</returns>
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
         Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options);
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options);
 
         /// <summary>
         /// Gets all languages for the specified repository.
@@ -414,6 +503,16 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
         Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(string owner, string name);
+
+        /// <summary>
+        /// Gets all languages for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-languages">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(int repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -432,11 +531,32 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId);
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
         Task<IReadOnlyList<Team>> GetAllTeams(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -455,11 +575,32 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All of the repositories tags.</returns>
+        Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId);
+
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
         Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All of the repositories tags.</returns>
+        Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -468,10 +609,21 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
-        Task<Branch> GetBranch(string owner, string repositoryName, string branchName);
+        Task<Branch> GetBranch(string owner, string name, string branchName);
+
+        /// <summary>
+        /// Gets the specified branch.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
+        Task<Branch> GetBranch(int repositoryId, string branchName);
 
         /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
@@ -483,6 +635,14 @@ namespace Octokit
         Task<Repository> Edit(string owner, string name, RepositoryUpdate update);
 
         /// <summary>
+        /// Updates the specified repository with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="update">New values to update the repository with</param>
+        /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        Task<Repository> Edit(int repositoryId, RepositoryUpdate update);
+
+        /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -491,6 +651,15 @@ namespace Octokit
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
+
+        /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repository Pages API.

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -879,8 +879,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            var repositoryTeams = ApiUrls.RepositoryTeams(owner, name);
-            return ApiConnection.GetAll<Team>(repositoryTeams, options);
+            return ApiConnection.GetAll<Team>(ApiUrls.RepositoryTeams(owner, name), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -156,6 +156,36 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Deletes the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#delete-a-repository">API documentation</a> for more information.
+        /// Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public Task Delete(int repositoryId)
+        {
+            return ApiConnection.Delete(ApiUrls.Repository(repositoryId));
+        }
+
+        /// <summary>
+        /// Gets the specified branch.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
+        public Task<Branch> GetBranch(int repositoryId, string branchName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
+
+            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(repositoryId, branchName), null, AcceptHeaders.ProtectedBranchesApiPreview);
+        }
+
+        /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
@@ -169,6 +199,19 @@ namespace Octokit
             Ensure.ArgumentNotNull(update, "update");
 
             return ApiConnection.Patch<Repository>(ApiUrls.Repository(owner, name), update);
+        }
+
+        /// <summary>
+        /// Updates the specified repository with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="update">New values to update the repository with</param>
+        /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        public Task<Repository> Edit(int repositoryId, RepositoryUpdate update)
+        {
+            Ensure.ArgumentNotNull(update, "update");
+
+            return ApiConnection.Patch<Repository>(ApiUrls.Repository(repositoryId), update);
         }
 
         /// <summary>
@@ -190,6 +233,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Edit the specified branch with the values given in <paramref name="update"/>
+        /// </summary>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        /// <param name="update">New values to update the branch with</param>
+        /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        public Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+            Ensure.ArgumentNotNull(update, "update");
+
+            return ApiConnection.Patch<Branch>(ApiUrls.RepoBranch(repositoryId, branch), update, AcceptHeaders.ProtectedBranchesApiPreview);
+        }
+
+        /// <summary>
         /// Gets the specified repository.
         /// </summary>
         /// <remarks>
@@ -205,6 +263,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return ApiConnection.Get<Repository>(ApiUrls.Repository(owner, name));
+        }
+
+        /// <summary>
+        /// Gets the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#get">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="Repository"/></returns>
+        public Task<Repository> Get(int repositoryId)
+        {
+            return ApiConnection.Get<Repository>(ApiUrls.Repository(repositoryId));
         }
 
         /// <summary>
@@ -378,7 +450,10 @@ namespace Octokit
         /// that announced this feature.
         /// </remarks>
         [Obsolete("Use Status instead")]
-        public ICommitStatusClient CommitStatus { get { return Status; } }
+        public ICommitStatusClient CommitStatus
+        {
+            get { return Status; }
+        }
 
         /// <summary>
         /// A client for GitHub's Commit Status API.
@@ -533,6 +608,20 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        public Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId)
+        {
+            return GetAllBranches(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -545,6 +634,23 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Branch>(ApiUrls.RepoBranches(owner, name), null, AcceptHeaders.ProtectedBranchesApiPreview, options);
+        }
+
+        /// <summary>
+        /// Gets all the branches for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
+        public Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Branch>(ApiUrls.RepoBranches(repositoryId), null, AcceptHeaders.ProtectedBranchesApiPreview, options);
         }
 
         /// <summary>
@@ -570,6 +676,19 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All contributors of the repository.</returns>
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId)
+        {
+            return GetAllContributors(repositoryId, false);
+        }
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -581,6 +700,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return GetAllContributors(owner, name, false, options);
+        }
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. Does not include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return GetAllContributors(repositoryId, false, options);
         }
 
         /// <summary>
@@ -599,6 +734,20 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             return GetAllContributors(owner, name, false, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <returns>All contributors of the repository.</returns>
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous)
+        {
+            return GetAllContributors(repositoryId, false, ApiOptions.None);
         }
 
         /// <summary>
@@ -626,6 +775,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-contributors">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All contributors of the repository.</returns>
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            var parameters = new Dictionary<string, string>();
+            if (includeAnonymous)
+                parameters.Add("anon", "1");
+
+            return ApiConnection.GetAll<RepositoryContributor>(ApiUrls.RepositoryContributors(repositoryId), parameters, options);
+        }
+
+        /// <summary>
         /// Gets all languages for the specified repository.
         /// </summary>
         /// <remarks>
@@ -640,6 +810,23 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
             var endpoint = ApiUrls.RepositoryLanguages(owner, name);
+            var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
+
+            return new ReadOnlyCollection<RepositoryLanguage>(
+                data.Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());
+        }
+
+        /// <summary>
+        /// Gets all languages for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-languages">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(int repositoryId)
+        {
+            var endpoint = ApiUrls.RepositoryLanguages(repositoryId);
             var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
 
             return new ReadOnlyCollection<RepositoryLanguage>(
@@ -669,6 +856,19 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
         /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        public Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId)
+        {
+            return GetAllTeams(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
@@ -680,6 +880,22 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, "options");
 
             return ApiConnection.GetAll<Team>(ApiUrls.RepositoryTeams(owner, name), options);
+        }
+
+        /// <summary>
+        /// Gets all teams for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-teams">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        public Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Team>(ApiUrls.RepositoryTeams(repositoryId), options);
         }
 
         /// <summary>
@@ -699,6 +915,18 @@ namespace Octokit
             return GetAllTags(owner, name, ApiOptions.None);
         }
 
+        /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <returns>All of the repositories tags.</returns>
+        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId)
+        {
+            return GetAllTags(repositoryId, ApiOptions.None);
+        }
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -720,22 +948,38 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets all tags for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-tags">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The ID of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>All of the repositories tags.</returns>
+        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<RepositoryTag>(ApiUrls.RepositoryTags(repositoryId), options);
+        }
+
+        /// <summary>
         /// Gets the specified branch.
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#get-branch">API documentation</a> for more details
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repositoryName">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
-        public Task<Branch> GetBranch(string owner, string repositoryName, string branchName)
+        public Task<Branch> GetBranch(string owner, string name, string branchName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(repositoryName, "repositoryName");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
 
-            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, repositoryName, branchName), null, AcceptHeaders.ProtectedBranchesApiPreview);
+            return ApiConnection.Get<Branch>(ApiUrls.RepoBranch(owner, name, branchName), null, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -733,7 +733,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return GetAllContributors(owner, name, false, ApiOptions.None);
+            return GetAllContributors(owner, name, includeAnonymous, ApiOptions.None);
         }
 
         /// <summary>
@@ -747,7 +747,7 @@ namespace Octokit
         /// <returns>All contributors of the repository.</returns>
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous)
         {
-            return GetAllContributors(repositoryId, false, ApiOptions.None);
+            return GetAllContributors(repositoryId, includeAnonymous, ApiOptions.None);
         }
 
         /// <summary>
@@ -879,7 +879,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Team>(ApiUrls.RepositoryTeams(owner, name), options);
+            var repositoryTeams = ApiUrls.RepositoryTeams(owner, name);
+            return ApiConnection.GetAll<Team>(repositoryTeams, options);
         }
 
         /// <summary>


### PR DESCRIPTION
As part of my work on #1120 I've added new overloads on I(Observable)RepositoriesClient to get access by repository id.

- [x] **Add overloads to IRepositoriesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add overloads to IObservableRepositoriesClient.**

	  Just add overloads of existing methods that use repositoryId to work with repo.
- [x] **Add unit tests.**

	  I've added new unit tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.
- [x] **Add integration tests.**

	  I've added new integration tests that use repositoryId to work with repo that is just a full copy of existing tests that use (owner, name) key.
	  Also I've found out that not all methods are covered by tests and added them for new and for old methods.