### PR TITLE
Fix Issue Timeline exceptions by adding new EventInfoState values

### DIFF
--- a/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
@@ -26,24 +26,15 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanRetrieveTimelineForIssue()
         {
-            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
-            var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
-
-            var timelineEventInfos = await _issueTimelineClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-            Assert.Empty(timelineEventInfos);
-
-            var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate() { State = ItemState.Closed });
-            Assert.NotNull(closed);
-
-            timelineEventInfos = await _issueTimelineClient.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-            Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(EventInfoState.Closed, timelineEventInfos[0].Event);
+            var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", 1503);
+            Assert.NotEmpty(timelineEventInfos);
+            Assert.NotEqual(0, timelineEventInfos.Count);
         }
 
         [IntegrationTest]
         public async Task CanRetrieveTimelineForIssueWithApiOptions()
         {
-            var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", 1115);
+            var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", 1503);
             Assert.NotEmpty(timelineEventInfos);
             Assert.NotEqual(1, timelineEventInfos.Count);
 
@@ -54,7 +45,7 @@ namespace Octokit.Tests.Integration.Clients
                 StartPage = 1
             };
 
-            timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", 1115, pageOptions);
+            timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", 1503, pageOptions);
             Assert.NotEmpty(timelineEventInfos);
             Assert.Equal(1, timelineEventInfos.Count);
         }

--- a/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
@@ -53,7 +53,7 @@ namespace Octokit.Tests.Integration.Clients
         [IntegrationTest]
         public async Task CanRetrieveTimelineForRecentIssues()
         {
-            // Make sure we can deserialize the event timeline for the 20 most recent closed PRs and 20 most recent open Issues from octokit.net
+            // Make sure we can deserialize the event timeline for recent closed PRs and open Issues in a heavy activity repository (microsoft/vscode)
 
             // Search request
             var github = Helper.GetAuthenticatedClient();
@@ -62,7 +62,7 @@ namespace Octokit.Tests.Integration.Clients
                 PerPage = 20,
                 Page = 1
             };
-            search.Repos.Add("octokit", "octokit.net");
+            search.Repos.Add("microsoft", "vscode");
 
             // 20 most recent closed PRs
             search.Type = IssueTypeQualifier.PullRequest;
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Integration.Clients
             var pullRequestResults = await github.Search.SearchIssues(search);
             foreach (var pullRequest in pullRequestResults.Items)
             {
-                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", pullRequest.Number);
+                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("microsoft", "vscode", pullRequest.Number);
                 Assert.NotEmpty(timelineEventInfos);
             }
 
@@ -80,7 +80,7 @@ namespace Octokit.Tests.Integration.Clients
             var issueResults = await github.Search.SearchIssues(search);
             foreach (var issue in issueResults.Items)
             {
-                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", issue.Number);
+                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("microsoft", "vscode", issue.Number);
 
                 Assert.NotNull(timelineEventInfos);
             }

--- a/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
@@ -51,6 +51,42 @@ namespace Octokit.Tests.Integration.Clients
         }
 
         [IntegrationTest]
+        public async Task CanRetrieveTimelineForRecentIssues()
+        {
+            // Make sure we can deserialize the event timeline for the 20 most recent closed PRs and 20 most recent open Issues from octokit.net
+
+            // Search request
+            var github = Helper.GetAuthenticatedClient();
+            var search = new SearchIssuesRequest
+            {
+                PerPage = 20,
+                Page = 1
+            };
+            search.Repos.Add("octokit", "octokit.net");
+
+            // 20 most recent closed PRs
+            search.Type = IssueTypeQualifier.PullRequest;
+            search.State = ItemState.Closed;
+            var pullRequestResults = await github.Search.SearchIssues(search);
+            foreach (var pullRequest in pullRequestResults.Items)
+            {
+                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", pullRequest.Number);
+                Assert.NotEmpty(timelineEventInfos);
+            }
+
+            // 20 most recent open Issues
+            search.Type = IssueTypeQualifier.Issue;
+            search.State = ItemState.Open;
+            var issueResults = await github.Search.SearchIssues(search);
+            foreach (var issue in issueResults.Items)
+            {
+                var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("octokit", "octokit.net", issue.Number);
+
+                Assert.NotNull(timelineEventInfos);
+            }
+        }
+
+        [IntegrationTest]
         public async Task CanDeserializeRenameEvent()
         {
             var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };

--- a/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueTimelineClientTests.cs
@@ -82,7 +82,7 @@ namespace Octokit.Tests.Integration.Clients
             {
                 var timelineEventInfos = await _issueTimelineClient.GetAllForIssue("microsoft", "vscode", issue.Number);
 
-                Assert.NotNull(timelineEventInfos);
+                Assert.NotEmpty(timelineEventInfos);
             }
         }
 

--- a/Octokit.Tests.Integration/Reactive/ObservableIssueTimelineClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableIssueTimelineClientTests.cs
@@ -24,28 +24,16 @@ namespace Octokit.Tests.Integration.Reactive
         [IntegrationTest]
         public async Task CanRetrieveTimelineForIssue()
         {
-            var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
-            var observable = _client.Issue.Create(_context.Repository.Id, newIssue);
-            var issue = await observable;
-
-            var observableTimeline = _client.Issue.Timeline.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
+            var observableTimeline = _client.Issue.Timeline.GetAllForIssue("octokit", "octokit.net", 1503);
             var timelineEventInfos = await observableTimeline.ToList();
-            Assert.Empty(timelineEventInfos);
-
-            observable = _client.Issue.Update(_context.Repository.Id, issue.Number, new IssueUpdate { State = ItemState.Closed });
-            var closed = await observable;
-            Assert.NotNull(closed);
-
-            observableTimeline = _client.Issue.Timeline.GetAllForIssue(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
-            timelineEventInfos = await observableTimeline.ToList();
-            Assert.Equal(1, timelineEventInfos.Count);
-            Assert.Equal(EventInfoState.Closed, timelineEventInfos[0].Event);
+            Assert.NotEmpty(timelineEventInfos);
+            Assert.NotEqual(0, timelineEventInfos.Count);
         }
 
         [IntegrationTest]
         public async Task CanRetrieveTimelineForIssueWithApiOptions()
         {
-            var observableTimeline = _client.Issue.Timeline.GetAllForIssue("octokit", "octokit.net", 1115);
+            var observableTimeline = _client.Issue.Timeline.GetAllForIssue("octokit", "octokit.net", 1503);
             var timelineEventInfos = await observableTimeline.ToList();
             Assert.NotEmpty(timelineEventInfos);
             Assert.NotEqual(1, timelineEventInfos.Count);
@@ -56,7 +44,7 @@ namespace Octokit.Tests.Integration.Reactive
                 PageCount = 1,
                 StartPage = 1
             };
-            observableTimeline = _client.Issue.Timeline.GetAllForIssue("octokit", "octokit.net", 1115, pageOptions);
+            observableTimeline = _client.Issue.Timeline.GetAllForIssue("octokit", "octokit.net", 1503, pageOptions);
             timelineEventInfos = await observableTimeline.ToList();
             Assert.NotEmpty(timelineEventInfos);
             Assert.Equal(1, timelineEventInfos.Count);

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -204,6 +204,17 @@ namespace Octokit
         /// url of the reference's source.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Crossreferenced")]
-        Crossreferenced
+        Crossreferenced,
+
+        /// <summary>
+        /// The issue was reveiewed.
+        /// </summary>
+        Reviewed,
+
+        /// <summary>
+        /// A line comment was made.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Linecommented")]
+        Linecommented
     }
 }

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -215,6 +215,12 @@ namespace Octokit
         /// A line comment was made.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Linecommented")]
-        Linecommented
+        Linecommented,
+
+        /// <summary>
+        /// A commit comment was made.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Commitcommented")]
+        Commitcommented
     }
 }

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -214,13 +214,11 @@ namespace Octokit
         /// <summary>
         /// A line comment was made.
         /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Linecommented")]
-        Linecommented,
+        LineCommented,
 
         /// <summary>
         /// A commit comment was made.
         /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Commitcommented")]
-        Commitcommented
+        CommitCommented
     }
 }


### PR DESCRIPTION
Fixes #1559 
Fixes #1525

This fix adds 3 more undocumented event types in the TimeLine API: `linecommented` `commitcommented` and `reviewed`

Also added an integration test that will hopefully help with identifying more missing values in the future, it now runs against the most recent 20 closed PRs and 20 open issues in a heavy activity repository.  

I picked [Microsoft/vscode](https://github.com/Microsoft/vscode) 😀 the theory being that it's a very active repository, and the most recent activity is more likely to have new event types in their timeline/event stream.

The strategy seemed to work, as I discovered 2 extra event types that hadn't been reported by users as causing a crash yet 😸 

In the short term, we will still throw an exception whenever we encounter an event type not previously implemented, a potential longer term solution is being hashed out in #1504 