### PR TITLE
Remove obsoleted repository update constructor of RepositoryUpdate

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -340,7 +340,7 @@ public class RepositoriesClientTests
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-            var update = new RepositoryUpdate { Name = updatedName };
+            var update = new RepositoryUpdate(updatedName);
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -354,7 +354,7 @@ public class RepositoriesClientTests
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
             var updatedName = Helper.MakeNameWithTimestamp("updated-repo");
-            var update = new RepositoryUpdate { Name = updatedName };
+            var update = new RepositoryUpdate(updatedName);
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -367,7 +367,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Description = "Updated description" };
+            var update = new RepositoryUpdate(repoName) { Description = "Updated description" };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -380,7 +380,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Description = "Updated description" };
+            var update = new RepositoryUpdate(repoName) { Description = "Updated description" };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -393,7 +393,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Homepage = "http://aUrl.to/nowhere" };
+            var update = new RepositoryUpdate(repoName) { Homepage = "http://aUrl.to/nowhere" };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -406,7 +406,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Homepage = "http://aUrl.to/nowhere" };
+            var update = new RepositoryUpdate(repoName) { Homepage = "http://aUrl.to/nowhere" };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -426,7 +426,7 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Private = true };
+            var update = new RepositoryUpdate(repoName) { Private = true };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -446,7 +446,7 @@ public class RepositoriesClientTests
 
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, Private = true };
+            var update = new RepositoryUpdate(repoName) { Private = true };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -459,7 +459,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasDownloads = false };
+            var update = new RepositoryUpdate(repoName) { HasDownloads = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -472,7 +472,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasDownloads = false };
+            var update = new RepositoryUpdate(repoName) { HasDownloads = false };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -485,7 +485,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasIssues = false };
+            var update = new RepositoryUpdate(repoName) { HasIssues = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -498,7 +498,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasIssues = false };
+            var update = new RepositoryUpdate(repoName) { HasIssues = false };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 
@@ -511,7 +511,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasWiki = false };
+            var update = new RepositoryUpdate(repoName) { HasWiki = false };
 
             _repository = await github.Repository.Edit(Helper.UserName, repoName, update);
 
@@ -524,7 +524,7 @@ public class RepositoriesClientTests
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
             _repository = await github.Repository.Create(new NewRepository(repoName) { AutoInit = true });
-            var update = new RepositoryUpdate { Name = repoName, HasWiki = false };
+            var update = new RepositoryUpdate(repoName) { HasWiki = false };
 
             _repository = await github.Repository.Edit(_repository.Id, update);
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1040,7 +1040,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("anyreponame");
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit(null, "repo", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Edit("owner", null, update));

--- a/Octokit.Tests/Models/RepositoryUpdateTests.cs
+++ b/Octokit.Tests/Models/RepositoryUpdateTests.cs
@@ -21,13 +21,15 @@ namespace Octokit.Tests.Models
                            "\"has_wiki\":true," +
                            "\"has_downloads\":true}";
 
-            var update = new RepositoryUpdate("Hello-World");
-            update.Description = "This is your first repository";
-            update.Homepage = "https://github.com";
-            update.Private = true;
-            update.HasIssues = true;
-            update.HasWiki = true;
-            update.HasDownloads = true;
+            var update = new RepositoryUpdate("Hello-World")
+            {
+                Description = "This is your first repository",
+                Homepage = "https://github.com",
+                Private = true,
+                HasIssues = true,
+                HasWiki = true,
+                HasDownloads = true
+            };
 
             var json = new SimpleJsonSerializer().Serialize(update);
 

--- a/Octokit.Tests/Models/RepositoryUpdateTests.cs
+++ b/Octokit.Tests/Models/RepositoryUpdateTests.cs
@@ -21,16 +21,13 @@ namespace Octokit.Tests.Models
                            "\"has_wiki\":true," +
                            "\"has_downloads\":true}";
 
-            var update = new RepositoryUpdate
-            {
-                Name = "Hello-World",
-                Description = "This is your first repository",
-                Homepage = "https://github.com",
-                Private = true,
-                HasIssues = true,
-                HasWiki = true,
-                HasDownloads = true
-            };
+            var update = new RepositoryUpdate("Hello-World");
+            update.Description = "This is your first repository";
+            update.Homepage = "https://github.com";
+            update.Private = true;
+            update.HasIssues = true;
+            update.HasWiki = true;
+            update.HasDownloads = true;
 
             var json = new SimpleJsonSerializer().Serialize(update);
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -888,7 +888,7 @@ namespace Octokit.Tests.Reactive
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("anyreponame");
 
                 client.Edit("owner", "repo", update);
 
@@ -900,7 +900,7 @@ namespace Octokit.Tests.Reactive
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoriesClient(github);
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("anyreponame");
 
                 client.Edit(1, update);
 
@@ -911,7 +911,7 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
-                var update = new RepositoryUpdate();
+                var update = new RepositoryUpdate("anyreponame");
 
                 Assert.Throws<ArgumentNullException>(() => client.Edit(null, "repo", update));
                 Assert.Throws<ArgumentNullException>(() => client.Edit("owner", null, update));

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -12,10 +12,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryUpdate
     {
-        [Obsolete("Please use the ctor RepositoryUpdate(string name) as Name is a required field")]
-        public RepositoryUpdate()
-        {
-        }
 
         /// <summary>
         /// Creates an object that describes an update to a repository on GitHub.


### PR DESCRIPTION
This is a PR to remove obsoleted paramless constructor of RepositoryUpdate, it is related to issue #1568 