### PR TITLE
Add repository settings to configure PR merge methods

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -268,6 +268,36 @@ public class RepositoriesClientTests
                 Task.WhenAll(deleteRepos).Wait();
             }
         }
+
+        [IntegrationTest]
+        public async Task CreatesARepositoryWithRequestedMergeMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            var newRepository = new NewRepository(repoName)
+            {
+                AllowMergeCommit = false,
+                AllowSquashMerge = true,
+                AllowRebaseMerge = false
+            };
+
+            using (var context = await github.CreateRepositoryContext(newRepository))
+            {
+                var createdRepository = context.Repository;
+
+                Assert.Equal(repoName, createdRepository.Name);
+                Assert.False(createdRepository.AllowMergeCommit);
+                Assert.True(createdRepository.AllowSquashMerge);
+                Assert.False(createdRepository.AllowRebaseMerge);
+
+                var repository = await github.Repository.Get(Helper.UserName, repoName);
+                Assert.Equal(repoName, repository.Name);
+                Assert.False(repository.AllowMergeCommit);
+                Assert.True(repository.AllowSquashMerge);
+                Assert.False(repository.AllowRebaseMerge);
+            }
+        }
     }
 
     public class TheCreateMethodForOrganization

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -268,36 +268,6 @@ public class RepositoriesClientTests
                 Task.WhenAll(deleteRepos).Wait();
             }
         }
-
-        [IntegrationTest]
-        public async Task CreatesARepositoryWithRequestedMergeMethod()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-
-            var newRepository = new NewRepository(repoName)
-            {
-                AllowMergeCommit = false,
-                AllowSquashMerge = true,
-                AllowRebaseMerge = false
-            };
-
-            using (var context = await github.CreateRepositoryContext(newRepository))
-            {
-                var createdRepository = context.Repository;
-
-                Assert.Equal(repoName, createdRepository.Name);
-                Assert.False(createdRepository.AllowMergeCommit);
-                Assert.True(createdRepository.AllowSquashMerge);
-                Assert.False(createdRepository.AllowRebaseMerge);
-
-                var repository = await github.Repository.Get(Helper.UserName, repoName);
-                Assert.Equal(repoName, repository.Name);
-                Assert.False(repository.AllowMergeCommit);
-                Assert.True(repository.AllowSquashMerge);
-                Assert.False(repository.AllowRebaseMerge);
-            }
-        }
     }
 
     public class TheCreateMethodForOrganization

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -531,6 +531,58 @@ public class RepositoriesClientTests
             Assert.Equal(false, _repository.HasWiki);
         }
 
+        [IntegrationTest]
+        public async Task UpdatesMergeMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var updateRepository = new RepositoryUpdate(context.RepositoryName)
+                {
+                    AllowMergeCommit = false,
+                    AllowSquashMerge = false,
+                    AllowRebaseMerge = true
+                };
+
+                var editedRepository = await github.Repository.Edit(context.RepositoryOwner, context.RepositoryName, updateRepository);
+                Assert.False(editedRepository.AllowMergeCommit);
+                Assert.False(editedRepository.AllowSquashMerge);
+                Assert.True(editedRepository.AllowRebaseMerge);
+
+                var repository = await github.Repository.Get(context.RepositoryOwner, context.RepositoryName);
+                Assert.False(repository.AllowMergeCommit);
+                Assert.False(repository.AllowSquashMerge);
+                Assert.True(repository.AllowRebaseMerge);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task UpdatesMergeMethodWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext("public-repo"))
+            {
+                var updateRepository = new RepositoryUpdate(context.RepositoryName)
+                {
+                    AllowMergeCommit = true,
+                    AllowSquashMerge = true,
+                    AllowRebaseMerge = false
+                };
+
+                var editedRepository = await github.Repository.Edit(context.RepositoryId, updateRepository);
+                Assert.True(editedRepository.AllowMergeCommit);
+                Assert.True(editedRepository.AllowSquashMerge);
+                Assert.False(editedRepository.AllowRebaseMerge);
+
+                var repository = await github.Repository.Get(context.RepositoryId);
+                Assert.True(repository.AllowMergeCommit);
+                Assert.True(repository.AllowSquashMerge);
+                Assert.False(repository.AllowRebaseMerge);
+            }
+        }
+
         public void Dispose()
         {
             Helper.DeleteRepo(Helper.GetAuthenticatedClient().Connection, _repository);

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -664,6 +664,36 @@ public class RepositoriesClientTests
             Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
             Assert.True(repository.Fork);
         }
+
+        [IntegrationTest]
+        public async Task ReturnsRepositoryMergeOptions()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var repository = await github.Repository.Get(context.RepositoryOwner, context.RepositoryName);
+
+                Assert.NotNull(repository.AllowRebaseMerge);
+                Assert.NotNull(repository.AllowSquashMerge);
+                Assert.NotNull(repository.AllowMergeCommit);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsRepositoryMergeOptionsWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var repository = await github.Repository.Get(context.RepositoryId);
+
+                Assert.NotNull(repository.AllowRebaseMerge);
+                Assert.NotNull(repository.AllowSquashMerge);
+                Assert.NotNull(repository.AllowMergeCommit);
+            }
+        }
     }
 
     public class TheGetAllPublicMethod

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -258,7 +258,10 @@ namespace Octokit.Tests.Clients
 
                 await client.Get("owner", "name");
 
-                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name"));
+                connection.Received().Get<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/owner/name"),
+                    null,
+                    "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -269,7 +272,10 @@ namespace Octokit.Tests.Clients
 
                 await client.Get(1);
 
-                connection.Received().Get<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1"));
+                connection.Received().Get<Repository>(
+                    Arg.Is<Uri>(u => u.ToString() == "repositories/1"),
+                    null,
+                    "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1015,12 +1015,12 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("repo");
 
                 client.Edit("owner", "repo", update);
 
                 connection.Received()
-                    .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo"), Arg.Any<RepositoryUpdate>());
+                    .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo"), Arg.Any<RepositoryUpdate>(), "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -1028,12 +1028,12 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("repo");
 
                 client.Edit(1, update);
 
                 connection.Received()
-                    .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1"), Arg.Any<RepositoryUpdate>());
+                    .Patch<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories/1"), Arg.Any<RepositoryUpdate>(), "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(new NewRepository("aName"));
 
-                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Arg.Any<NewRepository>(), "application/vnd.github.polaris-preview+json");
+                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Arg.Any<NewRepository>());
             }
 
             [Fact]
@@ -52,7 +52,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json");
+                connection.Received().Post<Repository>(Args.Uri, newRepository);
             }
 
             [Fact]
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository)
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -95,7 +95,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository)
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -127,8 +127,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Post<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/theLogin/repos"),
-                    Args.NewRepository,
-                    "application/vnd.github.polaris-preview+json");
+                    Args.NewRepository);
             }
 
             [Fact]
@@ -140,7 +139,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Create("aLogin", newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json");
+                connection.Received().Post<Repository>(Args.Uri, newRepository);
             }
 
             [Fact]
@@ -154,7 +153,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository)
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -179,7 +178,7 @@ namespace Octokit.Tests.Clients
                     + @"""http://developer.github.com/v3/repos/#create"",""errors"":[]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository)
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -200,7 +199,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(new Uri("https://example.com"));
-                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
+                connection.Post<Repository>(Args.Uri, newRepository)
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -40,7 +40,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(new NewRepository("aName"));
 
-                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Arg.Any<NewRepository>());
+                connection.Received().Post<Repository>(Arg.Is<Uri>(u => u.ToString() == "user/repos"), Arg.Any<NewRepository>(), "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -52,7 +52,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository);
+                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository)
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -95,7 +95,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
                 connection.Connection.Credentials.Returns(credentials);
-                connection.Post<Repository>(Args.Uri, newRepository)
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -127,7 +127,8 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Post<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/theLogin/repos"),
-                    Args.NewRepository);
+                    Args.NewRepository,
+                    "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -139,7 +140,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Create("aLogin", newRepository);
 
-                connection.Received().Post<Repository>(Args.Uri, newRepository);
+                connection.Received().Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json");
             }
 
             [Fact]
@@ -153,7 +154,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository)
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -178,7 +179,7 @@ namespace Octokit.Tests.Clients
                     + @"""http://developer.github.com/v3/repos/#create"",""errors"":[]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(GitHubClient.GitHubApiUrl);
-                connection.Post<Repository>(Args.Uri, newRepository)
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 
@@ -199,7 +200,7 @@ namespace Octokit.Tests.Clients
                     + @"""code"":""custom"",""field"":""name"",""message"":""name already exists on this account""}]}");
                 var connection = Substitute.For<IApiConnection>();
                 connection.Connection.BaseAddress.Returns(new Uri("https://example.com"));
-                connection.Post<Repository>(Args.Uri, newRepository)
+                connection.Post<Repository>(Args.Uri, newRepository, "application/vnd.github.polaris-preview+json")
                     .Returns<Task<Repository>>(_ => { throw new ApiValidationException(response); });
                 var client = new RepositoriesClient(connection);
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -91,18 +91,18 @@ namespace Octokit.Tests.Reactive
                 var response = Task.Factory.StartNew<IApiResponse<Repository>>(() =>
                     new ApiResponse<Repository>(new Response(), repository));
                 var connection = Substitute.For<IConnection>();
-                connection.Get<Repository>(Args.Uri, null, null).Returns(response);
+                connection.Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json").Returns(response);
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoriesClient(gitHubClient);
                 var observable = client.Get("stark", "ned");
 
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
 
                 var result = await observable;
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
                 var result2 = await observable;
                 // TODO: If we change this to a warm observable, we'll need to change this to Received(2)
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
 
                 Assert.Same(repository, result);
                 Assert.Same(repository, result2);
@@ -117,18 +117,18 @@ namespace Octokit.Tests.Reactive
                 var response = Task.Factory.StartNew<IApiResponse<Repository>>(() =>
                     new ApiResponse<Repository>(new Response(), repository));
                 var connection = Substitute.For<IConnection>();
-                connection.Get<Repository>(Args.Uri, null, null).Returns(response);
+                connection.Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json").Returns(response);
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoriesClient(gitHubClient);
                 var observable = client.Get(1);
 
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
 
                 var result = await observable;
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
                 var result2 = await observable;
                 // TODO: If we change this to a warm observable, we'll need to change this to Received(2)
-                connection.Received(1).Get<Repository>(Args.Uri, null, null);
+                connection.Received(1).Get<Repository>(Args.Uri, null, "application/vnd.github.polaris-preview+json");
 
                 Assert.Same(repository, result);
                 Assert.Same(repository, result2);

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -82,7 +82,7 @@ namespace Octokit
         {
             try
             {
-                return await ApiConnection.Post<Repository>(url, newRepository, AcceptHeaders.SquashCommitPreview).ConfigureAwait(false);
+                return await ApiConnection.Post<Repository>(url, newRepository).ConfigureAwait(false);
             }
             catch (ApiValidationException e)
             {

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -82,7 +82,7 @@ namespace Octokit
         {
             try
             {
-                return await ApiConnection.Post<Repository>(url, newRepository).ConfigureAwait(false);
+                return await ApiConnection.Post<Repository>(url, newRepository, AcceptHeaders.SquashCommitPreview).ConfigureAwait(false);
             }
             catch (ApiValidationException e)
             {

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -259,7 +259,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<Repository>(ApiUrls.Repository(owner, name));
+            return ApiConnection.Get<Repository>(ApiUrls.Repository(owner, name), null, AcceptHeaders.SquashCommitPreview);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         public Task<Repository> Get(long repositoryId)
         {
-            return ApiConnection.Get<Repository>(ApiUrls.Repository(repositoryId));
+            return ApiConnection.Get<Repository>(ApiUrls.Repository(repositoryId), null, AcceptHeaders.SquashCommitPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -192,8 +192,9 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(update, "update");
+            Ensure.ArgumentNotNull(update.Name, "update.Name");
 
-            return ApiConnection.Patch<Repository>(ApiUrls.Repository(owner, name), update);
+            return ApiConnection.Patch<Repository>(ApiUrls.Repository(owner, name), update, AcceptHeaders.SquashCommitPreview);
         }
 
         /// <summary>
@@ -206,7 +207,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(update, "update");
 
-            return ApiConnection.Patch<Repository>(ApiUrls.Repository(repositoryId), update);
+            return ApiConnection.Patch<Repository>(ApiUrls.Repository(repositoryId), update, AcceptHeaders.SquashCommitPreview);
         }
 
         /// <summary>

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -82,6 +82,21 @@ namespace Octokit
         /// </summary>
         public int? TeamId { get; set; }
 
+        /// <summary>
+        /// Optional. Allows the "Rebase and Merge" method to be used.
+        /// </summary>
+        public bool? AllowRebaseMerge { get; set; }
+
+        /// <summary>
+        /// Optional. Allows the "Squash Merge" merge method to be used.
+        /// </summary>
+        public bool? AllowSquashMerge { get; set; }
+
+        /// <summary>
+        /// Optional. Allows the "Create a merge commit" merge method to be used.
+        /// </summary>
+        public bool? AllowMergeCommit { get; set; }
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/NewRepository.cs
+++ b/Octokit/Models/Request/NewRepository.cs
@@ -82,21 +82,6 @@ namespace Octokit
         /// </summary>
         public int? TeamId { get; set; }
 
-        /// <summary>
-        /// Optional. Allows the "Rebase and Merge" method to be used.
-        /// </summary>
-        public bool? AllowRebaseMerge { get; set; }
-
-        /// <summary>
-        /// Optional. Allows the "Squash Merge" merge method to be used.
-        /// </summary>
-        public bool? AllowSquashMerge { get; set; }
-
-        /// <summary>
-        /// Optional. Allows the "Create a merge commit" merge method to be used.
-        /// </summary>
-        public bool? AllowMergeCommit { get; set; }
-
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
@@ -11,38 +12,77 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryUpdate
     {
+        [Obsolete("Please use the ctor RepositoryUpdate(string name) as Name is a required field")]
+        public RepositoryUpdate()
+        {
+
+        }
+
+        /// <summary>
+        /// Creates an object that describes an update to a repository on GitHub.
+        /// </summary>
+        /// <param name="name">The name of the repository. This is the only required parameter.</param>
+        public RepositoryUpdate(string name)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+
+            Name = name;
+        }
+
         /// <summary>
         /// Required. Gets or sets the repository name.
         /// </summary>
         public string Name { get; set; }
+        
         /// <summary>
         /// Optional. Gets or sets the repository description. The default is null (do not update)
         /// </summary>
         public string Description { get; set; }
+        
         /// <summary>
         /// Optional. Gets or sets the repository homepage url. The default is null (do not update).
         /// </summary>
         public string Homepage { get; set; }
+        
         /// <summary>
         /// Gets or sets whether to make the repository private. The default is null (do not update).
         /// </summary>
         public bool? Private { get; set; }
+        
         /// <summary>
         /// Gets or sets whether to enable issues for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasIssues { get; set; }
+        
         /// <summary>
         /// Optional. Gets or sets whether to enable the wiki for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasWiki { get; set; }
+        
         /// <summary>
         /// Optional. Gets or sets whether to enable downloads for the repository. The default is null (do not update).
         /// </summary>
         public bool? HasDownloads { get; set; }
+        
         /// <summary>
         /// Optional. Gets or sets the default branch. The default is null (do not update).
         /// </summary>
         public string DefaultBranch { get; set; }
+        
+        /// <summary>
+        /// Optional. Allows the "Rebase and Merge" method to be used.
+        /// </summary>
+        public bool? AllowRebaseMerge { get; set; }
+
+        /// <summary>
+        /// Optional. Allows the "Squash Merge" merge method to be used.
+        /// </summary>
+        public bool? AllowSquashMerge { get; set; }
+
+        /// <summary>
+        /// Optional. Allows the "Create a merge commit" merge method to be used.
+        /// </summary>
+        public bool? AllowMergeCommit { get; set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal string DebuggerDisplay

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, bool hasIssues, bool hasWiki, bool hasDownloads, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -45,6 +45,9 @@ namespace Octokit
             HasIssues = hasIssues;
             HasWiki = hasWiki;
             HasDownloads = hasDownloads;
+            AllowRebaseMerge = allowRebaseMerge;
+            AllowSquashMerge = allowSquashMerge;
+            AllowMergeCommit = allowMergeCommit;
         }
 
         public string Url { get; protected set; }
@@ -104,6 +107,12 @@ namespace Octokit
         public bool HasWiki { get; protected set; }
 
         public bool HasDownloads { get; protected set; }
+        
+        public bool? AllowRebaseMerge { get; protected set; }
+
+        public bool? AllowSquashMerge { get; protected set; }
+
+        public bool? AllowMergeCommit { get; protected set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION
Fixes #1475 

- [x] Add new options to Get Repository methods
- [x] Poke API to figure out whether any of the GetAll (for Current, Public, For Organization, etc) methods return these new fields (despite API docs not mentioning it) and implement if so

(confirmed no other methods like GetAllForCurrent, GetAllPublic, GetAllForOrg return the new fields even when accepts header is provided, so only the individual Get Repository call needs to be implemented)
- [x] Add new options to Create Repository request
- [x] Add new options to Edit Repository request
- [x]  Waiting for github support to advise regarding Create Repository call still not appearing to support the new fields

(support confirmed this was a documentation error and Create Repository call does not support these parameters)

I've had to contact GitHub support as the new fields aren't actually being returned but I'm pretty sure everything is correct on my side...