### PR TITLE
Add missing fields to Repository class - HasPages, SubscribersCount, Size

### DIFF
--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int watchersCount, int subscribersCount, long size)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -45,6 +45,10 @@ namespace Octokit
             HasIssues = hasIssues;
             HasWiki = hasWiki;
             HasDownloads = hasDownloads;
+            HasPages = hasPages;
+            SubscribersCount = subscribersCount;
+            WatchersCount = watchersCount;
+            Size = size;
         }
 
         public string Url { get; protected set; }
@@ -104,6 +108,14 @@ namespace Octokit
         public bool HasWiki { get; protected set; }
 
         public bool HasDownloads { get; protected set; }
+
+        public bool HasPages { get; protected set; }
+
+        public int SubscribersCount { get; protected set; }
+
+        public int WatchersCount { get; protected set; }
+
+        public long Size { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int watchersCount, int subscribersCount, long size)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -47,7 +47,6 @@ namespace Octokit
             HasDownloads = hasDownloads;
             HasPages = hasPages;
             SubscribersCount = subscribersCount;
-            WatchersCount = watchersCount;
             Size = size;
         }
 
@@ -112,8 +111,6 @@ namespace Octokit
         public bool HasPages { get; protected set; }
 
         public int SubscribersCount { get; protected set; }
-
-        public int WatchersCount { get; protected set; }
 
         public long Size { get; protected set; }
 


### PR DESCRIPTION
As discussed in #1470 this PR adds back the `SubscribersCount` property on `Repository` which is the number of "watchers".  This field was removed in the past however it does contain the correct value and would avoid additional API calls to the `WatchedClient` to retrieve this info.

Also added some other fields that are missing in octokit.net such as `Size` and `HasPages`

Fixes #1470 