### PR TITLE
add GitVersion configuration file

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,11 @@
+branches:
+  master:
+    mode: ContinuousDeployment
+    increment: Minor
+    tag: alpha
+  dotnetcore:
+    mode: ContinuousDeployment
+    increment: Minor
+    tag: alpha
+ignore:
+  sha: []

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,7 +2,7 @@ branches:
   master:
     mode: ContinuousDeployment
     increment: Minor
-    tag: alpha
+    tag: beta
   dotnetcore:
     mode: ContinuousDeployment
     increment: Minor


### PR DESCRIPTION
Closes #1554.

Right now we use GitVersion with the default settings.

`master`, by default, uses the [Continuous Delivery](https://gitversion.readthedocs.io/en/latest/reference/continuous-delivery/) mode which generates the same version for all the commits until we tag the repo with that version.

Since we might want to publish pre-release packages in the future, we could take advantage of the other mode named [Continuous Deployment](https://gitversion.readthedocs.io/en/latest/reference/continuous-deployment/). This mode generates a new version for each commit. To avoid the version going through the roof, a pre-release tag is forced with this mode. By default, the tag for `master` is `ci`. As we used the `alpha` one for the pre-release NuGet package, I thought we might use the same.

Also, right now GitVersion increments the `minor` after the repo has been tagged (see [that AppVeyor build](https://ci.appveyor.com/project/github-windows/octokit-net/build/0.24.1-dotnetcore.1+4.build.1969)). It looks more natural to me to go with the assumption that the next release will contain a new feature. We can always force a bugfix release by using either a release branch - `release/0.24.1` - or use the convention-based commit messages - `+semver: minor` - to instruct GitVersion of the version we want it to generate.

At the moment the file contains configuration for both `master` and `dotnetcore` since it's the branch we're working on. When the branch gets merged into `master` we can get rid of `dotnetcore`