### PR TITLE
Add new AccountType "Bot" to prevent deserialization errors

### DIFF
--- a/Octokit/Models/Response/AccountType.cs
+++ b/Octokit/Models/Response/AccountType.cs
@@ -10,6 +10,11 @@
         /// <summary>
         /// Organization account
         /// </summary>
-        Organization
+        Organization,
+
+        /// <summary>
+        /// Bot account
+        /// </summary>
+        Bot
     }
 }


### PR DESCRIPTION
The GitHub API is apparently now returning "Bot" account types.  This was causing a deserialization exception when encountering repositories that had a "bot" user (perhaps related to the new API integrations features) performing actions.  Example here: https://github.com/depfutest/devfu/issues/2