### PR TITLE
Allow base64 content for create/update file

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -308,7 +308,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50"));
+                    new CreateFileRequest("Test commit", "Some Content"));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -319,7 +319,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha));
+                    new UpdateFileRequest("Updating file", "New Content", fileSha));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -351,7 +351,7 @@ namespace Octokit.Tests.Integration.Clients
                 var file = await fixture.CreateFile(
                     repository.Id,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50"));
+                    new CreateFileRequest("Test commit", "Some Content"));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -361,7 +361,7 @@ namespace Octokit.Tests.Integration.Clients
                 var update = await fixture.UpdateFile(
                     repository.Id,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha));
+                    new UpdateFileRequest("Updating file", "New Content", fileSha));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -396,7 +396,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName));
+                    new CreateFileRequest("Test commit", "Some Content", branchName));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -407,7 +407,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName));
+                    new UpdateFileRequest("Updating file", "New Content", fileSha, branchName));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -442,7 +442,7 @@ namespace Octokit.Tests.Integration.Clients
                 var file = await fixture.CreateFile(
                     repository.Id,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName));
+                    new CreateFileRequest("Test commit", "Some Content", branchName));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -452,7 +452,183 @@ namespace Octokit.Tests.Integration.Clients
                 var update = await fixture.UpdateFile(
                     repository.Id,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName));
+                    new UpdateFileRequest("Updating file", "New Content", fileSha, branchName));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha, branchName));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                    () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CrudTestWithExplicitBase64()
+        {
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
+
+                var file = await fixture.CreateFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", false));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, false));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CrudTestWithRepositoryIdWithExplicitBase64()
+        {
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
+
+                var file = await fixture.CreateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", false));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, false));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                     () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CrudTestWithNamedBranchWithExplicitBase64()
+        {
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+            var branchName = "other-branch";
+
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
+
+                var master = await client.Git.Reference.Get(Helper.UserName, repository.Name, "heads/master");
+                await client.Git.Reference.Create(Helper.UserName, repository.Name, new NewReference("refs/heads/" + branchName, master.Object.Sha));
+                var file = await fixture.CreateFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName, false));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName, false));
+                Assert.Equal("somefile.txt", update.Content.Name);
+
+                contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                Assert.Equal("New Content", contents.First().Content);
+                fileSha = contents.First().Sha;
+
+                await fixture.DeleteFile(
+                    repository.Owner.Login,
+                    repository.Name,
+                    "somefile.txt",
+                    new DeleteFileRequest("Deleted file", fileSha, branchName));
+
+                await Assert.ThrowsAsync<NotFoundException>(
+                    () => fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt"));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task CrudTestWithNamedBranchWithRepositoryIdWithExplicitBase64()
+        {
+            var client = Helper.GetAuthenticatedClient();
+            var fixture = client.Repository.Content;
+            var repoName = Helper.MakeNameWithTimestamp("source-repo");
+            var branchName = "other-branch";
+
+            using (var context = await client.CreateRepositoryContext(new NewRepository(repoName) { AutoInit = true }))
+            {
+                var repository = context.Repository;
+
+                var master = await client.Git.Reference.Get(Helper.UserName, repository.Name, "heads/master");
+                await client.Git.Reference.Create(Helper.UserName, repository.Name, new NewReference("refs/heads/" + branchName, master.Object.Sha));
+                var file = await fixture.CreateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName, false));
+                Assert.Equal("somefile.txt", file.Content.Name);
+
+                var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
+                string fileSha = contents.First().Sha;
+                Assert.Equal("Some Content", contents.First().Content);
+
+                var update = await fixture.UpdateFile(
+                    repository.Id,
+                    "somefile.txt",
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName, false));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);

--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -308,7 +308,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "Some Content"));
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50"));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -319,7 +319,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "New Content", fileSha));
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -351,7 +351,7 @@ namespace Octokit.Tests.Integration.Clients
                 var file = await fixture.CreateFile(
                     repository.Id,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "Some Content"));
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50"));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -361,7 +361,7 @@ namespace Octokit.Tests.Integration.Clients
                 var update = await fixture.UpdateFile(
                     repository.Id,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "New Content", fileSha));
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContents(repository.Owner.Login, repository.Name, "somefile.txt");
@@ -396,7 +396,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "Some Content", branchName));
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -407,7 +407,7 @@ namespace Octokit.Tests.Integration.Clients
                     repository.Owner.Login,
                     repository.Name,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "New Content", fileSha, branchName));
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -442,7 +442,7 @@ namespace Octokit.Tests.Integration.Clients
                 var file = await fixture.CreateFile(
                     repository.Id,
                     "somefile.txt",
-                    new CreateFileRequest("Test commit", "Some Content", branchName));
+                    new CreateFileRequest("Test commit", "U29tZSBDb250ZW50", branchName));
                 Assert.Equal("somefile.txt", file.Content.Name);
 
                 var contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);
@@ -452,7 +452,7 @@ namespace Octokit.Tests.Integration.Clients
                 var update = await fixture.UpdateFile(
                     repository.Id,
                     "somefile.txt",
-                    new UpdateFileRequest("Updating file", "New Content", fileSha, branchName));
+                    new UpdateFileRequest("Updating file", "TmV3IENvbnRlbnQ=", fileSha, branchName));
                 Assert.Equal("somefile.txt", update.Content.Name);
 
                 contents = await fixture.GetAllContentsByRef(repository.Owner.Login, repository.Name, "somefile.txt", branchName);

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -320,7 +320,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -332,7 +332,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -343,13 +343,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -359,13 +359,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -480,7 +480,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -492,7 +492,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -503,13 +503,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }
@@ -520,13 +520,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -320,7 +320,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -332,7 +332,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -343,7 +343,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -359,7 +359,63 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -480,7 +536,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -492,7 +548,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryContentsClient(connection);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -503,7 +559,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -520,7 +576,65 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryContentsClient(connection);
 
-                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public async Task PassesRequestObjectWithRepositoriesIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
 
                 connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -406,7 +406,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -419,7 +419,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -431,13 +431,13 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -448,13 +448,13 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<CreateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Branch == "mybranch"));
             }
 
@@ -575,7 +575,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -588,7 +588,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -600,13 +600,13 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }
@@ -618,13 +618,13 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
                     Arg.Is<UpdateFileRequest>(a =>
                         a.Message == "message"
-                        && a.Content == "myfilecontents"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
                         && a.Sha == "1234abc"
                         && a.Branch == "mybranch"));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -406,7 +406,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -419,7 +419,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -431,7 +431,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -448,7 +448,66 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch"));
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "myfilecontents", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+            [Fact]
+            public void RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile("org", "repo", "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<CreateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.CreateFile(1, "path/to/file", new CreateFileRequest("message", "bXlmaWxlY29udGVudHM=", "mybranch", false));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -575,7 +634,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repos/org/repo/contents/path/to/file";
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -588,7 +647,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
                 string expectedUri = "repositories/1/contents/path/to/file";
-                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
             }
@@ -600,7 +659,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),
@@ -618,7 +677,69 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableRepositoryContentsClient(gitHubClient);
 
-                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch"));
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "myfilecontents", "1234abc", "mybranch"));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repos/org/repo/contents/path/to/file";
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                string expectedUri = "repositories/1/contents/path/to/file";
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(Arg.Is<Uri>(u => u.ToString() == expectedUri), Arg.Any<object>());
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile("org", "repo", "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
+
+                gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
+                    Arg.Any<Uri>(),
+                    Arg.Is<UpdateFileRequest>(a =>
+                        a.Message == "message"
+                        && a.Content == "bXlmaWxlY29udGVudHM="
+                        && a.Sha == "1234abc"
+                        && a.Branch == "mybranch"));
+            }
+
+            [Fact]
+            public void PassesRequestObjectWithRepositoriesIdWithExplicitBase64()
+            {
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                client.UpdateFile(1, "path/to/file", new UpdateFileRequest("message", "bXlmaWxlY29udGVudHM=", "1234abc", "mybranch", false));
 
                 gitHubClient.Connection.Received().Put<RepositoryContentChangeSet>(
                     Arg.Any<Uri>(),

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -106,11 +106,33 @@ namespace Octokit
         /// Creates an instance of a <see cref="CreateFileRequest" />.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <param name="content">The content encoded in base64.</param>
-        public CreateFileRequest(string message, string content) : base(message)
+        /// <param name="content">The content.</param>
+        public CreateFileRequest(string message, string content) : this(message, content, true)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateFileRequest"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="branch">The branch the request is for.</param>
+        public CreateFileRequest(string message, string content, string branch) : this(message, content, branch, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="CreateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public CreateFileRequest(string message, string content, bool convertContentToBase64) : base(message)
         {
             Ensure.ArgumentNotNull(content, "content");
 
+            if (convertContentToBase64)
+            {
+                content = content.ToBase64String();
+            }
             Content = content;
         }
 
@@ -118,12 +140,17 @@ namespace Octokit
         /// Initializes a new instance of the <see cref="CreateFileRequest"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <param name="content">The content encoded in base64.</param>
+        /// <param name="content">The content.</param>
         /// <param name="branch">The branch the request is for.</param>
-        public CreateFileRequest(string message, string content, string branch) : base(message, branch)
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public CreateFileRequest(string message, string content, string branch, bool convertContentToBase64) : base(message, branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(content, "content");
 
+            if (convertContentToBase64)
+            {
+                content = content.ToBase64String();
+            }
             Content = content;
         }
 
@@ -154,7 +181,29 @@ namespace Octokit
         /// <param name="content">The content.</param>
         /// <param name="sha">The sha.</param>
         public UpdateFileRequest(string message, string content, string sha)
-            : base(message, content)
+            : this(message, content, sha, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="UpdateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="sha">The sha.</param>
+        /// <param name="branch">The branch the request is for.</param>
+        public UpdateFileRequest(string message, string content, string sha, string branch)
+           : this(message, content, sha, branch, true)
+        { }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="UpdateFileRequest" />.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="content">The content.</param>
+        /// <param name="sha">The sha.</param>
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public UpdateFileRequest(string message, string content, string sha, bool convertContentToBase64)
+            : base(message, content, convertContentToBase64)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 
@@ -168,8 +217,9 @@ namespace Octokit
         /// <param name="content">The content.</param>
         /// <param name="sha">The sha.</param>
         /// <param name="branch">The branch the request is for.</param>
-        public UpdateFileRequest(string message, string content, string sha, string branch)
-           : base(message, content, branch)
+        /// <param name="convertContentToBase64">True to convert content to base64.</param>
+        public UpdateFileRequest(string message, string content, string sha, string branch, bool convertContentToBase64)
+           : base(message, content, branch, convertContentToBase64)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, "sha");
 

--- a/Octokit/Models/Request/CreateFileRequest.cs
+++ b/Octokit/Models/Request/CreateFileRequest.cs
@@ -106,7 +106,7 @@ namespace Octokit
         /// Creates an instance of a <see cref="CreateFileRequest" />.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <param name="content">The content.</param>
+        /// <param name="content">The content encoded in base64.</param>
         public CreateFileRequest(string message, string content) : base(message)
         {
             Ensure.ArgumentNotNull(content, "content");
@@ -118,7 +118,7 @@ namespace Octokit
         /// Initializes a new instance of the <see cref="CreateFileRequest"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
-        /// <param name="content">The content.</param>
+        /// <param name="content">The content encoded in base64.</param>
         /// <param name="branch">The branch the request is for.</param>
         public CreateFileRequest(string message, string content, string branch) : base(message, branch)
         {
@@ -126,10 +126,10 @@ namespace Octokit
 
             Content = content;
         }
+
         /// <summary>
-        /// The contents of the file to create. This is required.
+        /// The contents of the file to create, Base64 encoded. This is required.
         /// </summary>
-        [SerializeAsBase64]
         public string Content { get; private set; }
 
         internal virtual string DebuggerDisplay


### PR DESCRIPTION
Fixes #1143.
Since 1.0 has not been reached yet, I made the fix minimal and as I think the method should have been originally, but there is a breaking change.

If you want to mitigate the breaking change I propose three ways:
1. `Content` contains base64 content. Breaking change on `Content.Get()`. Could add corresponding ctors with bool if convert to base64.
2. Insert base class `Base64CreateFileRequest` with a virtual `Content` property wich contains base64 content. `CreateFileRequest` overrides it and provides decoded content.
3. Add `SerializeIgnore` and `SerializeName` attributes, add first on `Content` and second on new property `Base64Content`. When set, `Content` convert value to base64 and set `Base64Content`.
