### PR TITLE
Add Missing Event Types

### DIFF
--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -194,7 +194,7 @@ namespace Octokit
         ReviewRequestRemoved,
 
         /// <summary>
-        /// Not documented in GitHub API.
+        /// Base branch of the pull request was changed.
         /// </summary>
         BaseRefChanged,
 

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -152,10 +152,10 @@ namespace Octokit
         /// </summary>
         Unlocked,
 
-        /// <summary>
-        /// The pull request’s branch was deleted.
-        /// </summary>
-        HeadRefDeleted,
+		/// <summary>
+		/// The pull request’s branch was deleted.
+		/// </summary>
+		HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
@@ -177,6 +177,26 @@ namespace Octokit
         /// Only provided for pull requests.
         /// </summary>
         Committed,
+
+		/// <summary>
+		/// The actor requested review from the subject on this pull request.
+		/// </summary>
+		ReviewRequested,
+
+		/// <summary>
+		/// The actor dismissed a review from the pull request.
+		/// </summary>
+		ReviewDismissed,
+
+		/// <summary>
+		/// The actor removed the review request for the subject on this pull request.
+		/// </summary>
+		ReviewRequestRemoved,
+
+		/// <summary>
+		/// Not documented in GitHub API.
+		/// </summary>
+		BaseRefChanged,
 
         /// <summary>
         /// The issue was referenced from another issue.

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -152,10 +152,10 @@ namespace Octokit
         /// </summary>
         Unlocked,
 
-		/// <summary>
-		/// The pull request’s branch was deleted.
-		/// </summary>
-		HeadRefDeleted,
+        /// <summary>
+        /// The pull request’s branch was deleted.
+        /// </summary>
+        HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
@@ -178,25 +178,25 @@ namespace Octokit
         /// </summary>
         Committed,
 
-		/// <summary>
-		/// The actor requested review from the subject on this pull request.
-		/// </summary>
-		ReviewRequested,
+        /// <summary>
+        /// The actor requested review from the subject on this pull request.
+        /// </summary>
+        ReviewRequested,
 
-		/// <summary>
-		/// The actor dismissed a review from the pull request.
-		/// </summary>
-		ReviewDismissed,
+        /// <summary>
+        /// The actor dismissed a review from the pull request.
+        /// </summary>
+        ReviewDismissed,
 
-		/// <summary>
-		/// The actor removed the review request for the subject on this pull request.
-		/// </summary>
-		ReviewRequestRemoved,
+        /// <summary>
+        /// The actor removed the review request for the subject on this pull request.
+        /// </summary>
+        ReviewRequestRemoved,
 
-		/// <summary>
-		/// Not documented in GitHub API.
-		/// </summary>
-		BaseRefChanged,
+        /// <summary>
+        /// Not documented in GitHub API.
+        /// </summary>
+        BaseRefChanged,
 
         /// <summary>
         /// The issue was referenced from another issue.


### PR DESCRIPTION
Fixes Issue #1502.

Updates the EventInfo list to the latest values published in [GitHub API](https://developer.github.com/v3/issues/events/), plus an undocumented one we stumbled across.

PR #1504 is a much better long-term solution, but in the mean time this is blocking us from parsing Git diffs using OctoKit.  Thought we'd share the fix.

