### PR TITLE
Remove Rx-Main dependency from samples

### DIFF
--- a/samples/linqpad-samples/1-introducing-octokit.linq
+++ b/samples/linqpad-samples/1-introducing-octokit.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System.Reactive.Linq</Namespace>
   <Namespace>System.Threading.Tasks</Namespace>

--- a/samples/linqpad-samples/10-search-issues.linq
+++ b/samples/linqpad-samples/10-search-issues.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>Octokit.Reactive</Namespace>
   <Namespace>System</Namespace>

--- a/samples/linqpad-samples/2-releases.linq
+++ b/samples/linqpad-samples/2-releases.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System.Net</Namespace>
   <Namespace>System.Threading.Tasks</Namespace>

--- a/samples/linqpad-samples/3-browse-repositories.linq
+++ b/samples/linqpad-samples/3-browse-repositories.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System.Threading.Tasks</Namespace>
 </Query>

--- a/samples/linqpad-samples/4-observable-browse-repositories.linq
+++ b/samples/linqpad-samples/4-observable-browse-repositories.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System</Namespace>
   <Namespace>System.Reactive.Linq</Namespace>

--- a/samples/linqpad-samples/5-interact-with-git-database.linq
+++ b/samples/linqpad-samples/5-interact-with-git-database.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System.Threading.Tasks</Namespace>
 </Query>

--- a/samples/linqpad-samples/6-create-repository.linq
+++ b/samples/linqpad-samples/6-create-repository.linq
@@ -3,7 +3,6 @@
   <Reference>&lt;RuntimeDirectory&gt;\System.Runtime.dll</Reference>
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>System.Net.Http.Headers</Namespace>
   <Namespace>System.Reactive.Linq</Namespace>

--- a/samples/linqpad-samples/7-search-for-repos.linq
+++ b/samples/linqpad-samples/7-search-for-repos.linq
@@ -3,7 +3,6 @@
   <Reference>&lt;RuntimeDirectory&gt;\System.Runtime.dll</Reference>
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>System.Reactive.Linq</Namespace>
   <Namespace>System.Net.Http.Headers</Namespace>
   <Namespace>Octokit</Namespace>

--- a/samples/linqpad-samples/8-gists.linq
+++ b/samples/linqpad-samples/8-gists.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>Octokit.Reactive</Namespace>
   <Namespace>System</Namespace>

--- a/samples/linqpad-samples/9-issues.linq
+++ b/samples/linqpad-samples/9-issues.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
   <NuGetReference>Octokit</NuGetReference>
   <NuGetReference>Octokit.Reactive</NuGetReference>
-  <NuGetReference>Rx-Main</NuGetReference>
   <Namespace>Octokit</Namespace>
   <Namespace>Octokit.Reactive</Namespace>
   <Namespace>System</Namespace>


### PR DESCRIPTION
This resolves #1592 - LINQPad doesn't understand how to restore this unlisted package and it's not actually needed in the samples.