### PR TITLE
Update ApiErrorMessageSafe to return null for empty and whitespace strings

### DIFF
--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -349,7 +349,7 @@ namespace Octokit.Tests.Http
                 Assert.Equal(45, exception.RetryAfterSeconds);
             }
 
-            [Fact(Skip = "Fails due to https://github.com/octokit/octokit.net/issues/1529. The message is empty but the default message isn't displayed. However, this isn't due to the introduction of AbuseException, but rather something else.")]
+            [Fact]
             public async Task ThrowsAbuseExceptionWithDefaultMessageForUnsafeAbuseResponse()
             {
                 string messageText = string.Empty;

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -178,7 +178,12 @@ namespace Octokit
         {
             get
             {
-                return ApiError != null ? ApiError.Message : null;
+                if (ApiError != null && !string.IsNullOrWhiteSpace(ApiError.Message))
+                {
+                    return ApiError.Message;
+                }
+
+                return null;
             }
         }
 


### PR DESCRIPTION
Resolves #1529.

## Background
If an API Error is returned and the message is empty, the default error message is not shown, and instead an empty string is shown.

##Fix
Per discussion on #1529, we'll resolve this by modifying ApiErrorMessageSafe to return null when an empty or whitespace string is provided.

## Work
* [x] Un-skip the failing test
* [x] Modify ApiErrorMessageSafe code