### PR TITLE
Add BranchProtection.EnforceAdmins object

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
@@ -315,6 +315,69 @@ namespace Octokit.Reactive
         IObservable<string> DeleteRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts);
 
         /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<bool> RemoveAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<bool> RemoveAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
         /// Get the restrictions for the specified branch (applies only to Organization owned repositories)
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
@@ -499,6 +499,54 @@ namespace Octokit.Reactive
             return _client.DeleteRequiredStatusChecksContexts(repositoryId, branch, contexts).ToObservable().SelectMany(x => x);
         }
 
+        public IObservable<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.GetAdminEnforcement(owner, name, branch).ToObservable();
+        }
+
+        public IObservable<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.GetAdminEnforcement(repositoryId, branch).ToObservable();
+        }
+
+        public IObservable<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.AddAdminEnforcement(owner, name, branch).ToObservable();
+        }
+
+        public IObservable<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.AddAdminEnforcement(repositoryId, branch).ToObservable();
+        }
+
+        public IObservable<bool> RemoveAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.RemoveAdminEnforcement(owner, name, branch).ToObservable();
+        }
+
+        public IObservable<bool> RemoveAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.RemoveAdminEnforcement(repositoryId, branch).ToObservable();
+        }
+
         /// <summary>
         /// Get the restrictions for the specified branch (applies only to Organization owned repositories)
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
@@ -499,6 +499,15 @@ namespace Octokit.Reactive
             return _client.DeleteRequiredStatusChecksContexts(repositoryId, branch, contexts).ToObservable().SelectMany(x => x);
         }
 
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public IObservable<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -508,6 +517,14 @@ namespace Octokit.Reactive
             return _client.GetAdminEnforcement(owner, name, branch).ToObservable();
         }
 
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public IObservable<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
@@ -515,6 +532,15 @@ namespace Octokit.Reactive
             return _client.GetAdminEnforcement(repositoryId, branch).ToObservable();
         }
 
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public IObservable<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -531,6 +557,15 @@ namespace Octokit.Reactive
             return _client.AddAdminEnforcement(repositoryId, branch).ToObservable();
         }
 
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public IObservable<bool> RemoveAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -540,6 +575,14 @@ namespace Octokit.Reactive
             return _client.RemoveAdminEnforcement(owner, name, branch).ToObservable();
         }
 
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public IObservable<bool> RemoveAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -860,7 +860,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task GetAdminEnforcement()
+        public async Task GetsAdminEnforcement()
         {
             var repoOwner = _userRepoContext.RepositoryOwner;
             var repoName = _userRepoContext.RepositoryName;
@@ -871,7 +871,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task GetAdminEnforcementWithRepositoryId()
+        public async Task GetsAdminEnforcementWithRepositoryId()
         {
             var repoId = _userRepoContext.RepositoryId;
             var enforceAdmins = await _client.GetAdminEnforcement(repoId, "master");
@@ -903,7 +903,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task AddAdminEnforcement()
+        public async Task AddsAdminEnforcement()
         {
             var repoOwner = _userRepoContext.RepositoryOwner;
             var repoName = _userRepoContext.RepositoryName;
@@ -916,7 +916,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task AddAdminEnforcementoWithRepositoryId()
+        public async Task AddsAdminEnforcementoWithRepositoryId()
         {
             var repoId = _userRepoContext.RepositoryId;
 
@@ -948,7 +948,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task RemoveAdminEnforcement()
+        public async Task RemovesAdminEnforcement()
         {
             using (var context = await _github.CreateRepositoryWithProtectedBranch())
             {
@@ -966,7 +966,7 @@ public class RepositoryBranchesClientTests
         }
 
         [IntegrationTest]
-        public async Task RemoveAdminEnforcementWithRepositoryId()
+        public async Task RemovesAdminEnforcementWithRepositoryId()
         {
             using (var context = await _github.CreateRepositoryWithProtectedBranch())
             {

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -846,6 +846,141 @@ public class RepositoryBranchesClientTests
         }
     }
 
+    public class TheGetAdminEnforcementMethod : IDisposable
+    {
+        private readonly IRepositoryBranchesClient _client;
+        private readonly RepositoryContext _userRepoContext;
+
+        public TheGetAdminEnforcementMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            _client = github.Repository.Branch;
+
+            _userRepoContext = github.CreateRepositoryWithProtectedBranch().Result;
+        }
+
+        [IntegrationTest]
+        public async Task GetAdminEnforcement()
+        {
+            var repoOwner = _userRepoContext.RepositoryOwner;
+            var repoName = _userRepoContext.RepositoryName;
+            var enforceAdmins = await _client.GetAdminEnforcement(repoOwner, repoName, "master");
+
+            Assert.NotNull(enforceAdmins);
+            Assert.True(enforceAdmins.Enabled);
+        }
+
+        [IntegrationTest]
+        public async Task GetAdminEnforcementWithRepositoryId()
+        {
+            var repoId = _userRepoContext.RepositoryId;
+            var enforceAdmins = await _client.GetAdminEnforcement(repoId, "master");
+
+            Assert.NotNull(enforceAdmins);
+            Assert.True(enforceAdmins.Enabled);
+        }
+
+        public void Dispose()
+        {
+            if (_userRepoContext != null)
+            {
+                _userRepoContext.Dispose();
+            }
+        }
+    }
+
+    public class TheAddAdminEnforcementMethod : IDisposable
+    {
+        private readonly IRepositoryBranchesClient _client;
+        private readonly RepositoryContext _userRepoContext;
+
+        public TheAddAdminEnforcementMethod()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            _client = github.Repository.Branch;
+
+            _userRepoContext = github.CreateRepositoryWithProtectedBranch().Result;
+        }
+
+        [IntegrationTest]
+        public async Task AddAdminEnforcement()
+        {
+            var repoOwner = _userRepoContext.RepositoryOwner;
+            var repoName = _userRepoContext.RepositoryName;
+
+            var enforceAdmins = await _client.AddAdminEnforcement(repoOwner, repoName, "master");
+
+            Assert.NotNull(enforceAdmins);
+            Assert.True(enforceAdmins.Enabled);
+        }
+
+        [IntegrationTest]
+        public async Task AddAdminEnforcementoWithRepositoryId()
+        {
+            var repoId = _userRepoContext.RepositoryId;
+
+            var enforceAdmins = await _client.AddAdminEnforcement(repoId, "master");
+
+            Assert.NotNull(enforceAdmins);
+            Assert.True(enforceAdmins.Enabled);
+        }
+
+        public void Dispose()
+        {
+            if (_userRepoContext != null)
+            {
+                _userRepoContext.Dispose();
+            }
+        }
+    }
+
+    public class TheRemoveAdminEnforcementMethod
+    {
+        private readonly IRepositoryBranchesClient _client;
+        private readonly IGitHubClient _github;
+
+        public TheRemoveAdminEnforcementMethod()
+        {
+            _github = Helper.GetAuthenticatedClient();
+            _client = _github.Repository.Branch;
+        }
+
+        [IntegrationTest]
+        public async Task RemoveAdminEnforcement()
+        {
+            using (var context = await _github.CreateRepositoryWithProtectedBranch())
+            {
+                var repoOwner = context.RepositoryOwner;
+                var repoName = context.RepositoryName;
+                var deleted = await _client.RemoveAdminEnforcement(repoOwner, repoName, "master");
+
+                Assert.True(deleted);
+
+                var enforceAdmins = await _client.GetAdminEnforcement(repoOwner, repoName, "master");
+
+                Assert.NotNull(enforceAdmins);
+                Assert.False(enforceAdmins.Enabled);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task RemoveAdminEnforcementWithRepositoryId()
+        {
+            using (var context = await _github.CreateRepositoryWithProtectedBranch())
+            {
+                var repoId = context.RepositoryId;
+                var deleted = await _client.RemoveAdminEnforcement(repoId, "master");
+
+                Assert.True(deleted);
+
+                var enforceAdmins = await _client.GetAdminEnforcement(repoId, "master");
+
+                Assert.NotNull(enforceAdmins);
+                Assert.False(enforceAdmins.Enabled);
+            }
+        }
+    }
+
     public class TheGetProtectedBranchRestrictionsMethod : IDisposable
     {
         IRepositoryBranchesClient _client;

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -329,7 +329,7 @@ public class RepositoryBranchesClientTests
             var repoName = _userRepoContext.RepositoryName;
             var protection = await _client.GetBranchProtection(repoOwner, repoName, "master");
 
-            Assert.True(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.True(protection.EnforceAdmins.Enabled);
             Assert.True(protection.RequiredStatusChecks.Strict);
             Assert.Equal(2, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -342,7 +342,7 @@ public class RepositoryBranchesClientTests
             var repoId = _userRepoContext.RepositoryId;
             var protection = await _client.GetBranchProtection(repoId, "master");
 
-            Assert.True(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.True(protection.EnforceAdmins.Enabled);
             Assert.True(protection.RequiredStatusChecks.Strict);
             Assert.Equal(2, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -356,7 +356,7 @@ public class RepositoryBranchesClientTests
             var repoName = _orgRepoContext.RepositoryContext.RepositoryName;
             var protection = await _client.GetBranchProtection(repoOwner, repoName, "master");
 
-            Assert.True(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.True(protection.EnforceAdmins.Enabled);
             Assert.True(protection.RequiredStatusChecks.Strict);
             Assert.Equal(2, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -370,7 +370,7 @@ public class RepositoryBranchesClientTests
             var repoId = _orgRepoContext.RepositoryContext.RepositoryId;
             var protection = await _client.GetBranchProtection(repoId, "master");
 
-            Assert.True(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.True(protection.EnforceAdmins.Enabled);
             Assert.True(protection.RequiredStatusChecks.Strict);
             Assert.Equal(2, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -409,11 +409,11 @@ public class RepositoryBranchesClientTests
             var repoOwner = _userRepoContext.RepositoryOwner;
             var repoName = _userRepoContext.RepositoryName;
             var update = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(false, false, new[] { "new" }));
+                new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }));
 
             var protection = await _client.UpdateBranchProtection(repoOwner, repoName, "master", update);
 
-            Assert.False(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.False(protection.EnforceAdmins.Enabled);
             Assert.False(protection.RequiredStatusChecks.Strict);
             Assert.Equal(1, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -425,11 +425,11 @@ public class RepositoryBranchesClientTests
         {
             var repoId = _userRepoContext.RepositoryId;
             var update = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(false, false, new[] { "new" }));
+                new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }));
 
             var protection = await _client.UpdateBranchProtection(repoId, "master", update);
 
-            Assert.False(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.False(protection.EnforceAdmins.Enabled);
             Assert.False(protection.RequiredStatusChecks.Strict);
             Assert.Equal(1, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -442,12 +442,13 @@ public class RepositoryBranchesClientTests
             var repoOwner = _orgRepoContext.RepositoryContext.RepositoryOwner;
             var repoName = _orgRepoContext.RepositoryContext.RepositoryName;
             var update = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(false, false, new[] { "new" }),
-                new BranchProtectionPushRestrictionsUpdate());
+                new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }),
+                new BranchProtectionPushRestrictionsUpdate(),
+                false);
 
             var protection = await _client.UpdateBranchProtection(repoOwner, repoName, "master", update);
 
-            Assert.False(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.False(protection.EnforceAdmins.Enabled);
             Assert.False(protection.RequiredStatusChecks.Strict);
             Assert.Equal(1, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -460,12 +461,13 @@ public class RepositoryBranchesClientTests
         {
             var repoId = _orgRepoContext.RepositoryContext.RepositoryId;
             var update = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(false, false, new[] { "new" }),
-                new BranchProtectionPushRestrictionsUpdate());
+                new BranchProtectionRequiredStatusChecksUpdate(false, new[] { "new" }),
+                new BranchProtectionPushRestrictionsUpdate(),
+                false);
 
             var protection = await _client.UpdateBranchProtection(repoId, "master", update);
 
-            Assert.False(protection.RequiredStatusChecks.IncludeAdmins);
+            Assert.False(protection.EnforceAdmins.Enabled);
             Assert.False(protection.RequiredStatusChecks.Strict);
             Assert.Equal(1, protection.RequiredStatusChecks.Contexts.Count);
 
@@ -567,7 +569,6 @@ public class RepositoryBranchesClientTests
 
             Assert.NotNull(requiredStatusChecks);
             Assert.NotNull(requiredStatusChecks.Contexts);
-            Assert.True(requiredStatusChecks.IncludeAdmins);
             Assert.True(requiredStatusChecks.Strict);
             Assert.Equal(2, requiredStatusChecks.Contexts.Count);
         }
@@ -580,7 +581,6 @@ public class RepositoryBranchesClientTests
 
             Assert.NotNull(requiredStatusChecks);
             Assert.NotNull(requiredStatusChecks.Contexts);
-            Assert.True(requiredStatusChecks.IncludeAdmins);
             Assert.True(requiredStatusChecks.Strict);
             Assert.Equal(2, requiredStatusChecks.Contexts.Count);
         }
@@ -610,13 +610,12 @@ public class RepositoryBranchesClientTests
         {
             var repoOwner = _userRepoContext.RepositoryOwner;
             var repoName = _userRepoContext.RepositoryName;
-            var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "new" });
+            var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "new" });
             var requiredStatusChecks = await _client.UpdateRequiredStatusChecks(repoOwner, repoName, "master", update);
 
             Assert.NotNull(requiredStatusChecks);
             Assert.NotNull(requiredStatusChecks.Contexts);
             Assert.True(requiredStatusChecks.Contexts.Contains("new"));
-            Assert.True(requiredStatusChecks.IncludeAdmins);
             Assert.True(requiredStatusChecks.Strict);
             Assert.Equal(1, requiredStatusChecks.Contexts.Count);
         }
@@ -625,13 +624,12 @@ public class RepositoryBranchesClientTests
         public async Task UpdatesRequiredStatusChecksWithRepositoryId()
         {
             var repoId = _userRepoContext.RepositoryId;
-            var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "new" });
+            var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "new" });
             var requiredStatusChecks = await _client.UpdateRequiredStatusChecks(repoId, "master", update);
 
             Assert.NotNull(requiredStatusChecks);
             Assert.NotNull(requiredStatusChecks.Contexts);
             Assert.True(requiredStatusChecks.Contexts.Contains("new"));
-            Assert.True(requiredStatusChecks.IncludeAdmins);
             Assert.True(requiredStatusChecks.Strict);
             Assert.Equal(1, requiredStatusChecks.Contexts.Count);
         }

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -908,6 +908,7 @@ public class RepositoryBranchesClientTests
             var repoOwner = _userRepoContext.RepositoryOwner;
             var repoName = _userRepoContext.RepositoryName;
 
+            await _client.RemoveAdminEnforcement(repoOwner, repoName, "master");
             var enforceAdmins = await _client.AddAdminEnforcement(repoOwner, repoName, "master");
 
             Assert.NotNull(enforceAdmins);
@@ -919,6 +920,7 @@ public class RepositoryBranchesClientTests
         {
             var repoId = _userRepoContext.RepositoryId;
 
+            await _client.RemoveAdminEnforcement(repoId, "master");
             var enforceAdmins = await _client.AddAdminEnforcement(repoId, "master");
 
             Assert.NotNull(enforceAdmins);

--- a/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
+++ b/Octokit.Tests.Integration/Helpers/OrganizationRepositoryWithTeamContext.cs
@@ -30,8 +30,7 @@ namespace Octokit.Tests.Integration.Helpers
             var contextUserRepo = await client.CreateRepositoryContext(userRepo);
 
             // Protect master branch
-            var update = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "build", "test" }));
+            var update = new BranchProtectionSettingsUpdate(new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }), null, true);
 
             await client.Repository.Branch.UpdateBranchProtection(contextUserRepo.RepositoryOwner, contextUserRepo.RepositoryName, "master", update);
 
@@ -56,8 +55,9 @@ namespace Octokit.Tests.Integration.Helpers
 
             // Protect master branch
             var protection = new BranchProtectionSettingsUpdate(
-                new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "build", "test" }),
-                new BranchProtectionPushRestrictionsUpdate(new BranchProtectionTeamCollection { contextOrgTeam.TeamName }));
+                new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "build", "test" }),
+                new BranchProtectionPushRestrictionsUpdate(new BranchProtectionTeamCollection { contextOrgTeam.TeamName }),
+                true);
             await client.Repository.Branch.UpdateBranchProtection(contextOrgRepo.RepositoryOwner, contextOrgRepo.RepositoryName, "master", protection);
 
             return new OrganizationRepositoryWithTeamContext

--- a/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
@@ -257,7 +257,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryBranchesClient(connection);
                 var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                    new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
                 client.UpdateBranchProtection("owner", "repo", "branch", update);
@@ -272,7 +272,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryBranchesClient(connection);
                 var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                    new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
                 client.UpdateBranchProtection(1, "branch", update);
@@ -286,7 +286,7 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
                 var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                    new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateBranchProtection(null, "repo", "branch", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateBranchProtection("owner", null, "branch", update));
@@ -405,7 +405,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryBranchesClient(connection);
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
                 client.UpdateRequiredStatusChecks("owner", "repo", "branch", update);
@@ -419,7 +419,7 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryBranchesClient(connection);
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
                 client.UpdateRequiredStatusChecks(1, "branch", update);
@@ -432,7 +432,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateRequiredStatusChecks(null, "repo", "branch", update));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.UpdateRequiredStatusChecks("owner", null, "branch", update));

--- a/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
@@ -806,7 +806,7 @@ namespace Octokit.Tests.Clients
                 client.RemoveAdminEnforcement("owner", "repo", "branch");
 
                 connection.Connection.Received()
-                    .Delete<bool>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+                    .Delete(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
             }
 
             [Fact]
@@ -819,7 +819,7 @@ namespace Octokit.Tests.Clients
                 client.RemoveAdminEnforcement(1, "branch");
 
                 connection.Connection.Received()
-                    .Delete<bool>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+                    .Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
@@ -700,6 +700,147 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetAdminEnforcementMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.GetAdminEnforcement("owner", "repo", "branch");
+
+                connection.Received()
+                    .Get<EnforceAdmins>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/enforce_admins"), null, previewAcceptsHeader);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.GetAdminEnforcement(1, "branch");
+
+                connection.Received()
+                    .Get<EnforceAdmins>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/enforce_admins"), null, previewAcceptsHeader);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAdminEnforcement(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAdminEnforcement("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAdminEnforcement("owner", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAdminEnforcement(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAdminEnforcement("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAdminEnforcement("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAdminEnforcement("owner", "repo", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAdminEnforcement(1, ""));
+            }
+        }
+
+        public class TheAddAdminEnforcement
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.AddAdminEnforcement("owner", "repo", "branch");
+
+                connection.Received()
+                    .Post<EnforceAdmins>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.AddAdminEnforcement(1, "branch");
+
+                connection.Received()
+                    .Post<EnforceAdmins>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAdminEnforcement(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAdminEnforcement("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAdminEnforcement("owner", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddAdminEnforcement(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAdminEnforcement("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAdminEnforcement("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAdminEnforcement("owner", "repo", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddAdminEnforcement(1, ""));
+            }
+        }
+
+        public class TheRemoveAdminEnforcement
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.RemoveAdminEnforcement("owner", "repo", "branch");
+
+                connection.Connection.Received()
+                    .Delete<bool>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryBranchesClient(connection);
+                const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
+
+                client.RemoveAdminEnforcement(1, "branch");
+
+                connection.Connection.Received()
+                    .Delete<bool>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/enforce_admins"), Arg.Any<object>(), previewAcceptsHeader);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAdminEnforcement(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAdminEnforcement("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAdminEnforcement("owner", "repo", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.RemoveAdminEnforcement(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAdminEnforcement("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAdminEnforcement("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAdminEnforcement("owner", "repo", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.RemoveAdminEnforcement(1, ""));
+            }
+        }
+
         public class TheGetProtectedBranchRestrictionsMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
@@ -672,6 +672,135 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheGetAdminEnforcementMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.GetAdminEnforcement("owner", "repo", "branch");
+
+                gitHubClient.Repository.Branch.Received().GetAdminEnforcement("owner", "repo", "branch");
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.GetAdminEnforcement(1, "branch");
+
+                gitHubClient.Repository.Branch.Received().GetAdminEnforcement(1, "branch");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAdminEnforcement(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAdminEnforcement("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAdminEnforcement("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAdminEnforcement(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetAdminEnforcement("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAdminEnforcement("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAdminEnforcement("owner", "repo", ""));
+
+                Assert.Throws<ArgumentException>(() => client.GetAdminEnforcement(1, ""));
+            }
+        }
+
+        public class TheAddAdminEnforcement
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.AddAdminEnforcement("owner", "repo", "branch");
+
+                gitHubClient.Repository.Branch.Received().AddAdminEnforcement("owner", "repo", "branch");
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.AddAdminEnforcement(1, "branch");
+
+                gitHubClient.Repository.Branch.Received().AddAdminEnforcement(1, "branch");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.AddAdminEnforcement(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.AddAdminEnforcement("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.AddAdminEnforcement("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.AddAdminEnforcement(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.AddAdminEnforcement("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.AddAdminEnforcement("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.AddAdminEnforcement("owner", "repo", ""));
+
+                Assert.Throws<ArgumentException>(() => client.AddAdminEnforcement(1, ""));
+            }
+        }
+
+        public class TheRemoveAdminEnforcement
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.RemoveAdminEnforcement("owner", "repo", "branch");
+
+                gitHubClient.Repository.Branch.Received().RemoveAdminEnforcement("owner", "repo", "branch");
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryBranchesClient(gitHubClient);
+
+                client.RemoveAdminEnforcement(1, "branch");
+
+                gitHubClient.Repository.Branch.Received().RemoveAdminEnforcement(1, "branch");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
+
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAdminEnforcement(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAdminEnforcement("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAdminEnforcement("owner", "repo", null));
+
+                Assert.Throws<ArgumentNullException>(() => client.RemoveAdminEnforcement(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveAdminEnforcement("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.RemoveAdminEnforcement("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.RemoveAdminEnforcement("owner", "repo", ""));
+
+                Assert.Throws<ArgumentException>(() => client.RemoveAdminEnforcement(1, ""));
+            }
+        }
+
         public class TheGetProtectedBranchRestrictionsMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
@@ -249,8 +249,7 @@ namespace Octokit.Tests.Reactive
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
-                var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                var update = new BranchProtectionSettingsUpdate(new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
 
                 client.UpdateBranchProtection("owner", "repo", "branch", update);
 
@@ -263,8 +262,7 @@ namespace Octokit.Tests.Reactive
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
-                var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                var update = new BranchProtectionSettingsUpdate(new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
 
                 client.UpdateBranchProtection(1, "branch", update);
 
@@ -276,8 +274,7 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
-                var update = new BranchProtectionSettingsUpdate(
-                    new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" }));
+                var update = new BranchProtectionSettingsUpdate(new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" }));
 
                 Assert.Throws<ArgumentNullException>(() => client.UpdateBranchProtection(null, "repo", "branch", update));
                 Assert.Throws<ArgumentNullException>(() => client.UpdateBranchProtection("owner", null, "branch", update));
@@ -392,7 +389,7 @@ namespace Octokit.Tests.Reactive
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
 
                 client.UpdateRequiredStatusChecks("owner", "repo", "branch", update);
 
@@ -405,7 +402,7 @@ namespace Octokit.Tests.Reactive
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
 
                 client.UpdateRequiredStatusChecks(1, "branch", update);
 
@@ -417,7 +414,7 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
-                var update = new BranchProtectionRequiredStatusChecksUpdate(true, true, new[] { "test" });
+                var update = new BranchProtectionRequiredStatusChecksUpdate(true, new[] { "test" });
 
                 Assert.Throws<ArgumentNullException>(() => client.UpdateRequiredStatusChecks(null, "repo", "branch", update));
                 Assert.Throws<ArgumentNullException>(() => client.UpdateRequiredStatusChecks("owner", null, "branch", update));

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -323,6 +323,69 @@ namespace Octokit
         Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts);
 
         /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<bool> RemoveAdminEnforcement(string owner, string name, string branch);
+
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        Task<bool> RemoveAdminEnforcement(long repositoryId, string branch);
+
+        /// <summary>
         /// Get restrictions for the specified branch (applies only to Organization owned repositories)
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -538,6 +538,15 @@ namespace Octokit
             return ApiConnection.Delete<IReadOnlyList<string>>(ApiUrls.RepoRequiredStatusChecksContexts(repositoryId, branch), contexts, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -547,6 +556,14 @@ namespace Octokit
             return ApiConnection.Get<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
+        /// <summary>
+        /// Get admin enforcement of protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public Task<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
@@ -555,6 +572,15 @@ namespace Octokit
 
         }
 
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -564,6 +590,14 @@ namespace Octokit
             return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), new object(), AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
+        /// <summary>
+        /// Add admin enforcement to protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
@@ -571,6 +605,15 @@ namespace Octokit
             return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), new object(), AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -590,6 +633,14 @@ namespace Octokit
             }
         }
 
+        /// <summary>
+        /// Remove admin enforcement on protected branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
         public async Task<bool> RemoveAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -561,14 +561,14 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
-            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), new object(), AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
         public Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
-            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), new object(), AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
         public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -538,6 +538,75 @@ namespace Octokit
             return ApiConnection.Delete<IReadOnlyList<string>>(ApiUrls.RepoRequiredStatusChecksContexts(repositoryId, branch), contexts, AcceptHeaders.ProtectedBranchesApiPreview);
         }
 
+        public Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return ApiConnection.Get<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+        }
+
+        public Task<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return ApiConnection.Get<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+
+        }
+
+        public Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+        }
+
+        public Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return ApiConnection.Post<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
+        }
+
+        public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            var endpoint = ApiUrls.RepoProtectedBranchAdminEnforcement(owner, name, branch);
+
+            try
+            {
+                var httpStatusCode = await Connection.Delete(endpoint, null, AcceptHeaders.ProtectedBranchesApiPreview).ConfigureAwait(false);
+                return httpStatusCode == HttpStatusCode.NoContent;
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
+        public async Task<bool> RemoveAdminEnforcement(long repositoryId, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            var endpoint = ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch);
+
+            try
+            {
+                var httpStatusCode = await Connection.Delete(endpoint, null, AcceptHeaders.ProtectedBranchesApiPreview).ConfigureAwait(false);
+                return httpStatusCode == HttpStatusCode.NoContent;
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Get restrictions for the specified branch (applies only to Organization owned repositories)
         /// </summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1734,6 +1734,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for admin enforcement for a protected branch
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        public static Uri RepoProtectedBranchAdminEnforcement(string owner, string name, string branchName)
+        {
+            return "repos/{0}/{1}/branches/{2}/protection/enforce_admins".FormatUri(owner, name, branchName);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> for admin enforcement for a protected branch
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branchName">The name of the branch</param>
+        public static Uri RepoProtectedBranchAdminEnforcement(long repositoryId, string branchName)
+        {
+            return "repositories/{0}/branches/{1}/protection/enforce_admins".FormatUri(repositoryId, branchName);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for restrictions for a protected branch.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -29,13 +29,30 @@ namespace Octokit
         /// <summary>
         /// Create a BranchProtection update request
         /// </summary>
+        /// <param name="restrictions">Specifies the requested push access restrictions (applies only to Organization owned repositories). Pass null to disable push access restrictions</param>
+        public BranchProtectionSettingsUpdate(BranchProtectionPushRestrictionsUpdate restrictions)
+        {
+            RequiredStatusChecks = null;
+            Restrictions = restrictions;
+        }
+
+        /// <summary>
+        /// Create a BranchProtection update request
+        /// </summary>
         /// <param name="requiredStatusChecks">Specifies the requested status check settings. Pass null to disable status checks</param>
         /// <param name="restrictions">Specifies the requested push access restrictions (applies only to Organization owned repositories). Pass null to disable push access restrictions</param>
-        public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionPushRestrictionsUpdate restrictions)
+        /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
+        public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionPushRestrictionsUpdate restrictions, bool enforceAdmins)
         {
             RequiredStatusChecks = requiredStatusChecks;
             Restrictions = restrictions;
+            EnforceAdmins = enforceAdmins;
         }
+
+        /// <summary>
+        /// Specifies whether the protections applied to this branch also apply to repository admins
+        /// </summary>
+        public bool EnforceAdmins { get; set; }
 
         /// <summary>
         /// Status check settings for the protected branch
@@ -54,9 +71,10 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "StatusChecks: {0} Restrictions: {1}",
+                    "StatusChecks: {0} Restrictions: {1} EnforceAdmins: {2}",
                     RequiredStatusChecks == null ? "disabled" : RequiredStatusChecks.DebuggerDisplay,
-                    Restrictions == null ? "disabled" : Restrictions.DebuggerDisplay);
+                    Restrictions == null ? "disabled" : Restrictions.DebuggerDisplay,
+                    EnforceAdmins);
             }
         }
     }
@@ -70,12 +88,10 @@ namespace Octokit
         /// <summary>
         /// Status check settings for branch protection
         /// </summary>
-        /// <param name="includeAdmins">Enforce required status checks for repository administrators</param>
         /// <param name="strict">Require branches to be up to date before merging</param>
         /// <param name="contexts">Require status checks to pass before merging</param>
-        public BranchProtectionRequiredStatusChecksUpdate(bool includeAdmins, bool strict, IReadOnlyList<string> contexts)
+        public BranchProtectionRequiredStatusChecksUpdate(bool strict, IReadOnlyList<string> contexts)
         {
-            IncludeAdmins = includeAdmins;
             Strict = strict;
             Contexts = contexts;
         }
@@ -83,6 +99,7 @@ namespace Octokit
         /// <summary>
         /// Enforce required status checks for repository administrators
         /// </summary>
+        [Obsolete("This property is obsolete. Use EnforceAdmins on the BranchProtectionUpdate class")]
         public bool IncludeAdmins { get; protected set; }
 
         /// <summary>
@@ -99,7 +116,7 @@ namespace Octokit
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "IncludeAdmins: {0} Strict: {1} Contexts: {2}", IncludeAdmins, Strict, Contexts == null ? "" : String.Join(",", Contexts));
+                return string.Format(CultureInfo.InvariantCulture, "Strict: {0} Contexts: {1}", Strict, Contexts == null ? "" : string.Join(",", Contexts));
             }
         }
     }

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -19,6 +19,17 @@ namespace Octokit
         /// <summary>
         /// Create a BranchProtection update request
         /// </summary>
+        /// <param name="enforceAdmins">Specifies whether the protections applied to this branch also apply to repository admins</param>
+        public BranchProtectionSettingsUpdate(bool enforceAdmins)
+        {
+            EnforceAdmins = enforceAdmins;
+            RequiredStatusChecks = null;
+            Restrictions = null;
+        }
+
+        /// <summary>
+        /// Create a BranchProtection update request
+        /// </summary>
         /// <param name="requiredStatusChecks">Specifies the requested status check settings. Pass null to disable status checks</param>
         public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks)
         {

--- a/Octokit/Models/Request/BranchProtectionUpdate.cs
+++ b/Octokit/Models/Request/BranchProtectionUpdate.cs
@@ -108,12 +108,6 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Enforce required status checks for repository administrators
-        /// </summary>
-        [Obsolete("This property is obsolete. Use EnforceAdmins on the BranchProtectionUpdate class")]
-        public bool IncludeAdmins { get; protected set; }
-
-        /// <summary>
         /// Require branches to be up to date before merging
         /// </summary>
         public bool Strict { get; protected set; }

--- a/Octokit/Models/Response/BranchProtection.cs
+++ b/Octokit/Models/Response/BranchProtection.cs
@@ -78,7 +78,7 @@ namespace Octokit
     /// <summary>
     /// The enforcement levels that are available
     /// </summary>
-    [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please see BranchProtectionRequiredStatusChecks.IncludeAdmins instead.")]
+    [Obsolete("This existing implementation will cease to work when the Branch Protection API preview period ends.  Please see BranchProtection.EnforceAdmins instead.")]
     public enum EnforcementLevel
     {
         /// <summary>
@@ -134,6 +134,28 @@ namespace Octokit
                     Restrictions == null ? "disabled" : Restrictions.DebuggerDisplay);
             }
         }
+
+        /// <summary>
+        /// Specifies whether the protections applied to this branch also apply to repository admins
+        /// </summary>
+        public EnforceAdmins EnforceAdmins { get; protected set; }
+    }
+
+    /// <summary>
+    /// Specifies whether the protections applied to this branch also apply to repository admins
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class EnforceAdmins
+    {
+        public bool Enabled { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Enabled: {0}", Enabled);
+            }
+        }
     }
 
     /// <summary>
@@ -144,17 +166,11 @@ namespace Octokit
     {
         public BranchProtectionRequiredStatusChecks() { }
 
-        public BranchProtectionRequiredStatusChecks(bool includeAdmins, bool strict, IReadOnlyList<string> contexts)
+        public BranchProtectionRequiredStatusChecks(bool strict, IReadOnlyList<string> contexts)
         {
-            IncludeAdmins = includeAdmins;
             Strict = strict;
             Contexts = contexts;
         }
-
-        /// <summary>
-        /// Enforce required status checks for repository administrators
-        /// </summary>
-        public bool IncludeAdmins { get; protected set; }
 
         /// <summary>
         /// Require branches to be up to date before merging
@@ -171,10 +187,9 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture,
-                    "IncludeAdmins: {0} Strict: {1} Contexts: {2}",
-                    IncludeAdmins,
+                    "Strict: {0} Contexts: {1}",
                     Strict,
-                    Contexts == null ? "" : String.Join(",", Contexts));
+                    Contexts == null ? "" : string.Join(",", Contexts));
             }
         }
     }


### PR DESCRIPTION
This replaces the `IncludeAdmins` property on sub-classes.
Fixes #1597 
TODO:
- [x] client methods for dealing directly with the `EnforceAdmins` setting
- [x] unit tests for the client methods
- [x] integration tests for the client methods
Breaking changes:
- `public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionPushRestrictionsUpdate restrictions)` ctor is now `public BranchProtectionSettingsUpdate(BranchProtectionRequiredStatusChecksUpdate requiredStatusChecks, BranchProtectionPushRestrictionsUpdate restrictions, bool enforceAdmins)`