### PR TITLE
Support changing PullRequest base branch

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -441,11 +441,12 @@ public class PullRequestsClientTests : IDisposable
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
-        var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body" };
+        var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body", Base = "my-other-branch" };
         var result = await _fixture.Update(Helper.UserName, _context.RepositoryName, pullRequest.Number, updatePullRequest);
 
         Assert.Equal(updatePullRequest.Title, result.Title);
         Assert.Equal(updatePullRequest.Body, result.Body);
+        Assert.Equal(updatePullRequest.Base, result.Base.Ref);
     }
 
     [IntegrationTest]
@@ -456,11 +457,12 @@ public class PullRequestsClientTests : IDisposable
         var newPullRequest = new NewPullRequest("a pull request", branchName, "master");
         var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
 
-        var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body" };
+        var updatePullRequest = new PullRequestUpdate { Title = "updated title", Body = "Hello New Body", Base = "my-other-branch" };
         var result = await _fixture.Update(_context.Repository.Id, pullRequest.Number, updatePullRequest);
 
         Assert.Equal(updatePullRequest.Title, result.Title);
         Assert.Equal(updatePullRequest.Body, result.Body);
+        Assert.Equal(updatePullRequest.Base, result.Base.Ref);
     }
 
     [IntegrationTest]

--- a/Octokit/Models/Request/PullRequestUpdate.cs
+++ b/Octokit/Models/Request/PullRequestUpdate.cs
@@ -24,6 +24,11 @@ namespace Octokit
         /// </summary>
         public string Body { get; set; }
 
+        /// <summary>
+        /// The base branch of the pull request.
+        /// </summary>
+        public string Base { get; set; }
+
         internal string DebuggerDisplay
         {
             get


### PR DESCRIPTION
Fixes #1449 

Added new `base` property on `PullRequestUpdate`
Updated existing `PullRequestClientTests.CanUpdate()` and `PullRequestClientTests.CanUpdateWithRepositoryId()` tests to change the base branch and assert the result