### PR TITLE
Spring cleaning

### DIFF
--- a/Octokit.Reactive/Clients/IObservableUsersClient.cs
+++ b/Octokit.Reactive/Clients/IObservableUsersClient.cs
@@ -50,15 +50,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
-        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
-        IObservableUserKeysClient Keys { get; }
-
-        /// <summary>
-        /// A client for GitHub's User Keys API
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
-        ///</remarks>
         IObservableUserKeysClient GitSshKey { get; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -9,14 +9,6 @@ namespace Octokit.Reactive
     {
         readonly IMiscellaneousClient _client;
 
-        [Obsolete("Please use the IGitHubClient overload constructor")]
-        public ObservableMiscellaneousClient(IMiscellaneousClient client)
-        {
-            Ensure.ArgumentNotNull(client, "client");
-
-            _client = client;
-        }
-
         public ObservableMiscellaneousClient(IGitHubClient client)
         {
             Ensure.ArgumentNotNull(client, "client");

--- a/Octokit.Reactive/Clients/ObservableUsersClient.cs
+++ b/Octokit.Reactive/Clients/ObservableUsersClient.cs
@@ -16,9 +16,6 @@ namespace Octokit.Reactive
 
             Followers = new ObservableFollowersClient(client);
             Email = new ObservableUserEmailsClient(client);
-#pragma warning disable CS0618 // Type or member is obsolete
-            Keys = new ObservableUserKeysClient(client);
-#pragma warning restore CS0618 // Type or member is obsolete
             GitSshKey = new ObservableUserKeysClient(client);
             GpgKey = new ObservableUserGpgKeysClient(client);
             Administration = new ObservableUserAdministrationClient(client);
@@ -73,15 +70,6 @@ namespace Octokit.Reactive
         /// See the <a href="http://developer.github.com/v3/users/emails/">Emails API documentation</a> for more information.
         ///</remarks>
         public IObservableUserEmailsClient Email { get; private set; }
-
-        /// <summary>
-        /// A client for GitHub's User Keys API
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
-        ///</remarks>
-        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
-        public IObservableUserKeysClient Keys { get; private set; }
 
         /// <summary>
         /// A client for GitHub's User Keys API

--- a/Octokit/Clients/IUsersClient.cs
+++ b/Octokit/Clients/IUsersClient.cs
@@ -26,15 +26,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
         ///</remarks>
-        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
-        IUserKeysClient Keys { get; }
-
-        /// <summary>
-        /// A client for GitHub's User Keys API
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
-        ///</remarks>
         IUserKeysClient GitSshKey { get; }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Gpg")]

--- a/Octokit/Clients/UsersClient.cs
+++ b/Octokit/Clients/UsersClient.cs
@@ -21,9 +21,6 @@ namespace Octokit
         {
             Email = new UserEmailsClient(apiConnection);
             Followers = new FollowersClient(apiConnection);
-#pragma warning disable CS0618 // Type or member is obsolete
-            Keys = new UserKeysClient(apiConnection);
-#pragma warning restore CS0618 // Type or member is obsolete
             GitSshKey = new UserKeysClient(apiConnection);
             GpgKey = new UserGpgKeysClient(apiConnection);
 
@@ -37,15 +34,6 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/emails/">Emails API documentation</a> for more information.
         ///</remarks>
         public IUserEmailsClient Email { get; private set; }
-
-        /// <summary>
-        /// A client for GitHub's User Keys API
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/users/keys/">Keys API documentation</a> for more information.
-        ///</remarks>
-        [Obsolete("Ssh key information is now available under the GitSshKey property. This will be removed in a future update.")]
-        public IUserKeysClient Keys { get; private set; }
 
         /// <summary>
         /// A client for GitHub's User Keys API

--- a/Octokit/Helpers/ApiExtensions.cs
+++ b/Octokit/Helpers/ApiExtensions.cs
@@ -74,15 +74,6 @@ namespace Octokit
             return connection.Get<T>(uri, null, null);
         }
 
-        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
-        public static Task<IApiResponse<T>> GetRedirect<T>(this IConnection connection, Uri uri)
-        {
-            Ensure.ArgumentNotNull(connection, "connection");
-            Ensure.ArgumentNotNull(uri, "uri");
-
-            return connection.Get<T>(uri, null, null);
-        }
-
         /// <summary>
         /// Gets the API resource at the specified URI.
         /// </summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1303,18 +1303,6 @@ namespace Octokit
         /// <param name="owner">The owner of the blob</param>
         /// <param name="name">The name of the organization</param>
         /// <returns></returns>
-        [Obsolete("This method is obsolete. Please use ApiUrls.Blobs(owner, name) instead.")]
-        public static Uri Blob(string owner, string name)
-        {
-            return Blob(owner, name, "");
-        }
-
-        /// <summary>
-        /// Returns the <see cref="Uri"/> for a specific blob.
-        /// </summary>
-        /// <param name="owner">The owner of the blob</param>
-        /// <param name="name">The name of the organization</param>
-        /// <returns></returns>
         public static Uri Blobs(string owner, string name)
         {
             return Blob(owner, name, "");

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -493,28 +493,6 @@ namespace Octokit
 
             return Connection.Delete(uri, data, accepts);
         }
-        /// <summary>
-        /// Executes a GET to the API object at the specified URI. This operation is appropriate for
-        /// API calls which wants to return the redirect URL.
-        /// It expects the API to respond with a 302 Found.
-        /// </summary>
-        /// <param name="uri">URI of the API resource to get</param>
-        /// <returns>The URL returned by the API in the Location header</returns>
-        /// <exception cref="ApiException">Thrown when an API error occurs, or the API does not respond with a 302 Found</exception>
-        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
-        public async Task<string> GetRedirect(Uri uri)
-        {
-            Ensure.ArgumentNotNull(uri, "uri");
-            var response = await Connection.GetRedirect<string>(uri).ConfigureAwait(false);
-
-            if (response.HttpResponse.StatusCode == HttpStatusCode.Redirect)
-            {
-                return response.HttpResponse.Headers["Location"];
-            }
-
-            throw new ApiException("Redirect Operation expect status code of Redirect.",
-                response.HttpResponse.StatusCode);
-        }
 
         /// <summary>
         /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which 

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -321,17 +321,6 @@ namespace Octokit
         Task Delete(Uri uri, object data, string accepts);
 
         /// <summary>
-        /// Executes a GET to the API object at the specified URI. This operation is appropriate for
-        /// API calls which wants to return the redirect URL.
-        /// It expects the API to respond with a 302 Found.
-        /// </summary>
-        /// <param name="uri">URI of the API resource to get</param>
-        /// <returns>The URL returned by the API in the Location header</returns>
-        /// <exception cref="ApiException">Thrown when an API error occurs, or the API does not respond with a 302 Found</exception>
-        [Obsolete("Octokit's HTTP library now follows redirects by default - this API will be removed in a future release")]
-        Task<string> GetRedirect(Uri uri);
-
-        /// <summary>
         /// Executes a GET to the API object at the specified URI. This operation is appropriate for API calls which 
         /// queue long running calculations and return a collection of a resource.
         /// It expects the API to respond with an initial 202 Accepted, and queries again until a 200 OK is received.

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -435,9 +435,6 @@ namespace Octokit
 
     public enum IssueTypeQualifier
     {
-        [Obsolete("Use IssueTypeQualifier.PullRequest instead")]
-        [Parameter(Value = "pr")]
-        PR,
         [Parameter(Value = "pr")]
         PullRequest,
         [Parameter(Value = "issue")]

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -482,10 +482,6 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixir")]
         Elixir,
-        [Obsolete("This item is incorrect and will be removed in a future update. Use Elixir instead.")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Elixer")]
-        Elixer,
         Elm,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Emacs")]
@@ -716,10 +712,6 @@ namespace Octokit
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Parallel")]
         [Parameter(Value = "Unified Parallel C")]
         UnifiedParallelC,
-        [Obsolete("This item is incorrect and will be removed in a future update. Use UnifiedParallelC instead.")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Paralel")]
-        [Parameter(Value = "Unified Paralel C")]
-        UnifiedParalelC,
         Unknown,
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Vala")]
         Vala,

--- a/Octokit/Models/Response/CompareResult.cs
+++ b/Octokit/Models/Response/CompareResult.cs
@@ -33,8 +33,6 @@ namespace Octokit
         public string DiffUrl { get; protected set; }
         public string PatchUrl { get; protected set; }
         public GitHubCommit BaseCommit { get; protected set; }
-        [Obsolete("This property is obsolete. Use MergeBaseCommit instead.", false)]
-        public GitHubCommit MergedBaseCommit { get; protected set; }
         public GitHubCommit MergeBaseCommit { get; protected set; }
         public string Status { get; protected set; }
         public int AheadBy { get; protected set; }


### PR DESCRIPTION
As per the normal process this PR removes any `[Obsolete]` items that have been obsolete for at least 2 releases

- Remove previously obsoleted UsersClient.Keys property
- Remove previously obsoleted IConnection.GetRedirect and IApiConnectio
- Remove previously obsoleted IssueTypeQualifier.PR enum value
- Remove previously obsoleted mis-spelled Language enum values
- Remove previously obsoleted ObservableMiscellaneousClient ctor
- Remove previously obsoleted CompareResult.MergedBaseCommit property
- Remove previously obsoleted ApiUrls.Blob method