### PR TITLE
Flag obsolete warnings for initial Protected Branch API preview functionality

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -509,6 +509,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
 
         /// <summary>
@@ -518,6 +519,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -769,6 +769,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         public IObservable<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -786,6 +787,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         public IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -612,6 +612,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update);
 
         /// <summary>
@@ -621,6 +622,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -213,6 +213,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         public Task<Branch> EditBranch(string owner, string name, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -230,6 +231,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
         public Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit/Models/Request/BranchUpdate.cs
+++ b/Octokit/Models/Request/BranchUpdate.cs
@@ -9,6 +9,7 @@ namespace Octokit
     /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
     public class BranchUpdate
     {
         /// <summary>

--- a/Octokit/Models/Response/Branch.cs
+++ b/Octokit/Models/Response/Branch.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -8,12 +9,14 @@ namespace Octokit
     {
         public Branch() { }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public Branch(string name, GitReference commit, BranchProtection protection)
         {
             Name = name;
             Commit = commit;
             Protection = protection;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Name of this <see cref="Branch"/>.
@@ -24,6 +27,7 @@ namespace Octokit
         /// The <see cref="BranchProtection"/> details for this <see cref="Branch"/>.
         /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
         /// </summary>
+        [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.", false)]
         public BranchProtection Protection { get; protected set; }
 
         /// <summary>

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -12,6 +12,7 @@ namespace Octokit
     /// Note: this is a PREVIEW api: https://developer.github.com/changes/2015-11-11-protected-branches-api/
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
     public class BranchProtection
     {
         public BranchProtection() { }
@@ -42,6 +43,7 @@ namespace Octokit
     }
 
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
     public class RequiredStatusChecks
     {
         public RequiredStatusChecks() { }
@@ -74,6 +76,7 @@ namespace Octokit
     /// <summary>
     /// The enforcement levels that are available
     /// </summary>
+    [Obsolete("BranchProtection preview functionality in the GitHub API has had breaking changes.  This existing implementation will cease to work when the preview period ends.")]
     public enum EnforcementLevel
     {
         /// <summary>


### PR DESCRIPTION
Protected Branches Preview API has had pretty large scale (breaking) changes made (see #1407).  During the preview period both the new and old implementations are available but once preview period ends, support for the older implementation will be removed.

I have started working on the new implementation, but incase that doesn't make the next release this PR will at the very least give some heads up to users of the first preview implementation, that it is not going to be supported by GitHub API at some point in the future