### PR TITLE
Adding RemovedFromProject and other missing EventInfoState types.

### DIFF
--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -194,7 +194,7 @@ namespace Octokit
         ReviewRequestRemoved,
 
         /// <summary>
-        /// Not documented in GitHub API.
+        /// Base branch of the pull request was changed.
         /// </summary>
         BaseRefChanged,
 

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -152,10 +152,10 @@ namespace Octokit
         /// </summary>
         Unlocked,
 
-        /// <summary>
-        /// The pull request’s branch was deleted.
-        /// </summary>
-        HeadRefDeleted,
+		/// <summary>
+		/// The pull request’s branch was deleted.
+		/// </summary>
+		HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
@@ -177,6 +177,26 @@ namespace Octokit
         /// Only provided for pull requests.
         /// </summary>
         Committed,
+
+		/// <summary>
+		/// The actor requested review from the subject on this pull request.
+		/// </summary>
+		ReviewRequested,
+
+		/// <summary>
+		/// The actor dismissed a review from the pull request.
+		/// </summary>
+		ReviewDismissed,
+
+		/// <summary>
+		/// The actor removed the review request for the subject on this pull request.
+		/// </summary>
+		ReviewRequestRemoved,
+
+		/// <summary>
+		/// Not documented in GitHub API.
+		/// </summary>
+		BaseRefChanged,
 
         /// <summary>
         /// The issue was referenced from another issue.

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -152,10 +152,10 @@ namespace Octokit
         /// </summary>
         Unlocked,
 
-		/// <summary>
-		/// The pull request’s branch was deleted.
-		/// </summary>
-		HeadRefDeleted,
+        /// <summary>
+        /// The pull request’s branch was deleted.
+        /// </summary>
+        HeadRefDeleted,
 
         /// <summary>
         /// The pull request’s branch was restored.
@@ -178,25 +178,25 @@ namespace Octokit
         /// </summary>
         Committed,
 
-		/// <summary>
-		/// The actor requested review from the subject on this pull request.
-		/// </summary>
-		ReviewRequested,
+        /// <summary>
+        /// The actor requested review from the subject on this pull request.
+        /// </summary>
+        ReviewRequested,
 
-		/// <summary>
-		/// The actor dismissed a review from the pull request.
-		/// </summary>
-		ReviewDismissed,
+        /// <summary>
+        /// The actor dismissed a review from the pull request.
+        /// </summary>
+        ReviewDismissed,
 
-		/// <summary>
-		/// The actor removed the review request for the subject on this pull request.
-		/// </summary>
-		ReviewRequestRemoved,
+        /// <summary>
+        /// The actor removed the review request for the subject on this pull request.
+        /// </summary>
+        ReviewRequestRemoved,
 
-		/// <summary>
-		/// Not documented in GitHub API.
-		/// </summary>
-		BaseRefChanged,
+        /// <summary>
+        /// Not documented in GitHub API.
+        /// </summary>
+        BaseRefChanged,
 
         /// <summary>
         /// The issue was referenced from another issue.

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -163,6 +163,41 @@ namespace Octokit
         HeadRefRestored,
 
         /// <summary>
+        /// The actor dismissed a review from the pull request.
+        /// </summary>
+        ReviewDismissed,
+
+        /// <summary>
+        /// The actor requested review from the subject on this pull request.
+        /// </summary>
+        ReviewRequested,
+
+        /// <summary>
+        /// The actor removed the review request for the subject on this pull request.
+        /// </summary>
+        ReviewRequestRemoved,
+
+        /// <summary>
+        /// The issue was added to a project board.
+        /// </summary>
+        AddedToProject,
+
+        /// <summary>
+        /// The issue was moved between columns in a project board.
+        /// </summary>
+        MovedColumnsInProject,
+
+        /// <summary>
+        /// The issue was removed from a project board.
+        /// </summary>
+        RemovedFromProject,
+
+        /// <summary>
+        /// The issue was created by converting a note in a project board to an issue.
+        /// </summary>
+        ConvertedNoteToIssue,
+
+        /// <summary>
         /// The actor unsubscribed from notifications for an issue.
         /// </summary>
         Unsubscribed,
@@ -177,21 +212,6 @@ namespace Octokit
         /// Only provided for pull requests.
         /// </summary>
         Committed,
-
-        /// <summary>
-        /// The actor requested review from the subject on this pull request.
-        /// </summary>
-        ReviewRequested,
-
-        /// <summary>
-        /// The actor dismissed a review from the pull request.
-        /// </summary>
-        ReviewDismissed,
-
-        /// <summary>
-        /// The actor removed the review request for the subject on this pull request.
-        /// </summary>
-        ReviewRequestRemoved,
 
         /// <summary>
         /// Base branch of the pull request was changed.


### PR DESCRIPTION
The problem described in PR #1536 / Issue #1502 cropped up again.  Apparently GitHub has added more event types.  

This change incorporates all of the states in the [GitHub API](https://developer.github.com/v3/issues/events/) plus some undocumented ones we encountered during prior testing.  

I put them in the order that they're listed in the GitHub API so you can easily skim the list and compare.