### PR TITLE
Remove other obsoleted methods except Branch protection related methods (part 1)

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -53,15 +53,6 @@ namespace Octokit.Reactive
         /// Returns all the organizations for the specified user
         /// </summary>
         /// <param name="user">The login for the user</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        IObservable<Organization> GetAll(string user, ApiOptions options);
-
-        /// <summary>
-        /// Returns all the organizations for the specified user
-        /// </summary>
-        /// <param name="user">The login for the user</param>
         /// <returns></returns>
         IObservable<Organization> GetAllForUser(string user);
 

--- a/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationsClient.cs
@@ -46,14 +46,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [Obsolete("Please use IObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        IObservable<Organization> GetAll(string user);
-
-        /// <summary>
-        /// Returns all the organizations for the specified user
-        /// </summary>
-        /// <param name="user">The login for the user</param>
-        /// <returns></returns>
         IObservable<Organization> GetAllForUser(string user);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -222,18 +222,6 @@ namespace Octokit.Reactive
         IObservableMergingClient Merging { get; }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(long repositoryId);
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -227,19 +227,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(string owner, string name);
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -261,19 +261,6 @@ namespace Octokit.Reactive
         IObservable<Branch> GetAllBranches(string owner, string name, ApiOptions options);
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(long repositoryId, ApiOptions options);
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -234,20 +234,6 @@ namespace Octokit.Reactive
         IObservable<Branch> GetAllBranches(long repositoryId);
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        IObservable<Branch> GetAllBranches(string owner, string name, ApiOptions options);
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -72,19 +72,6 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
-        [Obsolete("Please use ObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        public IObservable<Organization> GetAll(string user)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(user, "user");
-
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user));
-        }
-
-        /// <summary>
-        /// Returns all the organizations for the specified user
-        /// </summary>
-        /// <param name="user">The login for the user</param>
-        /// <returns></returns>
         public IObservable<Organization> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, "user");

--- a/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationsClient.cs
@@ -84,21 +84,6 @@ namespace Octokit.Reactive
         /// Returns all the organizations for the specified user
         /// </summary>
         /// <param name="user">The login for the user</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
-        [Obsolete("Please use ObservableOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        public IObservable<Organization> GetAll(string user, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(user, "user");
-            Ensure.ArgumentNotNull(options, "options");
-
-            return _connection.GetAndFlattenAllPages<Organization>(ApiUrls.UserOrganizations(user), options);
-        }
-
-        /// <summary>
-        /// Returns all the organizations for the specified user
-        /// </summary>
-        /// <param name="user">The login for the user</param>
         /// <returns></returns>
         public IObservable<Organization> GetAllForUser(string user)
         {

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -378,24 +378,6 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(long repositoryId, ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, "options");
-
-            return Branch.GetAll(repositoryId, options);
-        }
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -328,25 +328,6 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(string owner, string name)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return Branch.GetAll(owner, name, ApiOptions.None);
-        }
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -338,27 +338,6 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(string owner, string name, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(options, "options");
-
-            return Branch.GetAll(owner, name, options);
-        }
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -323,21 +323,6 @@ namespace Octokit.Reactive
         public IObservableMergingClient Merging { get; private set; }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use ObservableRepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public IObservable<Branch> GetAllBranches(long repositoryId)
-        {
-            return Branch.GetAll(repositoryId, ApiOptions.None);
-        }
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1513,7 +1513,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var branches = await github.Repository.GetAllBranches(7528679, options);
+            var branches = await github.Repository.Branch.GetAll(7528679, options);
 
             Assert.Equal(5, branches.Count);
         }
@@ -1547,7 +1547,7 @@ public class RepositoriesClientTests
                 StartPage = 2
             };
 
-            var branches = await github.Repository.GetAllBranches(7528679, options);
+            var branches = await github.Repository.Branch.GetAll(7528679, options);
 
             Assert.Equal(5, branches.Count);
         }
@@ -1597,7 +1597,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var firstPage = await github.Repository.GetAllBranches(7528679, firstPageOptions);
+            var firstPage = await github.Repository.Branch.GetAll(7528679, firstPageOptions);
 
             var secondPageOptions = new ApiOptions
             {
@@ -1606,7 +1606,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var secondPage = await github.Repository.GetAllBranches(7528679, secondPageOptions);
+            var secondPage = await github.Repository.Branch.GetAll(7528679, secondPageOptions);
 
             Assert.Equal(5, firstPage.Count);
             Assert.Equal(5, secondPage.Count);

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1465,7 +1465,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var branches = await github.Repository.GetAllBranches("octokit", "octokit.net");
+            var branches = await github.Repository.Branch.GetAll("octokit", "octokit.net");
 
             Assert.NotEmpty(branches);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1475,7 +1475,7 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var branches = await github.Repository.GetAllBranches(7528679);
+            var branches = await github.Repository.Branch.GetAll(7528679);
 
             Assert.NotEmpty(branches);
 

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1497,7 +1497,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var branches = await github.Repository.GetAllBranches("octokit", "octokit.net", options);
+            var branches = await github.Repository.Branch.GetAll("octokit", "octokit.net", options);
 
             Assert.Equal(5, branches.Count);
         }
@@ -1530,7 +1530,7 @@ public class RepositoriesClientTests
                 StartPage = 2
             };
 
-            var branches = await github.Repository.GetAllBranches("octokit", "octokit.net", options);
+            var branches = await github.Repository.Branch.GetAll("octokit", "octokit.net", options);
 
             Assert.Equal(5, branches.Count);
         }
@@ -1564,7 +1564,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var firstPage = await github.Repository.GetAllBranches("octokit", "octokit.net", firstPageOptions);
+            var firstPage = await github.Repository.Branch.GetAll("octokit", "octokit.net", firstPageOptions);
 
             var secondPageOptions = new ApiOptions
             {
@@ -1573,7 +1573,7 @@ public class RepositoriesClientTests
                 PageCount = 1
             };
 
-            var secondPage = await github.Repository.GetAllBranches("octokit", "octokit.net", secondPageOptions);
+            var secondPage = await github.Repository.Branch.GetAll("octokit", "octokit.net", secondPageOptions);
 
             Assert.Equal(5, firstPage.Count);
             Assert.Equal(5, secondPage.Count);

--- a/Octokit.Tests.Integration/Helpers/ReferenceExtensionsTests.cs
+++ b/Octokit.Tests.Integration/Helpers/ReferenceExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Octokit.Tests.Integration.Helpers
 
                 var branchFromPath = await fixture.CreateBranch(context.RepositoryOwner, context.RepositoryName, "patch-2", branchFromMaster);
 
-                var allBranchNames = (await client.Repository.GetAllBranches(context.RepositoryOwner, context.RepositoryName)).Select(b => b.Name);
+                var allBranchNames = (await client.Repository.Branch.GetAll(context.RepositoryOwner, context.RepositoryName)).Select(b => b.Name);
 
                 Assert.Contains("patch-1", allBranchNames);
                 Assert.Contains("patch-2", allBranchNames);

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                await client.GetAll("username", options);
+                await client.GetAllForUser("username", options);
 
                 connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), options);
             }
@@ -82,11 +82,11 @@ namespace Octokit.Tests.Clients
                 var client = new OrganizationsClient(connection);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser((string)null));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("username", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser("username", null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Clients/OrganizationsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationsClientTests.cs
@@ -52,7 +52,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new OrganizationsClient(connection);
 
-                await client.GetAll("username");
+                await client.GetAllForUser("username");
 
                 connection.Received().GetAll<Organization>(Arg.Is<Uri>(u => u.ToString() == "users/username/orgs"), Args.ApiOptions);
             }
@@ -81,11 +81,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new OrganizationsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll((string)null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForUser((string)null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("username", null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForUser(""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
             }
         }

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -533,7 +533,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.GetAllBranches(1);
+                await client.Branch.GetAll(1);
 
                 connection.Received()
                     .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches"), null, "application/vnd.github.loki-preview+json", Args.ApiOptions);

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -571,7 +571,7 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                await client.GetAllBranches(1, options);
+                await client.Branch.GetAll(1, options);
 
                 connection.Received()
                     .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches"), null, "application/vnd.github.loki-preview+json", options);
@@ -589,7 +589,7 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("owner", ""));

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -552,7 +552,7 @@ namespace Octokit.Tests.Clients
                     PageSize = 1
                 };
 
-                await client.GetAllBranches("owner", "name", options);
+                await client.Branch.GetAll("owner", "name", options);
 
                 connection.Received()
                     .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"), null, "application/vnd.github.loki-preview+json", options);
@@ -585,16 +585,16 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll("owner", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll("owner", "name", null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll(1, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("owner", ""));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("owner", "", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -521,7 +521,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
 
-                await client.GetAllBranches("owner", "name");
+                await client.Branch.GetAll("owner", "name");
 
                 connection.Received()
                     .GetAll<Branch>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/branches"), null, "application/vnd.github.loki-preview+json", Args.ApiOptions);
@@ -582,8 +582,8 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoriesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Branch.GetAll("owner", null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
@@ -591,8 +591,8 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllBranches(1, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Branch.GetAll("owner", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
             }

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -50,7 +50,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAll("username");
 
-                gitHubClient.Received().Organization.GetAll("username");
+                gitHubClient.Received().Organization.GetAllForUser("username");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -68,7 +68,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForUser("username", options);
 
-                gitHubClient.Received().Organization.GetAll("username", options);
+                gitHubClient.Received().Organization.GetAllForUser("username", options);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableOrganizationsClient(gitHubClient);
 
-                client.GetAll("username");
+                client.GetAllForUser("username");
 
                 gitHubClient.Received().Organization.GetAllForUser("username");
             }
@@ -77,11 +77,11 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableOrganizationsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAll((string)null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForUser((string)null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForUser("username", null));
 
-                Assert.Throws<ArgumentException>(() => client.GetAll(""));
+                Assert.Throws<ArgumentException>(() => client.GetAllForUser(""));
                 Assert.Throws<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
             }
         }

--- a/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationsClientTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                client.GetAll("username", options);
+                client.GetAllForUser("username", options);
 
                 gitHubClient.Received().Organization.GetAll("username", options);
             }
@@ -78,11 +78,11 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableOrganizationsClient(gitHubClient);
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAll((string)null));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("username", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForUser(null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForUser("username", null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll(""));
-                Assert.Throws<ArgumentException>(() => client.GetAll("", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.GetAllForUser("", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -329,7 +329,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoriesClient(gitHubClient);
                 var expected = new Uri("repos/owner/repo/branches", UriKind.Relative);
 
-                client.GetAllBranches("owner", "repo");
+                client.Branch.GetAll("owner", "repo");
 
                 gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Args.EmptyDictionary, null);
             }
@@ -389,8 +389,8 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoriesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "name"));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll("owner", null));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
@@ -398,8 +398,8 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(1, null));
 
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name"));
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.Branch.GetAll("", "name"));
+                Assert.Throws<ArgumentException>(() => client.Branch.GetAll("owner", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -360,7 +360,7 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                client.GetAllBranches("owner", "name", options);
+                client.Branch.GetAll("owner", "name", options);
 
                 gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
             }
@@ -392,16 +392,16 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(null, "name"));
                 Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll("owner", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(null, "name", ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(null, "name", ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll("owner", null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll("owner", "name", null));
 
                 Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.Branch.GetAll("", "name"));
                 Assert.Throws<ArgumentException>(() => client.Branch.GetAll("owner", ""));
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name", ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", "", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.Branch.GetAll("", "name", ApiOptions.None));
+                Assert.Throws<ArgumentException>(() => client.Branch.GetAll("owner", "", ApiOptions.None));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -341,7 +341,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservableRepositoriesClient(gitHubClient);
                 var expected = new Uri("repositories/1/branches", UriKind.Relative);
 
-                client.GetAllBranches(1);
+                client.Branch.GetAll(1);
 
                 gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Args.EmptyDictionary, null);
             }

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -379,7 +379,7 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                client.GetAllBranches(1, options);
+                client.Branch.GetAll(1, options);
 
                 gitHubClient.Connection.Received(1).Get<List<Branch>>(expected, Arg.Is<IDictionary<string, string>>(d => d.Count == 2 && d["page"] == "1" && d["per_page"] == "1"), null);
             }
@@ -396,7 +396,7 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", null, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllBranches("owner", "name", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllBranches(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.Branch.GetAll(1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllBranches("", "name"));
                 Assert.Throws<ArgumentException>(() => client.GetAllBranches("owner", ""));

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -57,14 +57,6 @@ namespace Octokit
         /// <summary>
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
-        [Obsolete("Please use IOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        Task<IReadOnlyList<Organization>> GetAll(string user);
-
-        /// <summary>
-        /// Returns all <see cref="Organization" />s for the specified user.
-        /// </summary>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -57,16 +57,6 @@ namespace Octokit
         /// <summary>
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
-        /// <param name="user">The login of the user</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
-        [Obsolete("Please use IOrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options);
-
-        /// <summary>
-        /// Returns all <see cref="Organization" />s for the specified user.
-        /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         Task<IReadOnlyList<Organization>> GetAllForUser(string user);

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -339,19 +339,6 @@ namespace Octokit
         Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name, ApiOptions options);
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId, ApiOptions options);
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -325,20 +325,6 @@ namespace Octokit
         IMergingClient Merging { get; }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name, ApiOptions options);
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -330,19 +330,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name);
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -330,18 +330,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>All <see cref="T:Octokit.Branch"/>es of the repository</returns>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId);
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="http://developer.github.com/v3/repos/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -74,20 +74,6 @@ namespace Octokit
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
         /// <param name="user">The login of the user</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
-        [Obsolete("Please use OrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        public Task<IReadOnlyList<Organization>> GetAll(string user)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(user, "user");
-
-            return GetAll(user, ApiOptions.None);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="Organization" />s for the specified user.
-        /// </summary>
-        /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -74,22 +74,6 @@ namespace Octokit
         /// Returns all <see cref="Organization" />s for the specified user.
         /// </summary>
         /// <param name="user">The login of the user</param>
-        /// <param name="options">Options for changing the API response</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
-        [Obsolete("Please use OrganizationsClient.GetAllForUser() instead. This method will be removed in a future version")]
-        public Task<IReadOnlyList<Organization>> GetAll(string user, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(user, "user");
-            Ensure.ArgumentNotNull(options, "options");
-
-            return ApiConnection.GetAll<Organization>(ApiUrls.UserOrganizations(user), options);
-        }
-
-        /// <summary>
-        /// Returns all <see cref="Organization" />s for the specified user.
-        /// </summary>
-        /// <param name="user">The login of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
         public Task<IReadOnlyList<Organization>> GetAllForUser(string user)

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -556,19 +556,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId)
-        {
-            return Branch.GetAll(repositoryId);
-        }
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -551,25 +551,6 @@ namespace Octokit
         public IRepositoryContentsClient Content { get; private set; }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNull(options, "options");
-
-            return Branch.GetAll(owner, name, options);
-        }
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -556,23 +556,6 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(string owner, string name)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-
-            return Branch.GetAll(owner, name);
-        }
-
-        /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
         public Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId)

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -570,22 +570,6 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets all the branches for the specified repository.
-        /// </summary>
-        /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
-        /// </remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="options">Options for changing the API response</param>
-        [Obsolete("Please use RepositoriesClient.Branch.GetAll() instead.  This method will be removed in a future version")]
-        public Task<IReadOnlyList<Branch>> GetAllBranches(long repositoryId, ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, "options");
-
-            return Branch.GetAll(repositoryId, options);
-        }
-
-        /// <summary>
         /// Gets all contributors for the specified repository. Does not include anonymous contributors.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This is the next removal of obsoleted methods, while waiting for Branch protection API review. Therefore removal of obsoleted methods will not touch Branch protection API (obsoleted) methods.
I deliberately submit this PR first to notify that this is part 1 of the obsoleted method removal to ease PR review.

cc @ryangribble @shiftkey 