### PR TITLE
Add ApiInfo Rate limiting description to Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,4 +91,4 @@ var whenDoesTheLimitReset = rateLimit?.Reset;
 
 An authenticated client will have a significantly higher limit than an anonymous client. 
 
-For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/rate_limit/).
+For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/#rate-limiting).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,4 +89,6 @@ var howManyRequestsDoIHaveLeft = rateLimit?.Remaining;
 var whenDoesTheLimitReset = rateLimit?.Reset;
 ```
 
+An authenticated client will have a higher limit than an anonymous client. 
+
 For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/rate_limit/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,6 +89,6 @@ var howManyRequestsDoIHaveLeft = rateLimit?.Remaining;
 var whenDoesTheLimitReset = rateLimit?.Reset;
 ```
 
-An authenticated client will have a higher limit than an anonymous client. 
+An authenticated client will have a significantly higher limit than an anonymous client. 
 
 For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/rate_limit/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,6 @@ var apiInfo = client.GetLastApiInfo();
 var rateLimit = apiInfo?.RateLimit;
 
 var howManyRequestsCanIMakePerHour = rateLimit?.Limit;
-var howManyRequestsToIHaveLeft = rateLimit?.Remaining;
+var howManyRequestsDoIHaveLeft = rateLimit?.Remaining;
 var whenDoesTheLimitReset = rateLimit?.Reset;
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,8 @@ Like any popular API, Github needs to throttle some requests. The OctoKit.NET cl
 Example usage:
 
 ```csharp
-var client; //Create the client up here
+GithubClient client; 
+//Create & initialize the client here
 
 // Prior to first API call, this will be null, because it only deals with the last call.
 var apiInfo = client.GetLastApiInfo();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,3 +88,5 @@ var howManyRequestsCanIMakePerHour = rateLimit?.Limit;
 var howManyRequestsDoIHaveLeft = rateLimit?.Remaining;
 var whenDoesTheLimitReset = rateLimit?.Reset;
 ```
+
+For more information on the API and understanding rate limits, you may want to consult [the Github API docs on rate limits](https://developer.github.com/v3/rate_limit/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,3 +69,22 @@ If you've authenticated as a given user, you can query their details directly:
 ```
 var user = await client.User.Current();
 ```
+
+### Too Much of a Good Thing: Dealing with API Rate Limits
+Like any popular API, Github needs to throttle some requests. The OctoKit.NET client allows you to get some insight into how many requests you have left and when you can start making requests again. It does this via the `ApiInfo` object and the `GetLastApiInfo()` method.
+
+Example usage:
+
+```csharp
+var client; //Create the client up here
+
+// Prior to first API call, this will be null, because it only deals with the last call.
+var apiInfo = client.GetLastApiInfo();
+
+// If the ApiInfo isn't null, there will be a property called RateLimit
+var rateLimit = apiInfo?.RateLimit;
+
+var howManyRequestsCanIMakePerHour = rateLimit?.Limit;
+var howManyRequestsToIHaveLeft = rateLimit?.Remaining;
+var whenDoesTheLimitReset = rateLimit?.Reset;
+```


### PR DESCRIPTION
Supports #1142. 

## Remaining Work

* [x] Add a quick section on rate limits to the getting started doc
* [x] Add links to the Github API rate limit docs
* [x] Note that authorized clients have a higher rate limit.

If you'd like to break this PR up at all to get some of the basic info in, let me know and I'll switch it up.