### PR TITLE
Change repository id from int to long

### DIFF
--- a/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<User> GetAllForRepository(int repositoryId);
+        IObservable<User> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">The options to change API's behaviour.</param>
-        IObservable<User> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<User> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.
@@ -51,6 +51,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
-        IObservable<bool> CheckAssignee(int repositoryId, string assignee);
+        IObservable<bool> CheckAssignee(long repositoryId, string assignee);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableBlobsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableBlobsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Blob> Get(int repositoryId, string reference);
+        IObservable<Blob> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a new Blob
@@ -52,6 +52,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob);
+        IObservable<BlobReference> Create(long repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitCommentReactionsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
         /// <returns></returns>
-        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction);
 
         /// <summary>
         /// List reactions for a specified Commit Comment
@@ -48,6 +48,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
-        IObservable<Reaction> GetAll(int repositoryId, int number);
+        IObservable<Reaction> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitStatusClient.cs
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        IObservable<CommitStatus> GetAll(int repositoryId, string reference);
+        IObservable<CommitStatus> GetAll(long repositoryId, string reference);
 
         /// <summary>
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options);
+        IObservable<CommitStatus> GetAll(long repositoryId, string reference, ApiOptions options);
 
         /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
+        IObservable<CombinedCommitStatus> GetCombined(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a commit status for the specified ref.
@@ -84,6 +84,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
+        IObservable<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCommitsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="reference">Tha sha reference of the commit</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<Commit> Get(int repositoryId, string reference);
+        IObservable<Commit> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Create a commit for a given repository
@@ -55,6 +55,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commit">The commit to create</param>
-        IObservable<Commit> Create(int repositoryId, NewCommit commit);
+        IObservable<Commit> Create(long repositoryId, NewCommit commit);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentStatusClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId);
+        IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -57,7 +57,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options);
+        IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -82,6 +82,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        IObservable<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableDeploymentsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/repos/deployments/#list-deployments
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Deployment> GetAll(int repositoryId);
+        IObservable<Deployment> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the deployments for the specified repository. Any user with pull access
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Deployment> GetAll(int repositoryId, ApiOptions options);
+        IObservable<Deployment> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deployment for the specified repository.
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
-        IObservable<Deployment> Create(int repositoryId, NewDeployment newDeployment);
+        IObservable<Deployment> Create(long repositoryId, NewDeployment newDeployment);
 
         /// <summary>
         /// Client for managing deployment status.

--- a/Octokit.Reactive/Clients/IObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableEventsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Activity> GetAllForRepository(int repositoryId);
+        IObservable<Activity> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the events for a given repository
@@ -66,7 +66,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<Activity> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -85,7 +85,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Activity> GetAllIssuesForRepository(int repositoryId);
+        IObservable<Activity> GetAllIssuesForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
+        IObservable<Activity> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentReactionsClient.cs
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction);
 
         /// <summary>
         /// List reactions for a specified Issue Comment
@@ -44,6 +44,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        IObservable<Reaction> GetAll(int repositoryId, int number);
+        IObservable<Reaction> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="id">The issue comment id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<IssueComment> Get(int repositoryId, int id);
+        IObservable<IssueComment> Get(long repositoryId, int id);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<IssueComment> GetAllForRepository(int repositoryId);
+        IObservable<IssueComment> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<IssueComment> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<IssueComment> GetAllForIssue(int repositoryId, int number);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The text of the new comment</param>
-        IObservable<IssueComment> Create(int repositoryId, int number, string newComment);
+        IObservable<IssueComment> Create(long repositoryId, int number, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.
@@ -137,7 +137,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
-        IObservable<IssueComment> Update(int repositoryId, int id, string commentUpdate);
+        IObservable<IssueComment> Update(long repositoryId, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -154,6 +154,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
-        IObservable<Unit> Delete(int repositoryId, int id);
+        IObservable<Unit> Delete(long repositoryId, int id);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>        
-        IObservable<Reaction> GetAll(int repositoryId, int number);
+        IObservable<Reaction> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Creates a reaction for a specified Issue.
@@ -44,6 +44,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(int repositoryId, int number);
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -52,6 +52,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(int repositoryId, int number);
+        IObservable<Issue> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -208,7 +208,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Issue> GetAllForRepository(int repositoryId);
+        IObservable<Issue> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user for the repository.
@@ -229,7 +229,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<Issue> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -250,7 +250,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
+        IObservable<Issue> GetAllForRepository(long repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -273,7 +273,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
+        IObservable<Issue> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -292,7 +292,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        IObservable<Issue> Create(int repositoryId, NewIssue newIssue);
+        IObservable<Issue> Create(long repositoryId, NewIssue newIssue);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -315,7 +315,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -332,7 +332,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Lock(int repositoryId, int number);
+        IObservable<Unit> Lock(long repositoryId, int number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -349,6 +349,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(int repositoryId, int number);
+        IObservable<Unit> Unlock(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<EventInfo> GetAllForIssue(int repositoryId, int number);
+        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<IssueEvent> GetAllForRepository(int repositoryId);
+        IObservable<IssueEvent> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -93,7 +93,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<IssueEvent> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single event
@@ -118,6 +118,6 @@ namespace Octokit.Reactive
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<IssueEvent> Get(int repositoryId, int number);
+        IObservable<IssueEvent> Get(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        IObservable<Label> GetAllForIssue(int repositoryId, int number);
+        IObservable<Label> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        IObservable<Label> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Label> GetAllForRepository(int repositoryId);
+        IObservable<Label> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<Label> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        IObservable<Label> GetAllForMilestone(int repositoryId, int number);
+        IObservable<Label> GetAllForMilestone(long repositoryId, int number);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -138,7 +138,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
+        IObservable<Label> GetAllForMilestone(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -163,7 +163,7 @@ namespace Octokit.Reactive
         /// <param name="labelName">The name of the label</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Label> Get(int repositoryId, string labelName);
+        IObservable<Label> Get(long repositoryId, string labelName);
 
         /// <summary>
         /// Deletes a label.
@@ -184,7 +184,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        IObservable<Unit> Delete(int repositoryId, string labelName);
+        IObservable<Unit> Delete(long repositoryId, string labelName);
 
         /// <summary>
         /// Creates a label.
@@ -205,7 +205,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        IObservable<Label> Create(int repositoryId, NewLabel newLabel);
+        IObservable<Label> Create(long repositoryId, NewLabel newLabel);
 
         /// <summary>
         /// Updates a label.
@@ -228,7 +228,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
+        IObservable<Label> Update(long repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
         /// Adds a label to an issue
@@ -251,7 +251,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels);
+        IObservable<Label> AddToIssue(long repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -274,7 +274,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName);
+        IObservable<Unit> RemoveFromIssue(long repositoryId, int number, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -297,7 +297,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
+        IObservable<Label> ReplaceAllForIssue(long repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -318,6 +318,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number);
+        IObservable<Unit> RemoveAllFromIssue(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMergingClient.cs
@@ -31,6 +31,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        IObservable<Merge> Create(int repositoryId, NewMerge merge);
+        IObservable<Merge> Create(long repositoryId, NewMerge merge);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMilestonesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<Milestone> Get(int repositoryId, int number);
+        IObservable<Milestone> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        IObservable<Milestone> GetAllForRepository(int repositoryId);
+        IObservable<Milestone> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        IObservable<Milestone> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<Milestone> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
-        IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request);
+        IObservable<Milestone> GetAllForRepository(long repositoryId, MilestoneRequest request);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -124,7 +124,7 @@ namespace Octokit.Reactive
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options);
+        IObservable<Milestone> GetAllForRepository(long repositoryId, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create a
@@ -145,7 +145,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
-        IObservable<Milestone> Create(int repositoryId, NewMilestone newMilestone);
+        IObservable<Milestone> Create(long repositoryId, NewMilestone newMilestone);
 
         /// <summary>
         /// Updates a milestone for the specified repository. Any user with pull access to a repository can create a
@@ -170,7 +170,7 @@ namespace Octokit.Reactive
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        IObservable<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate);
+        IObservable<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -191,6 +191,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(int repositoryId, int number);
+        IObservable<Unit> Delete(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableNotificationsClient.cs
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<Notification> GetAllForRepository(int repositoryId);
+        IObservable<Notification> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -57,7 +57,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<Notification> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request);
+        IObservable<Notification> GetAllForRepository(long repositoryId, NotificationsRequest request);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -110,7 +110,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
+        IObservable<Notification> GetAllForRepository(long repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
@@ -138,7 +138,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        IObservable<Unit> MarkAsReadForRepository(int repositoryId);
+        IObservable<Unit> MarkAsReadForRepository(long repositoryId);
 
         /// <summary>
         /// Marks the notifications for a given repository as read.
@@ -155,7 +155,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
+        IObservable<Unit> MarkAsReadForRepository(long repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentReactionsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        IObservable<Reaction> GetAll(int repositoryId, int number);
+        IObservable<Reaction> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
@@ -44,6 +44,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewCommentsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number);
+        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId);
+        IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
+        IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
+        IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets a single pull request review comment by number.
@@ -130,7 +130,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number);
+        IObservable<PullRequestReviewComment> GetComment(long repositoryId, int number);
 
         /// <summary>
         /// Creates a comment on a pull request review.
@@ -149,7 +149,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
+        IObservable<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
@@ -168,7 +168,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
+        IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.
@@ -187,7 +187,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
+        IObservable<PullRequestReviewComment> Edit(long repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
         /// Deletes a comment on a pull request review.
@@ -204,6 +204,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        IObservable<Unit> Delete(int repositoryId, int number);
+        IObservable<Unit> Delete(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -39,7 +39,7 @@ namespace Octokit.Reactive
         /// <param name="number">The number of the pull request</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<PullRequest> Get(int repositoryId, int number);
+        IObservable<PullRequest> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets all open pull requests for the repository.
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<PullRequest> GetAllForRepository(int repositoryId);
+        IObservable<PullRequest> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all open pull requests for the repository.
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<PullRequest> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request);
+        IObservable<PullRequest> GetAllForRepository(long repositoryId, PullRequestRequest request);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -123,7 +123,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
+        IObservable<PullRequest> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a pull request for the specified repository.
@@ -140,7 +140,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
+        IObservable<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
         /// Update a pull request for the specified repository.
@@ -161,7 +161,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+        IObservable<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
         /// Merge a pull request.
@@ -180,7 +180,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
+        IObservable<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Gets the pull request merge status.
@@ -197,7 +197,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<bool> Merged(int repositoryId, int number);
+        IObservable<bool> Merged(long repositoryId, int number);
 
         /// <summary>
         /// Gets the list of commits on a pull request.
@@ -214,7 +214,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<PullRequestCommit> Commits(int repositoryId, int number);
+        IObservable<PullRequestCommit> Commits(long repositoryId, int number);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -231,6 +231,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<PullRequestFile> Files(int repositoryId, int number);
+        IObservable<PullRequestFile> Files(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<Reference> Get(int repositoryId, string reference);
+        IObservable<Reference> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        IObservable<Reference> GetAll(int repositoryId);
+        IObservable<Reference> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        IObservable<Reference> GetAllForSubNamespace(int repositoryId, string subNamespace);
+        IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace);
 
         /// <summary>
         /// Creates a reference for a given repository
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
-        IObservable<Reference> Create(int repositoryId, NewReference reference);
+        IObservable<Reference> Create(long repositoryId, NewReference reference);
 
         /// <summary>
         /// Updates a reference for a given repository by reference name
@@ -129,7 +129,7 @@ namespace Octokit.Reactive
         /// <param name="reference">The name of the reference</param>
         /// <param name="referenceUpdate">The updated reference data</param>
         /// <returns></returns>
-        IObservable<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate);
+        IObservable<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
         /// Deletes a reference for a given repository by reference name
@@ -152,6 +152,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(int repositoryId, string reference);
+        IObservable<Unit> Delete(long repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> GetAll(int repositoryId);
+        IObservable<Release> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all <see cref="Release"/>s for the specified repository.
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> GetAll(int repositoryId, ApiOptions options);
+        IObservable<Release> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
-        IObservable<Release> Get(int repositoryId, int id);
+        IObservable<Release> Get(long repositoryId, int id);
 
         /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> GetLatest(int repositoryId);
+        IObservable<Release> GetLatest(long repositoryId);
 
         /// <summary>
         /// Creates a new <see cref="Release"/> for the specified repository.
@@ -123,7 +123,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Create(int repositoryId, NewRelease data);
+        IObservable<Release> Create(long repositoryId, NewRelease data);
 
         /// <summary>
         /// Edits an existing <see cref="Release"/> for the specified repository.
@@ -148,7 +148,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Release> Edit(int repositoryId, int id, ReleaseUpdate data);
+        IObservable<Release> Edit(long repositoryId, int id, ReleaseUpdate data);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -171,7 +171,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(int repositoryId, int id);
+        IObservable<Unit> Delete(long repositoryId, int id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -194,7 +194,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(int repositoryId, int id);
+        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -219,7 +219,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<ReleaseAsset> GetAllAssets(int repositoryId, int id, ApiOptions options);
+        IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id, ApiOptions options);
 
         /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.
@@ -251,7 +251,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
-        IObservable<ReleaseAsset> GetAsset(int repositoryId, int assetId);
+        IObservable<ReleaseAsset> GetAsset(long repositoryId, int assetId);
 
         /// <summary>
         /// Edits the <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -274,7 +274,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
-        IObservable<ReleaseAsset> EditAsset(int repositoryId, int assetId, ReleaseAssetUpdate data);
+        IObservable<ReleaseAsset> EditAsset(long repositoryId, int assetId, ReleaseAssetUpdate data);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository
@@ -295,6 +295,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        IObservable<Unit> DeleteAsset(int repositoryId, int id);
+        IObservable<Unit> DeleteAsset(long repositoryId, int id);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepoCollaboratorsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<User> GetAll(int repositoryId);
+        IObservable<User> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the collaborators on a repository.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<User> GetAll(int repositoryId, ApiOptions options);
+        IObservable<User> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repository.
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<bool> IsCollaborator(int repositoryId, string user);
+        IObservable<bool> IsCollaborator(long repositoryId, string user);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Add(int repositoryId, string user);
+        IObservable<Unit> Add(long repositoryId, string user);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -124,7 +124,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<bool> Add(int repositoryId, string user, CollaboratorRequest permission);
+        IObservable<bool> Add(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Invites a user as a collaborator to a repository.
@@ -158,7 +158,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<RepositoryInvitation> Invite(int repositoryId, string user);
+        IObservable<RepositoryInvitation> Invite(long repositoryId, string user);
 
         /// <summary>
         /// Invites a user as a collaborator to a repository.
@@ -170,7 +170,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<RepositoryInvitation> Invite(int repositoryId, string user, CollaboratorRequest permission);
+        IObservable<RepositoryInvitation> Invite(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Deletes a collaborator from the repository.
@@ -193,6 +193,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        IObservable<Unit> Delete(int repositoryId, string user);
+        IObservable<Unit> Delete(long repositoryId, string user);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.</remarks>
         /// <returns>An <see cref="IObservable{Unit}"/> for the operation</returns>
-        IObservable<Unit> Delete(int repositoryId);
+        IObservable<Unit> Delete(long repositoryId);
 
         /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>A <see cref="Repository"/></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Repository> Get(int repositoryId);
+        IObservable<Repository> Get(long repositoryId);
 
         /// <summary>
         /// Retrieves every public <see cref="Repository"/>.
@@ -244,7 +244,7 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(int repositoryId);
+        IObservable<Branch> GetAllBranches(long repositoryId);
 
         /// <summary>
         /// Gets all the branches for the specified repository.
@@ -271,7 +271,7 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(int repositoryId, ApiOptions options);
+        IObservable<Branch> GetAllBranches(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -292,7 +292,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All contributors of the repository.</returns>
-        IObservable<RepositoryContributor> GetAllContributors(int repositoryId);
+        IObservable<RepositoryContributor> GetAllContributors(long repositoryId);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -315,7 +315,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, ApiOptions options);
+        IObservable<RepositoryContributor> GetAllContributors(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -338,7 +338,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
-        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous);
+        IObservable<RepositoryContributor> GetAllContributors(long repositoryId, bool includeAnonymous);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -363,7 +363,7 @@ namespace Octokit.Reactive
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options);
+        IObservable<RepositoryContributor> GetAllContributors(long repositoryId, bool includeAnonymous, ApiOptions options);
 
         /// <summary>
         /// Gets all languages for the specified repository.
@@ -384,7 +384,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
-        IObservable<RepositoryLanguage> GetAllLanguages(int repositoryId);
+        IObservable<RepositoryLanguage> GetAllLanguages(long repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -405,7 +405,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        IObservable<Team> GetAllTeams(int repositoryId);
+        IObservable<Team> GetAllTeams(long repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -428,7 +428,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        IObservable<Team> GetAllTeams(int repositoryId, ApiOptions options);
+        IObservable<Team> GetAllTeams(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -449,7 +449,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All of the repositories tags.</returns>
-        IObservable<RepositoryTag> GetAllTags(int repositoryId);
+        IObservable<RepositoryTag> GetAllTags(long repositoryId);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -472,7 +472,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
-        IObservable<RepositoryTag> GetAllTags(int repositoryId, ApiOptions options);
+        IObservable<RepositoryTag> GetAllTags(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -497,7 +497,7 @@ namespace Octokit.Reactive
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.Get() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetBranch(int repositoryId, string branchName);
+        IObservable<Branch> GetBranch(long repositoryId, string branchName);
 
         /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
@@ -514,7 +514,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
-        IObservable<Repository> Edit(int repositoryId, RepositoryUpdate update);
+        IObservable<Repository> Edit(long repositoryId, RepositoryUpdate update);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
@@ -535,7 +535,7 @@ namespace Octokit.Reactive
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use the ObservableRepositoryBranchesClient methods instead.")]
-        IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
+        IObservable<Branch> EditBranch(long repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repo Collaborators.

--- a/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        IObservable<Branch> GetAll(int repositoryId);
+        IObservable<Branch> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the branches for the specified repository.
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Branch> GetAll(int repositoryId, ApiOptions options);
+        IObservable<Branch> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Branch> Get(int repositoryId, string branch);
+        IObservable<Branch> Get(long repositoryId, string branch);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use other ObservableRepositoryBranchesClient methods instead.")]
-        IObservable<Branch> Edit(int repositoryId, string branch, BranchUpdate update);
+        IObservable<Branch> Edit(long repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// Get the branch protection settings for the specified branch />
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        IObservable<BranchProtectionSettings> GetBranchProtection(int repositoryId, string branch);
+        IObservable<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch);
 
         /// <summary>
         /// Update the branch protection settings for the specified branch />
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
-        IObservable<BranchProtectionSettings> UpdateBranchProtection(int repositoryId, string branch, BranchProtectionSettingsUpdate update);
+        IObservable<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update);
 
         /// <summary>
         /// Remove the branch protection settings for the specified branch />
@@ -156,6 +156,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        IObservable<bool> DeleteBranchProtection(int repositoryId, string branch);
+        IObservable<bool> DeleteBranchProtection(long repositoryId, string branch);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<CommitComment> Get(int repositoryId, int number);
+        IObservable<CommitComment> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets Commit Comments for a repository.
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<CommitComment> GetAllForRepository(int repositoryId);
+        IObservable<CommitComment> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets Commit Comments for a repository.
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
-        IObservable<CommitComment> GetAllForRepository(int repositoryId, ApiOptions options);
+        IObservable<CommitComment> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets Commit Comments for a specified Commit.
@@ -80,7 +80,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
-        IObservable<CommitComment> GetAllForCommit(int repositoryId, string sha);
+        IObservable<CommitComment> GetAllForCommit(long repositoryId, string sha);
 
         /// <summary>
         /// Gets Commit Comments for a specified Commit.
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
-        IObservable<CommitComment> GetAllForCommit(int repositoryId, string sha, ApiOptions options);
+        IObservable<CommitComment> GetAllForCommit(long repositoryId, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
-        IObservable<CommitComment> Create(int repositoryId, string sha, NewCommitComment newCommitComment);
+        IObservable<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment);
 
         /// <summary>
         /// Updates a specified Commit Comment.
@@ -137,7 +137,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
-        IObservable<CommitComment> Update(int repositoryId, int number, string commentUpdate);
+        IObservable<CommitComment> Update(long repositoryId, int number, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Commit Comment
@@ -154,6 +154,6 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        IObservable<Unit> Delete(int repositoryId, int number);
+        IObservable<Unit> Delete(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryCommitsClients.cs
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
-        IObservable<CompareResult> Compare(int repositoryId, string @base, string head);
+        IObservable<CompareResult> Compare(long repositoryId, string @base, string head);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="reference">The reference for the commit</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        IObservable<GitHubCommit> Get(int repositoryId, string reference);
+        IObservable<GitHubCommit> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<GitHubCommit> GetAll(int repositoryId);
+        IObservable<GitHubCommit> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options);
+        IObservable<GitHubCommit> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request);
+        IObservable<GitHubCommit> GetAll(long repositoryId, CommitRequest request);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
+        IObservable<GitHubCommit> GetAll(long repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
         /// Get the SHA-1 of a commit reference
@@ -122,6 +122,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
-        IObservable<string> GetSha1(int repositoryId, string reference);
+        IObservable<string> GetSha1(long repositoryId, string reference);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -22,7 +22,7 @@ namespace Octokit.Reactive
         /// Returns the HTML rendered README.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Readme> GetReadme(int repositoryId);
+        IObservable<Readme> GetReadme(long repositoryId);
 
         /// <summary>
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<string> GetReadmeHtml(int repositoryId);
+        IObservable<string> GetReadmeHtml(long repositoryId);
         
         /// <summary>
         /// Get an archive of a given repository's contents
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<byte[]> GetArchive(int repositoryId);
+        IObservable<byte[]> GetArchive(long repositoryId);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
+        IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat);
 
         /// <summary>
         /// Get an archive of a given repository's contents, using a specific format and reference
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
+        IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
+        IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -128,7 +128,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        IObservable<RepositoryContent> GetAllContents(int repositoryId, string path);
+        IObservable<RepositoryContent> GetAllContents(long repositoryId, string path);
 
         /// <summary>
         /// Returns the contents of the root directory in a repository.
@@ -141,7 +141,7 @@ namespace Octokit.Reactive
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<RepositoryContent> GetAllContents(int repositoryId);
+        IObservable<RepositoryContent> GetAllContents(long repositoryId);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -166,7 +166,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path);
+        IObservable<RepositoryContent> GetAllContentsByRef(long repositoryId, string reference, string path);
         
         /// <summary>
         /// Returns the contents of the home directory in a repository.
@@ -181,7 +181,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference);
+        IObservable<RepositoryContent> GetAllContentsByRef(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a commit that creates a new file in a repository.
@@ -198,7 +198,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
+        IObservable<RepositoryContentChangeSet> CreateFile(long repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
         /// Creates a commit that updates the contents of a file in a repository.
@@ -215,7 +215,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
+        IObservable<RepositoryContentChangeSet> UpdateFile(long repositoryId, string path, UpdateFileRequest request);
 
         /// <summary>
         /// Creates a commit that deletes a file in a repository.
@@ -232,6 +232,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request);
+        IObservable<Unit> DeleteFile(long repositoryId, string path, DeleteFileRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryDeployKeysClient.cs
@@ -33,7 +33,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<DeployKey> Get(int repositoryId, int number);
+        IObservable<DeployKey> Get(long repositoryId, int number);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        IObservable<DeployKey> GetAll(int repositoryId);
+        IObservable<DeployKey> GetAll(long repositoryId);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options);
+        IObservable<DeployKey> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deploy key for a repository.
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
+        IObservable<DeployKey> Create(long repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>
         /// Deletes a deploy key from a repository.
@@ -115,6 +115,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        IObservable<Unit> Delete(int repositoryId, int number);
+        IObservable<Unit> Delete(long repositoryId, int number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryForksClient.cs
@@ -27,7 +27,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Repository> GetAll(int repositoryId);
+        IObservable<Repository> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Repository> GetAll(int repositoryId, ApiOptions options);
+        IObservable<Repository> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request);
+        IObservable<Repository> GetAll(long repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -92,7 +92,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
+        IObservable<Repository> GetAll(long repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
@@ -113,6 +113,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork);
+        IObservable<Repository> Create(long repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryHooksClient.cs
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        IObservable<RepositoryHook> GetAll(int repositoryId);
+        IObservable<RepositoryHook> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options);
+        IObservable<RepositoryHook> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keyworks")]
-        IObservable<RepositoryHook> Get(int repositoryId, int hookId);
+        IObservable<RepositoryHook> Get(long repositoryId, int hookId);
 
         /// <summary>
         /// Creates a hook for a repository
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
+        IObservable<RepositoryHook> Create(long repositoryId, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
@@ -97,7 +97,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
+        IObservable<RepositoryHook> Edit(long repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        IObservable<Unit> Test(int repositoryId, int hookId);
+        IObservable<Unit> Test(long repositoryId, int hookId);
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        IObservable<Unit> Ping(int repositoryId, int hookId);
+        IObservable<Unit> Ping(long repositoryId, int hookId);
 
         /// <summary>
         /// Deletes a hook for a repository
@@ -152,6 +152,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        IObservable<Unit> Delete(int repositoryId, int hookId);
+        IObservable<Unit> Delete(long repositoryId, int hookId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="invitationId">The id of the invitation.</param>        
-        IObservable<bool> Delete(int repositoryId, int invitationId);
+        IObservable<bool> Delete(long repositoryId, int invitationId);
 
         /// <summary>
         /// Gets all invitations for the current user.
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>         
-        IObservable<RepositoryInvitation> GetAllForRepository(int repositoryId);
+        IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Updates a repository invitation.
@@ -62,6 +62,6 @@ namespace Octokit.Reactive
         /// <param name="invitationId">The id of the invitation.</param>   
         /// <param name="permissions">The permission to set.</param>
         /// <returns><see cref="RepositoryInvitation"/></returns>
-        IObservable<RepositoryInvitation> Edit(int repositoryId, int invitationId, InvitationUpdate permissions);
+        IObservable<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryPagesClient.cs
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<Page> Get(int repositoryId);
+        IObservable<Page> Get(long repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        IObservable<PagesBuild> GetAll(int repositoryId);
+        IObservable<PagesBuild> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options);
+        IObservable<PagesBuild> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        IObservable<PagesBuild> GetLatest(int repositoryId);
+        IObservable<PagesBuild> GetLatest(long repositoryId);
 
         /// <summary>
         /// Requests your site be built from the latest revision on the default branch for a given repository
@@ -108,6 +108,6 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
-        IObservable<PagesBuild> RequestPageBuild(int repositoryId);
+        IObservable<PagesBuild> RequestPageBuild(long repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStarredClient.cs
@@ -23,7 +23,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        IObservable<User> GetAllStargazers(int repositoryId);
+        IObservable<User> GetAllStargazers(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options);
+        IObservable<User> GetAllStargazers(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId);
+        IObservable<UserStar> GetAllStargazersWithTimestamps(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
+        IObservable<UserStar> GetAllStargazersWithTimestamps(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user

--- a/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
@@ -22,7 +22,7 @@ namespace Octokit.Reactive
         /// Returns a list of <see cref="Contributor"/> for the given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<IEnumerable<Contributor>> GetContributors(int repositoryId);
+        IObservable<IEnumerable<Contributor>> GetContributors(long repositoryId);
 
         /// <summary>
         /// Returns the last year of commit activity grouped by week.
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         /// Returns the last year of commit activity grouped by week.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<CommitActivity> GetCommitActivity(int repositoryId);
+        IObservable<CommitActivity> GetCommitActivity(long repositoryId);
 
         /// <summary>
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<CodeFrequency> GetCodeFrequency(int repositoryId);
+        IObservable<CodeFrequency> GetCodeFrequency(long repositoryId);
 
         /// <summary>
         /// Returns the total commit counts for the owner and total commit counts in total. 
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         /// Returns the total commit counts for the owner and total commit counts in total. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<Participation> GetParticipation(int repositoryId);
+        IObservable<Participation> GetParticipation(long repositoryId);
 
         /// <summary>
         /// Returns a list of the number of commits per hour in each day
@@ -74,6 +74,6 @@ namespace Octokit.Reactive
         /// Returns a list of the number of commits per hour in each day
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        IObservable<PunchCard> GetPunchCard(int repositoryId);
+        IObservable<PunchCard> GetPunchCard(long repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTagsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="reference">Tha sha reference of the tag</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<GitTag> Get(int repositoryId, string reference);
+        IObservable<GitTag> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Create a tag for a given repository
@@ -55,6 +55,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag to create</param>
-        IObservable<GitTag> Create(int repositoryId, NewTag tag);
+        IObservable<GitTag> Create(long repositoryId, NewTag tag);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableTreesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTreesClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        IObservable<TreeResponse> Get(int repositoryId, string reference);
+        IObservable<TreeResponse> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets a Tree Response for a given SHA.
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        IObservable<TreeResponse> GetRecursive(int repositoryId, string reference);
+        IObservable<TreeResponse> GetRecursive(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a new Tree in the specified repo
@@ -73,6 +73,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
-        IObservable<TreeResponse> Create(int repositoryId, NewTree newTree);
+        IObservable<TreeResponse> Create(long repositoryId, NewTree newTree);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/IObservableWatchedClient.cs
@@ -24,7 +24,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        IObservable<User> GetAllWatchers(int repositoryId);
+        IObservable<User> GetAllWatchers(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the watchers for the passed repository
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options);
+        IObservable<User> GetAllWatchers(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user
@@ -85,7 +85,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        IObservable<bool> CheckWatched(int repositoryId);
+        IObservable<bool> CheckWatched(long repositoryId);
 
         /// <summary>
         /// Stars a repository for the authenticated user.
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
+        IObservable<Subscription> WatchRepo(long repositoryId, NewSubscription newSubscription);
 
         /// <summary>
         /// Unstars a repository for the authenticated user.
@@ -117,6 +117,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
-        IObservable<bool> UnwatchRepo(int repositoryId);
+        IObservable<bool> UnwatchRepo(long repositoryId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -40,7 +40,7 @@ namespace Octokit.Reactive
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<User> GetAllForRepository(int repositoryId)
+        public IObservable<User> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">The options to change API's behaviour.</param>
-        public IObservable<User> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<User> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -92,7 +92,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
-        public IObservable<bool> CheckAssignee(int repositoryId, string assignee)
+        public IObservable<bool> CheckAssignee(long repositoryId, string assignee)
         {
             Ensure.ArgumentNotNullOrEmptyString(assignee, "assignee");
 

--- a/Octokit.Reactive/Clients/ObservableBlobClient.cs
+++ b/Octokit.Reactive/Clients/ObservableBlobClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        public IObservable<Blob> Get(int repositoryId, string reference)
+        public IObservable<Blob> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        public IObservable<BlobReference> Create(int repositoryId, NewBlob newBlob)
+        public IObservable<BlobReference> Create(long repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");
 

--- a/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitCommentReactionsClient.cs
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
         /// <returns></returns>
-        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
-        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }

--- a/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitStatusClient.cs
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        public IObservable<CommitStatus> GetAll(int repositoryId, string reference)
+        public IObservable<CommitStatus> GetAll(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<CommitStatus> GetAll(int repositoryId, string reference, ApiOptions options)
+        public IObservable<CommitStatus> GetAll(long repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(options, "options");
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// <remarks>Only users with pull access can see this.</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        public IObservable<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
+        public IObservable<CombinedCommitStatus> GetCombined(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -143,7 +143,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        public IObservable<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
+        public IObservable<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");

--- a/Octokit.Reactive/Clients/ObservableCommitsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCommitsClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        public IObservable<Commit> Get(int repositoryId, string reference)
+        public IObservable<Commit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commit">The commit to create</param>
-        public IObservable<Commit> Create(int repositoryId, NewCommit commit)
+        public IObservable<Commit> Create(long repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");
 

--- a/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentStatusClient.cs
@@ -51,7 +51,7 @@ namespace Octokit.Reactive.Clients
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId)
+        public IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
         }
@@ -87,7 +87,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<DeploymentStatus> GetAll(int repositoryId, int deploymentId, ApiOptions options)
+        public IObservable<DeploymentStatus> GetAll(long repositoryId, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -125,7 +125,7 @@ namespace Octokit.Reactive.Clients
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        public IObservable<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public IObservable<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
 

--- a/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableDeploymentsClient.cs
@@ -51,7 +51,7 @@ namespace Octokit.Reactive.Clients
         /// http://developer.github.com/v3/repos/deployments/#list-deployments
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Deployment> GetAll(int repositoryId)
+        public IObservable<Deployment> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -85,7 +85,7 @@ namespace Octokit.Reactive.Clients
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Deployment> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<Deployment> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -119,7 +119,7 @@ namespace Octokit.Reactive.Clients
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
-        public IObservable<Deployment> Create(int repositoryId, NewDeployment newDeployment)
+        public IObservable<Deployment> Create(long repositoryId, NewDeployment newDeployment)
         {
             Ensure.ArgumentNotNull(newDeployment, "newDeployment");
 

--- a/Octokit.Reactive/Clients/ObservableEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableEventsClient.cs
@@ -68,7 +68,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Activity> GetAllForRepository(int repositoryId)
+        public IObservable<Activity> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -99,7 +99,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Activity> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Activity> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -129,7 +129,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Activity> GetAllIssuesForRepository(int repositoryId)
+        public IObservable<Activity> GetAllIssuesForRepository(long repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
         }
@@ -160,7 +160,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Activity> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Activity> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create </param>
-        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The issue comment id</param>
-        public IObservable<IssueComment> Get(int repositoryId, int id)
+        public IObservable<IssueComment> Get(long repositoryId, int id)
         {
             return _client.Get(repositoryId, id).ToObservable();
         }
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<IssueComment> GetAllForRepository(int repositoryId)
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -124,7 +124,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<IssueComment> GetAllForIssue(int repositoryId, int number)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -153,7 +153,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -184,7 +184,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The text of the new comment</param>
-        public IObservable<IssueComment> Create(int repositoryId, int number, string newComment)
+        public IObservable<IssueComment> Create(long repositoryId, int number, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, "newComment");
 
@@ -215,7 +215,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
-        public IObservable<IssueComment> Update(int repositoryId, int id, string commentUpdate)
+        public IObservable<IssueComment> Update(long repositoryId, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
@@ -243,7 +243,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
-        public IObservable<Unit> Delete(int repositoryId, int id)
+        public IObservable<Unit> Delete(long repositoryId, int id)
         {
             return _client.Delete(repositoryId, id).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>        
-        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create </param>
-        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 

--- a/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(int repositoryId, int number)
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Issue> Get(int repositoryId, int number)
+        public IObservable<Issue> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -299,7 +299,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Issue> GetAllForRepository(int repositoryId)
+        public IObservable<Issue> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -330,7 +330,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Issue> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Issue> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -363,7 +363,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
+        public IObservable<Issue> GetAllForRepository(long repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -399,7 +399,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Issue> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
+        public IObservable<Issue> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -431,7 +431,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        public IObservable<Issue> Create(int repositoryId, NewIssue newIssue)
+        public IObservable<Issue> Create(long repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
 
@@ -466,7 +466,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
 
@@ -494,7 +494,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Lock(int repositoryId, int number)
+        public IObservable<Unit> Lock(long repositoryId, int number)
         {
             return _client.Lock(repositoryId, number).ToObservable();
         }
@@ -520,7 +520,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(int repositoryId, int number)
+        public IObservable<Unit> Unlock(long repositoryId, int number)
         {
             return _client.Unlock(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number)
+        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<EventInfo> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<IssueEvent> GetAllForRepository(int repositoryId)
+        public IObservable<IssueEvent> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -142,7 +142,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueEvent> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The event id</param>
-        public IObservable<IssueEvent> Get(int repositoryId, int number)
+        public IObservable<IssueEvent> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        public IObservable<Label> GetAllForIssue(int repositoryId, int number)
+        public IObservable<Label> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -83,7 +83,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public IObservable<Label> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Label> GetAllForRepository(int repositoryId)
+        public IObservable<Label> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Label> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -176,7 +176,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        public IObservable<Label> GetAllForMilestone(int repositoryId, int number)
+        public IObservable<Label> GetAllForMilestone(long repositoryId, int number)
         {
             return GetAllForMilestone(repositoryId, number, ApiOptions.None);
         }
@@ -209,7 +209,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
+        public IObservable<Label> GetAllForMilestone(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -242,7 +242,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        public IObservable<Label> Get(int repositoryId, string labelName)
+        public IObservable<Label> Get(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -275,7 +275,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        public IObservable<Unit> Delete(int repositoryId, string labelName)
+        public IObservable<Unit> Delete(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -308,7 +308,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        public IObservable<Label> Create(int repositoryId, NewLabel newLabel)
+        public IObservable<Label> Create(long repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
 
@@ -344,7 +344,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        public IObservable<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
+        public IObservable<Label> Update(long repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
             Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
@@ -382,7 +382,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        public IObservable<Label> AddToIssue(int repositoryId, int number, string[] labels)
+        public IObservable<Label> AddToIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
 
@@ -419,7 +419,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public IObservable<Unit> RemoveFromIssue(int repositoryId, int number, string labelName)
+        public IObservable<Unit> RemoveFromIssue(long repositoryId, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -456,7 +456,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        public IObservable<Label> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
 
@@ -490,7 +490,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        public IObservable<Unit> RemoveAllFromIssue(int repositoryId, int number)
+        public IObservable<Unit> RemoveAllFromIssue(long repositoryId, int number)
         {
             return _client.RemoveAllFromIssue(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableMergingClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMergingClient.cs
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        public IObservable<Merge> Create(int repositoryId, NewMerge merge)
+        public IObservable<Merge> Create(long repositoryId, NewMerge merge)
         {
             Ensure.ArgumentNotNull(merge, "merge");
 

--- a/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMilestonesClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
-        public IObservable<Milestone> Get(int repositoryId, int number)
+        public IObservable<Milestone> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        public IObservable<Milestone> GetAllForRepository(int repositoryId)
+        public IObservable<Milestone> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -109,7 +109,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        public IObservable<Milestone> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Milestone> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
-        public IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request)
+        public IObservable<Milestone> GetAllForRepository(long repositoryId, MilestoneRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -183,7 +183,7 @@ namespace Octokit.Reactive
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        public IObservable<Milestone> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options)
+        public IObservable<Milestone> GetAllForRepository(long repositoryId, MilestoneRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -218,7 +218,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
-        public IObservable<Milestone> Create(int repositoryId, NewMilestone newMilestone)
+        public IObservable<Milestone> Create(long repositoryId, NewMilestone newMilestone)
         {
             Ensure.ArgumentNotNull(newMilestone, "newMilestone");
 
@@ -255,7 +255,7 @@ namespace Octokit.Reactive
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        public IObservable<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        public IObservable<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNull(milestoneUpdate, "milestoneUpdate");
 
@@ -287,7 +287,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(int repositoryId, int number)
+        public IObservable<Unit> Delete(long repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableNotificationsClient.cs
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<Notification> GetAllForRepository(int repositoryId)
+        public IObservable<Notification> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -91,7 +91,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<Notification> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<Notification> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -146,7 +146,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request)
+        public IObservable<Notification> GetAllForRepository(long repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -178,7 +178,7 @@ namespace Octokit.Reactive
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<Notification> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
+        public IObservable<Notification> GetAllForRepository(long repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -226,7 +226,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        public IObservable<Unit> MarkAsReadForRepository(int repositoryId)
+        public IObservable<Unit> MarkAsReadForRepository(long repositoryId)
         {
             return _notificationsClient.MarkAsReadForRepository(repositoryId).ToObservable();
         }
@@ -253,7 +253,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        public IObservable<Unit> MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
+        public IObservable<Unit> MarkAsReadForRepository(long repositoryId, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
 

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        public IObservable<Reaction> GetAll(int repositoryId, int number)
+        public IObservable<Reaction> GetAll(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        public IObservable<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number)
+        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
         }
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAll(int repositoryId, int number, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId)
+        public IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
         }
@@ -127,7 +127,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -156,7 +156,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
+        public IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -189,7 +189,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequestReviewComment> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
+        public IObservable<PullRequestReviewComment> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -222,7 +222,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        public IObservable<PullRequestReviewComment> GetComment(int repositoryId, int number)
+        public IObservable<PullRequestReviewComment> GetComment(long repositoryId, int number)
         {
             return _client.GetComment(repositoryId, number).ToObservable();
         }
@@ -251,7 +251,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
+        public IObservable<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -282,7 +282,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public IObservable<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
+        public IObservable<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -313,7 +313,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        public IObservable<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
+        public IObservable<PullRequestReviewComment> Edit(long repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -341,7 +341,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        public IObservable<Unit> Delete(int repositoryId, int number)
+        public IObservable<Unit> Delete(long repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestsClient.cs
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the pull request</param>
-        public IObservable<PullRequest> Get(int repositoryId, int number)
+        public IObservable<PullRequest> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<PullRequest> GetAllForRepository(int repositoryId)
+        public IObservable<PullRequest> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -110,7 +110,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequest> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<PullRequest> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -143,7 +143,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request)
+        public IObservable<PullRequest> GetAllForRepository(long repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -180,7 +180,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<PullRequest> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
+        public IObservable<PullRequest> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -211,7 +211,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        public IObservable<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
+        public IObservable<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
 
@@ -244,7 +244,7 @@ namespace Octokit.Reactive
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        public IObservable<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        public IObservable<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
 
@@ -275,7 +275,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        public IObservable<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
+        public IObservable<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
 
@@ -303,7 +303,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<bool> Merged(int repositoryId, int number)
+        public IObservable<bool> Merged(long repositoryId, int number)
         {
             return _client.Merged(repositoryId, number).ToObservable();
         }
@@ -329,7 +329,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestCommit> Commits(int repositoryId, int number)
+        public IObservable<PullRequestCommit> Commits(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
         }
@@ -355,7 +355,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<PullRequestFile> Files(int repositoryId, int number)
+        public IObservable<PullRequestFile> Files(long repositoryId, int number)
         {
             return _connection.GetAndFlattenAllPages<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
         }

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -52,7 +52,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public IObservable<Reference> Get(int repositoryId, string reference)
+        public IObservable<Reference> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -84,7 +84,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        public IObservable<Reference> GetAll(int repositoryId)
+        public IObservable<Reference> GetAll(long repositoryId)
         {
             return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId));
         }
@@ -117,7 +117,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        public IObservable<Reference> GetAllForSubNamespace(int repositoryId, string subNamespace)
+        public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
 
@@ -152,7 +152,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
-        public IObservable<Reference> Create(int repositoryId, NewReference reference)
+        public IObservable<Reference> Create(long repositoryId, NewReference reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
 
@@ -190,7 +190,7 @@ namespace Octokit.Reactive
         /// <param name="reference">The name of the reference</param>
         /// <param name="referenceUpdate">The updated reference data</param>
         /// <returns></returns>
-        public IObservable<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate)
+        public IObservable<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(referenceUpdate, "update");
@@ -226,7 +226,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(int repositoryId, string reference)
+        public IObservable<Unit> Delete(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> GetAll(int repositoryId)
+        public IObservable<Release> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<Release> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -116,7 +116,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Get(int repositoryId, int id)
+        public IObservable<Release> Get(long repositoryId, int id)
         {
             return _client.Get(repositoryId, id).ToObservable();
         }
@@ -146,7 +146,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> GetLatest(int repositoryId)
+        public IObservable<Release> GetLatest(long repositoryId)
         {
             return _client.GetLatest(repositoryId).ToObservable();
         }
@@ -179,7 +179,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Create(int repositoryId, NewRelease data)
+        public IObservable<Release> Create(long repositoryId, NewRelease data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -216,7 +216,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Release> Edit(int repositoryId, int id, ReleaseUpdate data)
+        public IObservable<Release> Edit(long repositoryId, int id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -250,7 +250,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(int repositoryId, int id)
+        public IObservable<Unit> Delete(long repositoryId, int id)
         {
             return _client.Delete(repositoryId, id).ToObservable();
         }
@@ -282,7 +282,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(int repositoryId, int id)
+        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id)
         {
             return GetAllAssets(repositoryId, id, ApiOptions.None);
         }
@@ -317,7 +317,7 @@ namespace Octokit.Reactive
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<ReleaseAsset> GetAllAssets(int repositoryId, int id, ApiOptions options)
+        public IObservable<ReleaseAsset> GetAllAssets(long repositoryId, int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -350,7 +350,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
-        public IObservable<ReleaseAsset> GetAsset(int repositoryId, int assetId)
+        public IObservable<ReleaseAsset> GetAsset(long repositoryId, int assetId)
         {
             Ensure.ArgumentNotNull(assetId, "assetId");
 
@@ -402,7 +402,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
-        public IObservable<ReleaseAsset> EditAsset(int repositoryId, int assetId, ReleaseAssetUpdate data)
+        public IObservable<ReleaseAsset> EditAsset(long repositoryId, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -434,7 +434,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        public IObservable<Unit> DeleteAsset(int repositoryId, int id)
+        public IObservable<Unit> DeleteAsset(long repositoryId, int id)
         {
             return _client.DeleteAsset(repositoryId, id).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepoCollaboratorsClient.cs
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<User> GetAll(int repositoryId)
+        public IObservable<User> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<User> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<User> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -121,7 +121,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<bool> IsCollaborator(int repositoryId, string user)
+        public IObservable<bool> IsCollaborator(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -177,7 +177,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Add(int repositoryId, string user)
+        public IObservable<Unit> Add(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -194,7 +194,7 @@ namespace Octokit.Reactive
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<bool> Add(int repositoryId, string user, CollaboratorRequest permission)
+        public IObservable<bool> Add(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(permission, "permission");
@@ -249,7 +249,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">The username of the prospective collaborator</param>
 
-        public IObservable<RepositoryInvitation> Invite(int repositoryId, string user)
+        public IObservable<RepositoryInvitation> Invite(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -265,7 +265,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">The username of the prospective collaborator</param>   
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
-        public IObservable<RepositoryInvitation> Invite(int repositoryId, string user, CollaboratorRequest permission)
+        public IObservable<RepositoryInvitation> Invite(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(permission, "psermission");
@@ -301,7 +301,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public IObservable<Unit> Delete(int repositoryId, string user)
+        public IObservable<Unit> Delete(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>Deleting a repository requires admin access. If OAuth is used, the `delete_repo` scope is required.</remarks>
         /// <returns>An <see cref="IObservable{Unit}"/> for the operation</returns>
-        public IObservable<Unit> Delete(int repositoryId)
+        public IObservable<Unit> Delete(long repositoryId)
         {
             return _client.Delete(repositoryId).ToObservable();
         }
@@ -113,7 +113,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>A <see cref="Repository"/></returns>
-        public IObservable<Repository> Get(int repositoryId)
+        public IObservable<Repository> Get(long repositoryId)
         {
             return _client.Get(repositoryId).ToObservable();
         }
@@ -350,7 +350,7 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(int repositoryId)
+        public IObservable<Branch> GetAllBranches(long repositoryId)
         {
             return Branch.GetAll(repositoryId, ApiOptions.None);
         }
@@ -387,7 +387,7 @@ namespace Octokit.Reactive
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(int repositoryId, ApiOptions options)
+        public IObservable<Branch> GetAllBranches(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -419,7 +419,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All contributors of the repository.</returns>
-        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId)
+        public IObservable<RepositoryContributor> GetAllContributors(long repositoryId)
         {
             return GetAllContributors(repositoryId, ApiOptions.None);
         }
@@ -452,7 +452,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, ApiOptions options)
+        public IObservable<RepositoryContributor> GetAllContributors(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -486,7 +486,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
-        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous)
+        public IObservable<RepositoryContributor> GetAllContributors(long repositoryId, bool includeAnonymous)
         {
             return GetAllContributors(repositoryId, includeAnonymous, ApiOptions.None);
         }
@@ -526,7 +526,7 @@ namespace Octokit.Reactive
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        public IObservable<RepositoryContributor> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options)
+        public IObservable<RepositoryContributor> GetAllContributors(long repositoryId, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -566,7 +566,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
-        public IObservable<RepositoryLanguage> GetAllLanguages(int repositoryId)
+        public IObservable<RepositoryLanguage> GetAllLanguages(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryLanguages(repositoryId);
             return _connection
@@ -599,7 +599,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        public IObservable<Team> GetAllTeams(int repositoryId)
+        public IObservable<Team> GetAllTeams(long repositoryId)
         {
             return GetAllTeams(repositoryId, ApiOptions.None);
         }
@@ -632,7 +632,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        public IObservable<Team> GetAllTeams(int repositoryId, ApiOptions options)
+        public IObservable<Team> GetAllTeams(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -664,7 +664,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All of the repositories tags.</returns>
-        public IObservable<RepositoryTag> GetAllTags(int repositoryId)
+        public IObservable<RepositoryTag> GetAllTags(long repositoryId)
         {
             return GetAllTags(repositoryId, ApiOptions.None);
         }
@@ -697,7 +697,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
-        public IObservable<RepositoryTag> GetAllTags(int repositoryId, ApiOptions options)
+        public IObservable<RepositoryTag> GetAllTags(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -734,7 +734,7 @@ namespace Octokit.Reactive
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("Please use ObservableRepositoriesClient.Branch.Get() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetBranch(int repositoryId, string branchName)
+        public IObservable<Branch> GetBranch(long repositoryId, string branchName)
         {
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
 
@@ -763,7 +763,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
-        public IObservable<Repository> Edit(int repositoryId, RepositoryUpdate update)
+        public IObservable<Repository> Edit(long repositoryId, RepositoryUpdate update)
         {
             Ensure.ArgumentNotNull(update, "update");
 
@@ -797,7 +797,7 @@ namespace Octokit.Reactive
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use the ObservableRepositoryBranchesClient methods instead.")]
-        public IObservable<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
+        public IObservable<Branch> EditBranch(long repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");

--- a/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        public IObservable<Branch> GetAll(int repositoryId)
+        public IObservable<Branch> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Branch> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<Branch> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -108,7 +108,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        public IObservable<Branch> Get(int repositoryId, string branch)
+        public IObservable<Branch> Get(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
@@ -140,7 +140,7 @@ namespace Octokit.Reactive
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use other ObservableRepositoryBranchesClient methods instead.")]
-        public IObservable<Branch> Edit(int repositoryId, string branch, BranchUpdate update)
+        public IObservable<Branch> Edit(long repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public IObservable<BranchProtectionSettings> GetBranchProtection(int repositoryId, string branch)
+        public IObservable<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
@@ -210,7 +210,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
-        public IObservable<BranchProtectionSettings> UpdateBranchProtection(int repositoryId, string branch, BranchProtectionSettingsUpdate update)
+        public IObservable<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
@@ -244,7 +244,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public IObservable<bool> DeleteBranchProtection(int repositoryId, string branch)
+        public IObservable<bool> DeleteBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommentsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
-        public IObservable<CommitComment> Get(int repositoryId, int number)
+        public IObservable<CommitComment> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
-        public IObservable<CommitComment> GetAllForRepository(int repositoryId)
+        public IObservable<CommitComment> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -96,7 +96,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
-        public IObservable<CommitComment> GetAllForRepository(int repositoryId, ApiOptions options)
+        public IObservable<CommitComment> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -125,7 +125,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        public IObservable<CommitComment> GetAllForCommit(int repositoryId, string sha)
+        public IObservable<CommitComment> GetAllForCommit(long repositoryId, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
@@ -157,7 +157,7 @@ namespace Octokit.Reactive
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        public IObservable<CommitComment> GetAllForCommit(int repositoryId, string sha, ApiOptions options)
+        public IObservable<CommitComment> GetAllForCommit(long repositoryId, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
             Ensure.ArgumentNotNull(options, "options");
@@ -190,7 +190,7 @@ namespace Octokit.Reactive
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
-        public IObservable<CommitComment> Create(int repositoryId, string sha, NewCommitComment newCommitComment)
+        public IObservable<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
             Ensure.ArgumentNotNull(newCommitComment, "newCommitComment");
@@ -222,7 +222,7 @@ namespace Octokit.Reactive
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#update-a-commit-comment</remarks>
-        public IObservable<CommitComment> Update(int repositoryId, int number, string commentUpdate)
+        public IObservable<CommitComment> Update(long repositoryId, int number, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
@@ -250,7 +250,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
-        public IObservable<Unit> Delete(int repositoryId, int number)
+        public IObservable<Unit> Delete(long repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryCommitsClients.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        public IObservable<CompareResult> Compare(int repositoryId, string @base, string head)
+        public IObservable<CompareResult> Compare(long repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
             Ensure.ArgumentNotNullOrEmptyString(head, "head");
@@ -74,7 +74,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference for the commit</param>
-        public IObservable<GitHubCommit> Get(int repositoryId, string reference)
+        public IObservable<GitHubCommit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -98,7 +98,7 @@ namespace Octokit.Reactive
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<GitHubCommit> GetAll(int repositoryId)
+        public IObservable<GitHubCommit> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
         }
@@ -123,7 +123,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<GitHubCommit> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<GitHubCommit> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -150,7 +150,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request)
+        public IObservable<GitHubCommit> GetAll(long repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -180,7 +180,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<GitHubCommit> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
+        public IObservable<GitHubCommit> GetAll(long repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -208,7 +208,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
-        public IObservable<string> GetSha1(int repositoryId, string reference)
+        public IObservable<string> GetSha1(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// Returns the HTML rendered README.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Readme> GetReadme(int repositoryId)
+        public IObservable<Readme> GetReadme(long repositoryId)
         {
             return _client.Repository.Content.GetReadme(repositoryId).ToObservable();
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// Returns just the HTML portion of the README without the surrounding HTML document. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<string> GetReadmeHtml(int repositoryId)
+        public IObservable<string> GetReadmeHtml(long repositoryId)
         {
             return _client.Repository.Content.GetReadmeHtml(repositoryId).ToObservable();
         }
@@ -89,7 +89,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<byte[]> GetArchive(int repositoryId)
+        public IObservable<byte[]> GetArchive(long repositoryId)
         {
             return GetArchive(repositoryId, ArchiveFormat.Tarball);
         }
@@ -115,7 +115,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
+        public IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat)
         {
             return GetArchive(repositoryId, archiveFormat, string.Empty);
         }
@@ -144,7 +144,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
+        public IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
 
@@ -178,7 +178,7 @@ namespace Octokit.Reactive
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        public IObservable<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        public IObservable<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.GreaterThanZero(timeout, "timeout");
             Ensure.ArgumentNotNull(reference, "reference");
@@ -214,7 +214,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        public IObservable<RepositoryContent> GetAllContents(int repositoryId, string path)
+        public IObservable<RepositoryContent> GetAllContents(long repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
@@ -242,7 +242,7 @@ namespace Octokit.Reactive
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<RepositoryContent> GetAllContents(int repositoryId)
+        public IObservable<RepositoryContent> GetAllContents(long repositoryId)
         {
             return _client
                 .Connection
@@ -280,7 +280,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
-        public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference, string path)
+        public IObservable<RepositoryContent> GetAllContentsByRef(long repositoryId, string reference, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
@@ -308,7 +308,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        public IObservable<RepositoryContent> GetAllContentsByRef(int repositoryId, string reference)
+        public IObservable<RepositoryContent> GetAllContentsByRef(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -338,7 +338,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        public IObservable<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
+        public IObservable<RepositoryContentChangeSet> CreateFile(long repositoryId, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");
@@ -369,7 +369,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        public IObservable<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
+        public IObservable<RepositoryContentChangeSet> UpdateFile(long repositoryId, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");
@@ -400,7 +400,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        public IObservable<Unit> DeleteFile(int repositoryId, string path, DeleteFileRequest request)
+        public IObservable<Unit> DeleteFile(long repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");

--- a/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryDeployKeysClient.cs
@@ -49,7 +49,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        public IObservable<DeployKey> Get(int repositoryId, int number)
+        public IObservable<DeployKey> Get(long repositoryId, int number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        public IObservable<DeployKey> GetAll(int repositoryId)
+        public IObservable<DeployKey> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -108,7 +108,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<DeployKey> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<DeployKey> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -148,7 +148,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        public IObservable<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
+        public IObservable<DeployKey> Create(long repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
 
@@ -187,7 +187,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        public IObservable<Unit> Delete(int repositoryId, int number)
+        public IObservable<Unit> Delete(long repositoryId, int number)
         {
             return _client.Delete(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryForksClient.cs
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Repository> GetAll(int repositoryId)
+        public IObservable<Repository> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Repository> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<Repository> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -114,7 +114,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request)
+        public IObservable<Repository> GetAll(long repositoryId, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -150,7 +150,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Repository> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
+        public IObservable<Repository> GetAll(long repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -184,7 +184,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        public IObservable<Repository> Create(int repositoryId, NewRepositoryFork fork)
+        public IObservable<Repository> Create(long repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");
 

--- a/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryHooksClient.cs
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        public IObservable<RepositoryHook> GetAll(int repositoryId)
+        public IObservable<RepositoryHook> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -70,7 +70,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        public IObservable<RepositoryHook> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<RepositoryHook> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -98,7 +98,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        public IObservable<RepositoryHook> Get(int repositoryId, int hookId)
+        public IObservable<RepositoryHook> Get(long repositoryId, int hookId)
         {
             return _client.Get(repositoryId, hookId).ToObservable();
         }
@@ -125,7 +125,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        public IObservable<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
+        public IObservable<RepositoryHook> Create(long repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
 
@@ -156,7 +156,7 @@ namespace Octokit.Reactive
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        public IObservable<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
+        public IObservable<RepositoryHook> Edit(long repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
 
@@ -188,7 +188,7 @@ namespace Octokit.Reactive
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        public IObservable<Unit> Test(int repositoryId, int hookId)
+        public IObservable<Unit> Test(long repositoryId, int hookId)
         {
             return _client.Test(repositoryId, hookId).ToObservable();
         }
@@ -214,7 +214,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        public IObservable<Unit> Ping(int repositoryId, int hookId)
+        public IObservable<Unit> Ping(long repositoryId, int hookId)
         {
             return _client.Ping(repositoryId, hookId).ToObservable();
         }
@@ -240,7 +240,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        public IObservable<Unit> Delete(int repositoryId, int hookId)
+        public IObservable<Unit> Delete(long repositoryId, int hookId)
         {
             return _client.Delete(repositoryId, hookId).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
@@ -51,7 +51,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="invitationId">The id of the invitation.</param>        
-        public IObservable<bool> Delete(int repositoryId, int invitationId)
+        public IObservable<bool> Delete(long repositoryId, int invitationId)
         {
             return _client.Delete(repositoryId, invitationId).ToObservable();
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="invitationId">The id of the invitatio.n</param>   
         /// <param name="permissions">The permission to set.</param>
-        public IObservable<RepositoryInvitation> Edit(int repositoryId, int invitationId, InvitationUpdate permissions)
+        public IObservable<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions)
         {
             Ensure.ArgumentNotNull(permissions, "persmissions");
 
@@ -90,7 +90,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>  
-        public IObservable<RepositoryInvitation> GetAllForRepository(int repositoryId)
+        public IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId)
         {
             return _connection.GetAndFlattenAllPages<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), null, AcceptHeaders.InvitationsApiPreview, ApiOptions.None);
         }

--- a/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryPagesClient.cs
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        public IObservable<Page> Get(int repositoryId)
+        public IObservable<Page> Get(long repositoryId)
         {
             return _client.Get(repositoryId).ToObservable();
         }
@@ -76,7 +76,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        public IObservable<PagesBuild> GetAll(int repositoryId)
+        public IObservable<PagesBuild> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        public IObservable<PagesBuild> GetAll(int repositoryId, ApiOptions options)
+        public IObservable<PagesBuild> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -137,7 +137,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        public IObservable<PagesBuild> GetLatest(int repositoryId)
+        public IObservable<PagesBuild> GetLatest(long repositoryId)
         {
             return _client.GetLatest(repositoryId).ToObservable();
         }
@@ -165,7 +165,7 @@ namespace Octokit.Reactive
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
-        public IObservable<PagesBuild> RequestPageBuild(int repositoryId)
+        public IObservable<PagesBuild> RequestPageBuild(long repositoryId)
         {
             return _client.RequestPageBuild(repositoryId).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableStarredClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStarredClient.cs
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        public IObservable<User> GetAllStargazers(int repositoryId)
+        public IObservable<User> GetAllStargazers(long repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
         }
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        public IObservable<User> GetAllStargazers(int repositoryId, ApiOptions options)
+        public IObservable<User> GetAllStargazers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -95,7 +95,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId)
+        public IObservable<UserStar> GetAllStargazersWithTimestamps(long repositoryId)
         {
             return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
         }
@@ -122,7 +122,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public IObservable<UserStar> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
+        public IObservable<UserStar> GetAllStargazersWithTimestamps(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit.Reactive
         /// Returns a list of <see cref="Contributor"/> for the given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<IEnumerable<Contributor>> GetContributors(int repositoryId)
+        public IObservable<IEnumerable<Contributor>> GetContributors(long repositoryId)
         {
             return _client.Repository.Statistics.GetContributors(repositoryId).ToObservable();
         }
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// Returns the last year of commit activity grouped by week.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<CommitActivity> GetCommitActivity(int repositoryId)
+        public IObservable<CommitActivity> GetCommitActivity(long repositoryId)
         {
             return _client.Repository.Statistics.GetCommitActivity(repositoryId).ToObservable();
         }
@@ -82,7 +82,7 @@ namespace Octokit.Reactive
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<CodeFrequency> GetCodeFrequency(int repositoryId)
+        public IObservable<CodeFrequency> GetCodeFrequency(long repositoryId)
         {
             return _client.Repository.Statistics.GetCodeFrequency(repositoryId).ToObservable();
         }
@@ -104,7 +104,7 @@ namespace Octokit.Reactive
         /// Returns the total commit counts for the owner and total commit counts in total. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<Participation> GetParticipation(int repositoryId)
+        public IObservable<Participation> GetParticipation(long repositoryId)
         {
             return _client.Repository.Statistics.GetParticipation(repositoryId).ToObservable();
         }
@@ -126,7 +126,7 @@ namespace Octokit.Reactive
         /// Returns a list of the number of commits per hour in each day
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<PunchCard> GetPunchCard(int repositoryId)
+        public IObservable<PunchCard> GetPunchCard(long repositoryId)
         {
             return _client.Repository.Statistics.GetPunchCard(repositoryId).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableTagsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTagsClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        public IObservable<GitTag> Get(int repositoryId, string reference)
+        public IObservable<GitTag> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag to create</param>
-        public IObservable<GitTag> Create(int repositoryId, NewTag tag)
+        public IObservable<GitTag> Create(long repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");
 

--- a/Octokit.Reactive/Clients/ObservableTreesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTreesClient.cs
@@ -46,7 +46,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        public IObservable<TreeResponse> Get(int repositoryId, string reference)
+        public IObservable<TreeResponse> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -79,7 +79,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        public IObservable<TreeResponse> GetRecursive(int repositoryId, string reference)
+        public IObservable<TreeResponse> GetRecursive(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -112,7 +112,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
-        public IObservable<TreeResponse> Create(int repositoryId, NewTree newTree)
+        public IObservable<TreeResponse> Create(long repositoryId, NewTree newTree)
         {
             Ensure.ArgumentNotNull(newTree, "newTree");
 

--- a/Octokit.Reactive/Clients/ObservableWatchedClient.cs
+++ b/Octokit.Reactive/Clients/ObservableWatchedClient.cs
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        public IObservable<User> GetAllWatchers(int repositoryId)
+        public IObservable<User> GetAllWatchers(long repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
         }
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        public IObservable<User> GetAllWatchers(int repositoryId, ApiOptions options)
+        public IObservable<User> GetAllWatchers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -142,7 +142,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated</exception>
-        public IObservable<bool> CheckWatched(int repositoryId)
+        public IObservable<bool> CheckWatched(long repositoryId)
         {
             return _client.CheckWatched(repositoryId).ToObservable();
         }
@@ -167,7 +167,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        public IObservable<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
+        public IObservable<Subscription> WatchRepo(long repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
 
@@ -191,7 +191,7 @@ namespace Octokit.Reactive
         /// Unstars a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public IObservable<bool> UnwatchRepo(int repositoryId)
+        public IObservable<bool> UnwatchRepo(long repositoryId)
         {
             return _client.UnwatchRepo(repositoryId).ToObservable();
         }

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -17,7 +17,7 @@ public class IssueCommentsClientTests
         const string owner = "octokit";
         const string name = "octokit.net";
         const int id = 12067722;
-        const int repositoryId = 7528679;
+        const long repositoryId = 7528679;
 
         public TheGetMethod()
         {
@@ -76,7 +76,7 @@ public class IssueCommentsClientTests
 
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int repositoryId = 7528679;
+        const long repositoryId = 7528679;
 
         public TheGetAllForRepositoryMethod()
         {
@@ -261,7 +261,7 @@ public class IssueCommentsClientTests
         const string owner = "octokit";
         const string name = "octokit.net";
         const int number = 1115;
-        const int repositoryId = 7528679;
+        const long repositoryId = 7528679;
 
         public TheGetAllForIssueMethod()
         {

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -807,7 +807,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
         return createdComment;
     }
 
-    async Task<PullRequestReviewComment> CreateComment(string body, int position, int repositoryId, string pullRequestCommitId, int pullRequestNumber)
+    async Task<PullRequestReviewComment> CreateComment(string body, int position, long repositoryId, string pullRequestCommitId, int pullRequestNumber)
     {
         var comment = new PullRequestReviewCommentCreate(body, pullRequestCommitId, path, position);
 

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -173,7 +173,7 @@ public class ReleasesClientTests
         readonly IReleasesClient _releaseClient;
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int repositoryId = 252774;
+        const long repositoryId = 252774;
 
         public TheGetAllMethod()
         {
@@ -414,7 +414,7 @@ public class ReleasesClientTests
         const string owner = "octokit";
         const string name = "octokit.net";
         const int releaseId = 2248679;
-        const int repositoryId = 7528679;
+        const long repositoryId = 7528679;
 
         public TheUploadAssetMethod()
         {

--- a/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCommentsClientTests.cs
@@ -15,7 +15,7 @@ public class RepositoryCommentsClientTests
         readonly IRepositoryCommentsClient _fixture;
         const string owner = "octocat";
         const string name = "Hello-World";
-        const int repositoryId = 1296269;
+        const long repositoryId = 1296269;
 
         public TheGetMethod()
         {
@@ -71,7 +71,7 @@ public class RepositoryCommentsClientTests
         readonly IRepositoryCommentsClient _fixture;
         const string owner = "octocat";
         const string name = "Hello-World";
-        const int repositoryId = 1296269;
+        const long repositoryId = 1296269;
 
         public TheGetAllForRepositoryMethod()
         {
@@ -246,7 +246,7 @@ public class RepositoryCommentsClientTests
         readonly IRepositoryCommentsClient _fixture;
         const string owner = "octocat";
         const string name = "Hello-World";
-        const int repositoryId = 1296269;
+        const long repositoryId = 1296269;
 
         public TheGetAllForCommitMethod()
         {

--- a/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryPagesClientTests.cs
@@ -10,7 +10,7 @@ public class RepositoryPagesClientTests
         readonly IRepositoryPagesClient _repositoryPagesClient;
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int repositoryId = 7528679;
+        const long repositoryId = 7528679;
 
         public TheGetMethod()
         {

--- a/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
@@ -19,7 +19,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private IConnection _connection;
-        internal int RepositoryId { get; private set; }
+        internal long RepositoryId { get; private set; }
         internal string RepositoryOwner { get; private set; }
         internal string RepositoryName { get; private set; }
 

--- a/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
+++ b/Octokit.Tests.Integration/fixtures/RepositoriesHooksFixture.cs
@@ -29,7 +29,7 @@ namespace Octokit.Tests.Integration.fixtures
 
         public string RepositoryName { get { return _repository.Name; } }
 
-        public int RepositoryId { get { return _repository.Id; } }
+        public long RepositoryId { get { return _repository.Id; } }
 
         public RepositoryHook ExpectedHook { get { return _hook; } }
 

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -12,7 +12,7 @@ public class DeploymentsClientTests
     {
         const string name = "name";
         const string owner = "owner";
-        const int repositoryId = 1;
+        const long repositoryId = 1;
 
         [Fact]
         public async Task EnsuresNonNullArguments()

--- a/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableAssigneesClientTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Reactive
         private const string owner = "owner";
         private const string name = "name";
         private const string assignee = "assignee";
-        private const int repositoryId = 1;
+        private const long repositoryId = 1;
 
         public class TheGetAllMethod
         {

--- a/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableDeploymentsClientTests.cs
@@ -17,7 +17,7 @@ namespace Octokit.Tests.Reactive
             private readonly ObservableDeploymentsClient _client;
             private const string owner = "owner";
             private const string name = "name";
-            private const int repositoryId = 1;
+            private const long repositoryId = 1;
 
             public TheGetAllMethod()
             {

--- a/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepoCollaboratorsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Reactive
             private readonly IObservableRepoCollaboratorsClient _client;
             private const string owner = "owner";
             private const string name = "name";
-            private const int repositoryId = 1;
+            private const long repositoryId = 1;
 
             public TheGetAllMethod()
             {
@@ -233,9 +233,10 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                _client.IsCollaborator(1, "user");
+                var id = 1L;
+                _client.IsCollaborator(id, "user");
 
-                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(1),
+                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(id),
                     Arg.Is("user"));
             }
 
@@ -244,9 +245,10 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                _client.IsCollaborator(1, "user");
+                var id = 1L;
+                _client.IsCollaborator(id, "user");
 
-                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(1),
+                _githubClient.Repository.Collaborator.Received(1).IsCollaborator(Arg.Is(id),
                     Arg.Is("user"));
             }
         }
@@ -324,9 +326,10 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                _client.Add(1, "user");
+                var id = 1L;
+                _client.Add(id, "user");
 
-                _githubClient.Repository.Collaborator.Received(1).Add(Arg.Is(1),
+                _githubClient.Repository.Collaborator.Received(1).Add(Arg.Is(id),
                     Arg.Is("user"));
             }
         }
@@ -478,9 +481,10 @@ namespace Octokit.Tests.Reactive
             {
                 SetupWithoutNonReactiveClient();
 
-                _client.Delete(1, "user");
+                var id = 1L;
+                _client.Delete(id, "user");
 
-                _githubClient.Repository.Collaborator.Received(1).Delete(Arg.Is(1),
+                _githubClient.Repository.Collaborator.Received(1).Delete(Arg.Is(id),
                     Arg.Is("user"));
             }
         }

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -36,7 +36,7 @@ namespace Octokit
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<User>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -63,7 +63,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">The options to change API's response.</param>
-        public Task<IReadOnlyList<User>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -100,7 +100,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
-        public async Task<bool> CheckAssignee(int repositoryId, string assignee)
+        public async Task<bool> CheckAssignee(long repositoryId, string assignee)
         {
             Ensure.ArgumentNotNullOrEmptyString(assignee, "assignee");
 

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
-        public Task<Blob> Get(int repositoryId, string reference)
+        public Task<Blob> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -78,7 +78,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        public Task<BlobReference> Create(int repositoryId, NewBlob newBlob)
+        public Task<BlobReference> Create(long repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, "newBlob");
 

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
-        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 
@@ -72,7 +72,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
-        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.CommitCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference)
+        public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -85,7 +85,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options)
+        public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(options, "options");
@@ -121,7 +121,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        public Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference)
+        public Task<CombinedCommitStatus> GetCombined(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -157,7 +157,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        public Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus)
+        public Task<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(newCommitStatus, "newCommitStatus");

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
-        public Task<Commit> Get(int repositoryId, string reference)
+        public Task<Commit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -78,7 +78,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commit">The commit to create</param>
-        public Task<Commit> Create(int repositoryId, NewCommit commit)
+        public Task<Commit> Create(long repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, "commit");
 

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -44,7 +44,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
         }
@@ -82,7 +82,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options)
+        public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        public Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
+        public Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, "newDeploymentStatus");
 

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// http://developer.github.com/v3/repos/deployments/#list-deployments
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Deployment>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<Deployment>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -83,7 +83,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Deployment>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Deployment>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -120,7 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
-        public Task<Deployment> Create(int repositoryId, NewDeployment newDeployment)
+        public Task<Deployment> Create(long repositoryId, NewDeployment newDeployment)
         {
             Ensure.ArgumentNotNull(newDeployment, "newDeployment");
 

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -69,7 +69,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -100,7 +100,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -130,7 +130,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId)
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
         }
@@ -161,7 +161,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -22,7 +22,7 @@ namespace Octokit
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<User>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
@@ -37,7 +37,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">The options to change API's response.</param>
-        Task<IReadOnlyList<User>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.
@@ -52,6 +52,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
-        Task<bool> CheckAssignee(int repositoryId, string assignee);
+        Task<bool> CheckAssignee(long repositoryId, string assignee);
     }
 }

--- a/Octokit/Clients/IBlobsClient.cs
+++ b/Octokit/Clients/IBlobsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Blob> Get(int repositoryId, string reference);
+        Task<Blob> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a new Blob
@@ -52,6 +52,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newBlob">The new Blob</param>
-        Task<BlobReference> Create(int repositoryId, NewBlob newBlob);
+        Task<BlobReference> Create(long repositoryId, NewBlob newBlob);
     }
 }

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
-        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, int number, NewReaction reaction);
 
         /// <summary>
         /// Get all reactions for a specified Commit Comment
@@ -49,6 +49,6 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
-        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/ICommitStatusClient.cs
+++ b/Octokit/Clients/ICommitStatusClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference);
+        Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference);
 
         /// <summary>
         /// Retrieves commit statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -57,7 +57,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<CommitStatus>> GetAll(int repositoryId, string reference, ApiOptions options);
+        Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference, ApiOptions options);
 
         /// <summary>
         /// Retrieves a combined view of statuses for the specified reference. A reference can be a commit SHA, a branch name, or
@@ -80,7 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
-        Task<CombinedCommitStatus> GetCombined(int repositoryId, string reference);
+        Task<CombinedCommitStatus> GetCombined(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a commit status for the specified ref.
@@ -103,6 +103,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
-        Task<CommitStatus> Create(int repositoryId, string reference, NewCommitStatus newCommitStatus);
+        Task<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus);
     }
 }

--- a/Octokit/Clients/ICommitsClient.cs
+++ b/Octokit/Clients/ICommitsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit
         /// <param name="reference">Tha sha reference of the commit</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<Commit> Get(int repositoryId, string reference);
+        Task<Commit> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Create a commit for a given repository
@@ -55,6 +55,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commit">The commit to create</param>
-        Task<Commit> Create(int repositoryId, NewCommit commit);
+        Task<Commit> Create(long repositoryId, NewCommit commit);
     }
 }

--- a/Octokit/Clients/IDeploymentStatusClient.cs
+++ b/Octokit/Clients/IDeploymentStatusClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId);
 
         /// <summary>
         /// Gets all the statuses for the given deployment. Any user with pull access to a repository can
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeploymentStatus>> GetAll(int repositoryId, int deploymentId, ApiOptions options);
+        Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options);
 
         /// <summary>
         /// Creates a new status for the given deployment. Users with push access can create deployment
@@ -83,6 +83,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
-        Task<DeploymentStatus> Create(int repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
+        Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus);
     }
 }

--- a/Octokit/Clients/IDeploymentsClient.cs
+++ b/Octokit/Clients/IDeploymentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// http://developer.github.com/v3/repos/deployments/#list-deployments
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Deployment>> GetAll(int repositoryId);
+        Task<IReadOnlyList<Deployment>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the deployments for the specified repository. Any user with pull access
@@ -54,7 +54,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Deployment>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Deployment>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deployment for the specified repository.
@@ -77,7 +77,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
-        Task<Deployment> Create(int repositoryId, NewDeployment newDeployment);
+        Task<Deployment> Create(long repositoryId, NewDeployment newDeployment);
 
         /// <summary>
         /// Client for managing deployment status.

--- a/Octokit/Clients/IEventsClient.cs
+++ b/Octokit/Clients/IEventsClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the events for a given repository
@@ -68,7 +68,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Activity>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -87,7 +87,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId);
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all the issue events for a given repository
@@ -108,7 +108,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Activity>> GetAllIssuesForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all the events for a given repository network

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, int number, NewReaction reaction);
 
         /// <summary>
         /// Get all reactions for a specified Issue Comment
@@ -45,6 +45,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="id">The issue comment id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueComment> Get(int repositoryId, int id);
+        Task<IssueComment> Get(long repositoryId, int id);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -46,7 +46,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets Issue Comments for a repository.
@@ -63,7 +63,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -80,7 +80,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(int repositoryId, int number);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -118,7 +118,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        Task<IssueComment> Create(int repositoryId, int number, string newComment);
+        Task<IssueComment> Create(long repositoryId, int number, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.
@@ -137,7 +137,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
-        Task<IssueComment> Update(int repositoryId, int id, string commentUpdate);
+        Task<IssueComment> Update(long repositoryId, int id, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Issue Comment
@@ -154,6 +154,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
-        Task Delete(int repositoryId, int id);
+        Task Delete(long repositoryId, int id);
     }
 }

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>        
-        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Creates a reaction for a specified Issue
@@ -45,6 +45,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IIssueTimelineClient.cs
+++ b/Octokit/Clients/IIssueTimelineClient.cs
@@ -44,7 +44,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(int repositoryId, int number);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -55,6 +55,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(int repositoryId, int number);
+        Task<Issue> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -205,7 +205,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user for the repository.
@@ -226,7 +226,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -247,7 +247,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request);
+        Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request);
 
         /// <summary>
         /// Gets issues for a repository.
@@ -270,7 +270,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options);
+        Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -289,7 +289,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        Task<Issue> Create(int repositoryId, NewIssue newIssue);
+        Task<Issue> Create(long repositoryId, NewIssue newIssue);
 
         /// <summary>
         /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
@@ -312,7 +312,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate);
+        Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -329,7 +329,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Lock(int repositoryId, int number);
+        Task Lock(long repositoryId, int number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -346,6 +346,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Unlock(int repositoryId, int number);
+        Task Unlock(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -73,7 +73,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -94,7 +94,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single event
@@ -119,6 +119,6 @@ namespace Octokit
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueEvent> Get(int repositoryId, int number);
+        Task<IssueEvent> Get(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number);
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -73,7 +73,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -94,7 +94,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -115,7 +115,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number);
+        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number);
 
         /// <summary>
         /// Gets labels for every issue in a milestone
@@ -138,7 +138,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a single Label by name.
@@ -163,7 +163,7 @@ namespace Octokit
         /// <param name="labelName">The name of the label</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        Task<Label> Get(int repositoryId, string labelName);
+        Task<Label> Get(long repositoryId, string labelName);
 
         /// <summary>
         /// Deletes a label.
@@ -184,7 +184,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        Task Delete(int repositoryId, string labelName);
+        Task Delete(long repositoryId, string labelName);
 
         /// <summary>
         /// Creates a label.
@@ -205,7 +205,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        Task<Label> Create(int repositoryId, NewLabel newLabel);
+        Task<Label> Create(long repositoryId, NewLabel newLabel);
 
         /// <summary>
         /// Updates a label.
@@ -228,7 +228,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate);
+        Task<Label> Update(long repositoryId, string labelName, LabelUpdate labelUpdate);
 
         /// <summary>
         /// Adds a label to an issue
@@ -251,7 +251,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels);
+        Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -274,7 +274,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        Task RemoveFromIssue(int repositoryId, int number, string labelName);
+        Task RemoveFromIssue(long repositoryId, int number, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -297,7 +297,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels);
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int number, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -318,6 +318,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        Task RemoveAllFromIssue(int repositoryId, int number);
+        Task RemoveAllFromIssue(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IMergingClient.cs
+++ b/Octokit/Clients/IMergingClient.cs
@@ -31,6 +31,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        Task<Merge> Create(int repositoryId, NewMerge merge);
+        Task<Merge> Create(long repositoryId, NewMerge merge);
     }
 }

--- a/Octokit/Clients/IMilestonesClient.cs
+++ b/Octokit/Clients/IMilestonesClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Milestone> Get(int repositoryId, int number);
+        Task<Milestone> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -53,7 +53,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -76,7 +76,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request);
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request);
 
         /// <summary>
         /// Gets all open milestones for the repository.
@@ -124,7 +124,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options);
+        Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -145,7 +145,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
-        Task<Milestone> Create(int repositoryId, NewMilestone newMilestone);
+        Task<Milestone> Create(long repositoryId, NewMilestone newMilestone);
 
         /// <summary>
         /// Creates a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -170,7 +170,7 @@ namespace Octokit
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        Task<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate);
+        Task<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate);
 
         /// <summary>
         /// Deletes a milestone for the specified repository. Any user with pull access to a repository can create an
@@ -191,6 +191,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        Task Delete(int repositoryId, int number);
+        Task Delete(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/INotificationsClient.cs
+++ b/Octokit/Clients/INotificationsClient.cs
@@ -57,7 +57,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -74,7 +74,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -91,7 +91,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request);
+        Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request);
 
         /// <summary>
         /// Retrieves all of the <see cref="Notification"/>s for the current user specific to the specified repository.
@@ -110,7 +110,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options);
+        Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request, ApiOptions options);
 
         /// <summary>
         /// Marks all notifications as read.
@@ -138,7 +138,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        Task MarkAsReadForRepository(int repositoryId);
+        Task MarkAsReadForRepository(long repositoryId);
 
         /// <summary>
         /// Marks the notifications for a given repository as read.
@@ -155,7 +155,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest);
+        Task MarkAsReadForRepository(long repositoryId, MarkAsReadRequest markAsReadRequest);
 
         /// <summary>
         /// Retrives a single <see cref="Notification"/> by Id.

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Creates a reaction for a specified Pull Request Review Comment.
@@ -45,6 +45,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(int repositoryId, int number, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, int number, NewReaction reaction);
     }
 }

--- a/Octokit/Clients/IPullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number);
 
         /// <summary>
         /// Gets review comments for a specified pull request.
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -60,7 +60,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -77,7 +77,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -94,7 +94,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request);
 
         /// <summary>
         /// Gets a list of the pull request review comments in a specified repository.
@@ -113,7 +113,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
+        Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets a single pull request review comment by number.
@@ -130,7 +130,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        Task<PullRequestReviewComment> GetComment(int repositoryId, int number);
+        Task<PullRequestReviewComment> GetComment(long repositoryId, int number);
 
         /// <summary>
         /// Creates a comment on a pull request review.
@@ -149,7 +149,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment);
+        Task<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment);
 
         /// <summary>
         /// Creates a comment on a pull request review as a reply to another comment.
@@ -168,7 +168,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
+        Task<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment);
 
         /// <summary>
         /// Edits a comment on a pull request review.
@@ -187,7 +187,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment);
+        Task<PullRequestReviewComment> Edit(long repositoryId, int number, PullRequestReviewCommentEdit comment);
 
         /// <summary>
         /// Deletes a comment on a pull request review.
@@ -204,6 +204,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        Task Delete(int repositoryId, int number);
+        Task Delete(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IPullRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestsClient.cs
@@ -35,7 +35,7 @@ namespace Octokit
         /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<PullRequest> Get(int repositoryId, int number);
+        Task<PullRequest> Get(long repositoryId, int number);
 
         /// <summary>
         /// Get all open pull requests for the repository.
@@ -54,7 +54,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Get all open pull requests for the repository.
@@ -75,7 +75,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -96,7 +96,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request);
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request);
 
         /// <summary>
         /// Query pull requests for the repository based on criteria
@@ -119,7 +119,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options);
+        Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options);
 
         /// <summary>
         /// Create a pull request for the specified repository.
@@ -136,7 +136,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest);
+        Task<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest);
 
         /// <summary>
         /// Create a pull request for the specified repository. 
@@ -157,7 +157,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate);
+        Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate);
 
         /// <summary>
         /// Merge a pull request.
@@ -176,7 +176,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest);
+        Task<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest);
 
         /// <summary>
         /// Get the pull request merge status.
@@ -193,7 +193,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<bool> Merged(int repositoryId, int number);
+        Task<bool> Merged(long repositoryId, int number);
 
         /// <summary>
         /// Get the list of commits on a pull request.
@@ -210,7 +210,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number);
+        Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int number);
 
         /// <summary>
         /// Get the list of files on a pull request.
@@ -227,6 +227,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number);
+        Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -37,7 +37,7 @@ namespace Octokit
         /// <returns></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Reference> Get(int repositoryId, string reference);
+        Task<Reference> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -58,7 +58,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Reference>> GetAll(int repositoryId);
+        Task<IReadOnlyList<Reference>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -81,7 +81,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(int repositoryId, string subNamespace);
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace);
 
         /// <summary>
         /// Creates a reference for a given repository
@@ -104,7 +104,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
-        Task<Reference> Create(int repositoryId, NewReference reference);
+        Task<Reference> Create(long repositoryId, NewReference reference);
 
         /// <summary>
         /// Updates a reference for a given repository by reference name
@@ -129,7 +129,7 @@ namespace Octokit
         /// <param name="reference">The name of the reference</param>
         /// <param name="referenceUpdate">The updated reference data</param>
         /// <returns></returns>
-        Task<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate);
+        Task<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
         /// Deletes a reference for a given repository by reference name
@@ -152,6 +152,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        Task Delete(int repositoryId, string reference);
+        Task Delete(long repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<Release>> GetAll(int repositoryId);
+        Task<IReadOnlyList<Release>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all <see cref="Release"/>s for the specified repository.
@@ -56,7 +56,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<Release>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Release>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single <see cref="Release"/> for the specified repository.
@@ -81,7 +81,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
-        Task<Release> Get(int repositoryId, int id);
+        Task<Release> Get(long repositoryId, int id);
 
         /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.
@@ -102,7 +102,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> GetLatest(int repositoryId);
+        Task<Release> GetLatest(long repositoryId);
 
         /// <summary>
         /// Creates a new <see cref="Release"/> for the specified repository.
@@ -125,7 +125,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Create(int repositoryId, NewRelease data);
+        Task<Release> Create(long repositoryId, NewRelease data);
 
         /// <summary>
         /// Edits an existing <see cref="Release"/> for the specified repository.
@@ -150,7 +150,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Release> Edit(int repositoryId, int id, ReleaseUpdate data);
+        Task<Release> Edit(long repositoryId, int id, ReleaseUpdate data);
 
         /// <summary>
         /// Deletes an existing <see cref="Release"/> for the specified repository.
@@ -173,7 +173,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Delete(int repositoryId, int id);
+        Task Delete(long repositoryId, int id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -196,7 +196,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(int repositoryId, int id);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id);
 
         /// <summary>
         /// Gets all <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -221,7 +221,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(int repositoryId, int id, ApiOptions options);
+        Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id, ApiOptions options);
 
         /// <summary>
         /// Uploads a <see cref="ReleaseAsset"/> for the specified release.
@@ -253,7 +253,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
-        Task<ReleaseAsset> GetAsset(int repositoryId, int assetId);
+        Task<ReleaseAsset> GetAsset(long repositoryId, int assetId);
 
         /// <summary>
         /// Edits the <see cref="ReleaseAsset"/> for the specified release of the specified repository.
@@ -276,7 +276,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
-        Task<ReleaseAsset> EditAsset(int repositoryId, int assetId, ReleaseAssetUpdate data);
+        Task<ReleaseAsset> EditAsset(long repositoryId, int assetId, ReleaseAssetUpdate data);
 
         /// <summary>
         /// Deletes the specified <see cref="ReleaseAsset"/> from the specified repository
@@ -297,6 +297,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        Task DeleteAsset(int repositoryId, int id);
+        Task DeleteAsset(long repositoryId, int id);
     }
 }

--- a/Octokit/Clients/IRepoCollaboratorsClient.cs
+++ b/Octokit/Clients/IRepoCollaboratorsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<User>> GetAll(int repositoryId);
+        Task<IReadOnlyList<User>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the collaborators on a repository.
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Checks if a user is a collaborator on a repository.
@@ -78,7 +78,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> IsCollaborator(int repositoryId, string user);
+        Task<bool> IsCollaborator(long repositoryId, string user);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -114,7 +114,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Add(int repositoryId, string user);
+        Task Add(long repositoryId, string user);
 
         /// <summary>
         /// Adds a new collaborator to the repository.
@@ -126,7 +126,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Add(int repositoryId, string user, CollaboratorRequest permission);
+        Task<bool> Add(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Invites a new collaborator to the repo
@@ -162,7 +162,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="user">The name of the user to invite.</param>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<RepositoryInvitation> Invite(int repositoryId, string user);
+        Task<RepositoryInvitation> Invite(long repositoryId, string user);
 
         /// <summary>
         /// Invites a new collaborator to the repo
@@ -174,7 +174,7 @@ namespace Octokit
         /// <param name="user">The name of the user to invite.</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>        
-        Task<RepositoryInvitation> Invite(int repositoryId, string user, CollaboratorRequest permission);
+        Task<RepositoryInvitation> Invite(long repositoryId, string user, CollaboratorRequest permission);
 
         /// <summary>
         /// Deletes a collaborator from the repository.
@@ -197,6 +197,6 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the removed collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Delete(int repositoryId, string user);
+        Task Delete(long repositoryId, string user);
     }
 }

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -100,7 +100,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task Delete(int repositoryId);
+        Task Delete(long repositoryId);
 
         /// <summary>
         /// Gets the specified repository.
@@ -125,7 +125,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Repository> Get(int repositoryId);
+        Task<Repository> Get(long repositoryId);
 
         /// <summary>
         /// Gets all public repositories.
@@ -347,7 +347,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId);
+        Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId);
 
         /// <summary>
         /// Gets all the branches for the specified repository.
@@ -374,7 +374,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
         [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -395,7 +395,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All contributors of the repository.</returns>
-        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId);
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId);
 
         /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
@@ -418,7 +418,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -441,7 +441,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
-        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous);
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous);
 
         /// <summary>
         /// Gets all contributors for the specified repository. With the option to include anonymous contributors.
@@ -466,7 +466,7 @@ namespace Octokit
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options);
+        Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous, ApiOptions options);
 
         /// <summary>
         /// Gets all languages for the specified repository.
@@ -487,7 +487,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
-        Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(int repositoryId);
+        Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(long repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -508,7 +508,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId);
+        Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId);
 
         /// <summary>
         /// Gets all teams for the specified repository.
@@ -531,7 +531,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -552,7 +552,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All of the repositories tags.</returns>
-        Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId);
+        Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId);
 
         /// <summary>
         /// Gets all tags for the specified repository.
@@ -575,7 +575,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
-        Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -600,7 +600,7 @@ namespace Octokit
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The specified <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("Please use RepositoriesClient.Branch.Get() instead.  This method will be removed in a future version")]
-        Task<Branch> GetBranch(int repositoryId, string branchName);
+        Task<Branch> GetBranch(long repositoryId, string branchName);
 
         /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
@@ -617,7 +617,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
-        Task<Repository> Edit(int repositoryId, RepositoryUpdate update);
+        Task<Repository> Edit(long repositoryId, RepositoryUpdate update);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
@@ -638,7 +638,7 @@ namespace Octokit
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use the RepositoryBranchesClient methods instead.")]
-        Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update);
+        Task<Branch> EditBranch(long repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// A client for GitHub's Repository Pages API.

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
-        Task<IReadOnlyList<Branch>> GetAll(int repositoryId);
+        Task<IReadOnlyList<Branch>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all the branches for the specified repository.
@@ -54,7 +54,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Branch>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Branch>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the specified branch.
@@ -77,7 +77,7 @@ namespace Octokit
         /// <param name="repositoryId">The ID of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Branch> Get(int repositoryId, string branch);
+        Task<Branch> Get(long repositoryId, string branch);
 
         /// <summary>
         /// Edit the specified branch with the values given in <paramref name="update"/>
@@ -96,7 +96,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use other RepositoryBranchesClient methods instead.")]
-        Task<Branch> Edit(int repositoryId, string branch, BranchUpdate update);
+        Task<Branch> Edit(long repositoryId, string branch, BranchUpdate update);
 
         /// <summary>
         /// Get the branch protection settings for the specified branch />
@@ -117,7 +117,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        Task<BranchProtectionSettings> GetBranchProtection(int repositoryId, string branch);
+        Task<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch);
 
         /// <summary>
         /// Update the branch protection settings for the specified branch />
@@ -140,7 +140,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
-        Task<BranchProtectionSettings> UpdateBranchProtection(int repositoryId, string branch, BranchProtectionSettingsUpdate update);
+        Task<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update);
 
         /// <summary>
         /// Remove the branch protection settings for the specified branch />
@@ -161,6 +161,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        Task<bool> DeleteBranchProtection(int repositoryId, string branch);
+        Task<bool> DeleteBranchProtection(long repositoryId, string branch);
     }
 }

--- a/Octokit/Clients/IRepositoryCommentsClient.cs
+++ b/Octokit/Clients/IRepositoryCommentsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<CommitComment> Get(int repositoryId, int number);
+        Task<CommitComment> Get(long repositoryId, int number);
 
         /// <summary>
         /// Gets Commit Comments for a repository.
@@ -46,7 +46,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<CommitComment>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Gets Commit Comments for a repository.
@@ -63,7 +63,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
-        Task<IReadOnlyList<CommitComment>> GetAllForRepository(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets Commit Comments for a specified Commit.
@@ -80,7 +80,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
-        Task<IReadOnlyList<CommitComment>> GetAllForCommit(int repositoryId, string sha);
+        Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha);
 
         /// <summary>
         /// Gets Commit Comments for a specified Commit.
@@ -99,7 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
-        Task<IReadOnlyList<CommitComment>> GetAllForCommit(int repositoryId, string sha, ApiOptions options);
+        Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha, ApiOptions options);
 
         /// <summary>
         /// Creates a new Commit Comment for a specified Commit.
@@ -118,7 +118,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
-        Task<CommitComment> Create(int repositoryId, string sha, NewCommitComment newCommitComment);
+        Task<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment);
 
         /// <summary>
         /// Updates a specified Commit Comment.
@@ -137,7 +137,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
-        Task<CommitComment> Update(int repositoryId, int number, string commentUpdate);
+        Task<CommitComment> Update(long repositoryId, int number, string commentUpdate);
 
         /// <summary>
         /// Deletes the specified Commit Comment
@@ -154,6 +154,6 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        Task Delete(int repositoryId, int number);
+        Task Delete(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IRepositoryCommitsClient.cs
+++ b/Octokit/Clients/IRepositoryCommitsClient.cs
@@ -29,7 +29,7 @@ namespace Octokit
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "base")]
-        Task<CompareResult> Compare(int repositoryId, string @base, string head);
+        Task<CompareResult> Compare(long repositoryId, string @base, string head);
 
         /// <summary>
         /// Gets a single commit for a given repository
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="reference">The reference for the commit (SHA)</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Makes a network request")]
-        Task<GitHubCommit> Get(int repositoryId, string reference);
+        Task<GitHubCommit> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -61,7 +61,7 @@ namespace Octokit
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId);
+        Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -76,7 +76,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -91,7 +91,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request);
+        Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request);
 
         /// <summary>
         /// Gets all commits for a given repository
@@ -108,7 +108,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options);
+        Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request, ApiOptions options);
 
         /// <summary>
         /// Get the SHA-1 of a commit reference
@@ -123,6 +123,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
-        Task<string> GetSha1(int repositoryId, string reference);
+        Task<string> GetSha1(long repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path);
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId, string path);
 
         /// <summary>
         /// Returns the contents of the root directory in a repository.
@@ -51,7 +51,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId);
+        Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.
@@ -74,7 +74,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference);
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference);
 
         /// <summary>
         /// Returns the contents of the root directory in a repository.
@@ -97,7 +97,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference);
+        Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference);
 
         /// <summary>
         /// Gets the preferred README for the specified repository.
@@ -118,7 +118,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<Readme> GetReadme(int repositoryId);
+        Task<Readme> GetReadme(long repositoryId);
 
         /// <summary>
         /// Gets the preferred README's HTML for the specified repository.
@@ -139,7 +139,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<string> GetReadmeHtml(int repositoryId);
+        Task<string> GetReadmeHtml(long repositoryId);
 
         /// <summary>
         /// Get an archive of a given repository's contents
@@ -154,7 +154,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<byte[]> GetArchive(int repositoryId);
+        Task<byte[]> GetArchive(long repositoryId);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -171,7 +171,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat);
+        Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat);
 
         /// <summary>
         /// Get an archive of a given repository's contents, using a specific format and reference
@@ -190,7 +190,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference);
+        Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference);
 
         /// <summary>
         /// Get an archive of a given repository's contents, in a specific format
@@ -211,7 +211,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
+        Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout);
 
         /// <summary>
         /// Creates a commit that creates a new file in a repository.
@@ -228,7 +228,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request);
+        Task<RepositoryContentChangeSet> CreateFile(long repositoryId, string path, CreateFileRequest request);
 
         /// <summary>
         /// Creates a commit that updates the contents of a file in a repository.
@@ -245,7 +245,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request);
+        Task<RepositoryContentChangeSet> UpdateFile(long repositoryId, string path, UpdateFileRequest request);
 
         /// <summary>
         /// Creates a commit that deletes a file in a repository.
@@ -262,7 +262,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        Task DeleteFile(int repositoryId, string path, DeleteFileRequest request);
+        Task DeleteFile(long repositoryId, string path, DeleteFileRequest request);
     }
 
     /// <summary>

--- a/Octokit/Clients/IRepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/IRepositoryDeployKeysClient.cs
@@ -33,7 +33,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<DeployKey> Get(int repositoryId, int number);
+        Task<DeployKey> Get(long repositoryId, int number);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -52,7 +52,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId);
+        Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId);
 
         /// <summary>
         /// Get all deploy keys for a repository.
@@ -73,7 +73,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Creates a new deploy key for a repository.
@@ -94,7 +94,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey);
+        Task<DeployKey> Create(long repositoryId, NewDeployKey newDeployKey);
 
         /// <summary>
         /// Deletes a deploy key from a repository.
@@ -115,6 +115,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        Task Delete(int repositoryId, int number);
+        Task Delete(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IRepositoryForksClient.cs
+++ b/Octokit/Clients/IRepositoryForksClient.cs
@@ -28,7 +28,7 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Repository>> GetAll(int repositoryId);
+        Task<IReadOnlyList<Repository>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -49,7 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<Repository>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -70,7 +70,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request);
+        Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request);
 
         /// <summary>
         /// Gets the list of forks defined for a repository
@@ -93,7 +93,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options);
+        Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a fork for a repository. Specify organization in the fork parameter to create for an organization.
@@ -114,6 +114,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        Task<Repository> Create(int repositoryId, NewRepositoryFork fork);
+        Task<Repository> Create(long repositoryId, NewRepositoryFork fork);
     }
 }

--- a/Octokit/Clients/IRepositoryHooksClient.cs
+++ b/Octokit/Clients/IRepositoryHooksClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId);
+        Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets the list of hooks defined for a repository
@@ -42,7 +42,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets a single hook by Id
@@ -61,7 +61,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "This is ok; we're matching HTTP verbs not keywords")]
-        Task<RepositoryHook> Get(int repositoryId, int hookId);
+        Task<RepositoryHook> Get(long repositoryId, int hookId);
 
         /// <summary>
         /// Creates a hook for a repository
@@ -78,7 +78,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook);
+        Task<RepositoryHook> Create(long repositoryId, NewRepositoryHook hook);
 
         /// <summary>
         /// Edits a hook for a repository
@@ -97,7 +97,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook);
+        Task<RepositoryHook> Edit(long repositoryId, int hookId, EditRepositoryHook hook);
 
         /// <summary>
         /// Tests a hook for a repository
@@ -118,7 +118,7 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        Task Test(int repositoryId, int hookId);
+        Task Test(long repositoryId, int hookId);
 
         /// <summary>
         /// This will trigger a ping event to be sent to the hook.
@@ -135,7 +135,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        Task Ping(int repositoryId, int hookId);
+        Task Ping(long repositoryId, int hookId);
 
         /// <summary>
         /// Deletes a hook for a repository
@@ -152,6 +152,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        Task Delete(int repositoryId, int hookId);
+        Task Delete(long repositoryId, int hookId);
     }
 }

--- a/Octokit/Clients/IRepositoryInvitationsClient.cs
+++ b/Octokit/Clients/IRepositoryInvitationsClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<bool> Delete(int repositoryId, int invitationId);
+        Task<bool> Delete(long repositoryId, int invitationId);
 
         /// <summary>
         /// Gets all invitations for the current user.
@@ -61,7 +61,7 @@ namespace Octokit
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(int repositoryId);
+        Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId);
 
         /// <summary>
         /// Updates a repository invitation.
@@ -73,6 +73,6 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <param name="permissions">The permission for the collsborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        Task<RepositoryInvitation> Edit(int repositoryId, int invitationId, InvitationUpdate permissions);
+        Task<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions);
     }
 }

--- a/Octokit/Clients/IRepositoryPagesClient.cs
+++ b/Octokit/Clients/IRepositoryPagesClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<Page> Get(int repositoryId);
+        Task<Page> Get(long repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -50,7 +50,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId);
+        Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId);
 
         /// <summary>
         /// Gets all build metadata for a given repository
@@ -71,7 +71,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets the build metadata for the last build for a given repository
@@ -90,7 +90,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        Task<PagesBuild> GetLatest(int repositoryId);
+        Task<PagesBuild> GetLatest(long repositoryId);
 
         /// <summary>
         /// Requests your site be built from the latest revision on the default branch for a given repository
@@ -109,6 +109,6 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
-        Task<PagesBuild> RequestPageBuild(int repositoryId);
+        Task<PagesBuild> RequestPageBuild(long repositoryId);
     }
 }

--- a/Octokit/Clients/IStarredClient.cs
+++ b/Octokit/Clients/IStarredClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId);
+        Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository.
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -56,7 +56,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId);
+        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the stargazers for the passed repository with star creation timestamps.
@@ -73,7 +73,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user.

--- a/Octokit/Clients/IStatisticsClient.cs
+++ b/Octokit/Clients/IStatisticsClient.cs
@@ -23,7 +23,7 @@ namespace Octokit
         /// Returns a list of <see cref="Contributor"/> for the given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<IReadOnlyList<Contributor>> GetContributors(int repositoryId);
+        Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId);
 
         /// <summary>
         /// Returns a list of <see cref="Contributor"/> for the given repository
@@ -38,7 +38,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        Task<IReadOnlyList<Contributor>> GetContributors(int repositoryId, CancellationToken cancellationToken);
+        Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the last year of commit activity grouped by week.
@@ -51,7 +51,7 @@ namespace Octokit
         /// Returns the last year of commit activity grouped by week.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<CommitActivity> GetCommitActivity(int repositoryId);
+        Task<CommitActivity> GetCommitActivity(long repositoryId);
 
         /// <summary>
         /// Returns the last year of commit activity grouped by week.
@@ -66,7 +66,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        Task<CommitActivity> GetCommitActivity(int repositoryId, CancellationToken cancellationToken);
+        Task<CommitActivity> GetCommitActivity(long repositoryId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
@@ -79,7 +79,7 @@ namespace Octokit
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<CodeFrequency> GetCodeFrequency(int repositoryId);
+        Task<CodeFrequency> GetCodeFrequency(long repositoryId);
 
         /// <summary>
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
@@ -94,7 +94,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        Task<CodeFrequency> GetCodeFrequency(int repositoryId, CancellationToken cancellationToken);
+        Task<CodeFrequency> GetCodeFrequency(long repositoryId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the total commit counts for the owner and total commit counts in total. 
@@ -107,7 +107,7 @@ namespace Octokit
         /// Returns the total commit counts for the owner and total commit counts in total. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<Participation> GetParticipation(int repositoryId);
+        Task<Participation> GetParticipation(long repositoryId);
 
         /// <summary>
         /// Returns the total commit counts for the owner and total commit counts in total. 
@@ -122,7 +122,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        Task<Participation> GetParticipation(int repositoryId, CancellationToken cancellationToken);
+        Task<Participation> GetParticipation(long repositoryId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns a list of the number of commits per hour in each day
@@ -135,7 +135,7 @@ namespace Octokit
         /// Returns a list of the number of commits per hour in each day
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        Task<PunchCard> GetPunchCard(int repositoryId);
+        Task<PunchCard> GetPunchCard(long repositoryId);
 
         /// <summary>
         /// Returns a list of the number of commits per hour in each day
@@ -150,6 +150,6 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        Task<PunchCard> GetPunchCard(int repositoryId, CancellationToken cancellationToken);
+        Task<PunchCard> GetPunchCard(long repositoryId, CancellationToken cancellationToken);
     }
 }

--- a/Octokit/Clients/ITagsClient.cs
+++ b/Octokit/Clients/ITagsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit
         /// <param name="reference">Tha sha reference of the tag</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
             Justification = "Method makes a network request")]
-        Task<GitTag> Get(int repositoryId, string reference);
+        Task<GitTag> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Create a tag for a given repository
@@ -55,6 +55,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag to create</param>
-        Task<GitTag> Create(int repositoryId, NewTag tag);
+        Task<GitTag> Create(long repositoryId, NewTag tag);
     }
 }

--- a/Octokit/Clients/ITreesClient.cs
+++ b/Octokit/Clients/ITreesClient.cs
@@ -31,7 +31,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
-        Task<TreeResponse> Get(int repositoryId, string reference);
+        Task<TreeResponse> Get(long repositoryId, string reference);
 
         /// <summary>
         /// Gets a Tree Response for a given SHA.
@@ -52,7 +52,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        Task<TreeResponse> GetRecursive(int repositoryId, string reference);
+        Task<TreeResponse> GetRecursive(long repositoryId, string reference);
 
         /// <summary>
         /// Creates a new Tree in the specified repo
@@ -73,6 +73,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
-        Task<TreeResponse> Create(int repositoryId, NewTree newTree);
+        Task<TreeResponse> Create(long repositoryId, NewTree newTree);
     }
 }

--- a/Octokit/Clients/IWatchedClient.cs
+++ b/Octokit/Clients/IWatchedClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId);
+        Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId);
 
         /// <summary>
         /// Retrieves all of the watchers for the passed repository.
@@ -42,7 +42,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options);
+        Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Retrieves all of the watched <see cref="Repository"/>(ies) for the current user.
@@ -99,7 +99,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        Task<bool> CheckWatched(int repositoryId);
+        Task<bool> CheckWatched(long repositoryId);
 
         /// <summary>
         /// Watches a repository for the authenticated user.
@@ -114,7 +114,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription);
+        Task<Subscription> WatchRepo(long repositoryId, NewSubscription newSubscription);
 
         /// <summary>
         /// Unwatches a repository for the authenticated user.
@@ -131,6 +131,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Unwatch",
             Justification = "Unwatch is consistent with the GitHub website")]
-        Task<bool> UnwatchRepo(int repositoryId);
+        Task<bool> UnwatchRepo(long repositoryId);
     }
 }

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 
@@ -68,7 +68,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The issue comment id</param>
-        public Task<IssueComment> Get(int repositoryId, int id)
+        public Task<IssueComment> Get(long repositoryId, int id)
         {
             return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(repositoryId, id), null, AcceptHeaders.ReactionsPreview);
         }
@@ -64,7 +64,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -91,7 +91,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -119,7 +119,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(int repositoryId, int number)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -148,7 +148,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -179,7 +179,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        public Task<IssueComment> Create(int repositoryId, int number, string newComment)
+        public Task<IssueComment> Create(long repositoryId, int number, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, "newComment");
 
@@ -210,7 +210,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
-        public Task<IssueComment> Update(int repositoryId, int id, string commentUpdate)
+        public Task<IssueComment> Update(long repositoryId, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
@@ -238,7 +238,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
-        public Task Delete(int repositoryId, int id)
+        public Task Delete(long repositoryId, int id)
         {
             return ApiConnection.Delete(ApiUrls.IssueComment(repositoryId, id));
         }

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -37,7 +37,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>        
-        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueReactions(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
-        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -61,7 +61,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(int repositoryId, int number)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -75,7 +75,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -82,7 +82,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<Issue> Get(int repositoryId, int number)
+        public Task<Issue> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
@@ -294,7 +294,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new RepositoryIssueRequest());
         }
@@ -325,7 +325,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -358,7 +358,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
-        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request)
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -394,7 +394,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Issue>> GetAllForRepository(int repositoryId, RepositoryIssueRequest request, ApiOptions options)
+        public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -426,7 +426,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
-        public Task<Issue> Create(int repositoryId, NewIssue newIssue)
+        public Task<Issue> Create(long repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, "newIssue");
 
@@ -460,7 +460,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public Task<Issue> Update(int repositoryId, int number, IssueUpdate issueUpdate)
+        public Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
 
@@ -488,7 +488,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Lock(int repositoryId, int number)
+        public Task Lock(long repositoryId, int number)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
         }
@@ -514,7 +514,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Unlock(int repositoryId, int number)
+        public Task Unlock(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);
         }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -75,7 +75,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -105,7 +105,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -136,7 +136,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -168,7 +168,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The event id</param>
-        public Task<IssueEvent> Get(int repositoryId, int number)
+        public Task<IssueEvent> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));
         }

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -74,7 +74,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Label>> GetAllForIssue(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -104,7 +104,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -135,7 +135,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Label>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -167,7 +167,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number)
         {
             return GetAllForMilestone(repositoryId, number, ApiOptions.None);
         }
@@ -200,7 +200,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Label>> GetAllForMilestone(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -233,7 +233,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        public Task<Label> Get(int repositoryId, string labelName)
+        public Task<Label> Get(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -266,7 +266,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
-        public Task Delete(int repositoryId, string labelName)
+        public Task Delete(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -299,7 +299,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
-        public Task<Label> Create(int repositoryId, NewLabel newLabel)
+        public Task<Label> Create(long repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, "newLabel");
 
@@ -335,7 +335,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
-        public Task<Label> Update(int repositoryId, string labelName, LabelUpdate labelUpdate)
+        public Task<Label> Update(long repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
             Ensure.ArgumentNotNull(labelUpdate, "labelUpdate");
@@ -371,7 +371,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        public Task<IReadOnlyList<Label>> AddToIssue(int repositoryId, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
 
@@ -406,7 +406,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public Task RemoveFromIssue(int repositoryId, int number, string labelName)
+        public Task RemoveFromIssue(long repositoryId, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, "labelName");
 
@@ -441,7 +441,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(int repositoryId, int number, string[] labels)
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, "labels");
 
@@ -473,7 +473,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
-        public Task RemoveAllFromIssue(int repositoryId, int number)
+        public Task RemoveAllFromIssue(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, number));
         }

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -46,7 +46,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
-        public Task<Merge> Create(int repositoryId, NewMerge merge)
+        public Task<Merge> Create(long repositoryId, NewMerge merge)
         {
             Ensure.ArgumentNotNull(merge, "merge");
 

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
-        public Task<Milestone> Get(int repositoryId, int number)
+        public Task<Milestone> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<Milestone>(ApiUrls.Milestone(repositoryId, number));
         }
@@ -71,7 +71,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new MilestoneRequest());
         }
@@ -104,7 +104,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -139,7 +139,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request)
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -178,7 +178,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Milestone>> GetAllForRepository(int repositoryId, MilestoneRequest request, ApiOptions options)
+        public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -213,7 +213,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
-        public Task<Milestone> Create(int repositoryId, NewMilestone newMilestone)
+        public Task<Milestone> Create(long repositoryId, NewMilestone newMilestone)
         {
             Ensure.ArgumentNotNull(newMilestone, "newMilestone");
 
@@ -250,7 +250,7 @@ namespace Octokit
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
-        public Task<Milestone> Update(int repositoryId, int number, MilestoneUpdate milestoneUpdate)
+        public Task<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNull(milestoneUpdate, "milestoneUpdate");
 
@@ -282,7 +282,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        public Task Delete(int repositoryId, int number)
+        public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.Milestone(repositoryId, number));
         }

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -85,7 +85,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -112,7 +112,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -141,7 +141,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request)
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -173,7 +173,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<Notification>> GetAllForRepository(int repositoryId, NotificationsRequest request, ApiOptions options)
+        public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -221,7 +221,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        public Task MarkAsReadForRepository(int repositoryId)
+        public Task MarkAsReadForRepository(long repositoryId)
         {
             return ApiConnection.Put(ApiUrls.Notifications(repositoryId));
         }
@@ -248,7 +248,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
-        public Task MarkAsReadForRepository(int repositoryId, MarkAsReadRequest markAsReadRequest)
+        public Task MarkAsReadForRepository(long repositoryId, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, "markAsReadRequest");
 

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -37,7 +37,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
-        public Task<IReadOnlyList<Reaction>> GetAll(int repositoryId, int number)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), AcceptHeaders.ReactionsPreview);
         }
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
-        public Task<Reaction> Create(int repositoryId, int number, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, "reaction");
 

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
         }
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(int repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -93,7 +93,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
         }
@@ -120,7 +120,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -149,7 +149,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -181,7 +181,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(int repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
+        public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -210,7 +210,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        public Task<PullRequestReviewComment> GetComment(int repositoryId, int number)
+        public Task<PullRequestReviewComment> GetComment(long repositoryId, int number)
         {
             return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number));
         }
@@ -247,7 +247,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
-        public async Task<PullRequestReviewComment> Create(int repositoryId, int number, PullRequestReviewCommentCreate comment)
+        public async Task<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -294,7 +294,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
-        public async Task<PullRequestReviewComment> CreateReply(int repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
+        public async Task<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -333,7 +333,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
-        public Task<PullRequestReviewComment> Edit(int repositoryId, int number, PullRequestReviewCommentEdit comment)
+        public Task<PullRequestReviewComment> Edit(long repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, "comment");
 
@@ -361,7 +361,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
-        public Task Delete(int repositoryId, int number)
+        public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.PullRequestReviewComment(repositoryId, number));
         }

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
-        public Task<PullRequest> Get(int repositoryId, int number)
+        public Task<PullRequest> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number));
         }
@@ -70,7 +70,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestRequest(), ApiOptions.None);
         }
@@ -101,7 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -134,7 +134,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
-        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request)
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -171,7 +171,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(int repositoryId, PullRequestRequest request, ApiOptions options)
+        public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -202,7 +202,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
-        public Task<PullRequest> Create(int repositoryId, NewPullRequest newPullRequest)
+        public Task<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, "newPullRequest");
 
@@ -235,7 +235,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
-        public Task<PullRequest> Update(int repositoryId, int number, PullRequestUpdate pullRequestUpdate)
+        public Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, "pullRequestUpdate");
 
@@ -285,7 +285,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
-        public async Task<PullRequestMerge> Merge(int repositoryId, int number, MergePullRequest mergePullRequest)
+        public async Task<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, "mergePullRequest");
 
@@ -341,7 +341,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public async Task<bool> Merged(int repositoryId, int number)
+        public async Task<bool> Merged(long repositoryId, int number)
         {
             try
             {
@@ -376,7 +376,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public Task<IReadOnlyList<PullRequestCommit>> Commits(int repositoryId, int number)
+        public Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
         }
@@ -402,7 +402,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public Task<IReadOnlyList<PullRequestFile>> Files(int repositoryId, int number)
+        public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));
         }

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public Task<Reference> Get(int repositoryId, string reference)
+        public Task<Reference> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -80,7 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Reference>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<Reference>> GetAll(long repositoryId)
         {
             return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId));
         }
@@ -115,7 +115,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(int repositoryId, string subNamespace)
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
 
@@ -152,7 +152,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
-        public Task<Reference> Create(int repositoryId, NewReference reference)
+        public Task<Reference> Create(long repositoryId, NewReference reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
 
@@ -190,7 +190,7 @@ namespace Octokit
         /// <param name="reference">The name of the reference</param>
         /// <param name="referenceUpdate">The updated reference data</param>
         /// <returns></returns>
-        public Task<Reference> Update(int repositoryId, string reference, ReferenceUpdate referenceUpdate)
+        public Task<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
             Ensure.ArgumentNotNull(referenceUpdate, "update");
@@ -226,7 +226,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the reference</param>
         /// <returns></returns>
-        public Task Delete(int repositoryId, string reference)
+        public Task Delete(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -46,7 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<Release>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<Release>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -80,7 +80,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<Release>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Release>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -116,7 +116,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<Release> Get(int repositoryId, int id)
+        public Task<Release> Get(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Releases(repositoryId, id);
             return ApiConnection.Get<Release>(endpoint);
@@ -148,7 +148,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<Release> GetLatest(int repositoryId)
+        public Task<Release> GetLatest(long repositoryId)
         {
             var endpoint = ApiUrls.LatestRelease(repositoryId);
             return ApiConnection.Get<Release>(endpoint);
@@ -183,7 +183,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<Release> Create(int repositoryId, NewRelease data)
+        public Task<Release> Create(long repositoryId, NewRelease data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -222,7 +222,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<Release> Edit(int repositoryId, int id, ReleaseUpdate data)
+        public Task<Release> Edit(long repositoryId, int id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -258,7 +258,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task Delete(int repositoryId, int id)
+        public Task Delete(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Releases(repositoryId, id);
             return ApiConnection.Delete(endpoint);
@@ -291,7 +291,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(int repositoryId, int id)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id)
         {
             return GetAllAssets(repositoryId, id, ApiOptions.None);
         }
@@ -327,7 +327,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(int repositoryId, int id, ApiOptions options)
+        public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -394,7 +394,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
-        public Task<ReleaseAsset> GetAsset(int repositoryId, int assetId)
+        public Task<ReleaseAsset> GetAsset(long repositoryId, int assetId)
         {
             var endpoint = ApiUrls.Asset(repositoryId, assetId);
             return ApiConnection.Get<ReleaseAsset>(endpoint);
@@ -429,7 +429,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
-        public Task<ReleaseAsset> EditAsset(int repositoryId, int assetId, ReleaseAssetUpdate data)
+        public Task<ReleaseAsset> EditAsset(long repositoryId, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNull(data, "data");
 
@@ -463,7 +463,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
-        public Task DeleteAsset(int repositoryId, int id)
+        public Task DeleteAsset(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Asset(repositoryId, id);
             return ApiConnection.Delete(endpoint);

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<User>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<User>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -80,7 +80,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<User>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -123,7 +123,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public async Task<bool> IsCollaborator(int repositoryId, string user)
+        public async Task<bool> IsCollaborator(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -194,7 +194,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task Add(int repositoryId, string user)
+        public Task Add(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -211,7 +211,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public async Task<bool> Add(int repositoryId, string user, CollaboratorRequest permission)
+        public async Task<bool> Add(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -275,7 +275,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="user">The name of the user to invite.</param>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<RepositoryInvitation> Invite(int repositoryId, string user)
+        public Task<RepositoryInvitation> Invite(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
@@ -292,7 +292,7 @@ namespace Octokit
         /// <param name="user">The name of the user to invite.</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>        
-        public Task<RepositoryInvitation> Invite(int repositoryId, string user, CollaboratorRequest permission)
+        public Task<RepositoryInvitation> Invite(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
             Ensure.ArgumentNotNull(permission, "permission");
@@ -328,7 +328,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task Delete(int repositoryId, string user)
+        public Task Delete(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -158,7 +158,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task Delete(int repositoryId)
+        public Task Delete(long repositoryId)
         {
             return ApiConnection.Delete(ApiUrls.Repository(repositoryId));
         }
@@ -172,7 +172,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         [Obsolete("Please use RepositoriesClient.Branch.Get() instead.  This method will be removed in a future version")]
-        public Task<Branch> GetBranch(int repositoryId, string branchName)
+        public Task<Branch> GetBranch(long repositoryId, string branchName)
         {
             Ensure.ArgumentNotNullOrEmptyString(branchName, "branchName");
 
@@ -201,7 +201,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
-        public Task<Repository> Edit(int repositoryId, RepositoryUpdate update)
+        public Task<Repository> Edit(long repositoryId, RepositoryUpdate update)
         {
             Ensure.ArgumentNotNull(update, "update");
 
@@ -235,7 +235,7 @@ namespace Octokit
         /// <param name="update">New values to update the branch with</param>
         /// <returns>The updated <see cref="T:Octokit.Branch"/></returns>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use the RepositoryBranchesClient methods instead.")]
-        public Task<Branch> EditBranch(int repositoryId, string branch, BranchUpdate update)
+        public Task<Branch> EditBranch(long repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
@@ -270,7 +270,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
-        public Task<Repository> Get(int repositoryId)
+        public Task<Repository> Get(long repositoryId)
         {
             return ApiConnection.Get<Repository>(ApiUrls.Repository(repositoryId));
         }
@@ -573,7 +573,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId)
+        public Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId)
         {
             return Branch.GetAll(repositoryId);
         }
@@ -606,7 +606,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -638,7 +638,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All contributors of the repository.</returns>
-        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId)
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId)
         {
             return GetAllContributors(repositoryId, false);
         }
@@ -671,7 +671,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -705,7 +705,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
-        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous)
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous)
         {
             return GetAllContributors(repositoryId, includeAnonymous, ApiOptions.None);
         }
@@ -744,7 +744,7 @@ namespace Octokit
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
-        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(int repositoryId, bool includeAnonymous, ApiOptions options)
+        public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -784,7 +784,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
-        public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(int repositoryId)
+        public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryLanguages(repositoryId);
             var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
@@ -818,7 +818,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        public Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId)
+        public Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId)
         {
             return GetAllTeams(repositoryId, ApiOptions.None);
         }
@@ -851,7 +851,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
-        public Task<IReadOnlyList<Team>> GetAllTeams(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -883,7 +883,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All of the repositories tags.</returns>
-        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId)
+        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId)
         {
             return GetAllTags(repositoryId, ApiOptions.None);
         }
@@ -916,7 +916,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
-        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Branch>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<Branch>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -77,7 +77,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Branch>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Branch>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -110,7 +110,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public Task<Branch> Get(int repositoryId, string branch)
+        public Task<Branch> Get(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branchName");
 
@@ -142,7 +142,7 @@ namespace Octokit
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">New values to update the branch with</param>
         [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please use other RepositoryBranchesClient methods instead.")]
-        public Task<Branch> Edit(int repositoryId, string branch, BranchUpdate update)
+        public Task<Branch> Edit(long repositoryId, string branch, BranchUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
@@ -176,7 +176,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public Task<BranchProtectionSettings> GetBranchProtection(int repositoryId, string branch)
+        public Task<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
@@ -212,7 +212,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
-        public Task<BranchProtectionSettings> UpdateBranchProtection(int repositoryId, string branch, BranchProtectionSettingsUpdate update)
+        public Task<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
             Ensure.ArgumentNotNull(update, "update");
@@ -255,7 +255,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public async Task<bool> DeleteBranchProtection(int repositoryId, string branch)
+        public async Task<bool> DeleteBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -41,7 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
-        public Task<CommitComment> Get(int repositoryId, int number)
+        public Task<CommitComment> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<CommitComment>(ApiUrls.CommitComment(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
@@ -65,7 +65,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
-        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
         }
@@ -92,7 +92,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
-        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(int repositoryId, string sha)
+        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
@@ -153,7 +153,7 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
-        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(int repositoryId, string sha, ApiOptions options)
+        public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
             Ensure.ArgumentNotNull(options, "options");
@@ -186,7 +186,7 @@ namespace Octokit
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
-        public Task<CommitComment> Create(int repositoryId, string sha, NewCommitComment newCommitComment)
+        public Task<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
             Ensure.ArgumentNotNull(newCommitComment, "newCommitComment");
@@ -218,7 +218,7 @@ namespace Octokit
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#update-a-commit-comment</remarks>
-        public Task<CommitComment> Update(int repositoryId, int number, string commentUpdate)
+        public Task<CommitComment> Update(long repositoryId, int number, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, "commentUpdate");
 
@@ -246,7 +246,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
-        public Task Delete(int repositoryId, int number)
+        public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.CommitComment(repositoryId, number));
         }

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -39,7 +39,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
-        public Task<CompareResult> Compare(int repositoryId, string @base, string head)
+        public Task<CompareResult> Compare(long repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, "base");
             Ensure.ArgumentNotNullOrEmptyString(head, "head");
@@ -67,7 +67,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
-        public Task<GitHubCommit> Get(int repositoryId, string reference)
+        public Task<GitHubCommit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -91,7 +91,7 @@ namespace Octokit
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
         }
@@ -115,7 +115,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, ApiOptions options)
         {
             return GetAll(repositoryId, new CommitRequest(), options);
         }
@@ -140,7 +140,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
-        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request)
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -170,7 +170,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<GitHubCommit>> GetAll(int repositoryId, CommitRequest request, ApiOptions options)
+        public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -198,7 +198,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
-        public Task<string> GetSha1(int repositoryId, string reference)
+        public Task<string> GetSha1(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
-        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId, string path)
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
 
@@ -82,7 +82,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(int repositoryId)
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId)
         {
             var url = ApiUrls.RepositoryContent(repositoryId, string.Empty);
 
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string path, string reference)
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
@@ -160,7 +160,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
-        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(int repositoryId, string reference)
+        public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -197,7 +197,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public async Task<Readme> GetReadme(int repositoryId)
+        public async Task<Readme> GetReadme(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryReadme(repositoryId);
             var readmeInfo = await ApiConnection.Get<ReadmeResponse>(endpoint, null).ConfigureAwait(false);
@@ -230,7 +230,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<string> GetReadmeHtml(int repositoryId)
+        public Task<string> GetReadmeHtml(long repositoryId)
         {
             return ApiConnection.GetHtml(ApiUrls.RepositoryReadme(repositoryId), null);
         }
@@ -254,7 +254,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<byte[]> GetArchive(int repositoryId)
+        public Task<byte[]> GetArchive(long repositoryId)
         {
             return GetArchive(repositoryId, ArchiveFormat.Tarball, string.Empty);
         }
@@ -280,7 +280,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
-        public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat)
+        public Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat)
         {
             return GetArchive(repositoryId, archiveFormat, string.Empty);
         }
@@ -309,7 +309,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
-        public Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference)
+        public Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNull(reference, "reference");
 
@@ -347,7 +347,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
-        public async Task<byte[]> GetArchive(int repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
+        public async Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNull(reference, "reference");
             Ensure.GreaterThanZero(timeout, "timeout");
@@ -383,7 +383,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
-        public Task<RepositoryContentChangeSet> CreateFile(int repositoryId, string path, CreateFileRequest request)
+        public Task<RepositoryContentChangeSet> CreateFile(long repositoryId, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");
@@ -416,7 +416,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
-        public Task<RepositoryContentChangeSet> UpdateFile(int repositoryId, string path, UpdateFileRequest request)
+        public Task<RepositoryContentChangeSet> UpdateFile(long repositoryId, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");
@@ -449,7 +449,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
-        public Task DeleteFile(int repositoryId, string path, DeleteFileRequest request)
+        public Task DeleteFile(long repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, "path");
             Ensure.ArgumentNotNull(request, "request");

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -48,7 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
-        public Task<DeployKey> Get(int repositoryId, int number)
+        public Task<DeployKey> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
         }
@@ -76,7 +76,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
-        public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -107,7 +107,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<DeployKey>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -146,7 +146,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
-        public Task<DeployKey> Create(int repositoryId, NewDeployKey newDeployKey)
+        public Task<DeployKey> Create(long repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, "newDeployKey");
 
@@ -184,7 +184,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
-        public Task Delete(int repositoryId, int number)
+        public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, number));
         }

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -43,7 +43,7 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<Repository>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -74,7 +74,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -107,7 +107,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
-        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request)
+        public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNull(request, "request");
 
@@ -143,7 +143,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<Repository>> GetAll(int repositoryId, RepositoryForksListRequest request, ApiOptions options)
+        public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
@@ -177,7 +177,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
-        public Task<Repository> Create(int repositoryId, NewRepositoryFork fork)
+        public Task<Repository> Create(long repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, "fork");
 

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -39,7 +39,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
-        public Task<IReadOnlyList<RepositoryHook>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -94,7 +94,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
-        public Task<RepositoryHook> Get(int repositoryId, int hookId)
+        public Task<RepositoryHook> Get(long repositoryId, int hookId)
         {
             return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId));
         }
@@ -121,7 +121,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
-        public Task<RepositoryHook> Create(int repositoryId, NewRepositoryHook hook)
+        public Task<RepositoryHook> Create(long repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
 
@@ -152,7 +152,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        public Task<RepositoryHook> Edit(int repositoryId, int hookId, EditRepositoryHook hook)
+        public Task<RepositoryHook> Edit(long repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, "hook");
 
@@ -184,7 +184,7 @@ namespace Octokit
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
         /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
-        public Task Test(int repositoryId, int hookId)
+        public Task Test(long repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookTest(repositoryId, hookId));
         }
@@ -210,7 +210,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
-        public Task Ping(int repositoryId, int hookId)
+        public Task Ping(long repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookPing(repositoryId, hookId));
         }
@@ -236,7 +236,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
-        public Task Delete(int repositoryId, int hookId)
+        public Task Delete(long repositoryId, int hookId)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryHookById(repositoryId, hookId));
         }

--- a/Octokit/Clients/RepositoryInvitationsClient.cs
+++ b/Octokit/Clients/RepositoryInvitationsClient.cs
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public async Task<bool> Delete(int repositoryId, int invitationId)
+        public async Task<bool> Delete(long repositoryId, int invitationId)
         {
             var endpoint = ApiUrls.RepositoryInvitations(repositoryId, invitationId);
 
@@ -102,7 +102,7 @@ namespace Octokit
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(int repositoryId)
+        public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId)
         {
             return ApiConnection.GetAll<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), AcceptHeaders.InvitationsApiPreview);
         }
@@ -117,7 +117,7 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <param name="permissions">The permission for the collsborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        public Task<RepositoryInvitation> Edit(int repositoryId, int invitationId, InvitationUpdate permissions)
+        public Task<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions)
         {
             Ensure.ArgumentNotNull(permissions, "permissions");
 

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
-        public Task<Page> Get(int repositoryId)
+        public Task<Page> Get(long repositoryId)
         {
             return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(repositoryId));
         }
@@ -70,7 +70,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId)
+        public Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
         }
@@ -102,7 +102,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
-        public Task<IReadOnlyList<PagesBuild>> GetAll(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -133,7 +133,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
-        public Task<PagesBuild> GetLatest(int repositoryId)
+        public Task<PagesBuild> GetLatest(long repositoryId)
         {
             return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(repositoryId));
         }
@@ -161,7 +161,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
-        public Task<PagesBuild> RequestPageBuild(int repositoryId)
+        public Task<PagesBuild> RequestPageBuild(long repositoryId)
         {
             return ApiConnection.Post<PagesBuild>(ApiUrls.RepositoryPageBuilds(repositoryId), AcceptHeaders.PagesApiPreview);
         }

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -39,7 +39,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId)
+        public Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
         }
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<User>> GetAllStargazers(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -92,7 +92,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId)
+        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId)
         {
             return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
         }
@@ -119,7 +119,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -38,7 +38,7 @@ namespace Octokit
         /// Returns a list of <see cref="Contributor"/> for the given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<IReadOnlyList<Contributor>> GetContributors(int repositoryId)
+        public Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId)
         {
             return GetContributors(repositoryId, CancellationToken.None);
         }
@@ -62,7 +62,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        public Task<IReadOnlyList<Contributor>> GetContributors(int repositoryId, CancellationToken cancellationToken)
+        public Task<IReadOnlyList<Contributor>> GetContributors(long repositoryId, CancellationToken cancellationToken)
         {
             return ApiConnection.GetQueuedOperation<Contributor>(ApiUrls.StatsContributors(repositoryId), cancellationToken);
         }
@@ -84,7 +84,7 @@ namespace Octokit
         /// Returns the last year of commit activity grouped by week.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<CommitActivity> GetCommitActivity(int repositoryId)
+        public Task<CommitActivity> GetCommitActivity(long repositoryId)
         {
             return GetCommitActivity(repositoryId, CancellationToken.None);
         }
@@ -110,7 +110,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        public async Task<CommitActivity> GetCommitActivity(int repositoryId, CancellationToken cancellationToken)
+        public async Task<CommitActivity> GetCommitActivity(long repositoryId, CancellationToken cancellationToken)
         {
             var activity = await ApiConnection.GetQueuedOperation<WeeklyCommitActivity>(
                 ApiUrls.StatsCommitActivity(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -134,7 +134,7 @@ namespace Octokit
         /// Returns a weekly aggregate of the number of additions and deletions pushed to a repository. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<CodeFrequency> GetCodeFrequency(int repositoryId)
+        public Task<CodeFrequency> GetCodeFrequency(long repositoryId)
         {
             return GetCodeFrequency(repositoryId, CancellationToken.None);
         }
@@ -160,7 +160,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        public async Task<CodeFrequency> GetCodeFrequency(int repositoryId, CancellationToken cancellationToken)
+        public async Task<CodeFrequency> GetCodeFrequency(long repositoryId, CancellationToken cancellationToken)
         {
             var rawFrequencies = await ApiConnection.GetQueuedOperation<long[]>(
                 ApiUrls.StatsCodeFrequency(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -184,7 +184,7 @@ namespace Octokit
         /// Returns the total commit counts for the owner and total commit counts in total. 
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<Participation> GetParticipation(int repositoryId)
+        public Task<Participation> GetParticipation(long repositoryId)
         {
             return GetParticipation(repositoryId, CancellationToken.None);
         }
@@ -210,7 +210,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        public async Task<Participation> GetParticipation(int repositoryId, CancellationToken cancellationToken)
+        public async Task<Participation> GetParticipation(long repositoryId, CancellationToken cancellationToken)
         {
             var result = await ApiConnection.GetQueuedOperation<Participation>(
                 ApiUrls.StatsParticipation(repositoryId), cancellationToken).ConfigureAwait(false);
@@ -234,7 +234,7 @@ namespace Octokit
         /// Returns a list of the number of commits per hour in each day
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public Task<PunchCard> GetPunchCard(int repositoryId)
+        public Task<PunchCard> GetPunchCard(long repositoryId)
         {
             return GetPunchCard(repositoryId, CancellationToken.None);
         }
@@ -260,7 +260,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="cancellationToken">A token used to cancel this potentially long running request</param>
-        public async Task<PunchCard> GetPunchCard(int repositoryId, CancellationToken cancellationToken)
+        public async Task<PunchCard> GetPunchCard(long repositoryId, CancellationToken cancellationToken)
         {
             var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(
                 ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -45,7 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
-        public Task<GitTag> Get(int repositoryId, string reference)
+        public Task<GitTag> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -78,7 +78,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag to create</param>
-        public Task<GitTag> Create(int repositoryId, NewTag tag)
+        public Task<GitTag> Create(long repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, "tag");
 

--- a/Octokit/Clients/TreesClient.cs
+++ b/Octokit/Clients/TreesClient.cs
@@ -47,7 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        public Task<TreeResponse> Get(int repositoryId, string reference)
+        public Task<TreeResponse> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -80,7 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
-        public Task<TreeResponse> GetRecursive(int repositoryId, string reference)
+        public Task<TreeResponse> GetRecursive(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
@@ -118,7 +118,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
-        public Task<TreeResponse> Create(int repositoryId, NewTree newTree)
+        public Task<TreeResponse> Create(long repositoryId, NewTree newTree)
         {
             Ensure.ArgumentNotNull(newTree, "newTree");
 

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -40,7 +40,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId)
+        public Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
         }
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public Task<IReadOnlyList<User>> GetAllWatchers(int repositoryId, ApiOptions options)
+        public Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
 
@@ -162,7 +162,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
-        public async Task<bool> CheckWatched(int repositoryId)
+        public async Task<bool> CheckWatched(long repositoryId)
         {
             try
             {
@@ -197,7 +197,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
-        public Task<Subscription> WatchRepo(int repositoryId, NewSubscription newSubscription)
+        public Task<Subscription> WatchRepo(long repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, "newSubscription");
 
@@ -231,7 +231,7 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
-        public async Task<bool> UnwatchRepo(int repositoryId)
+        public async Task<bool> UnwatchRepo(long repositoryId)
         {
             try
             {

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -336,7 +336,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueReactions(int repositoryId, int number)
+        public static Uri IssueReactions(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/reactions".FormatUri(repositoryId, number);
         }
@@ -359,7 +359,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueTimeline(int repositoryId, int number)
+        public static Uri IssueTimeline(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/timeline".FormatUri(repositoryId, number);
         }
@@ -417,7 +417,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment number</param>
         /// <returns></returns>
-        public static Uri IssueCommentReactions(int repositoryId, int number)
+        public static Uri IssueCommentReactions(long repositoryId, int number)
         {
             return "repositories/{0}/issues/comments/{1}/reactions".FormatUri(repositoryId, number);
         }
@@ -475,7 +475,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <returns></returns>
-        public static Uri CommitCommentReactions(int repositoryId, int number)
+        public static Uri CommitCommentReactions(long repositoryId, int number)
         {
             return "repositories/{0}/comments/{1}/reactions".FormatUri(repositoryId, number);
         }
@@ -1281,7 +1281,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <returns></returns>
-        public static Uri PullRequestReviewCommentReaction(int repositoryId, int number)
+        public static Uri PullRequestReviewCommentReaction(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/comments/{1}/reactions".FormatUri(repositoryId, number);
         }
@@ -1461,7 +1461,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">The name of the user</param>
         /// <returns>The <see cref="Uri"/> to check user is collaborator</returns>
-        public static Uri RepoCollaborator(int repositoryId, string user)
+        public static Uri RepoCollaborator(long repositoryId, string user)
         {
             return "repositories/{0}/collaborators/{1}".FormatUri(repositoryId, user);
         }
@@ -1630,7 +1630,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns></returns>
-        public static Uri RepoBranchProtection(int repositoryId, string branchName)
+        public static Uri RepoBranchProtection(long repositoryId, string branchName)
         {
             return "repositories/{0}/branches/{1}/protection".FormatUri(repositoryId, branchName);
         }
@@ -2096,7 +2096,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release asset</param>
         /// <returns>The <see cref="Uri"/> that returns the assets specified by the asset id.</returns>
-        public static Uri Asset(int repositoryId, int id)
+        public static Uri Asset(long repositoryId, int id)
         {
             return "repositories/{0}/releases/assets/{1}".FormatUri(repositoryId, id);
         }
@@ -2106,7 +2106,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the assignees to which issues may be assigned.</returns>
-        public static Uri Assignees(int repositoryId)
+        public static Uri Assignees(long repositoryId)
         {
             return "repositories/{0}/assignees".FormatUri(repositoryId);
         }
@@ -2116,7 +2116,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for a specific blob.</returns>
-        public static Uri Blobs(int repositoryId)
+        public static Uri Blobs(long repositoryId)
         {
             return Blob(repositoryId, "");
         }
@@ -2127,7 +2127,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
         /// <returns>The <see cref="Uri"/> for a specific blob.</returns>
-        public static Uri Blob(int repositoryId, string reference)
+        public static Uri Blob(long repositoryId, string reference)
         {
             string blob = "repositories/{0}/git/blobs";
             if (!string.IsNullOrEmpty(reference))
@@ -2143,7 +2143,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="login">The login for the user</param>
         /// <returns>The <see cref="Uri"/> that returns a 204 if the login belongs to an assignee of the repository. Otherwire returns a 404.</returns>
-        public static Uri CheckAssignee(int repositoryId, string login)
+        public static Uri CheckAssignee(long repositoryId, string login)
         {
             return "repositories/{0}/assignees/{1}".FormatUri(repositoryId, login);
         }
@@ -2154,7 +2154,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <returns>The <see cref="Uri"/> that returns a combined view of commit statuses for the specified reference.</returns>
-        public static Uri CombinedCommitStatus(int repositoryId, string reference)
+        public static Uri CombinedCommitStatus(long repositoryId, string reference)
         {
             return "repositories/{0}/commits/{1}/status".FormatUri(repositoryId, reference);
         }
@@ -2165,7 +2165,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (SHA)</param>
         /// <returns>The <see cref="Uri"/> for the specified commit.</returns>
-        public static Uri Commit(int repositoryId, string reference)
+        public static Uri Commit(long repositoryId, string reference)
         {
             return "repositories/{0}/git/commits/{1}".FormatUri(repositoryId, reference);
         }
@@ -2176,7 +2176,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <returns>The <see cref="Uri"/> for the specified comment.</returns>
-        public static Uri CommitComment(int repositoryId, int number)
+        public static Uri CommitComment(long repositoryId, int number)
         {
             return "repositories/{0}/comments/{1}".FormatUri(repositoryId, number);
         }
@@ -2187,7 +2187,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <returns>The <see cref="Uri"/> for the comments of a specified commit.</returns>
-        public static Uri CommitComments(int repositoryId, string sha)
+        public static Uri CommitComments(long repositoryId, string sha)
         {
             return "repositories/{0}/commits/{1}/comments".FormatUri(repositoryId, sha);
         }
@@ -2197,7 +2197,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the comments of a specified commit.</returns>
-        public static Uri CommitComments(int repositoryId)
+        public static Uri CommitComments(long repositoryId)
         {
             return "repositories/{0}/comments".FormatUri(repositoryId);
         }
@@ -2208,7 +2208,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <returns>The <see cref="Uri"/> that lists the commit statuses for the specified reference.</returns>
-        public static Uri CommitStatuses(int repositoryId, string reference)
+        public static Uri CommitStatuses(long repositoryId, string reference)
         {
             return "repositories/{0}/commits/{1}/statuses".FormatUri(repositoryId, reference);
         }
@@ -2218,7 +2218,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for creating a commit object.</returns>
-        public static Uri CreateCommit(int repositoryId)
+        public static Uri CreateCommit(long repositoryId)
         {
             return "repositories/{0}/git/commits".FormatUri(repositoryId);
         }
@@ -2229,7 +2229,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <returns>The <see cref="Uri"/> to use when creating a commit status for the specified reference.</returns>
-        public static Uri CreateCommitStatus(int repositoryId, string reference)
+        public static Uri CreateCommitStatus(long repositoryId, string reference)
         {
             return "repositories/{0}/statuses/{1}".FormatUri(repositoryId, reference);
         }
@@ -2239,7 +2239,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for creating a merge object.</returns>
-        public static Uri CreateMerge(int repositoryId)
+        public static Uri CreateMerge(long repositoryId)
         {
             return "repositories/{0}/merges".FormatUri(repositoryId);
         }
@@ -2249,7 +2249,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for creating a tag object.</returns>
-        public static Uri CreateTag(int repositoryId)
+        public static Uri CreateTag(long repositoryId)
         {
             return "repositories/{0}/git/tags".FormatUri(repositoryId);
         }
@@ -2259,7 +2259,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the Deployments API for the given repository.</returns>
-        public static Uri Deployments(int repositoryId)
+        public static Uri Deployments(long repositoryId)
         {
             return "repositories/{0}/deployments".FormatUri(repositoryId);
         }
@@ -2270,7 +2270,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="deploymentId">Id of the deployment</param>
         /// <returns>The <see cref="Uri"/> for the Deployment Statuses API for the given deployment.</returns>
-        public static Uri DeploymentStatuses(int repositoryId, int deploymentId)
+        public static Uri DeploymentStatuses(long repositoryId, int deploymentId)
         {
             return "repositories/{0}/deployments/{1}/statuses".FormatUri(repositoryId, deploymentId);
         }
@@ -2280,7 +2280,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified repository.</returns>
-        public static Uri Events(int repositoryId)
+        public static Uri Events(long repositoryId)
         {
             return "repositories/{0}/events".FormatUri(repositoryId);
         }
@@ -2312,7 +2312,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue.</returns>
-        public static Uri Issue(int repositoryId, int number)
+        public static Uri Issue(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}".FormatUri(repositoryId, number);
         }
@@ -2323,7 +2323,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <returns>The <see cref="Uri"/> for the specified comment.</returns>
-        public static Uri IssueComment(int repositoryId, int id)
+        public static Uri IssueComment(long repositoryId, int id)
         {
             return "repositories/{0}/issues/comments/{1}".FormatUri(repositoryId, id);
         }
@@ -2333,7 +2333,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the comments for all issues in a specific repo.</returns>
-        public static Uri IssueComments(int repositoryId)
+        public static Uri IssueComments(long repositoryId)
         {
             return "repositories/{0}/issues/comments".FormatUri(repositoryId);
         }
@@ -2344,7 +2344,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the comments of a specified issue.</returns>
-        public static Uri IssueComments(int repositoryId, int number)
+        public static Uri IssueComments(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/comments".FormatUri(repositoryId, number);
         }
@@ -2356,7 +2356,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="labelName">The name of the label</param>
         /// <returns>The <see cref="Uri"/> that returns the named label for the specified issue.</returns>
-        public static Uri IssueLabel(int repositoryId, int number, string labelName)
+        public static Uri IssueLabel(long repositoryId, int number, string labelName)
         {
             return "repositories/{0}/issues/{1}/labels/{2}".FormatUri(repositoryId, number, labelName);
         }
@@ -2367,7 +2367,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for the specified issue.</returns>
-        public static Uri IssueLabels(int repositoryId, int number)
+        public static Uri IssueLabels(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/labels".FormatUri(repositoryId, number);
         }
@@ -2378,7 +2378,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue to be locked/unlocked.</returns>
-        public static Uri IssueLock(int repositoryId, int number)
+        public static Uri IssueLock(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/lock".FormatUri(repositoryId, number);
         }
@@ -2388,7 +2388,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the issues for the currently logged in user specific to the repository.</returns>
-        public static Uri Issues(int repositoryId)
+        public static Uri Issues(long repositoryId)
         {
             return "repositories/{0}/issues".FormatUri(repositoryId);
         }
@@ -2399,7 +2399,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The event id</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified event.</returns>
-        public static Uri IssuesEvent(int repositoryId, int id)
+        public static Uri IssuesEvent(long repositoryId, int id)
         {
             return "repositories/{0}/issues/events/{1}".FormatUri(repositoryId, id);
         }
@@ -2410,7 +2410,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.</returns>
-        public static Uri IssuesEvents(int repositoryId, int number)
+        public static Uri IssuesEvents(long repositoryId, int number)
         {
             return "repositories/{0}/issues/{1}/events".FormatUri(repositoryId, number);
         }
@@ -2420,7 +2420,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified repository.</returns>
-        public static Uri IssuesEvents(int repositoryId)
+        public static Uri IssuesEvents(long repositoryId)
         {
             return "repositories/{0}/issues/events".FormatUri(repositoryId);
         }
@@ -2431,7 +2431,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of label</param>
         /// <returns>The <see cref="Uri"/> that returns the specified label.</returns>
-        public static Uri Label(int repositoryId, string labelName)
+        public static Uri Label(long repositoryId, string labelName)
         {
             return "repositories/{0}/labels/{1}".FormatUri(repositoryId, labelName);
         }
@@ -2441,7 +2441,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for the specified repository.</returns>
-        public static Uri Labels(int repositoryId)
+        public static Uri Labels(long repositoryId)
         {
             return "repositories/{0}/labels".FormatUri(repositoryId);
         }
@@ -2451,7 +2451,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns the latest release for the specified repository</returns>
-        public static Uri LatestRelease(int repositoryId)
+        public static Uri LatestRelease(long repositoryId)
         {
             return "repositories/{0}/releases/latest".FormatUri(repositoryId);
         }
@@ -2462,7 +2462,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the pull request merge state.</returns>
-        public static Uri MergePullRequest(int repositoryId, int number)
+        public static Uri MergePullRequest(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/{1}/merge".FormatUri(repositoryId, number);
         }
@@ -2473,7 +2473,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns>The <see cref="Uri"/> that returns the specified milestone.</returns>
-        public static Uri Milestone(int repositoryId, int number)
+        public static Uri Milestone(long repositoryId, int number)
         {
             return "repositories/{0}/milestones/{1}".FormatUri(repositoryId, number);
         }
@@ -2484,7 +2484,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for all issues in the specified milestone.</returns>
-        public static Uri MilestoneLabels(int repositoryId, int number)
+        public static Uri MilestoneLabels(long repositoryId, int number)
         {
             return "repositories/{0}/milestones/{1}/labels".FormatUri(repositoryId, number);
         }
@@ -2494,7 +2494,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the milestones for the specified repository.</returns>
-        public static Uri Milestones(int repositoryId)
+        public static Uri Milestones(long repositoryId)
         {
             return "repositories/{0}/milestones".FormatUri(repositoryId);
         }
@@ -2504,7 +2504,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the notifications for the currently logged in user specific to the repository.</returns>
-        public static Uri Notifications(int repositoryId)
+        public static Uri Notifications(long repositoryId)
         {
             return "repositories/{0}/notifications".FormatUri(repositoryId);
         }
@@ -2515,7 +2515,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the specified pull request.</returns>
-        public static Uri PullRequest(int repositoryId, int number)
+        public static Uri PullRequest(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/{1}".FormatUri(repositoryId, number);
         }
@@ -2526,7 +2526,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the commits on a pull request.</returns>
-        public static Uri PullRequestCommits(int repositoryId, int number)
+        public static Uri PullRequestCommits(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/{1}/commits".FormatUri(repositoryId, number);
         }
@@ -2537,7 +2537,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that returns the files on a pull request.</returns>
-        public static Uri PullRequestFiles(int repositoryId, int number)
+        public static Uri PullRequestFiles(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/{1}/files".FormatUri(repositoryId, number);
         }
@@ -2548,7 +2548,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewComment(int repositoryId, int number)
+        public static Uri PullRequestReviewComment(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/comments/{1}".FormatUri(repositoryId, number);
         }
@@ -2559,7 +2559,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewComments(int repositoryId, int number)
+        public static Uri PullRequestReviewComments(long repositoryId, int number)
         {
             return "repositories/{0}/pulls/{1}/comments".FormatUri(repositoryId, number);
         }
@@ -2569,7 +2569,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that </returns>
-        public static Uri PullRequestReviewCommentsRepository(int repositoryId)
+        public static Uri PullRequestReviewCommentsRepository(long repositoryId)
         {
             return "repositories/{0}/pulls/comments".FormatUri(repositoryId);
         }
@@ -2579,7 +2579,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that lists the pull requests for a repository.</returns>
-        public static Uri PullRequests(int repositoryId)
+        public static Uri PullRequests(long repositoryId)
         {
             return "repositories/{0}/pulls".FormatUri(repositoryId);
         }
@@ -2589,7 +2589,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the specified reference.</returns>
-        public static Uri Reference(int repositoryId)
+        public static Uri Reference(long repositoryId)
         {
             return "repositories/{0}/git/refs".FormatUri(repositoryId);
         }
@@ -2600,7 +2600,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="referenceName">The reference name</param>
         /// <returns>The <see cref="Uri"/> for the specified reference.</returns>
-        public static Uri Reference(int repositoryId, string referenceName)
+        public static Uri Reference(long repositoryId, string referenceName)
         {
             return "repositories/{0}/git/refs/{1}".FormatUri(repositoryId, referenceName);
         }
@@ -2611,7 +2611,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <returns>The <see cref="Uri"/> that returns all the assets for the specified release for the specified repository.</returns>
-        public static Uri ReleaseAssets(int repositoryId, int id)
+        public static Uri ReleaseAssets(long repositoryId, int id)
         {
             return "repositories/{0}/releases/{1}/assets".FormatUri(repositoryId, id);
         }
@@ -2621,7 +2621,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the releases for the specified repository.</returns>
-        public static Uri Releases(int repositoryId)
+        public static Uri Releases(long repositoryId)
         {
             return "repositories/{0}/releases".FormatUri(repositoryId);
         }
@@ -2632,7 +2632,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <returns>The <see cref="Uri"/> that returns a single release for the specified repository</returns>
-        public static Uri Releases(int repositoryId, int id)
+        public static Uri Releases(long repositoryId, int id)
         {
             return "repositories/{0}/releases/{1}".FormatUri(repositoryId, id);
         }
@@ -2643,7 +2643,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branchName">The name of the branch</param>
         /// <returns>The <see cref="Uri"/> for a repository branch.</returns>
-        public static Uri RepoBranch(int repositoryId, string branchName)
+        public static Uri RepoBranch(long repositoryId, string branchName)
         {
             return "repositories/{0}/branches/{1}".FormatUri(repositoryId, branchName);
         }
@@ -2653,7 +2653,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the branches for the specified repository.</returns>
-        public static Uri RepoBranches(int repositoryId)
+        public static Uri RepoBranches(long repositoryId)
         {
             return "repositories/{0}/branches".FormatUri(repositoryId);
         }
@@ -2663,7 +2663,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that returns all of the collaborators for the specified repository.</returns>
-        public static Uri RepoCollaborators(int repositoryId)
+        public static Uri RepoCollaborators(long repositoryId)
         {
             return "repositories/{0}/collaborators".FormatUri(repositoryId);
         }
@@ -2675,7 +2675,7 @@ namespace Octokit
         /// <param name="base">The base commit</param>
         /// <param name="head">The head commit</param>
         /// <returns>The <see cref="Uri"/> for comparing two commits.</returns>
-        public static Uri RepoCompare(int repositoryId, string @base, string head)
+        public static Uri RepoCompare(long repositoryId, string @base, string head)
         {
 
 
@@ -2691,7 +2691,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for a repository.</returns>
-        public static Uri Repository(int repositoryId)
+        public static Uri Repository(long repositoryId)
         {
             return "repositories/{0}".FormatUri(repositoryId);
         }
@@ -2703,7 +2703,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <returns>The <see cref="Uri"/> for getting an archive of a given repository's contents, in a specific format</returns>
-        public static Uri RepositoryArchiveLink(int repositoryId, ArchiveFormat archiveFormat, string reference)
+        public static Uri RepositoryArchiveLink(long repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             return "repositories/{0}/{1}/{2}".FormatUri(repositoryId, archiveFormat.ToParameter(), reference);
         }
@@ -2714,7 +2714,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (SHA)</param>
         /// <returns>The <see cref="Uri"/> for repository commits.</returns>
-        public static Uri RepositoryCommit(int repositoryId, string reference)
+        public static Uri RepositoryCommit(long repositoryId, string reference)
         {
             return "repositories/{0}/commits/{1}".FormatUri(repositoryId, reference);
         }
@@ -2724,7 +2724,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository commits.</returns>
-        public static Uri RepositoryCommits(int repositoryId)
+        public static Uri RepositoryCommits(long repositoryId)
         {
             return "repositories/{0}/commits".FormatUri(repositoryId);
         }
@@ -2734,7 +2734,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for getting the contents of the specified repository's root</returns>
-        public static Uri RepositoryContent(int repositoryId)
+        public static Uri RepositoryContent(long repositoryId)
         {
             return "repositories/{0}/contents".FormatUri(repositoryId);
         }
@@ -2745,7 +2745,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path of the contents to get</param>
         /// <returns>The <see cref="Uri"/> for getting the contents of the specified repository and path</returns>
-        public static Uri RepositoryContent(int repositoryId, string path)
+        public static Uri RepositoryContent(long repositoryId, string path)
         {
             return "repositories/{0}/contents/{1}".FormatUri(repositoryId, path);
         }
@@ -2757,7 +2757,7 @@ namespace Octokit
         /// <param name="path">The path of the contents to get</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <returns>The <see cref="Uri"/> for getting the contents of the specified repository and path</returns>
-        public static Uri RepositoryContent(int repositoryId, string path, string reference)
+        public static Uri RepositoryContent(long repositoryId, string path, string reference)
         {
             return "repositories/{0}/contents/{1}?ref={2}".FormatUri(repositoryId, path, reference);
         }
@@ -2767,7 +2767,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository contributors.</returns>
-        public static Uri RepositoryContributors(int repositoryId)
+        public static Uri RepositoryContributors(long repositoryId)
         {
             return "repositories/{0}/contributors".FormatUri(repositoryId);
         }
@@ -2778,7 +2778,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The id of the deploy key of the repository</param>
         /// <returns>The <see cref="Uri"/> for a deploy key for a repository</returns>
-        public static Uri RepositoryDeployKey(int repositoryId, int number)
+        public static Uri RepositoryDeployKey(long repositoryId, int number)
         {
             return "repositories/{0}/keys/{1}".FormatUri(repositoryId, number);
         }
@@ -2788,7 +2788,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for deploy keys for a repository.</returns>
-        public static Uri RepositoryDeployKeys(int repositoryId)
+        public static Uri RepositoryDeployKeys(long repositoryId)
         {
             return "repositories/{0}/keys".FormatUri(repositoryId);
         }
@@ -2798,7 +2798,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that lists the repository forks for the specified reference.</returns>
-        public static Uri RepositoryForks(int repositoryId)
+        public static Uri RepositoryForks(long repositoryId)
         {
             return "repositories/{0}/forks".FormatUri(repositoryId);
         }
@@ -2809,7 +2809,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns>The <see cref="Uri"/> that gets the repository hook for the specified reference.</returns>
-        public static Uri RepositoryHookById(int repositoryId, int hookId)
+        public static Uri RepositoryHookById(long repositoryId, int hookId)
         {
             return "repositories/{0}/hooks/{1}".FormatUri(repositoryId, hookId);
         }
@@ -2820,7 +2820,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns>The <see cref="Uri"/> that can ping a specified repository hook</returns>
-        public static Uri RepositoryHookPing(int repositoryId, int hookId)
+        public static Uri RepositoryHookPing(long repositoryId, int hookId)
         {
             return "repositories/{0}/hooks/{1}/pings".FormatUri(repositoryId, hookId);
         }
@@ -2830,7 +2830,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that lists the repository hooks for the specified reference.</returns>
-        public static Uri RepositoryHooks(int repositoryId)
+        public static Uri RepositoryHooks(long repositoryId)
         {
             return "repositories/{0}/hooks".FormatUri(repositoryId);
         }
@@ -2841,7 +2841,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The identifier of the repository hook</param>
         /// <returns>The <see cref="Uri"/> that can tests a specified repository hook</returns>
-        public static Uri RepositoryHookTest(int repositoryId, int hookId)
+        public static Uri RepositoryHookTest(long repositoryId, int hookId)
         {
             return "repositories/{0}/hooks/{1}/tests".FormatUri(repositoryId, hookId);
         }
@@ -2851,7 +2851,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository languages.</returns>
-        public static Uri RepositoryLanguages(int repositoryId)
+        public static Uri RepositoryLanguages(long repositoryId)
         {
             return "repositories/{0}/languages".FormatUri(repositoryId);
         }
@@ -2861,7 +2861,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for getting the page metadata for a given repository</returns>
-        public static Uri RepositoryPage(int repositoryId)
+        public static Uri RepositoryPage(long repositoryId)
         {
             return "repositories/{0}/pages".FormatUri(repositoryId);
         }
@@ -2871,7 +2871,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for getting all build metadata for a given repository</returns>
-        public static Uri RepositoryPageBuilds(int repositoryId)
+        public static Uri RepositoryPageBuilds(long repositoryId)
         {
             return "repositories/{0}/pages/builds".FormatUri(repositoryId);
         }
@@ -2881,7 +2881,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for getting the build metadata for the last build for a given repository</returns>
-        public static Uri RepositoryPageBuildsLatest(int repositoryId)
+        public static Uri RepositoryPageBuildsLatest(long repositoryId)
         {
             return "repositories/{0}/pages/builds/latest".FormatUri(repositoryId);
         }
@@ -2891,7 +2891,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for getting the README of the specified repository</returns>
-        public static Uri RepositoryReadme(int repositoryId)
+        public static Uri RepositoryReadme(long repositoryId)
         {
             return "repositories/{0}/readme".FormatUri(repositoryId);
         }
@@ -2901,7 +2901,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository tags.</returns>
-        public static Uri RepositoryTags(int repositoryId)
+        public static Uri RepositoryTags(long repositoryId)
         {
             return "repositories/{0}/tags".FormatUri(repositoryId);
         }
@@ -2911,7 +2911,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository teams.</returns>
-        public static Uri RepositoryTeams(int repositoryId)
+        public static Uri RepositoryTeams(long repositoryId)
         {
             return "repositories/{0}/teams".FormatUri(repositoryId);
         }
@@ -2921,7 +2921,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that lists the starred repositories for the authenticated user.</returns>
-        public static Uri Stargazers(int repositoryId)
+        public static Uri Stargazers(long repositoryId)
         {
             return "repositories/{0}/stargazers".FormatUri(repositoryId);
         }
@@ -2931,7 +2931,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the code frequency for the given repository</returns>
-        public static Uri StatsCodeFrequency(int repositoryId)
+        public static Uri StatsCodeFrequency(long repositoryId)
         {
             return "repositories/{0}/stats/code_frequency".FormatUri(repositoryId);
         }
@@ -2941,7 +2941,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the commit activity for the given repository</returns>
-        public static Uri StatsCommitActivity(int repositoryId)
+        public static Uri StatsCommitActivity(long repositoryId)
         {
             return "repositories/{0}/stats/commit_activity".FormatUri(repositoryId);
         }
@@ -2951,7 +2951,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the contributors for the given repository</returns>
-        public static Uri StatsContributors(int repositoryId)
+        public static Uri StatsContributors(long repositoryId)
         {
             return "repositories/{0}/stats/contributors".FormatUri(repositoryId);
         }
@@ -2961,7 +2961,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the participation for the given repository</returns>
-        public static Uri StatsParticipation(int repositoryId)
+        public static Uri StatsParticipation(long repositoryId)
         {
             return "repositories/{0}/stats/participation".FormatUri(repositoryId);
         }
@@ -2971,7 +2971,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the punch card for the given repository</returns>
-        public static Uri StatsPunchCard(int repositoryId)
+        public static Uri StatsPunchCard(long repositoryId)
         {
             return "repositories/{0}/stats/punch_card".FormatUri(repositoryId);
         }
@@ -2982,7 +2982,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The tag reference (SHA)</param>
         /// <returns>The <see cref="Uri"/> for the specified tag.</returns>
-        public static Uri Tag(int repositoryId, string reference)
+        public static Uri Tag(long repositoryId, string reference)
         {
             return "repositories/{0}/git/tags/{1}".FormatUri(repositoryId, reference);
         }
@@ -2992,7 +2992,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> for the specified tree.</returns>
-        public static Uri Tree(int repositoryId)
+        public static Uri Tree(long repositoryId)
         {
             return "repositories/{0}/git/trees".FormatUri(repositoryId);
         }
@@ -3003,7 +3003,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The tree reference (SHA)</param>
         /// <returns>The <see cref="Uri"/> for the specified tree.</returns>
-        public static Uri Tree(int repositoryId, string reference)
+        public static Uri Tree(long repositoryId, string reference)
         {
             return "repositories/{0}/git/trees/{1}".FormatUri(repositoryId, reference);
         }
@@ -3014,7 +3014,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The tree reference (SHA)</param>
         /// <returns>The <see cref="Uri"/> for the specified tree.</returns>
-        public static Uri TreeRecursive(int repositoryId, string reference)
+        public static Uri TreeRecursive(long repositoryId, string reference)
         {
             return "repositories/{0}/git/trees/{1}?recursive=1".FormatUri(repositoryId, reference);
         }
@@ -3024,7 +3024,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that shows whether the repo is starred by the current user.</returns>
-        public static Uri Watched(int repositoryId)
+        public static Uri Watched(long repositoryId)
         {
             return "repositories/{0}/subscription".FormatUri(repositoryId);
         }
@@ -3034,7 +3034,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that lists the watched repositories for the authenticated user.</returns>
-        public static Uri Watchers(int repositoryId)
+        public static Uri Watchers(long repositoryId)
         {
             return "repositories/{0}/subscribers".FormatUri(repositoryId);
         }
@@ -3054,7 +3054,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The id of the repository</param>
         /// <returns>The <see cref="Uri"/> for repository invitations.</returns>
-        public static Uri RepositoryInvitations(int repositoryId)
+        public static Uri RepositoryInvitations(long repositoryId)
         {
             return "repositories/{0}/invitations".FormatUri(repositoryId);
         }
@@ -3065,7 +3065,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <returns>The <see cref="Uri"/> for repository invitations.</returns>
-        public static Uri RepositoryInvitations(int repositoryId, int invitationId)
+        public static Uri RepositoryInvitations(long repositoryId, int invitationId)
         {
             return "repositories/{0}/invitations/{1}".FormatUri(repositoryId, invitationId);
         }

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -9,12 +9,12 @@ namespace Octokit
     {
         public Repository() { }
 
-        public Repository(int id)
+        public Repository(long id)
         {
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, int id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -61,7 +61,7 @@ namespace Octokit
 
         public string MirrorUrl { get; protected set; }
 
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         public User Owner { get; protected set; }
 


### PR DESCRIPTION
Repository ids are global across github. On a completely noob assessment of the growth of the number of repositories over the last 6 months, if growth remains constant, we'll reach max int and overflow around September 2017. Since this is an identifier field, it should really be at least an `uint` (they can't be negative, can they?), but since we're already using a signed type, might as well go `long`.

Thoughts, concerns, emojis?