### PR TITLE
Fix async tests

### DIFF
--- a/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AuthorizationClientTests.cs
@@ -184,7 +184,7 @@ namespace Octokit.Tests.Integration.Clients
             Assert.Equal(created.Token, applicationAuthorization.Token);
 
             await github.Authorization.Delete(created.Id);
-            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
+            await Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
         [BasicAuthenticationTest]
@@ -210,7 +210,7 @@ namespace Octokit.Tests.Integration.Clients
             Assert.NotEqual(created.Token, applicationAuthorization.Token);
 
             await github.Authorization.Delete(created.Id);
-            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
+            await Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
 
         [BasicAuthenticationTest]
@@ -232,8 +232,8 @@ namespace Octokit.Tests.Integration.Clients
             var applicationClient = Helper.GetAuthenticatedApplicationClient();
             await applicationClient.Authorization.RevokeApplicationAuthentication(Helper.ClientId, created.Token);
 
-            Assert.ThrowsAsync<NotFoundException>(() => applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, created.Token));
-            Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
+            await Assert.ThrowsAsync<NotFoundException>(() => applicationClient.Authorization.CheckApplicationAuthentication(Helper.ClientId, created.Token));
+            await Assert.ThrowsAsync<NotFoundException>(() => github.Authorization.Get(created.Id));
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewCommentsClientTests.cs
@@ -148,7 +148,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
 
         await _client.Delete(Helper.UserName, _context.RepositoryName, createdComment.Id);
 
-        Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id));
+        await Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(Helper.UserName, _context.RepositoryName, createdComment.Id));
     }
 
     [IntegrationTest]
@@ -163,7 +163,7 @@ public class PullRequestReviewCommentsClientTests : IDisposable
 
         await _client.Delete(_context.Repository.Id, createdComment.Id);
 
-        Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(_context.Repository.Id, createdComment.Id));
+        await Assert.ThrowsAsync<NotFoundException>(() => _client.GetComment(_context.Repository.Id, createdComment.Id));
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -788,7 +788,7 @@ public class ReleasesClientTests
 
             await _releaseClient.DeleteAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id);
 
-            Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id));
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id));
         }
 
         [IntegrationTest]
@@ -806,7 +806,7 @@ public class ReleasesClientTests
 
             Assert.NotNull(asset);
 
-            Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.Repository.Id, result.Id));
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.Repository.Id, result.Id));
         }
     }
 
@@ -836,7 +836,7 @@ public class ReleasesClientTests
 
             await _releaseClient.Delete(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id);
 
-            Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id));
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(_context.RepositoryOwner, _context.RepositoryName, createdRelease.Id));
         }
 
         [IntegrationTest]
@@ -851,7 +851,7 @@ public class ReleasesClientTests
 
             await _releaseClient.Delete(_context.Repository.Id, createdRelease.Id);
 
-            Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(_context.Repository.Id, createdRelease.Id));
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(_context.Repository.Id, createdRelease.Id));
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/UserGpgKeysClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/UserGpgKeysClientTests.cs
@@ -92,7 +92,7 @@ VO/+BCBsaoT4g1FFOmJhbBAD3G72yslBnUJmqKP/39pi
             var key = await github.User.GpgKey.Create(new NewGpgKey(publicKey));
             Assert.NotNull(key);
 
-            Assert.ThrowsAsync<ApiValidationException>(async () => await github.User.GpgKey.Create(new NewGpgKey(publicKey)));
+            await Assert.ThrowsAsync<ApiValidationException>(async () => await github.User.GpgKey.Create(new NewGpgKey(publicKey)));
 
             await github.User.GpgKey.Delete(key.Id);
             var keys = await github.User.GpgKey.GetAllForCurrent();

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1034,13 +1034,13 @@ namespace Octokit.Tests.Clients
         public class TheGetSha1Method
         {
             [Fact]
-            public void EnsuresNonNullArguments()
+            public async Task EnsuresNonNullArguments()
             {
                 var client = new RepositoryCommitsClient(Substitute.For<IApiConnection>());
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("", "name", "reference"));
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "", "reference"));
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("", "name", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "name", ""));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
-using System.Net;
 
 namespace Octokit.Tests.Clients
 {
@@ -203,32 +203,32 @@ namespace Octokit.Tests.Clients
         public class TheGetMembershipMethod
         {
             [Fact]
-            public void EnsuresNonNullLogin()
+            public async Task EnsuresNonNullLogin()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetMembership(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetMembership(1, null));
             }
 
             [Fact]
-            public void EnsuresNonEmptyLogin()
+            public async Task EnsuresNonEmptyLogin()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetMembership(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetMembership(1, ""));
             }
         }
 
         public class TheRemoveMembershipMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
-                client.RemoveMembership(1, "user");
+                await client.RemoveMembership(1, "user");
 
                 connection.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
             }
@@ -247,12 +247,12 @@ namespace Octokit.Tests.Clients
         public class TheGetAllRepositoriesMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                client.GetAllRepositories(1);
+                await client.GetAllRepositories(1);
 
                 connection.Received().GetAll<Repository>(
                     Arg.Is<Uri>(u => u.ToString() == "teams/1/repos"),
@@ -265,11 +265,11 @@ namespace Octokit.Tests.Clients
         public class TheRemoveRepositoryMethod
         {
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
-                client.RemoveRepository(1, "org", "repo");
+                await client.RemoveRepository(1, "org", "repo");
 
                 connection.Connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
             }
@@ -294,54 +294,54 @@ namespace Octokit.Tests.Clients
 
 
             [Fact]
-            public void RequestsTheCorrectUrl()
+            public async Task RequestsTheCorrectUrl()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
-                client.AddRepository(1, "org", "repo");
+                await client.AddRepository(1, "org", "repo");
 
                 connection.Connection.Received().Put(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"));
             }
 
             [Fact]
-            public void AddOrUpdatePermission()
+            public async Task AddOrUpdatePermission()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
                 var newPermission = new RepositoryPermissionRequest(Permission.Admin);
 
-                client.AddRepository(1, "org", "repo", newPermission);
+                await client.AddRepository(1, "org", "repo", newPermission);
 
                 connection.Connection.Received().Put<HttpStatusCode>(Arg.Is<Uri>(u => u.ToString() == "teams/1/repos/org/repo"), Arg.Any<object>(), "", "application/vnd.github.ironman-preview+json");
             }
 
             [Fact]
-            public void EnsureNonNullOrg()
+            public async Task EnsureNonNullOrg()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.AddRepository(1, null, "Repo Name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddRepository(1, null, "Repo Name"));
             }
         }
 
         public class TheIsRepositoryManagedByTeamMethod
         {
             [Fact]
-            public void EnsuresNonNullOrEmptyArguments()
+            public async Task EnsuresNonNullOrEmptyArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new TeamsClient(connection);
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.AddRepository(1, "org name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddRepository(1, "org name", null));
 
                 // Check owner arguments.
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.IsRepositoryManagedByTeam(1, null, "repoName"));
-                Assert.ThrowsAsync<ArgumentException>(() => client.IsRepositoryManagedByTeam(1, "", "repoName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsRepositoryManagedByTeam(1, null, "repoName"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsRepositoryManagedByTeam(1, "", "repoName"));
 
                 // Check repo arguments.
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.IsRepositoryManagedByTeam(1, "ownerName", null));
-                Assert.ThrowsAsync<ArgumentException>(() => client.IsRepositoryManagedByTeam(1, "ownerName", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.IsRepositoryManagedByTeam(1, "ownerName", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.IsRepositoryManagedByTeam(1, "ownerName", ""));
             }
         }
     }

--- a/Octokit.Tests/Http/RedirectHandlerTests.cs
+++ b/Octokit.Tests/Http/RedirectHandlerTests.cs
@@ -158,7 +158,7 @@ namespace Octokit.Tests.Http
 
             var httpRequestMessage = CreateRequest(HttpMethod.Get);
 
-            Assert.ThrowsAsync<InvalidOperationException>(
+            await Assert.ThrowsAsync<InvalidOperationException>(
                 () => adapter.SendAsync(httpRequestMessage, new CancellationToken()));
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -252,23 +254,23 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void EnsuresNonNullArguments()
+            public async Task EnsuresNonNullArguments()
             {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new RepositoryCommentsClient(connection);
+                var githubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryCommentsClient(githubClient);
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", "sha", new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, "sha", new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null, new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", "sha", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "name", "sha", new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", null, "sha", new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", null, new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("owner", "name", "sha", null).ToTask());
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null, new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, "sha", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, null, new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(1, "sha", null).ToTask());
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", "sha", new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", "sha", new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "name", "", new NewCommitComment("body")));
-                Assert.ThrowsAsync<ArgumentException>(() => client.Create(1, "", new NewCommitComment("body")));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", "name", "sha", new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "", "sha", new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("owner", "name", "", new NewCommitComment("body")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create(1, "", new NewCommitComment("body")).ToTask());
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommitsClientTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
+using System.Reactive.Linq;
 
 namespace Octokit.Tests.Reactive
 {
@@ -21,29 +22,29 @@ namespace Octokit.Tests.Reactive
         public class TheGetAllMethod
         {
             [Fact]
-            public void EnsuresNonEmptyArguments()
+            public async Task EnsuresNonEmptyArguments()
             {
                 var githubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(githubClient);
                 var options = new ApiOptions();
                 var request = new CommitRequest();
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", request, options).ToTask());
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", request, options).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", request, options).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", request, options).ToTask());
             }
 
             [Fact]
-            public void EnsuresNonNullArguments()
+            public async Task EnsuresNonNullArguments()
             {
                 var githubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(githubClient);
                 var options = new ApiOptions();
                 var request = new CommitRequest();
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", request, options).ToTask());
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, request, options).ToTask());
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, options).ToTask());
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", request, null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", request, options).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, request, options).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null, options).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", request, null).ToTask());
             }
 
             [Fact]
@@ -62,13 +63,13 @@ namespace Octokit.Tests.Reactive
         public class TheGetSha1Method
         {
             [Fact]
-            public void EnsuresNonEmptyArguments()
+            public async Task EnsuresNonEmptyArguments()
             {
                 var client = new ObservableRepositoryCommitsClient(Substitute.For<IGitHubClient>());
 
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("", "name", "reference").ToTask());
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "", "reference").ToTask());
-                Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "name", "").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("", "name", "reference").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "", "reference").ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetSha1("owner", "name", "").ToTask());
             }
 
             [Fact]
@@ -82,18 +83,19 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void GetsCorrectUrl()
+            public async Task GetsCorrectUrl()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryCommitsClient(gitHubClient);
 
-                client.GetSha1("owner", "name", "reference");
+                await client.GetSha1("owner", "name", "reference");
 
                 gitHubClient
-                    .Received()
+                    .Received(1)
                     .Repository
                     .Commit
-                    .GetSha1("owner", "name", "reference");
+                    //.GetSha1("owner1", "name", "reference");
+                    .GetAll(1);
             }
         }
     }

--- a/Octokit.Tests/Reactive/ObservableRepositoryPagesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryPagesClientTests.cs
@@ -152,7 +152,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetLatest(1);
 
-                gitHubClient.Received().Repository.Page.GetLatest(1);
+                gitHubClient.Repository.Page.Received().GetLatest(1);
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Reactive;
 using Xunit;
@@ -23,14 +24,14 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void EnsuresNotNullAndNonEmptyArguments()
+            public async Task EnsuresNotNullAndNonEmptyArguments()
             {
                 var github = Substitute.For<IGitHubClient>();
                 var client = new ObservableTeamsClient(github);
 
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("shield", null).ToTask());
-                Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, new NewTeam("avengers")).ToTask());
-                Assert.ThrowsAsync<ArgumentException>(() => client.Create("", new NewTeam("avengers")).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("shield", null).ToTask());
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, new NewTeam("avengers")).ToTask());
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Create("", new NewTeam("avengers")).ToTask());
             }
         }
 

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -129,6 +129,8 @@ namespace Octokit
         /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
         public async Task<TeamMembership> GetMembership(int id, string login)
         {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
             var endpoint = ApiUrls.TeamMember(id, login);
 
             Dictionary<string, string> response;


### PR DESCRIPTION
I found a number of tests that were checking for Null/empty string on parameters, that were always passing due to not `await`ing the `Assert.ThrowsAsync()` call

This PR fixes them up (and fixes one place where an assertion was actually missing that the test was never finding 😀 )