### PR TITLE
Add MergeMethod property to PR merge request

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -638,6 +638,54 @@ public class PullRequestsClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task CanBeMergedWithMergeMethod()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("squash commit pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var merge = new MergePullRequest { CommitMessage = "fake commit message", CommitTitle = "fake title", MergeMethod = PullRequestMergeMethod.Merge };
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
+        var commit = await _github.Repository.Commit.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
+
+        Assert.True(result.Merged);
+        Assert.Equal("fake title\n\nfake commit message", commit.Commit.Message);
+    }
+
+    [IntegrationTest]
+    public async Task CanBeMergedWithSquashMethod()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("squash commit pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var merge = new MergePullRequest { CommitMessage = "fake commit message", CommitTitle = "fake title", MergeMethod = PullRequestMergeMethod.Squash };
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
+        var commit = await _github.Repository.Commit.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
+
+        Assert.True(result.Merged);
+        Assert.Equal("fake title\n\nfake commit message", commit.Commit.Message);
+    }
+
+    [IntegrationTest]
+    public async Task CanBeMergedWithRebaseMethod()
+    {
+        await CreateTheWorld();
+
+        var newPullRequest = new NewPullRequest("squash commit pull request", branchName, "master");
+        var pullRequest = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
+
+        var merge = new MergePullRequest { CommitMessage = "fake commit message", CommitTitle = "fake title", MergeMethod = PullRequestMergeMethod.Rebase };
+        var result = await _fixture.Merge(Helper.UserName, _context.RepositoryName, pullRequest.Number, merge);
+        var commit = await _github.Repository.Commit.Get(_context.RepositoryOwner, _context.RepositoryName, result.Sha);
+
+        Assert.True(result.Merged);
+        Assert.Equal("this is a 2nd commit to merge into the pull request", commit.Commit.Message);
+    }
+
+    [IntegrationTest]
     public async Task CannotBeMergedDueMismatchConflict()
     {
         await CreateTheWorld();
@@ -848,8 +896,11 @@ public class PullRequestsClientTests : IDisposable
         var featureBranchTree = await CreateTree(new Dictionary<string, string> { { "README.md", "I am overwriting this blob with something new" } });
         var featureBranchCommit = await CreateCommit("this is the commit to merge into the pull request", featureBranchTree.Sha, newMaster.Sha);
 
+        var featureBranchTree2 = await CreateTree(new Dictionary<string, string> { { "README.md", "I am overwriting this blob with something new a 2nd time" } });
+        var featureBranchCommit2 = await CreateCommit("this is a 2nd commit to merge into the pull request", featureBranchTree2.Sha, featureBranchCommit.Sha);
+
         // create branch
-        await _github.Git.Reference.Create(Helper.UserName, _context.RepositoryName, new NewReference("refs/heads/my-branch", featureBranchCommit.Sha));
+        await _github.Git.Reference.Create(Helper.UserName, _context.RepositoryName, new NewReference("refs/heads/my-branch", featureBranchCommit2.Sha));
 
         var otherFeatureBranchTree = await CreateTree(new Dictionary<string, string> { { "README.md", "I am overwriting this blob with something else" } });
         var otherFeatureBranchCommit = await CreateCommit("this is the other commit to merge into the other pull request", otherFeatureBranchTree.Sha, newMaster.Sha);

--- a/Octokit/Models/Request/MergePullRequest.cs
+++ b/Octokit/Models/Request/MergePullRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -30,14 +31,27 @@ namespace Octokit
         /// <summary>
         ///  Commit a single commit to the head branch (optional)
         /// </summary>
+        [Obsolete("Please use MergeMethod property.  This property will no longer be supported by the GitHub API and will be removed in a future version")]
         public bool Squash { get; set; }
+
+        /// <summary>
+        /// Specify the Merge method to use (optional - default is Merge)
+        /// </summary>
+        public PullRequestMergeMethod? MergeMethod { get; set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "Title: '{0}'  Message: '{1}', Sha: '{2}' , Squash: '{3}'", CommitTitle, CommitMessage, Sha, Squash);
+                return string.Format(CultureInfo.InvariantCulture, "Title: '{0}'  Message: '{1}', Sha: '{2}' , MergeMethod: '{3}'", CommitTitle, CommitMessage, Sha, MergeMethod.HasValue ? MergeMethod.Value.ToString() : "null");
             }
         }
+    }
+
+    public enum PullRequestMergeMethod
+    {
+        Merge,
+        Squash,
+        Rebase
     }
 }

--- a/Octokit/Models/Request/MergePullRequest.cs
+++ b/Octokit/Models/Request/MergePullRequest.cs
@@ -48,10 +48,24 @@ namespace Octokit
         }
     }
 
+    /// <summary>
+    /// Method to use when merging a PR
+    /// </summary>
     public enum PullRequestMergeMethod
     {
+        /// <summary>
+        /// Create a merge commit
+        /// </summary>
         Merge,
+
+        /// <summary>
+        /// Squash and merge
+        /// </summary>
         Squash,
+
+        /// <summary>
+        /// Rebase and merge
+        /// </summary>
         Rebase
     }
 }


### PR DESCRIPTION
Fixes #1474 

Add `MergeMethod` property to `MergePullRequest` request object

Added integration tests for Merge, Squash and Rebase options

Obsoleted previous `Squash` bool parameter - also tested that this property does still work if specified (and also that if the new MergeMethod property is specified, it overrides anything specified by the Squash boolean).  Therefore it is safe to leave this there for the time being, however marking it obsolete means we can remove it in a couple of releases