### PR TITLE
Surface exceptions in RepoCollaboratorsClient.Add method

### DIFF
--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -227,6 +227,28 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add("owner", "test", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Add(1, ""));
             }
+
+            [Fact]
+            public async Task SurfacesAuthorizationException()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                connection.Put(Arg.Any<Uri>()).Returns(x => { throw new AuthorizationException(); });
+
+                await Assert.ThrowsAsync<AuthorizationException>(() => client.Add("owner", "test", "user1"));
+            }
+
+            [Fact]
+            public async Task SurfacesAuthorizationExceptionWhenSpecifyingCollaboratorRequest()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepoCollaboratorsClient(connection);
+
+                connection.Connection.Put<object>(Arg.Any<Uri>(), Arg.Any<object>()).ThrowsAsync(new AuthorizationException());
+
+                await Assert.ThrowsAsync<AuthorizationException>(() => client.Add("owner", "test", "user1", new CollaboratorRequest(Permission.Pull)));
+            }
         }
 
         public class TheInviteMethod

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -237,6 +237,7 @@ namespace Octokit.Tests.Clients
                 connection.Put(Arg.Any<Uri>()).Returns(x => { throw new AuthorizationException(); });
 
                 await Assert.ThrowsAsync<AuthorizationException>(() => client.Add("owner", "test", "user1"));
+                await Assert.ThrowsAsync<AuthorizationException>(() => client.Add(1, "user1"));
             }
 
             [Fact]
@@ -248,6 +249,7 @@ namespace Octokit.Tests.Clients
                 connection.Connection.Put<object>(Arg.Any<Uri>(), Arg.Any<object>()).ThrowsAsync(new AuthorizationException());
 
                 await Assert.ThrowsAsync<AuthorizationException>(() => client.Add("owner", "test", "user1", new CollaboratorRequest(Permission.Pull)));
+                await Assert.ThrowsAsync<AuthorizationException>(() => client.Add(1, "user1", new CollaboratorRequest(Permission.Pull)));
             }
         }
 

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -174,8 +174,15 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-            var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
-            return response.HttpResponse.IsTrue();
+            try
+            { 
+                var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
+                return response.HttpResponse.IsTrue();
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -213,7 +220,7 @@ namespace Octokit
                 var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(repositoryId, user), permission).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }
-            catch
+            catch (NotFoundException)
             {
                 return false;
             }

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -174,15 +174,8 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
-            try
-            {
-                var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
-                return response.HttpResponse.IsTrue();
-            }
-            catch
-            {
-                return false;
-            }
+            var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
+            return response.HttpResponse.IsTrue();
         }
 
         /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ build_script:
   - cmd: build.cmd UnitTests
   - cmd: build.cmd ConventionTests
   - cmd: build.cmd CreatePackages
-  - cmd: build.cmd UnitTestsDotNetCore
 test: off
 artifacts:
 - path: 'packaging\octokit*.nupkg'


### PR DESCRIPTION
Fixes #1575

This PR removes the "swallowing" of exceptions in the overloaded `RepoCollaboratorsClient.Add` method making it possible to know what went wrong in case of an exception happening.

