### PR TITLE
Introduce AbuseException

### DIFF
--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -12,7 +12,7 @@ namespace Octokit.Tests.Exceptions
             public class Message
             {
                 [Fact]
-                public void PostsAbuseMessageFromApi()
+                public void ContainsAbuseMessageFromApi()
                 {
                     const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
                                                 "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Exceptions
                     }
 
                     [Fact]
-                    public void ZeroHeaderValue_RetryAfterSecondsIsZero()
+                    public void WithZeroHeaderValue_RetryAfterSecondsIsZero()
                     {
                         var headerDictionary = new Dictionary<string, string> { { "Retry-After", "0" } };
 

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit.Internal;
+using Xunit;
+
+namespace Octokit.Tests.Exceptions
+{
+    public class AbuseExceptionTests
+    {
+        [Fact]
+        public void PostsAbuseMessageFromApi()
+        {
+
+            const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
+                                        "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
+
+            var response = new Response(
+                HttpStatusCode.Forbidden,
+                responseBody,
+                new Dictionary<string, string>(),
+                "application/json");
+            var abuseException = new AbuseException(response);
+
+            Assert.Equal("You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.", abuseException.ApiError.Message);
+        }
+
+        [Fact]
+        public void HasDefaultMessage()
+        {
+            var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
+            var abuseException = new AbuseException(response);
+
+            Assert.Equal("Request Forbidden - Abuse Detection", abuseException.Message);
+        }
+
+        public class RetryAfterHeaderHandling
+        {
+            [Fact]
+            public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
+            {
+                var headerDictionary = new Dictionary<string, string>();
+                headerDictionary.Add("Retry-After", "60");
+
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
+
+                Assert.Equal(60, abuseException.RetryAfterSeconds);
+            }
+
+            [Fact]
+            public void NoHeader_RetryAfterSecondsDefaultsTo60()
+            {
+                throw new NotImplementedException();
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("    ")]
+            public void EmptyHeaderValue_RetryAfterSecondsDefaultsTo60()
+            {
+                throw new NotImplementedException();
+            }
+
+            [Fact]
+            public void NonParseableHeaderValue_RetryAfterSecondsDefaultsTo60()
+            {
+                throw new NotImplementedException();
+            }
+
+            [Fact]
+            public void NegativeHeaderValue_RetryAfterSecondsDefaultsTo60()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -7,116 +7,113 @@ namespace Octokit.Tests.Exceptions
 {
     public class AbuseExceptionTests
     {
-        [Fact]
-        public void PostsAbuseMessageFromApi()
+        public class TheConstructor
         {
-            const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
-                                        "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
-
-            var response = new Response(
-                HttpStatusCode.Forbidden,
-                responseBody,
-                new Dictionary<string, string>(),
-                "application/json");
-
-            var abuseException = new AbuseException(response);
-
-            Assert.Equal("You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.", abuseException.ApiError.Message);
-        }
-
-        [Fact]
-        public void HasDefaultMessage()
-        {
-            var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
-            var abuseException = new AbuseException(response);
-
-            Assert.Equal("Request Forbidden - Abuse Detection", abuseException.Message);
-        }
-
-        public class RetryAfterHeaderHandling
-        {
-            [Fact]
-            public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
+            public class Message
             {
-                var headerDictionary = new Dictionary<string, string>
+                [Fact]
+                public void PostsAbuseMessageFromApi()
                 {
-                    { "Retry-After", "30" }
-                };
+                    const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
+                                                "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
 
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
+                    var response = new Response(
+                        HttpStatusCode.Forbidden,
+                        responseBody,
+                        new Dictionary<string, string>(),
+                        "application/json");
 
-                Assert.Equal(30, abuseException.RetryAfterSeconds);
+                    var abuseException = new AbuseException(response);
+
+                    Assert.Equal("You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.", abuseException.ApiError.Message);
+                }
+
+                [Fact]
+                public void HasDefaultMessage()
+                {
+                    var response = new Response(HttpStatusCode.Forbidden, null, new Dictionary<string, string>(), "application/json");
+                    var abuseException = new AbuseException(response);
+
+                    Assert.Equal("Request Forbidden - Abuse Detection", abuseException.Message);
+                }
             }
 
-            [Fact]
-            public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefaultOfNull()
+            public class RetryAfterSeconds
             {
-                var headerDictionary = new Dictionary<string, string>();
-
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
-
-                Assert.False(abuseException.RetryAfterSeconds.HasValue);
-            }
-
-            [Theory]
-            [InlineData(null)]
-            [InlineData("")]
-            [InlineData("    ")]
-            public void EmptyHeaderValue_RetryAfterSecondsDefaultsToNull(string emptyValueToTry)
-            {
-                var headerDictionary = new Dictionary<string, string>
+                public class HappyPath
                 {
-                    { "Retry-After", emptyValueToTry }
-                };
+                    [Fact]
+                    public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "30" } };
 
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
 
-                Assert.False(abuseException.RetryAfterSeconds.HasValue);
-            }
+                        Assert.Equal(30, abuseException.RetryAfterSeconds);
+                    }
 
-            [Fact]
-            public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsToNull()
-            {
-                var headerDictionary = new Dictionary<string, string>
+                    [Fact]
+                    public void ZeroHeaderValue_RetryAfterSecondsIsZero()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "0" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.Equal(0, abuseException.RetryAfterSeconds);
+                    }
+                }
+
+                public class UnhappyPaths
                 {
-                    { "Retry-After", "ABC" }
-                };
+                    [Fact]
+                    public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefaultOfNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string>();
 
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
 
-                Assert.False(abuseException.RetryAfterSeconds.HasValue);
-            }
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
 
-            [Fact]
-            public void NegativeHeaderValue_RetryAfterSecondsDefaultsToNull()
-            {
-                var headerDictionary = new Dictionary<string, string>
-                {
-                    { "Retry-After", "-123" }
-                };
+                    [Theory]
+                    [InlineData(null)]
+                    [InlineData("")]
+                    [InlineData("    ")]
+                    public void EmptyHeaderValue_RetryAfterSecondsDefaultsToNull(string emptyValueToTry)
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", emptyValueToTry } };
 
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
 
-                Assert.False(abuseException.RetryAfterSeconds.HasValue);
-            }
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
 
-            [Fact]
-            public void ZeroHeaderValue_RetryAfterSecondsIsZero()
-            {
-                var headerDictionary = new Dictionary<string, string>
-                {
-                    { "Retry-After", "0" }
-                };
+                    [Fact]
+                    public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsToNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "ABC" } };
 
-                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
-                var abuseException = new AbuseException(response);
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
 
-                Assert.Equal(0, abuseException.RetryAfterSeconds);
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+
+                    [Fact]
+                    public void NegativeHeaderValue_RetryAfterSecondsDefaultsToNull()
+                    {
+                        var headerDictionary = new Dictionary<string, string> { { "Retry-After", "-123" } };
+
+                        var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                        var abuseException = new AbuseException(response);
+
+                        Assert.False(abuseException.RetryAfterSeconds.HasValue);
+                    }
+                }
             }
         }
     }

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -43,7 +43,33 @@ namespace Octokit.Tests.Exceptions
             public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
             {
                 var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", "60");
+                headerDictionary.Add("Retry-After", "30");
+
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
+
+                Assert.Equal(30, abuseException.RetryAfterSeconds);
+            }
+
+            [Fact]
+            public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefault()
+            {
+                var headerDictionary = new Dictionary<string, string>();
+
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
+
+                Assert.Equal(60, abuseException.RetryAfterSeconds);
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("    ")]
+            public void EmptyHeaderValue_RetryAfterSecondsDefaultsTo60(string emptyValueToTry)
+            {
+                var headerDictionary = new Dictionary<string, string>();
+                headerDictionary.Add("Retry-After", emptyValueToTry);
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
@@ -52,30 +78,27 @@ namespace Octokit.Tests.Exceptions
             }
 
             [Fact]
-            public void NoHeader_RetryAfterSecondsDefaultsTo60()
+            public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsTo60()
             {
-                throw new NotImplementedException();
-            }
+                var headerDictionary = new Dictionary<string, string>();
+                headerDictionary.Add("Retry-After", "ABC");
 
-            [Theory]
-            [InlineData(null)]
-            [InlineData("")]
-            [InlineData("    ")]
-            public void EmptyHeaderValue_RetryAfterSecondsDefaultsTo60()
-            {
-                throw new NotImplementedException();
-            }
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
 
-            [Fact]
-            public void NonParseableHeaderValue_RetryAfterSecondsDefaultsTo60()
-            {
-                throw new NotImplementedException();
+                Assert.Equal(60, abuseException.RetryAfterSeconds);
             }
 
             [Fact]
             public void NegativeHeaderValue_RetryAfterSecondsDefaultsTo60()
             {
-                throw new NotImplementedException();
+                var headerDictionary = new Dictionary<string, string>();
+                headerDictionary.Add("Retry-After", "-123");
+
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
+
+                Assert.Equal(60, abuseException.RetryAfterSeconds);
             }
         }
     }

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -10,7 +10,6 @@ namespace Octokit.Tests.Exceptions
         [Fact]
         public void PostsAbuseMessageFromApi()
         {
-
             const string responseBody = "{\"message\":\"You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.\"," +
                                         "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}";
 
@@ -19,6 +18,7 @@ namespace Octokit.Tests.Exceptions
                 responseBody,
                 new Dictionary<string, string>(),
                 "application/json");
+
             var abuseException = new AbuseException(response);
 
             Assert.Equal("You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.", abuseException.ApiError.Message);
@@ -118,7 +118,6 @@ namespace Octokit.Tests.Exceptions
 
                 Assert.Equal(0, abuseException.RetryAfterSeconds);
             }
-
         }
     }
 }

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using Octokit.Internal;
 using Xunit;
 
@@ -42,8 +38,10 @@ namespace Octokit.Tests.Exceptions
             [Fact]
             public void WithRetryAfterHeader_PopulatesRetryAfterSeconds()
             {
-                var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", "30");
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "30" }
+                };
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
@@ -68,8 +66,10 @@ namespace Octokit.Tests.Exceptions
             [InlineData("    ")]
             public void EmptyHeaderValue_RetryAfterSecondsDefaultsTo60(string emptyValueToTry)
             {
-                var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", emptyValueToTry);
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", emptyValueToTry }
+                };
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
@@ -80,8 +80,10 @@ namespace Octokit.Tests.Exceptions
             [Fact]
             public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsTo60()
             {
-                var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", "ABC");
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "ABC" }
+                };
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
@@ -92,8 +94,10 @@ namespace Octokit.Tests.Exceptions
             [Fact]
             public void NegativeHeaderValue_RetryAfterSecondsDefaultsTo60()
             {
-                var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", "-123");
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "-123" }
+                };
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -104,6 +104,21 @@ namespace Octokit.Tests.Exceptions
 
                 Assert.Equal(60, abuseException.RetryAfterSeconds);
             }
+
+            [Fact]
+            public void ZeroHeaderValue_RetryAfterSecondsIsZero()
+            {
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "0" }
+                };
+
+                var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
+                var abuseException = new AbuseException(response);
+
+                Assert.Equal(0, abuseException.RetryAfterSeconds);
+            }
+
         }
     }
 }

--- a/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/AbuseExceptionTests.cs
@@ -50,21 +50,21 @@ namespace Octokit.Tests.Exceptions
             }
 
             [Fact]
-            public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefault()
+            public void NoRetryAfterHeader_RetryAfterSecondsIsSetToTheDefaultOfNull()
             {
                 var headerDictionary = new Dictionary<string, string>();
 
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
 
-                Assert.Equal(60, abuseException.RetryAfterSeconds);
+                Assert.False(abuseException.RetryAfterSeconds.HasValue);
             }
 
             [Theory]
             [InlineData(null)]
             [InlineData("")]
             [InlineData("    ")]
-            public void EmptyHeaderValue_RetryAfterSecondsDefaultsTo60(string emptyValueToTry)
+            public void EmptyHeaderValue_RetryAfterSecondsDefaultsToNull(string emptyValueToTry)
             {
                 var headerDictionary = new Dictionary<string, string>
                 {
@@ -74,11 +74,11 @@ namespace Octokit.Tests.Exceptions
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
 
-                Assert.Equal(60, abuseException.RetryAfterSeconds);
+                Assert.False(abuseException.RetryAfterSeconds.HasValue);
             }
 
             [Fact]
-            public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsTo60()
+            public void NonParseableIntHeaderValue_RetryAfterSecondsDefaultsToNull()
             {
                 var headerDictionary = new Dictionary<string, string>
                 {
@@ -88,11 +88,11 @@ namespace Octokit.Tests.Exceptions
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
 
-                Assert.Equal(60, abuseException.RetryAfterSeconds);
+                Assert.False(abuseException.RetryAfterSeconds.HasValue);
             }
 
             [Fact]
-            public void NegativeHeaderValue_RetryAfterSecondsDefaultsTo60()
+            public void NegativeHeaderValue_RetryAfterSecondsDefaultsToNull()
             {
                 var headerDictionary = new Dictionary<string, string>
                 {
@@ -102,7 +102,7 @@ namespace Octokit.Tests.Exceptions
                 var response = new Response(HttpStatusCode.Forbidden, null, headerDictionary, "application/json");
                 var abuseException = new AbuseException(response);
 
-                Assert.Equal(60, abuseException.RetryAfterSeconds);
+                Assert.False(abuseException.RetryAfterSeconds.HasValue);
             }
 
             [Fact]

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -289,13 +289,11 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
             {
-                //TODO
-                throw new NotImplementedException();
-
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response(
                     HttpStatusCode.Forbidden,
-                    "YOU SHALL NOT PASS!",
+                    "{\"message\":\"blahblahblah this does not matter because we are testing the URL\"," +
+                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
                     new Dictionary<string, string>(),
                     "application/json");
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
@@ -305,10 +303,10 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await Assert.ThrowsAsync<ForbiddenException>(
+                var exception = await Assert.ThrowsAsync<AbuseException>(
                     () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
 
-                Assert.Equal("YOU SHALL NOT PASS!", exception.Message);
+                Assert.Contains("abuse-rate", exception.Message);
             }
 
         }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -296,14 +296,31 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
-            public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDescription()
             {
-                //TODO
-                throw new NotImplementedException();
+                var messageText = "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://ThisURLDoesNotMatter.com\"}",
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
             }
 
+
             [Fact]
-            public async Task ThrowsAbuseExceptionForResponseWithAbuseDescription()
+            public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
             {
                 //TODO
                 throw new NotImplementedException();

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -329,13 +329,14 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
             {
-                string bodyResponse = null; 
+                var messageText = string.Empty;
 
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response(
                     HttpStatusCode.Forbidden,
-                    bodyResponse,
-                    new Dictionary<string, string>(),
+                     "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
+                   new Dictionary<string, string>(),
                     "application/json");
                 httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
                 var connection = new Connection(new ProductHeaderValue("OctokitTests"),

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -276,18 +276,22 @@ namespace Octokit.Tests.Http
             public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
             {
                 //TODO
+                throw new NotImplementedException();
             }
 
             [Fact]
             public async Task ThrowsAbuseExceptionForResponseWithAbuseDescription()
             {
                 //TODO
+                throw new NotImplementedException();
             }
 
             [Fact]
             public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
             {
                 //TODO
+                throw new NotImplementedException();
+
                 var httpClient = Substitute.For<IHttpClient>();
                 IResponse response = new Response(
                     HttpStatusCode.Forbidden,

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -273,6 +273,31 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
+            {
+                var messageText = "blahblahblah this does not matter because we are testing the URL";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Contains(messageText, exception.Message);
+            }
+
+            [Fact]
             public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
             {
                 //TODO
@@ -287,26 +312,10 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
-            public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
+            public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
             {
-                var httpClient = Substitute.For<IHttpClient>();
-                IResponse response = new Response(
-                    HttpStatusCode.Forbidden,
-                    "{\"message\":\"blahblahblah this does not matter because we are testing the URL\"," +
-                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
-                    new Dictionary<string, string>(),
-                    "application/json");
-                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
-                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
-                    _exampleUri,
-                    Substitute.For<ICredentialStore>(),
-                    httpClient,
-                    Substitute.For<IJsonSerializer>());
-
-                var exception = await Assert.ThrowsAsync<AbuseException>(
-                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
-
-                Assert.Contains("abuse-rate", exception.Message);
+                //TODO
+                throw new NotImplementedException();
             }
 
         }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -325,8 +325,10 @@ namespace Octokit.Tests.Http
                 var messageText = "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.";
 
                 var httpClient = Substitute.For<IHttpClient>();
-                var headerDictionary = new Dictionary<string, string>();
-                headerDictionary.Add("Retry-After", "45");
+                var headerDictionary = new Dictionary<string, string>
+                {
+                    { "Retry-After", "45" }
+                };
 
                 IResponse response = new Response(
                     HttpStatusCode.Forbidden,

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -322,8 +322,29 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
             {
-                //TODO
-                throw new NotImplementedException();
+                var messageText = "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.";
+
+                var httpClient = Substitute.For<IHttpClient>();
+                var headerDictionary = new Dictionary<string, string>();
+                headerDictionary.Add("Retry-After", "45");
+
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "{\"message\":\"" + messageText + "\"," +
+                    "\"documentation_url\":\"https://ThisURLDoesNotMatter.com\"}",
+                    headerDictionary,
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Equal(45, exception.RetryAfterSeconds);
             }
         }
 

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -293,8 +293,6 @@ namespace Octokit.Tests.Http
 
                 var exception = await Assert.ThrowsAsync<AbuseException>(
                     () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
-
-                Assert.Contains(messageText, exception.Message);
             }
 
             [Fact]

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -271,6 +271,42 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal("YOU SHALL NOT PASS!", exception.Message);
             }
+
+            [Fact]
+            public async Task AbuseExceptionContainsTheRetryAfterHeaderAmount()
+            {
+                //TODO
+            }
+
+            [Fact]
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDescription()
+            {
+                //TODO
+            }
+
+            [Fact]
+            public async Task ThrowsAbuseExceptionForResponseWithAbuseDocumentationLink()
+            {
+                //TODO
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    "YOU SHALL NOT PASS!",
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<ForbiddenException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Equal("YOU SHALL NOT PASS!", exception.Message);
+            }
+
         }
 
         public class TheGetHtmlMethod

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -291,7 +291,7 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await Assert.ThrowsAsync<AbuseException>(
+                await Assert.ThrowsAsync<AbuseException>(
                     () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
             }
 
@@ -314,7 +314,7 @@ namespace Octokit.Tests.Http
                     httpClient,
                     Substitute.For<IJsonSerializer>());
 
-                var exception = await Assert.ThrowsAsync<AbuseException>(
+                await Assert.ThrowsAsync<AbuseException>(
                     () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
             }
 

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -329,8 +329,25 @@ namespace Octokit.Tests.Http
             [Fact]
             public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
             {
-                //TODO
-                throw new NotImplementedException();
+                string bodyResponse = null; 
+
+                var httpClient = Substitute.For<IHttpClient>();
+                IResponse response = new Response(
+                    HttpStatusCode.Forbidden,
+                    bodyResponse,
+                    new Dictionary<string, string>(),
+                    "application/json");
+                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                var exception = await Assert.ThrowsAsync<AbuseException>(
+                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
+
+                Assert.Equal("Request Forbidden - Abuse Detection", exception.Message);
             }
 
         }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -325,32 +325,6 @@ namespace Octokit.Tests.Http
                 //TODO
                 throw new NotImplementedException();
             }
-
-            [Fact]
-            public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
-            {
-                var messageText = string.Empty;
-
-                var httpClient = Substitute.For<IHttpClient>();
-                IResponse response = new Response(
-                    HttpStatusCode.Forbidden,
-                     "{\"message\":\"" + messageText + "\"," +
-                    "\"documentation_url\":\"https://developer.github.com/v3/#abuse-rate-limits\"}",
-                   new Dictionary<string, string>(),
-                    "application/json");
-                httpClient.Send(Args.Request, Args.CancellationToken).Returns(Task.FromResult(response));
-                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
-                    _exampleUri,
-                    Substitute.For<ICredentialStore>(),
-                    httpClient,
-                    Substitute.For<IJsonSerializer>());
-
-                var exception = await Assert.ThrowsAsync<AbuseException>(
-                    () => connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)));
-
-                Assert.Equal("Request Forbidden - Abuse Detection", exception.Message);
-            }
-
         }
 
         public class TheGetHtmlMethod

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Clients\UserEmailsClientTests.cs" />
     <Compile Include="Clients\WatchedClientTests.cs" />
     <Compile Include="Clients\FollowersClientTests.cs" />
+    <Compile Include="Exceptions\AbuseExceptionTests.cs" />
     <Compile Include="Exceptions\ApiErrorTests.cs" />
     <Compile Include="Exceptions\ApiExceptionTests.cs" />
     <Compile Include="Exceptions\ApiValidationExceptionTests.cs" />

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -35,7 +35,16 @@ namespace Octokit
         {
             Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Forbidden,
                 "AbuseException created with wrong status code");
+
+            SetRetryAfterSeconds(response);
         }
+
+        private void SetRetryAfterSeconds(IResponse response)
+        {
+            RetryAfterSeconds = 60;
+        }
+
+        public int RetryAfterSeconds { get; private set; }
 
         public override string Message
         {

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -43,26 +43,14 @@ namespace Octokit
         private static int? ParseRetryAfterSeconds(IResponse response)
         {
             string secondsValue;
-            if (response.Headers.TryGetValue("Retry-After", out secondsValue))
-            {
-                if (string.IsNullOrWhiteSpace(secondsValue))
-                {
-                    return null;
-                }
+            if (!response.Headers.TryGetValue("Retry-After", out secondsValue)) { return null; }
+            if (string.IsNullOrWhiteSpace(secondsValue)){ return null; }
 
-                int retrySeconds;
-                if (int.TryParse(secondsValue, out retrySeconds))
-                {
-                    if (retrySeconds < 0)
-                    {
-                        return null;
-                    }
-                    return retrySeconds;
-                }
+            int retrySeconds;
+            if (!int.TryParse(secondsValue, out retrySeconds)) { return null; }
+            if (retrySeconds < 0) { return null; }
 
-                return null;
-            }
-            return null;
+            return retrySeconds;
         }
 
         public int? RetryAfterSeconds { get; private set; }

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -56,7 +56,7 @@ namespace Octokit
             }
         }
 
-        private int ParseRetryAfterSeconds(string retryAfterString)
+        private static int ParseRetryAfterSeconds(string retryAfterString)
         {
             if (string.IsNullOrWhiteSpace(retryAfterString))
             {

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Security;
 
 namespace Octokit
 {
@@ -95,6 +96,14 @@ namespace Octokit
             : base(info, context)
         {
         }
+
+        [SecurityCritical]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("RetryAfterSeconds", RetryAfterSeconds);
+        }
+
 #endif
     }
 }

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -44,7 +44,6 @@ namespace Octokit
         {
             string secondsValue;
             if (!response.Headers.TryGetValue("Retry-After", out secondsValue)) { return null; }
-            if (string.IsNullOrWhiteSpace(secondsValue)){ return null; }
 
             int retrySeconds;
             if (!int.TryParse(secondsValue, out retrySeconds)) { return null; }

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -83,7 +83,6 @@ namespace Octokit
             base.GetObjectData(info, context);
             info.AddValue("RetryAfterSeconds", RetryAfterSeconds);
         }
-
 #endif
     }
 }

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -43,10 +43,13 @@ namespace Octokit
         private void SetRetryAfterSeconds(IResponse response)
         {
             string secondsValue;
+
+            // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
             if (response.Headers.TryGetValue("Retry-After", out secondsValue))
             {
                 RetryAfterSeconds = ParseRetryAfterSeconds(secondsValue);
             }
+
             else
             {
                 RetryAfterSeconds = RetrySecondsDefault;

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -63,7 +63,7 @@ namespace Octokit
             int retrySeconds;
             if (int.TryParse(retryAfterString, out retrySeconds))
             {
-                return retrySeconds <= 0 ? RetrySecondsDefault : retrySeconds;
+                return retrySeconds < 0 ? RetrySecondsDefault : retrySeconds;
             }
 
             return RetrySecondsDefault;

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -39,7 +39,7 @@ namespace Octokit
 
         public override string Message
         {
-            get { return ApiErrorMessageSafe ?? "Request Forbidden"; }
+            get { return ApiErrorMessageSafe ?? "Request Forbidden - Abuse Detection"; }
         }
 
 #if !NETFX_CORE

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -18,7 +18,7 @@ namespace Octokit
         Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
     public class AbuseException : ForbiddenException
     {
-        public const int RetrySecondsDefault = 60;
+        private readonly int? RetrySecondsDefault = null;
         /// <summary>
         /// Constructs an instance of AbuseException
         /// </summary>
@@ -57,7 +57,7 @@ namespace Octokit
             }
         }
 
-        private static int ParseRetryAfterSeconds(string retryAfterString)
+        private int? ParseRetryAfterSeconds(string retryAfterString)
         {
             if (string.IsNullOrWhiteSpace(retryAfterString))
             {
@@ -73,7 +73,7 @@ namespace Octokit
             return RetrySecondsDefault;
         }
 
-        public int RetryAfterSeconds { get; private set; }
+        public int? RetryAfterSeconds { get; private set; }
 
         public override string Message
         {

--- a/Octokit/Exceptions/AbuseException.cs
+++ b/Octokit/Exceptions/AbuseException.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Represents a subset of the HTTP 403 - Forbidden response returned from the API when the forbidden response is related to an abuse detection mechanism.
+    /// Containts the amount of seconds after which it's safe to retry the request.
+    /// </summary>
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "These exceptions are specific to the GitHub API and not general purpose exceptions")]
+    public class AbuseException : ForbiddenException
+    {
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        public AbuseException(IResponse response) : this(response, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="response">The HTTP payload from the server</param>
+        /// <param name="innerException">The inner exception</param>
+        public AbuseException(IResponse response, Exception innerException)
+            : base(response, innerException)
+        {
+            Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Forbidden,
+                "AbuseException created with wrong status code");
+        }
+
+        public override string Message
+        {
+            get { return ApiErrorMessageSafe ?? "Request Forbidden"; }
+        }
+
+#if !NETFX_CORE
+        /// <summary>
+        /// Constructs an instance of AbuseException
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected AbuseException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -611,11 +611,24 @@ namespace Octokit
         static Exception GetExceptionForForbidden(IResponse response)
         {
             string body = response.Body as string ?? "";
-            return body.Contains("rate limit exceeded")
-                ? new RateLimitExceededException(response)
-                : body.Contains("number of login attempts exceeded")
-                    ? new LoginAttemptsExceededException(response)
-                    : new ForbiddenException(response);
+
+            if (body.Contains("rate limit exceeded"))
+            {
+                return new RateLimitExceededException(response);
+            }
+
+            if (body.Contains("number of login attempts exceeded"))
+            {
+                return new LoginAttemptsExceededException(response);
+            }
+
+            if (body.Contains("abuse-rate-limits"))
+            {
+                return new AbuseException(response);
+                
+            }
+
+            return new ForbiddenException(response);
         }
 
         internal static TwoFactorType ParseTwoFactorType(IResponse restResponse)

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -622,10 +622,9 @@ namespace Octokit
                 return new LoginAttemptsExceededException(response);
             }
 
-            if (body.Contains("abuse-rate-limits"))
+            if (body.Contains("abuse-rate-limits") || body.Contains("abuse detection mechanism"))
             {
-                return new AbuseException(response);
-                
+                return new AbuseException(response);                
             }
 
             return new ForbiddenException(response);

--- a/Octokit/Octokit-Mono.csproj
+++ b/Octokit/Octokit-Mono.csproj
@@ -504,6 +504,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-MonoAndroid.csproj
+++ b/Octokit/Octokit-MonoAndroid.csproj
@@ -515,6 +515,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/Octokit/Octokit-Monotouch.csproj
+++ b/Octokit/Octokit-Monotouch.csproj
@@ -511,6 +511,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Octokit/Octokit-Portable.csproj
+++ b/Octokit/Octokit-Portable.csproj
@@ -501,6 +501,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit-netcore45.csproj
+++ b/Octokit/Octokit-netcore45.csproj
@@ -508,6 +508,7 @@
     <Compile Include="Clients\RepositoryTrafficClient.cs" />
     <Compile Include="Helpers\ExcludeFromPaginationConventionTest.cs" />
     <Compile Include="Models\Request\IssueCommentRequest.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Clients\UserGpgKeysClient.cs" />
     <Compile Include="Clients\UserKeysClient.cs" />
     <Compile Include="Clients\RepositoryContentsClient.cs" />
+    <Compile Include="Exceptions\AbuseException.cs" />
     <Compile Include="Exceptions\InvalidGitIgnoreTemplateException.cs" />
     <Compile Include="Exceptions\LegalRestrictionException.cs" />
     <Compile Include="Exceptions\PrivateRepositoryQuotaExceededException.cs" />


### PR DESCRIPTION
Resolves #1527.

This aims to Add and `AbuseException` that inherits from `ForbiddenException`. 

This exception will be thrown in place of the `ForbiddenException` when an abuse condition occurs. 

Additionally, the `AbuseException` will contain the `Retry-After` header field as an `int`. 

## Work Remaining
* [x] Create AbuseException
* [x] Tests for AbuseException
* [x] Throw AbuseException correctly within `Connection.cs`
* [x] Ensure AbuseException displays default message when response message is mal-formed.
* [x] Additional tests for `Connection.cs`
* [x] Add `Retry-After` field to AbuseException
* [x] Mark all methods as static that can be (per build failure)
* [x] Add `GetObjectData` for AbuseException? Comment: https://github.com/octokit/octokit.net/pull/1528#issuecomment-271296108

## Feedback to Address
* [x] Re-introduce and skip failing test with notes & pointer to new issue.
* [x] Make `RetryAfterSeconds` into an `int?` and use `null` instead of a default int value.
* [x] Consolidate / compact the private method for parsing the response.
* [x] Fix whitespace issues
* [x] Move test names / formatting toward standard xUnit conventions (nested classes, etc.)
* [x] Remove redundant code from the parse method
* [x] Demonstrate real-world usage