### PR TITLE
Fixes #1586 - Repository license API

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -56,9 +56,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/git/refs/#get-all-references
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
         IObservable<Reference> GetAll(long repositoryId);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -78,10 +101,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/git/refs/#get-all-references
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
         IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Creates a reference for a given repository

--- a/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryInvitationsClient.cs
@@ -44,6 +44,16 @@ namespace Octokit.Reactive
         IObservable<RepositoryInvitation> GetAllForCurrent();
 
         /// <summary>
+        /// Gets all invitations for the current user.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>        
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IObservable<RepositoryInvitation> GetAllForCurrent(ApiOptions options);
+
+        /// <summary>
         /// Gets all the invitations on a repository.
         /// </summary>
         /// <remarks>
@@ -51,6 +61,16 @@ namespace Octokit.Reactive
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>         
         IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId);
+
+        /// <summary>
+        /// Gets all the invitations on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
+        /// </remarks>        
+        /// <param name="repositoryId">The id of the repository</param>
+        /// /// <param name="options">Options for changing the API response</param>        
+        IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Updates a repository invitation.

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -70,10 +70,26 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAll(string owner, string name)
         {
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAll(string owner, string name, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name));
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name), options);
         }
 
         /// <summary>
@@ -86,7 +102,23 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAll(long repositoryId)
         {
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId));
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAll(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId), options);
         }
 
         /// <summary>
@@ -101,11 +133,28 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
+            return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name, subNamespace));
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
 
         /// <summary>
@@ -119,9 +168,25 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
-            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            return GetAllForSubNamespace(repositoryId, subNamespace, ApiOptions.None);
+        }
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -129,7 +129,7 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         public IObservable<Repository> GetAllPublic()
         {
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.AllPublicRepositories());
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.AllPublicRepositories(), null, AcceptHeaders.LicensesApiPreview);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace Octokit.Reactive
 
             var url = ApiUrls.AllPublicRepositories(request.Since);
 
-            return _connection.GetAndFlattenAllPages<Repository>(url);
+            return _connection.GetAndFlattenAllPages<Repository>(url, null, AcceptHeaders.LicensesApiPreview);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(), null, AcceptHeaders.LicensesApiPreview, options);
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNull(request, "request");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(), request.ToParametersDictionary());
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(), request.ToParametersDictionary(), AcceptHeaders.LicensesApiPreview);
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(login), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.Repositories(login), null, AcceptHeaders.LicensesApiPreview, options);
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(organization, "organization");
             Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.OrganizationRepositories(organization), options);
+            return _connection.GetAndFlattenAllPages<Repository>(ApiUrls.OrganizationRepositories(organization), null, AcceptHeaders.LicensesApiPreview, options);
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statuses/">Commit Status API documentation</a> for more
-        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a> 
+        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a>
         /// that announced this feature.
         /// </remarks>
         public IObservableCommitStatusClient Status { get; private set; }
@@ -303,7 +303,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// A client for GitHub's Repository Forks API.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>        
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>
         public IObservableRepositoryForksClient Forks { get; private set; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryInvitationsClient.cs
@@ -80,7 +80,20 @@ namespace Octokit.Reactive
         /// </remarks>        
         public IObservable<RepositoryInvitation> GetAllForCurrent()
         {
-            return _connection.GetAndFlattenAllPages<RepositoryInvitation>(ApiUrls.UserInvitations(), null, AcceptHeaders.InvitationsApiPreview, ApiOptions.None);
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all invitations for the current user.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>        
+        public IObservable<RepositoryInvitation> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+            return _connection.GetAndFlattenAllPages<RepositoryInvitation>(ApiUrls.UserInvitations(), null, AcceptHeaders.InvitationsApiPreview, options);
         }
 
         /// <summary>
@@ -92,7 +105,21 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The id of the repository</param>  
         public IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId)
         {
-            return _connection.GetAndFlattenAllPages<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), null, AcceptHeaders.InvitationsApiPreview, ApiOptions.None);
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the invitations on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
+        /// </remarks>        
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<RepositoryInvitation> GetAllForRepository(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+            return _connection.GetAndFlattenAllPages<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), null, AcceptHeaders.InvitationsApiPreview, options);
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -63,11 +63,113 @@ public class ReferencesClientTests : IDisposable
         Assert.NotEmpty(list);
     }
 
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAll("octokit", "octokit.net", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAll("octokit", "octokit.net", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAll("octokit", "octokit.net", startOptions);
+        var secondRefsPage = await _fixture.GetAll("octokit", "octokit.net", skipStartOptions);
+
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
+    }
+
     [IntegrationTest(Skip = "This is paging for a long long time")]
     public async Task CanGetListOfReferencesWithRepositoryId()
     {
         var list = await _fixture.GetAll(7528679);
         Assert.NotEmpty(list);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithRepositoryIdWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAll(7528679, options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithRepositoryIdWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAll(7528679, options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesWithRepositoryIdBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAll(7528679, startOptions);
+        var secondRefsPage = await _fixture.GetAll(7528679, skipStartOptions);
+
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest]
@@ -78,10 +180,112 @@ public class ReferencesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesInNamespaceBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", startOptions);
+        var secondRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", skipStartOptions);
+
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
+    }
+
+    [IntegrationTest]
     public async Task CanGetListOfReferencesInNamespaceWithRepositoryId()
     {
         var list = await _fixture.GetAllForSubNamespace(7528679, "heads");
         Assert.NotEmpty(list);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithRepositoryIdWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAllForSubNamespace(7528679, "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithRepositoryIdWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAllForSubNamespace(7528679, "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesInNamespaceWithRepositoryIdBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", startOptions);
+        var secondRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", skipStartOptions);
+
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/RepositoryInvitationsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryInvitationsClientTests.cs
@@ -1,4 +1,5 @@
-﻿using Octokit;
+﻿using System.Collections.Generic;
+using Octokit;
 using Octokit.Tests.Integration;
 using Octokit.Tests.Integration.Helpers;
 using System.Linq;
@@ -12,7 +13,72 @@ public class RepositoryInvitationsClientTests
         [IntegrationTest]
         public async Task CanGetAllInvitations()
         {
-            var collaborator = "octocat";
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator
+                var response = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                Assert.Equal(context.RepositoryOwner, response.Invitee.Login);
+                Assert.Equal(InvitationPermissionType.Write, response.Permissions);
+
+                var invitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id);
+
+                Assert.Equal(1, invitations.Count);
+                Assert.Equal(invitations[0].CreatedAt, response.CreatedAt);
+                Assert.Equal(invitations[0].Id, response.Id);
+                Assert.Equal(invitations[0].Invitee.Login, response.Invitee.Login);
+                Assert.Equal(invitations[0].Inviter.Login, response.Inviter.Login);
+                Assert.Equal(invitations[0].Permissions, response.Permissions);
+                Assert.Equal(invitations[0].Repository.Id, response.Repository.Id);
+            }
+        }
+
+        [DualAccountTest]
+        public async Task ReturnsCorrectCountOfInvitationsWithStart()
+        {
+            var collaborator1 = Helper.CredentialsSecondUser.Login;
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator
+                var response1 = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, collaborator1, permission);
+
+                Assert.Equal(collaborator1, response1.Invitee.Login);
+                Assert.Equal(InvitationPermissionType.Write, response1.Permissions);
+
+                var response2 = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                Assert.Equal(context.RepositoryOwner, response2.Invitee.Login);
+                Assert.Equal(InvitationPermissionType.Write, response2.Permissions);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var invitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id, options);
+
+                Assert.Equal(1, invitations.Count);
+            }
+        }
+
+        [DualAccountTest]
+        public async Task ReturnsCorrectCountOfInvitationsWithoutStart()
+        {
+            var collaborator = Helper.CredentialsSecondUser.Login;
             var github = Helper.GetAuthenticatedClient();
             var repoName = Helper.MakeNameWithTimestamp("public-repo");
 
@@ -27,15 +93,58 @@ public class RepositoryInvitationsClientTests
                 Assert.Equal(collaborator, response.Invitee.Login);
                 Assert.Equal(InvitationPermissionType.Write, response.Permissions);
 
-                var invitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id);
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                };
+
+                var invitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id, options);
 
                 Assert.Equal(1, invitations.Count);
-                Assert.Equal(invitations[0].CreatedAt, response.CreatedAt);
-                Assert.Equal(invitations[0].Id, response.Id);
-                Assert.Equal(invitations[0].Invitee.Login, response.Invitee.Login);
-                Assert.Equal(invitations[0].Inviter.Login, response.Inviter.Login);
-                Assert.Equal(invitations[0].Permissions, response.Permissions);
-                Assert.Equal(invitations[0].Repository.Id, response.Repository.Id);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctInvitationsBasedOnStart()
+        {
+            var collaborator1 = Helper.CredentialsSecondUser.Login;
+            var github = Helper.GetAuthenticatedClient();
+            var repoName = Helper.MakeNameWithTimestamp("public-repo");
+
+            using (var context = await github.CreateRepositoryContext(new NewRepository(repoName)))
+            {
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator
+                var response1 = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, collaborator1, permission);
+
+                Assert.Equal(collaborator1, response1.Invitee.Login);
+                Assert.Equal(InvitationPermissionType.Write, response1.Permissions);
+
+                var response2 = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                Assert.Equal(context.RepositoryOwner, response2.Invitee.Login);
+                Assert.Equal(InvitationPermissionType.Write, response2.Permissions);
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var firstInvitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id, startOptions);
+                var secondInvitations = await github.Repository.Invitation.GetAllForRepository(context.Repository.Id, skipStartOptions);
+
+                Assert.NotEqual(firstInvitations[0].Invitee.Login, secondInvitations[0].Invitee.Login);
             }
         }
     }
@@ -68,6 +177,164 @@ public class RepositoryInvitationsClientTests
                 Assert.NotNull(invitations.FirstOrDefault(i => i.Invitee.Login == response.Invitee.Login));
                 Assert.NotNull(invitations.FirstOrDefault(i => i.Permissions == response.Permissions));
                 Assert.NotNull(invitations.FirstOrDefault(i => i.Repository.Id == response.Repository.Id));
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfInvitationsWithStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoNames = Enumerable.Range(0, 2).Select(i => Helper.MakeNameWithTimestamp($"public-repo{i}")).ToList();
+
+            var contexts = new List<RepositoryContext>();
+            try
+            {
+                foreach (var repoName in repoNames)
+                {
+                    contexts.Add(await github.CreateRepositoryContext(new NewRepository(repoName)));
+                }
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator to all repos
+                foreach (var context in contexts)
+                {
+                    var response = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                    Assert.Equal(context.RepositoryOwner, response.Invitee.Login);
+                    Assert.Equal(InvitationPermissionType.Write, response.Permissions);
+                }
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+
+                var invitations = await github.Repository.Invitation.GetAllForCurrent(startOptions);
+                Assert.Equal(1, invitations.Count);
+            }
+            finally
+            {
+                if (contexts != null)
+                {
+                    foreach (var context in contexts)
+                    {
+                        context?.Dispose();
+                    }
+                }
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsCorrectCountOfInvitationsWithoutStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoNames = Enumerable.Range(0, 2).Select(i => Helper.MakeNameWithTimestamp($"public-repo{i}")).ToList();
+
+            var contexts = new List<RepositoryContext>();
+            try
+            {
+                foreach (var repoName in repoNames)
+                {
+                    contexts.Add(await github.CreateRepositoryContext(new NewRepository(repoName)));
+                }
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator to all repos
+                foreach (var context in contexts)
+                {
+                    var response = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                    Assert.Equal(context.RepositoryOwner, response.Invitee.Login);
+                    Assert.Equal(InvitationPermissionType.Write, response.Permissions);
+                }
+
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+
+                var invitations = await github.Repository.Invitation.GetAllForCurrent(startOptions);
+                Assert.Equal(1, invitations.Count);
+            }
+            finally
+            {
+                if (contexts != null)
+                {
+                    foreach (var context in contexts)
+                    {
+                        context?.Dispose();
+                    }
+                }
+            }
+        }
+
+        [IntegrationTest]
+        public async Task ReturnsDistinctInvitationsBasedOnStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var repoNames = Enumerable.Range(0, 2).Select(i => Helper.MakeNameWithTimestamp($"public-repo{i}")).ToList();
+
+            var contexts = new List<RepositoryContext>();
+            try
+            {
+                foreach (var repoName in repoNames)
+                {
+                    contexts.Add(await github.CreateRepositoryContext(new NewRepository(repoName)));
+                }
+                var fixture = github.Repository.Collaborator;
+                var permission = new CollaboratorRequest(Permission.Push);
+
+                // invite a collaborator to all repos
+                foreach (var context in contexts)
+                {
+                    var response = await fixture.Invite(context.RepositoryOwner, context.RepositoryName, context.RepositoryOwner, permission);
+
+                    Assert.Equal(context.RepositoryOwner, response.Invitee.Login);
+                    Assert.Equal(InvitationPermissionType.Write, response.Permissions);
+                }
+               
+                var startOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1
+                };
+
+                var skipStartOptions = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 2
+                };
+
+                var firstInvitations = await github.Repository.Invitation.GetAllForCurrent(startOptions);
+                var secondInvitations = await github.Repository.Invitation.GetAllForCurrent(skipStartOptions);
+
+                var invitations = firstInvitations.Concat(secondInvitations).ToArray();
+                var invitationsLength = invitations.Length;
+                for (int i = 0; i < invitationsLength; i++)
+                {
+                    for (int j = i+1; j < invitationsLength; j++)
+                    {
+                        Assert.NotEqual(invitations[i].Repository.FullName, invitations[j].Repository.FullName);
+                    }
+                }
+            }
+            finally
+            {
+                if(contexts != null)
+                {
+                    foreach (var context in contexts)
+                    {
+                        context?.Dispose();
+                    }
+                }
             }
         }
     }

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -69,8 +69,18 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
+
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
             }
 
             [Fact]
@@ -81,7 +91,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("owner", "repo");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"), Args.ApiOptions);
             }
 
             [Fact]
@@ -92,7 +102,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1);
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"), Args.ApiOptions);
             }
         }
 
@@ -107,13 +117,26 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", "heads", null));
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, "subnamespace", null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", ""));
 
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", "", ApiOptions.None));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace(1, "", ApiOptions.None));
             }
 
             [Fact]
@@ -124,7 +147,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForSubNamespace("owner", "repo", "heads");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"), Args.ApiOptions);
             }
 
             [Fact]
@@ -135,7 +158,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForSubNamespace(1, "heads");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"), Args.ApiOptions);
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoryInvitationsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryInvitationsClientTests.cs
@@ -2,6 +2,7 @@
 using Octokit;
 using System;
 using System.Threading.Tasks;
+using Octokit.Tests;
 using Xunit;
 
 public class RepositoryInvitationsClientTests
@@ -18,6 +19,15 @@ public class RepositoryInvitationsClientTests
     public class TheGetAllForRepositoryMethod
     {
         [Fact]
+        public async Task EnsuresNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new RepositoryInvitationsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForRepository(1, null));
+        }
+
+        [Fact]
         public async Task RequestsCorrectUrl()
         {
             var connection = Substitute.For<IApiConnection>();
@@ -25,12 +35,21 @@ public class RepositoryInvitationsClientTests
 
             await client.GetAllForRepository(1);
 
-            connection.Received().GetAll<RepositoryInvitation>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/invitations"), "application/vnd.github.swamp-thing-preview+json");
+            connection.Received().GetAll<RepositoryInvitation>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/invitations"), null, "application/vnd.github.swamp-thing-preview+json", Args.ApiOptions);
         }
     }
 
     public class TheGetAllForCurrentMethod
     {
+        [Fact]
+        public async Task EnsuresNonNullArguments()
+        {
+            var connection = Substitute.For<IApiConnection>();
+            var client = new RepositoryInvitationsClient(connection);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForCurrent(null));
+        }
+
         [Fact]
         public async Task RequestsCorrectUrl()
         {
@@ -39,7 +58,7 @@ public class RepositoryInvitationsClientTests
 
             await client.GetAllForCurrent();
 
-            connection.Received().GetAll<RepositoryInvitation>(Arg.Is<Uri>(u => u.ToString() == "user/repository_invitations"), "application/vnd.github.swamp-thing-preview+json");
+            connection.Received().GetAll<RepositoryInvitation>(Arg.Is<Uri>(u => u.ToString() == "user/repository_invitations"), null, "application/vnd.github.swamp-thing-preview+json", Args.ApiOptions);
         }
     }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -182,20 +182,20 @@ namespace Octokit.Tests.Reactive
                     });
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), null)
+                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => firstPageResponse));
-                gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), null)
+                gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => secondPageResponse));
-                gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, Arg.Any<IDictionary<string, string>>(), null)
+                gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, Arg.Any<IDictionary<string, string>>(), Args.AnyAcceptHeaders)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<Repository>>>(() => lastPageResponse));
                 var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
 
                 var results = await repositoriesClient.GetAllForCurrent().ToArray();
 
                 Assert.Equal(7, results.Length);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), null);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), null);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, Arg.Any<IDictionary<string, string>>(), null);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, Arg.Any<IDictionary<string, string>>(), "application/vnd.github.drax-preview+json");
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, Arg.Any<IDictionary<string, string>>(), "application/vnd.github.drax-preview+json");
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, Arg.Any<IDictionary<string, string>>(), "application/vnd.github.drax-preview+json");
             }
 
             [Fact(Skip = "See https://github.com/octokit/octokit.net/issues/1011 for issue to investigate this further")]
@@ -302,11 +302,11 @@ namespace Octokit.Tests.Reactive
                     });
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Repository>>(firstPageUrl, null, Args.AnyAcceptHeaders)
                     .Returns(Task.FromResult(firstPageResponse));
-                gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Repository>>(secondPageUrl, null, Args.AnyAcceptHeaders)
                     .Returns(Task.FromResult(secondPageResponse));
-                gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, null, null)
+                gitHubClient.Connection.Get<List<Repository>>(thirdPageUrl, null, Args.AnyAcceptHeaders)
                     .Returns(Task.FromResult(lastPageResponse));
 
                 var repositoriesClient = new ObservableRepositoriesClient(gitHubClient);
@@ -314,9 +314,9 @@ namespace Octokit.Tests.Reactive
                 var results = await repositoriesClient.GetAllPublic(new PublicRepositoryRequest(364L)).ToArray();
 
                 Assert.Equal(7, results.Length);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, null, null);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, null, null);
-                gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, null, null);
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(firstPageUrl, null, "application/vnd.github.drax-preview+json");
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(secondPageUrl, null, "application/vnd.github.drax-preview+json");
+                gitHubClient.Connection.Received(1).Get<List<Repository>>(thirdPageUrl, null, "application/vnd.github.drax-preview+json");
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryInvitationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryInvitationsClientTests.cs
@@ -19,6 +19,15 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllForRepositoryMethod
         {
             [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHub = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryInvitationsClient(gitHub);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForRepository(42, null));
+            }
+
+            [Fact]
             public void RequestsCorrectUrl()
             {
                 var gitHub = Substitute.For<IGitHubClient>();
@@ -32,6 +41,15 @@ namespace Octokit.Tests.Reactive
 
         public class TheGetAllForCurrentMethod
         {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHub = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryInvitationsClient(gitHub);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForCurrent(null));
+            }
+
             [Fact]
             public void RequestsCorrectUrl()
             {

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -48,8 +48,19 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -59,8 +70,18 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(long repositoryId);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -72,8 +93,20 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -84,8 +117,19 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Creates a reference for a given repository

--- a/Octokit/Clients/IRepositoryInvitationsClient.cs
+++ b/Octokit/Clients/IRepositoryInvitationsClient.cs
@@ -51,8 +51,18 @@ namespace Octokit
         /// </remarks>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent();
+
+        /// <summary>
+        /// Gets all invitations for the current user.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent(ApiOptions options);
 
         /// <summary>
         /// Gets all the invitations on a repository.
@@ -62,8 +72,18 @@ namespace Octokit
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId);
+
+        /// <summary>
+        /// Gets all the invitations on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
+        /// </remarks>        
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Updates a repository invitation.

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -66,10 +66,26 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name)
         {
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name), options);
         }
 
         /// <summary>
@@ -82,7 +98,23 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAll(long repositoryId)
         {
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId));
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAll(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId), options);
         }
 
         /// <summary>
@@ -97,13 +129,30 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
+            return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
             // TODO: Handle 404 when subNamespace cannot be found
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, subNamespace));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
 
         /// <summary>
@@ -117,11 +166,27 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
+            return GetAllForSubNamespace(repositoryId, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
             // TODO: Handle 404 when subNamespace cannot be found
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoryInvitationsClient.cs
+++ b/Octokit/Clients/RepositoryInvitationsClient.cs
@@ -91,7 +91,21 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent()
         {
-            return ApiConnection.GetAll<RepositoryInvitation>(ApiUrls.UserInvitations(), AcceptHeaders.InvitationsApiPreview);
+            return GetAllForCurrent(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all invitations for the current user.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+            return ApiConnection.GetAll<RepositoryInvitation>(ApiUrls.UserInvitations(), null, AcceptHeaders.InvitationsApiPreview, options);
         }
 
         /// <summary>
@@ -104,7 +118,22 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId)
         {
-            return ApiConnection.GetAll<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), AcceptHeaders.InvitationsApiPreview);
+            return GetAllForRepository(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all the invitations on a repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository">API documentation</a> for more information.
+        /// </remarks>        
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+            return ApiConnection.GetAll<RepositoryInvitation>(ApiUrls.RepositoryInvitations(repositoryId), null, AcceptHeaders.InvitationsApiPreview, options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1586

* [x] license information included in existing calls that return `Repository` objects
* [x] Get a repository's license call
* [x] write unit tests
* [x] write integration tests