### PR TITLE
Fix IssueCommentClient #1500

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -66,6 +66,42 @@ namespace Octokit.Reactive
         IObservable<IssueComment> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return GetAllForRepository(owner, name, new IssueCommentRequest(), ApiOptions.None);
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return GetAllForRepository(repositoryId, new IssueCommentRequest(), ApiOptions.None);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -100,7 +100,69 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId), options);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -136,9 +136,11 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null, ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForRepository("owner", ""));

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -84,9 +84,9 @@ namespace Octokit.Tests.Reactive
 
                 var request = new IssueCommentRequest()
                 {
-                    Direction = SortDirection.Ascending,
-                    Since = DateTime.UtcNow,
-                    Sort = PullRequestReviewCommentSort.Created
+                    Direction = SortDirection.Descending,
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                    Sort = PullRequestReviewCommentSort.Updated
                 };
                 var options = new ApiOptions
                 {
@@ -97,7 +97,13 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", request, options);
 
-                gitHubClient.Received().Issue.Comment.GetAllForRepository("fake", "repo", request, options);
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2016-11-23T11:11:11Z"
+                        && d["sort"] == "updated"),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -108,9 +114,9 @@ namespace Octokit.Tests.Reactive
 
                 var request = new IssueCommentRequest()
                 {
-                    Direction = SortDirection.Ascending,
-                    Since = DateTime.UtcNow,
-                    Sort = PullRequestReviewCommentSort.Created
+                    Direction = SortDirection.Descending,
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                    Sort = PullRequestReviewCommentSort.Updated
                 };
                 var options = new ApiOptions
                 {
@@ -121,7 +127,13 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, request, options);
 
-                gitHubClient.Received().Issue.Comment.GetAllForRepository(1, request, options);
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repositories/1/issues/comments", UriKind.Relative),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                        && d["direction"] == "desc"
+                        && d["since"] == "2016-11-23T11:11:11Z"
+                        && d["sort"] == "updated"),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -71,7 +71,9 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository(1);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/comments", UriKind.Relative), Arg.Any<IDictionary<string, string>>(), null);
+                    new Uri("repositories/1/issues/comments", UriKind.Relative),
+                    Arg.Any<IDictionary<string, string>>(),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -124,9 +124,11 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(null, "name", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", request: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository("owner", "name", options: null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, request: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(1, options: null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllForRepository("owner", ""));

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -99,7 +99,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["direction"] == "desc"
                         && d["since"] == "2016-11-23T11:11:11Z"
                         && d["sort"] == "updated"),
@@ -129,7 +129,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repositories/1/issues/comments", UriKind.Relative),
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
                         && d["direction"] == "desc"
                         && d["since"] == "2016-11-23T11:11:11Z"
                         && d["sort"] == "updated"),

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -80,6 +80,12 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
+                var request = new IssueCommentRequest()
+                {
+                    Direction = SortDirection.Ascending,
+                    Since = DateTime.UtcNow,
+                    Sort = PullRequestReviewCommentSort.Created
+                };
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -89,10 +95,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), 
-                    Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                gitHubClient.Received().Issue.Comment.GetAllForRepository("fake", "repo", request, options);
             }
 
             [Fact]
@@ -101,6 +104,12 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
+                var request = new IssueCommentRequest()
+                {
+                    Direction = SortDirection.Ascending,
+                    Since = DateTime.UtcNow,
+                    Sort = PullRequestReviewCommentSort.Created
+                };
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -110,8 +119,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/comments", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+                gitHubClient.Received().Issue.Comment.GetAllForRepository(1, request, options);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -93,9 +93,12 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForRepository("fake", "repo", options);
+                client.GetAllForRepository("fake", "repo", request, options);
 
-                gitHubClient.Received().Issue.Comment.GetAllForRepository("fake", "repo", request, options);
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
+                    request.ToParametersDictionary(),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -117,9 +120,12 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForRepository(1, options);
+                client.GetAllForRepository(1, request, options);
 
-                gitHubClient.Received().Issue.Comment.GetAllForRepository(1, request, options);
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repositories/1/issues/comments", UriKind.Relative),
+                    request.ToParametersDictionary(),
+                    null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -57,8 +57,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository("fake", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative), 
-                    Args.EmptyDictionary, 
+                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
+                    Arg.Any<IDictionary<string, string>>(), 
                     "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForRepository(1);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/comments", UriKind.Relative), Args.EmptyDictionary, null);
+                    new Uri("repositories/1/issues/comments", UriKind.Relative), Arg.Any<IDictionary<string, string>>(), null);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -97,7 +97,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
-                    request.ToParametersDictionary(),
+                    Arg.Is(request.ToParametersDictionary()),
                     "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -124,7 +124,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repositories/1/issues/comments", UriKind.Relative),
-                    request.ToParametersDictionary(),
+                    Arg.Is(request.ToParametersDictionary()),
                     null);
             }
 

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -95,10 +95,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", request, options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
-                    Arg.Is(request.ToParametersDictionary()),
-                    "application/vnd.github.squirrel-girl-preview");
+                gitHubClient.Received().Issue.Comment.GetAllForRepository("fake", "repo", request, options);
             }
 
             [Fact]
@@ -122,10 +119,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, request, options);
 
-                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/comments", UriKind.Relative),
-                    Arg.Is(request.ToParametersDictionary()),
-                    null);
+                gitHubClient.Received().Issue.Comment.GetAllForRepository(1, request, options);
             }
 
             [Fact]

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -66,6 +66,42 @@ namespace Octokit
         Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Gets Issue Comments for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -55,8 +55,8 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return GetAllForRepository(owner, name, ApiOptions.None);
+            
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId)
         {
-            return GetAllForRepository(repositoryId, ApiOptions.None);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), ApiOptions.None);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(owner, name, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -95,7 +95,69 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForRepository(repositoryId, new IssueCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(owner, name, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+
+            return GetAllForRepository(repositoryId, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a repository.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, "request");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit/Models/Request/IssueCommentRequest.cs
+++ b/Octokit/Models/Request/IssueCommentRequest.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to filter issue comments.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class IssueCommentRequest : RequestParameters
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IssueCommentRequest"/> class.
+        /// </summary>
+        public IssueCommentRequest()
+        {
+            // Default arguments
+            Sort = PullRequestReviewCommentSort.Created;
+            Direction = SortDirection.Ascending;
+            Since = null;
+        }
+
+        /// <summary>
+        /// Can be either created or updated. Default: created.
+        /// </summary>
+        public PullRequestReviewCommentSort Sort { get; set; }
+
+        /// <summary>
+        /// Can be either asc or desc. Default: asc.
+        /// </summary>
+        public SortDirection Direction { get; set; }
+
+        /// <summary>
+        /// Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.
+        /// </summary>
+        public DateTimeOffset? Since { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "Sort: {0}, Direction: {1}, Since: {2}", Sort, Direction, Since); }
+        }
+    }
+}

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -62,4 +62,17 @@ namespace Octokit
             get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} CreatedAt: {1}", Id, CreatedAt); }
         }
     }
+
+    public enum IssueCommentSort
+    {
+        /// <summary>
+        /// Sort by create date (default)
+        /// </summary>
+        Created,
+
+        /// <summary>
+        /// Sort by the date of the last update
+        /// </summary>
+        Updated
+    }
 }

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -502,6 +502,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -513,6 +513,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -509,6 +509,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -499,6 +499,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -506,6 +506,7 @@
     <Compile Include="Models\Request\RepositoryTrafficRequest.cs" />
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Models\Request\ApiOptions.cs" />
     <Compile Include="Models\Request\CollaboratorRequest.cs" />
     <Compile Include="Models\Request\InvitationUpdate.cs" />
+    <Compile Include="Models\Request\IssueCommentRequest.cs" />
     <Compile Include="Models\Request\NewReaction.cs" />
     <Compile Include="Models\Request\NewGpgKey.cs" />
     <Compile Include="Models\Request\NewImpersonationToken.cs" />


### PR DESCRIPTION
Original Issue : https://github.com/octokit/octokit.net/issues/1500

Hi,
I added 4 methods to `IssueCommentsClient.cs`.

But there are two duplicated options which named `IssueCommentSort` and `PullRequestReviewCommentSort`. I think these types can be merged like a `SortDirection` option.

Thanks.