### PR TITLE
Add convention test to ensure all response models have a public parameterless ctor

### DIFF
--- a/Octokit.Tests.Conventions/Exception/MissingPublicParameterlessCtorException.cs
+++ b/Octokit.Tests.Conventions/Exception/MissingPublicParameterlessCtorException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Octokit.Tests.Conventions
+{
+    public class MissingPublicParameterlessCtorException : Exception
+    {
+        public MissingPublicParameterlessCtorException(Type modelType)
+            : base(string.Format("Model type '{0}' is missing a Public Parameterless Constructor required by SimpleJson Deserializer.", modelType.FullName))
+        { }
+    }
+}

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -39,6 +39,18 @@ namespace Octokit.Tests.Conventions
 
         [Theory]
         [MemberData("ResponseModelTypes")]
+        public void AllResponseModelsHavePublicParameterlessCtors(Type modelType)
+        {
+            var ctor = modelType.GetConstructor(Type.EmptyTypes);
+
+            if (ctor == null || !ctor.IsPublic)
+            {
+                throw new MissingPublicParameterlessCtorException(modelType);
+            }
+        }
+
+        [Theory]
+        [MemberData("ResponseModelTypes")]
         public void ResponseModelsHaveGetterOnlyProperties(Type modelType)
         {
             var mutableProperties = new List<PropertyInfo>();

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Exception\MissingClientConstructorTestClassException.cs" />
     <Compile Include="Exception\MissingClientConstructorTestMethodException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayAttributeException.cs" />
+    <Compile Include="Exception\MissingPublicParameterlessCtorException.cs" />
     <Compile Include="Exception\MissingDebuggerDisplayPropertyException.cs" />
     <Compile Include="Exception\MutableModelPropertiesException.cs" />
     <Compile Include="Exception\PaginationGetAllMethodNameMismatchException.cs" />

--- a/Octokit/Models/Response/PunchCard.cs
+++ b/Octokit/Models/Response/PunchCard.cs
@@ -10,6 +10,9 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PunchCard
     {
+        public PunchCard()
+        { }
+
         public PunchCard(IEnumerable<IList<int>> punchCardData)
         {
             Ensure.ArgumentNotNull(punchCardData, "punchCardData");

--- a/Octokit/Models/Response/PunchCard.cs
+++ b/Octokit/Models/Response/PunchCard.cs
@@ -10,8 +10,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PunchCard
     {
-        public PunchCard()
-        { }
+        public PunchCard() { }
 
         public PunchCard(IEnumerable<IList<int>> punchCardData)
         {

--- a/Octokit/Models/Response/RepositoryLanguage.cs
+++ b/Octokit/Models/Response/RepositoryLanguage.cs
@@ -7,8 +7,7 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryLanguage
     {
-        public RepositoryLanguage()
-        { }
+        public RepositoryLanguage() { }
 
         public RepositoryLanguage(string name, long numberOfBytes)
         {

--- a/Octokit/Models/Response/RepositoryLanguage.cs
+++ b/Octokit/Models/Response/RepositoryLanguage.cs
@@ -7,6 +7,9 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryLanguage
     {
+        public RepositoryLanguage()
+        { }
+
         public RepositoryLanguage(string name, long numberOfBytes)
         {
             Name = name;


### PR DESCRIPTION
Fixes #1413

`PunchCard` and `RepositoryLanguage` classes were missing the `ctor` and failing this test.  Technically they don't actually need it since they are not being deserialized from json, but populated from basic data types but in the interest of consistency and ease of testing I've added the `ctor` to these 2 classes