### PR TITLE
Get a .NET Core project to build in AppVeyor and Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ docs/_build
 
 # it's 2015, no need to keep this around when migrating projects
 Backup/
+
+# .NET Core
+project.lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,13 @@ language: csharp
 
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      mono: 4.2.3
-      dotnet: 1.0.0-preview2-003121
     - os: osx
       osx_image: xcode8
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 
-before_install:  
-  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/Cellar/openssl/1.0.2h/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/Cellar/openssl/1.0.2h/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+before_install:
+  - ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/;
 
 install:
   - nuget restore Octokit-Mono.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 
+before_install:  
+  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/Cellar/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/Cellar/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+
 install:
   - nuget restore Octokit-Mono.sln
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ language: csharp
 
 matrix:
   include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      mono: 4.2.3
+      dotnet: 1.0.0-preview2-003121
     - os: osx
       osx_image: xcode8
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 
 before_install:
-  - ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/;
+  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 
 install:
   - nuget restore Octokit-Mono.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       dotnet: 1.0.0-preview2-003121
 
 before_install:  
-  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/Cellar/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/Cellar/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/Cellar/openssl/1.0.2h/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/Cellar/openssl/1.0.2h/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 
 install:
   - nuget restore Octokit-Mono.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      mono: latest
+      mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
     - os: osx
       osx_image: xcode7.2
-      mono: latest
+      mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
     - os: osx
-      osx_image: xcode7.2
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
     - os: osx
+      osx_image: xcode8
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
       mono: latest
       dotnet: 1.0.0-preview2-003121
 
+install:
+  - nuget restore Octokit-Mono.sln
+
 script:
+  - mono tools/nuget/NuGet.exe restore Octokit-Mono.sln
+  - ./build.sh BuildMono
+  - ./build.sh
   - dotnet --info
   - ./build.sh UnitTestsDotNetCore

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ language: csharp
 mono:
   - 4.2.3
 
-sudo: false  # use the new container-based Travis infrastructure
-os:
-  - osx
-  - linux
-install:
-  - nuget restore Octokit-Mono.sln 
-script: 
-  - mono tools/nuget/NuGet.exe restore Octokit-Mono.sln
-  - ./build.sh BuildMono 
-  - ./build.sh 
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      dotnet: 1.0.0-preview2-003121
+    - os: osx
+      osx_image: xcode7.2
+      dotnet: 1.0.0-preview2-003121
+
+script:
+  - ./build.sh UnitTestsDotNetCore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: csharp
-mono:
-  - 4.2.3
 
 matrix:
   include:
     - os: linux
       dist: trusty
-      sudo: false
+      sudo: required
+      mono: none
       dotnet: 1.0.0-preview2-003121
     - os: osx
       osx_image: xcode7.2
+      mono: none
       dotnet: 1.0.0-preview2-003121
 
 script:
+  - dotnet --info
   - ./build.sh UnitTestsDotNetCore

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      mono: none
+      mono: latest
       dotnet: 1.0.0-preview2-003121
     - os: osx
       osx_image: xcode7.2
-      mono: none
+      mono: latest
       dotnet: 1.0.0-preview2-003121
 
 script:

--- a/Octokit.Core.sln
+++ b/Octokit.Core.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Octokit.Next", "Octokit.Next\Octokit.Next.xproj", "{4052AF53-4C1B-48D1-B873-BFD0351481C3}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Octokit.Next.Tests", "Octokit.Next.Tests\Octokit.Next.Tests.xproj", "{2740AF44-CB2E-4FD8-A221-248693978A0C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4052AF53-4C1B-48D1-B873-BFD0351481C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4052AF53-4C1B-48D1-B873-BFD0351481C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4052AF53-4C1B-48D1-B873-BFD0351481C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4052AF53-4C1B-48D1-B873-BFD0351481C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2740AF44-CB2E-4FD8-A221-248693978A0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2740AF44-CB2E-4FD8-A221-248693978A0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2740AF44-CB2E-4FD8-A221-248693978A0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2740AF44-CB2E-4FD8-A221-248693978A0C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Octokit.Next.Tests/CalculatorTests.cs
+++ b/Octokit.Next.Tests/CalculatorTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Octokit.Next.Tests
+{
+    using Xunit;
+
+    public class CalculatorTests
+    {
+        private readonly Calculator _sut;
+
+        public CalculatorTests()
+        {
+            _sut = new Calculator();
+        }
+
+        [Theory]
+        [InlineData(1, 1, 2)]
+        [InlineData(1, 2, 3)]
+        [InlineData(2, 1, 3)]
+        [InlineData(-1, 1, 0)]
+        public void AddingTwoIntegers_ShouldReturnExpectedResult(int x, int y, int expected)
+        {
+            Assert.Equal(expected, _sut.Add(x, y));
+        }
+    }
+}

--- a/Octokit.Next.Tests/Octokit.Next.Tests.xproj
+++ b/Octokit.Next.Tests/Octokit.Next.Tests.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2740af44-cb2e-4fd8-a221-248693978a0c</ProjectGuid>
+    <RootNamespace>Octokit.Next.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Octokit.Next.Tests/Properties/AssemblyInfo.cs
+++ b/Octokit.Next.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Octokit.Next.Tests")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2740af44-cb2e-4fd8-a221-248693978a0c")]

--- a/Octokit.Next.Tests/project.json
+++ b/Octokit.Next.Tests/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0"
+    },
+    "Octokit.Next": "*",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "xunit": "2.2.0-beta2-build3300"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {}
+  }
+}

--- a/Octokit.Next/Calculator.cs
+++ b/Octokit.Next/Calculator.cs
@@ -1,0 +1,10 @@
+﻿namespace Octokit.Next
+{
+    public class Calculator
+    {
+        public int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/Octokit.Next/Octokit.Next.xproj
+++ b/Octokit.Next/Octokit.Next.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4052af53-4c1b-48d1-b873-bfd0351481c3</ProjectGuid>
+    <RootNamespace>Octokit.Next</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Octokit.Next/Properties/AssemblyInfo.cs
+++ b/Octokit.Next/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Octokit.Next")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4052af53-4c1b-48d1-b873-bfd0351481c3")]

--- a/Octokit.Next/project.json
+++ b/Octokit.Next/project.json
@@ -1,0 +1,11 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.1": {}
+  }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 init:
   - git config --global core.autocrlf input
 build_script:
+  - cmd: build.cmd BuildApp
+  - cmd: build.cmd UnitTests
+  - cmd: build.cmd ConventionTests
+  - cmd: build.cmd CreatePackages
   - cmd: build.cmd UnitTestsDotNetCore
 test: off
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,7 @@
 init:
   - git config --global core.autocrlf input
 build_script:
-  - cmd: build.cmd BuildApp
-  - cmd: build.cmd UnitTests
-  - cmd: build.cmd ConventionTests
-  - cmd: build.cmd CreatePackages
+  - cmd: build.cmd UnitTestsDotNetCore
 test: off
 nuget:
   account_feed: true

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 
 "tools\nuget\nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.1.0" -verbosity quiet
-"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.28.0" -verbosity quiet
+"tools\nuget\nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.39.1" -verbosity quiet
 "tools\nuget\nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0" -verbosity quiet
 "tools\nuget\nuget.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre -verbosity quiet
 "tools\nuget\nuget.exe" "install" "FSharp.Data" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.3.2" -verbosity quiet

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ then
   # use .Net
 
 "./tools/nuget/nuget.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.0.0" -verbosity quiet
-"./tools/nuget/nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.22.2"  -verbosity quiet
+"./tools/nuget/nuget.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.39.1"  -verbosity quiet
 "./tools/nuget/nuget.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0"  -verbosity quiet
 "./tools/nuget/nuget.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre -verbosity quiet
 "./tools/nuget/nuget.exe" "install" "FSharp.Data" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.3.2" -verbosity quiet
@@ -12,7 +12,7 @@ packages/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
 else
   # use mono
 mono "./tools/nuget/NuGet.exe" "install" "xunit.runner.console" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.0.0"  -verbosity quiet
-mono "./tools/nuget/NuGet.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.22.2"  -verbosity quiet
+mono "./tools/nuget/NuGet.exe" "install" "FAKE.Core" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "4.39.1"  -verbosity quiet
 mono "./tools/nuget/NuGet.exe" "install" "SourceLink.Fake" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.1.0"  -verbosity quiet
 mono "./tools/nuget/NuGet.exe" "install" "Octokit.CodeFormatter" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "1.0.0-preview" -Pre -verbosity quiet
 mono "./tools/nuget/NuGet.exe" "install" "FSharp.Data" "-OutputDirectory" "tools" "-ExcludeVersion" "-version" "2.3.2" -verbosity quiet


### PR DESCRIPTION
First step of #1419.

It looks like AppVeyor has the dotnet CLI installed in the image so no need to download it.  
Also, that's really as simple as it gets. Maybe you wanted something more ... realistic.

Made some comments in the F# code where I'm really not sure if that's The Way To Do Things.