### PR TITLE
Fix issue #1446: Organization can fail deserialization when user is not an org owner.:

### DIFF
--- a/Octokit.Tests/Models/OrganizationTests.cs
+++ b/Octokit.Tests/Models/OrganizationTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using Octokit;
+using Octokit.Internal;
+using Xunit;
+
+public class OrganizationTest
+{
+    [Fact]
+    public void CanBeDeserializedWithNullPrivateGistsDiskUsageAndCollaborators()
+    {
+        const string json = @"{
+  ""login"": ""octocat"",
+  ""id"": 1234,
+  ""url"": ""https://api.github.com/orgs/octocat"",
+  ""repos_url"": ""https://api.github.com/orgs/octocat/repos"",
+  ""events_url"": ""https://api.github.com/orgs/octocat/events"",
+  ""hooks_url"": ""https://api.github.com/orgs/octocat/hooks"",
+  ""issues_url"": ""https://api.github.com/orgs/octocat/issues"",
+  ""members_url"": ""https://api.github.com/orgs/octocat/members{/member}"",
+  ""public_members_url"": ""https://api.github.com/orgs/octocat/public_members{/member}"",
+  ""avatar_url"": ""https://avatars.githubusercontent.com/u/1234?v=3"",
+  ""description"": ""Test org."",
+  ""name"": ""Octocat"",
+  ""company"": null,
+  ""blog"": ""http://octocat.abc"",
+  ""location"": """",
+  ""email"": """",
+  ""public_repos"": 13,
+  ""public_gists"": 0,
+  ""followers"": 0,
+  ""following"": 0,
+  ""html_url"": ""https://github.com/octocat"",
+  ""created_at"": ""2012-09-11T21:54:25Z"",
+  ""updated_at"": ""2016-08-02T05:44:12Z"",
+  ""type"": ""Organization"",
+  ""total_private_repos"": 1,
+  ""owned_private_repos"": 1,
+  ""private_gists"": null,
+  ""disk_usage"": null,
+  ""collaborators"": null,
+  ""billing_email"": null,
+  ""plan"": {
+    ""name"": ""organization"",
+    ""space"": 976562499,
+    ""private_repos"": 9999,
+    ""filled_seats"": 45,
+    ""seats"": 45
+  }
+}";
+        var serializer = new SimpleJsonSerializer();
+
+        var org = serializer.Deserialize<Organization>(json);
+
+        Assert.Equal("octocat", org.Login);
+        Assert.Equal(1234, org.Id);
+    }
+}
+

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Models\DeploymentTests.cs" />
     <Compile Include="Models\GistTests.cs" />
     <Compile Include="Models\IssueEventTests.cs" />
+    <Compile Include="Models\OrganizationTests.cs" />
     <Compile Include="Models\IssueTest.cs" />
     <Compile Include="Models\MigrationTests.cs" />
     <Compile Include="Models\NewReferenceTests.cs" />

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -55,7 +55,7 @@ namespace Octokit
         /// <summary>
         /// Number of collaborators the account has.
         /// </summary>
-        public int Collaborators { get; protected set; }
+        public int? Collaborators { get; protected set; }
 
         /// <summary>
         /// Company the account works for.
@@ -70,7 +70,7 @@ namespace Octokit
         /// <summary>
         /// Amount of disk space the account is using.
         /// </summary>
-        public int DiskUsage { get; protected set; }
+        public int? DiskUsage { get; protected set; }
 
         /// <summary>
         /// The account's email.
@@ -138,7 +138,7 @@ namespace Octokit
         /// <summary>
         /// Number of private gists the account has created.
         /// </summary>
-        public int PrivateGists { get; protected set; }
+        public int? PrivateGists { get; protected set; }
 
         /// <summary>
         /// Number of public gists the account has created.


### PR DESCRIPTION
Make Collaborators, DiskUsage and PrivateGists properties nullable as they may be returned as null when fetching an organization of which the user is a member by not an owner.