### PR TITLE
Cloning ApiInfo object should work when some fields are null

### DIFF
--- a/Octokit.Tests/Http/ApiInfoTests.cs
+++ b/Octokit.Tests/Http/ApiInfoTests.cs
@@ -94,6 +94,50 @@ namespace Octokit.Tests.Http
                 Assert.Equal(original.RateLimit.Reset, clone.RateLimit.Reset);
                 Assert.NotSame(original.RateLimit.Reset, clone.RateLimit.Reset);
             }
+
+            [Fact]
+            public void CanCloneWithNullFields()
+            {
+                var original = new ApiInfo(
+                    new Dictionary<string, Uri>
+                    {
+                        {
+                            "next",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=4&per_page=5")
+                        },
+                        {
+                            "last",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=131&per_page=5")
+                        },
+                        {
+                            "first",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=1&per_page=5")
+                        },
+                        {
+                            "prev",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=2&per_page=5")
+                        }
+                    },
+                    new List<string>
+                    {
+                        "user"
+                    },
+                    new List<string>(),
+                    null,
+                    new RateLimit(100, 75, 1372700873)
+                );
+
+                var clone = original.Clone();
+
+                Assert.NotNull(clone);
+                Assert.Equal(4, clone.Links.Count);
+                Assert.Equal(1, clone.OauthScopes.Count);
+                Assert.Equal(0, clone.AcceptedOauthScopes.Count);
+                Assert.Null(clone.Etag);
+                Assert.Equal(100, clone.RateLimit.Limit);
+                Assert.Equal(75, clone.RateLimit.Remaining);
+                Assert.Equal(1372700873, clone.RateLimit.ResetAsUtcEpochSeconds);
+            }
         }
     }
 }

--- a/Octokit.Tests/Http/ApiInfoTests.cs
+++ b/Octokit.Tests/Http/ApiInfoTests.cs
@@ -96,7 +96,7 @@ namespace Octokit.Tests.Http
             }
 
             [Fact]
-            public void CanCloneWithNullFields()
+            public void CanCloneWithNullETag()
             {
                 var original = new ApiInfo(
                     new Dictionary<string, Uri>
@@ -137,6 +137,48 @@ namespace Octokit.Tests.Http
                 Assert.Equal(100, clone.RateLimit.Limit);
                 Assert.Equal(75, clone.RateLimit.Remaining);
                 Assert.Equal(1372700873, clone.RateLimit.ResetAsUtcEpochSeconds);
+            }
+
+            [Fact]
+            public void CanCloneWithNullRateLimit()
+            {
+                var original = new ApiInfo(
+                    new Dictionary<string, Uri>
+                    {
+                        {
+                            "next",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=4&per_page=5")
+                        },
+                        {
+                            "last",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=131&per_page=5")
+                        },
+                        {
+                            "first",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=1&per_page=5")
+                        },
+                        {
+                            "prev",
+                            new Uri("https://api.github.com/repos/rails/rails/issues?page=2&per_page=5")
+                        }
+                    },
+                    new List<string>
+                    {
+                        "user"
+                    },
+                    new List<string>(),
+                    "123abc",
+                    null
+                );
+
+                var clone = original.Clone();
+
+                Assert.NotNull(clone);
+                Assert.Equal(4, clone.Links.Count);
+                Assert.Equal(1, clone.OauthScopes.Count);
+                Assert.Equal(0, clone.AcceptedOauthScopes.Count);
+                Assert.Equal("123abc", clone.Etag);
+                Assert.Null(clone.RateLimit);
             }
         }
     }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -59,11 +59,11 @@ namespace Octokit
         /// <returns>A clone of <seealso cref="ApiInfo"/></returns>
         public ApiInfo Clone()
         {
-            return new ApiInfo(Links?.Clone() ?? new Dictionary<string, Uri>(),
-                                OauthScopes?.Clone() ?? new List<String>(),
-                                AcceptedOauthScopes?.Clone() ?? new List<String>(),
-                                new string(Etag?.ToCharArray()),
-                                RateLimit?.Clone());
+            return new ApiInfo(Links != null ? Links.Clone() : new Dictionary<string, Uri>(),
+                               OauthScopes != null ? OauthScopes.Clone() : new List<String>(),
+                               AcceptedOauthScopes != null ? AcceptedOauthScopes.Clone() : new List<String>(),
+                               Etag != null ? new string(Etag.ToCharArray()) : null,
+                               RateLimit != null ? RateLimit.Clone() : null);
         }
     }
 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -19,6 +19,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(links, "links");
             Ensure.ArgumentNotNull(oauthScopes, "oauthScopes");
+            Ensure.ArgumentNotNull(acceptedOauthScopes, "acceptedOauthScopes");
 
             Links = new ReadOnlyDictionary<string, Uri>(links);
             OauthScopes = new ReadOnlyCollection<string>(oauthScopes);
@@ -58,16 +59,11 @@ namespace Octokit
         /// <returns>A clone of <seealso cref="ApiInfo"/></returns>
         public ApiInfo Clone()
         {
-            // Seem to have to do this to pass a whole bunch of tests (for example Octokit.Tests.Clients.EventsClientTests.DeserializesCommitCommentEventCorrectly)
-            // I believe this has something to do with the Mocking framework.
-            if (Links == null || OauthScopes == null || RateLimit == null || Etag == null)
-                return null;
-
-            return new ApiInfo(Links.Clone(),
-                                OauthScopes.Clone(),
-                                AcceptedOauthScopes.Clone(),
-                                new string(Etag.ToCharArray()),
-                                RateLimit.Clone());
+            return new ApiInfo(Links?.Clone() ?? new Dictionary<string, Uri>(),
+                                OauthScopes?.Clone() ?? new List<String>(),
+                                AcceptedOauthScopes?.Clone() ?? new List<String>(),
+                                new string(Etag?.ToCharArray()),
+                                RateLimit?.Clone());
         }
     }
 }

--- a/Octokit/Http/ApiInfo.cs
+++ b/Octokit/Http/ApiInfo.cs
@@ -59,9 +59,9 @@ namespace Octokit
         /// <returns>A clone of <seealso cref="ApiInfo"/></returns>
         public ApiInfo Clone()
         {
-            return new ApiInfo(Links != null ? Links.Clone() : new Dictionary<string, Uri>(),
-                               OauthScopes != null ? OauthScopes.Clone() : new List<String>(),
-                               AcceptedOauthScopes != null ? AcceptedOauthScopes.Clone() : new List<String>(),
+            return new ApiInfo(Links.Clone(),
+                               OauthScopes.Clone(),
+                               AcceptedOauthScopes.Clone(),
                                Etag != null ? new string(Etag.ToCharArray()) : null,
                                RateLimit != null ? RateLimit.Clone() : null);
         }


### PR DESCRIPTION
Fixes #1509 

`ApiInfo.Clone()` previously returned `null` if any of the child properties of the object to clone were `null`.  

I encountered a situation where there was no ETag header in an API response, which caused the "Last Api Info" object to be `null` due to this logic.

With this change, the `Clone()` method will clone whatever fields do exist, which means we should now be correctly providing the "Last Api Info" in more cases.