### PR TITLE
React to change in the way the RepositoryTraffic API communicates time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
       mono: 4.2.3
       dotnet: 1.0.0-preview2-003121
 
-before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
-
 install:
   - nuget restore Octokit-Mono.sln
 

--- a/Octokit/Models/Response/RepositoryTrafficClone.cs
+++ b/Octokit/Models/Response/RepositoryTrafficClone.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Octokit.Helpers;
-using Octokit.Internal;
 
 namespace Octokit
 {
@@ -40,21 +38,14 @@ namespace Octokit
         public RepositoryTrafficClone() { }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public RepositoryTrafficClone(long timestamp, int count, int uniques)
+        public RepositoryTrafficClone(DateTimeOffset timestamp, int count, int uniques)
         {
-            TimestampAsUtcEpochSeconds = timestamp;
+            Timestamp = timestamp;
             Count = count;
             Uniques = uniques;
         }
 
-        [Parameter(Key = "ignoreThisField")]
-        public DateTimeOffset Timestamp
-        {
-            get { return TimestampAsUtcEpochSeconds.FromUnixTime(); }
-        }
-
-        [Parameter(Key = "timestamp")]
-        public long TimestampAsUtcEpochSeconds { get; protected set; }
+        public DateTimeOffset Timestamp { get; protected set; }
 
         public int Count { get; protected set; }
 

--- a/Octokit/Models/Response/RepositoryTrafficView.cs
+++ b/Octokit/Models/Response/RepositoryTrafficView.cs
@@ -40,21 +40,14 @@ namespace Octokit
         public RepositoryTrafficView() { }
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", Justification = "It's a property from the api.")]
-        public RepositoryTrafficView(long timestamp, int count, int uniques)
+        public RepositoryTrafficView(DateTimeOffset timestamp, int count, int uniques)
         {
-            TimestampAsUtcEpochSeconds = timestamp;
+            Timestamp = timestamp;
             Count = count;
             Uniques = uniques;
         }
 
-        [Parameter(Key = "ignoreThisField")]
-        public DateTimeOffset Timestamp
-        {
-            get { return TimestampAsUtcEpochSeconds.FromUnixTime(); }
-        }
-
-        [Parameter(Key = "timestamp")]
-        public long TimestampAsUtcEpochSeconds { get; protected set; }
+        public DateTimeOffset Timestamp { get; protected set; }
 
         public int Count { get; protected set; }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,6 @@ build_script:
   - cmd: build.cmd CreatePackages
   - cmd: build.cmd UnitTestsDotNetCore
 test: off
-nuget:
-  account_feed: true
-  project_feed: true
 artifacts:
 - path: 'packaging\octokit*.nupkg'
   name: OctokitPackages


### PR DESCRIPTION
Fixes #1558.
The API used to send times as number of seconds from Unix epoch time.
This has changed and is now ISO 8601.