### PR TITLE
Change PublicRepositoryRequest ctor to take long for "since" parameter

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -683,7 +683,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var request = new PublicRepositoryRequest(32732250);
+            var request = new PublicRepositoryRequest(32732250L);
             var repositories = await github.Repository.GetAllPublic(request);
 
             Assert.NotNull(repositories);

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoriesClientTests.cs
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Integration
                 var github = Helper.GetAuthenticatedClient();
 
                 var client = new ObservableRepositoriesClient(github);
-                var request = new PublicRepositoryRequest(32732250);
+                var request = new PublicRepositoryRequest(32732250L);
                 var repositories = await client.GetAllPublic(request).ToArray();
                 Assert.NotEmpty(repositories);
                 Assert.Equal(32732252, repositories[0].Id);

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -308,7 +308,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.GetAllPublic(new PublicRepositoryRequest(364));
+                await client.GetAllPublic(new PublicRepositoryRequest(364L));
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));
@@ -320,7 +320,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.GetAllPublic(new PublicRepositoryRequest(364));
+                await client.GetAllPublic(new PublicRepositoryRequest(364L));
 
                 connection.Received()
                     .GetAll<Repository>(Arg.Is<Uri>(u => u.ToString() == "repositories?since=364"));

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -311,7 +311,7 @@ namespace Octokit.Tests.Reactive
 
                 var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
 
-                var results = await repositoriesClient.GetAllPublic(new PublicRepositoryRequest(364)).ToArray();
+                var results = await repositoriesClient.GetAllPublic(new PublicRepositoryRequest(364L)).ToArray();
 
                 Assert.Equal(7, results.Length);
                 gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, null, null);

--- a/Octokit/Models/Request/PublicRepositoryRequest.cs
+++ b/Octokit/Models/Request/PublicRepositoryRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -13,10 +14,20 @@ namespace Octokit
         /// Initializes a new instance of the <see cref="PublicRepositoryRequest"/> class.
         /// </summary>
         /// <param name="since">The integer Id of the last Repository that you’ve seen.</param>
+        [Obsolete("Please use the alternative constructor taking a long, rather than int, typed parameter.  This constructor will be removed in a future release.")]
         public PublicRepositoryRequest(int since)
         {
             Ensure.ArgumentNotNull(since, "since");
 
+            Since = since;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PublicRepositoryRequest"/> class.
+        /// </summary>
+        /// <param name="since">The Id of the last Repository that you’ve seen.</param>
+        public PublicRepositoryRequest(long since)
+        {
             Since = since;
         }
 


### PR DESCRIPTION
We changed all repositoryId parameters from `int` to `long` in #1445 and missed this one.

The `ctor` on `PublicRepositoryRequest` takes a "since" parameter of type `int`.

If anyone is passing in a `repository.Id` (now a `long`) into this `ctor` it will result in a compilation error.

This PR adds a new `ctor` to PublicRepositoryRequest taking "since" parameter as a `long`, and obsoletes the old `ctor`.  I thought about simpl keeping the `int` `ctor` around indefinitely but I think in general we want to encourage/inform users that `repositoryId` (and any related uses, such as the "Since" parameter) are now `long` across the board, so I decided to start the process of removing the old `int` parameter via obsoletion.

Also updated any tests that use the `ctor` to use the new one instead...