### PR TITLE
Updated monotouch projects to unified Xamarin.iOS projects

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
+++ b/Octokit.Reactive/Octokit.Reactive-Monotouch.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F4ADA431-8344-4B36-9A0B-C4D96AF53908}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Octokit.Reactive</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
@@ -37,7 +37,6 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Reactive.Core">
       <HintPath>..\ext\Monotouch\System.Reactive.Core.dll</HintPath>
@@ -51,6 +50,7 @@
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\ext\Monotouch\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Octokit\Helpers\Ensure.cs">
@@ -182,16 +182,8 @@
     <Compile Include="Clients\IObservableMigrationsClient.cs" />
     <Compile Include="Clients\ObservableMigrationClient.cs" />
     <Compile Include="Clients\ObservableMigrationsClient.cs" />
-    <Compile Include="Clients\IObservableCommitCommentReaction.cs" />
     <Compile Include="Clients\IObservableReactionsClient.cs" />
-    <Compile Include="Clients\ObservableCommitCommentReaction.cs" />
     <Compile Include="Clients\ObservableReactionsClient.cs" />
-    <Compile Include="Clients\IObservableCommitCommentReactionClient.cs" />
-    <Compile Include="Clients\ObservableCommitCommentReactionClient.cs" />
-    <Compile Include="Clients\IObservableCommitCommentsReactionsClient.cs" />
-    <Compile Include="Clients\IObservableIssuesReactionsClient.cs" />
-    <Compile Include="Clients\ObservableCommitCommentsReactionClient.cs" />
-    <Compile Include="Clients\ObservableIssuesReactionsClient.cs" />
     <Compile Include="Clients\IObservableCommitCommentReactionsClient.cs" />
     <Compile Include="Clients\IObservableIssueReactionsClient.cs" />
     <Compile Include="Clients\ObservableCommitCommentReactionsClient.cs" />
@@ -211,7 +203,7 @@
     <Compile Include="Clients\IObservableRepositoryTrafficClient.cs" />
     <Compile Include="Clients\ObservableRepositoryTrafficClient.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Octokit\Octokit-Monotouch.csproj">
       <Project>{E4AD1421-8844-4236-9A0B-C4D96AF53908}</Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E4AD1421-8844-4236-9A0B-C4D96AF53908}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Octokit</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
@@ -18,9 +18,9 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <IntermediateOutputPath>obj\Debug\Monotouch</IntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
+    <DefineConstants>__IOS__;__UNIFIED__;__MOBILE__;__IOS__TRACE;TRACE;DEBUG;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
     <OutputPath>bin\Debug\Monotouch</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
+    <DefineConstants>__IOS__;__UNIFIED__;__MOBILE__;__IOS__TRACE;TRACE;DEBUG;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -28,7 +28,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
+    <DefineConstants>__IOS__;__UNIFIED__;__MOBILE__;__IOS__TRACE;TRACE;CODE_ANALYSIS;CODE_ANALYSIS;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_INTERNAL;NET_45</DefineConstants>
     <IntermediateOutputPath>obj\Release\Monotouch</IntermediateOutputPath>
     <OutputPath>bin\Release\Monotouch</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -39,8 +39,8 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs">
@@ -348,7 +348,6 @@
     <Compile Include="Models\Response\DeployKey.cs" />
     <Compile Include="Clients\IUserKeysClient.cs" />
     <Compile Include="Clients\UserKeysClient.cs" />
-    <Compile Include="Helpers\ApiUrls.Keys.cs" />
     <Compile Include="Helpers\SerializeNullAttribute.cs" />
     <Compile Include="Models\Request\CommitRequest.cs" />
     <Compile Include="Clients\IRepositoryForksClient.cs" />
@@ -437,7 +436,6 @@
     <Compile Include="Models\Response\Enterprise\LicenseInfo.cs" />
     <Compile Include="Clients\Enterprise\EnterpriseOrganizationClient.cs" />
     <Compile Include="Clients\Enterprise\IEnterpriseOrganizationClient.cs" />
-    <Compile Include="Models\Request\NewOrganization.cs" />
     <Compile Include="Clients\IUserAdministrationClient.cs" />
     <Compile Include="Clients\UserAdministrationClient.cs" />
     <Compile Include="Helpers\ReferenceExtensions.cs" />
@@ -463,8 +461,6 @@
     <Compile Include="Clients\IMigrationsClient.cs" />
     <Compile Include="Clients\MigrationClient.cs" />
     <Compile Include="Clients\MigrationsClient.cs" />
-    <Compile Include="Models\Request\Enterprise\StartMigrationRequest.cs" />
-    <Compile Include="Models\Response\Enterprise\Migration.cs" />
     <Compile Include="Models\Request\StartMigrationRequest.cs" />
     <Compile Include="Models\Response\Migration.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
@@ -510,6 +506,5 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>


### PR DESCRIPTION
When I tried to add the Octokit.net Nuget package to any of my Xamarin.iOS projects (10.0.1.10), they wouldn't install because the package couldn't target the platform. Xamarin.iOS 10+ requires that the Unified Xamarin iOS APIs be used, which is why I expect the installation was failing.

I've fixed the iOS projects in-place. This is probably not the best solution, because it means that the package will break things for anyone using Xamarin.iOS that is less than version 10. I don't presume to know how you want to structure your library around those changes. A better solution would probably be to have a new set of iOS projects that target Xamarin.iOS 10+ and leave the old monotouch projects as they are. But like I said, I won't presume to know how you want to deal with that.

There were also many files that were referenced in the iOS projects, but that were missing from the repo altogether. I have updated the projects to omit these files.