### PR TITLE
Allow users to access unsupported Activty event payloads as Json strings

### DIFF
--- a/Octokit.Tests.Integration/Clients/EventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/EventsClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -295,77 +296,161 @@ namespace Octokit.Tests.Integration.Clients
 
         public class EventPayloads
         {
-            readonly IEnumerable<Activity> _events;
+            readonly IGitHubClient _github;
+
             public EventPayloads()
             {
-                var github = Helper.GetAuthenticatedClient();
-                _events = github.Activity.Events.GetAllUserPerformed("shiftkey").Result;
+                _github = Helper.GetAuthenticatedClient();
             }
 
             [IntegrationTest]
             public void AllEventsHavePayloads()
             {
-                Assert.True(_events.All(e => e.Payload != null));
+                var events = _github.Activity.Events.GetAllUserPerformed("shiftkey", new ApiOptions { PageSize = 100, PageCount = 3 }).Result;
+                Assert.True(events.All(e => e.Payload != null));
             }
 
-            [IntegrationTest(Skip = "no longer able to access this event")]
-            public void IssueCommentPayloadEventDeserializesCorrectly()
+            [IntegrationTest]
+            public void AllEventsHaveJsonPayloads()
             {
-                var commentEvent = _events.FirstOrDefault(e => e.Id == "2628548686");
+                var events = _github.Activity.Events.GetAllUserPerformed("shiftkey", new ApiOptions { PageSize = 100, PageCount = 3 }).Result;
+                Assert.True(events.All(e => !string.IsNullOrEmpty(e.PayloadJson)));
+            }
+
+            [IntegrationTest]
+            public void CommitCommentPayloadDeserializesCorrectly()
+            {
+                var commitCommentEvent = FindEventOfType("CommitCommentEvent");
+                Assert.NotNull(commitCommentEvent);
+                Assert.Equal(typeof(CommitCommentPayload), commitCommentEvent.Payload.GetType());
+                var commentPayload = commitCommentEvent.Payload as CommitCommentPayload;
+                Assert.NotNull(commentPayload);
+                Assert.NotNull(commentPayload.Comment);
+                Assert.True(!string.IsNullOrEmpty(commentPayload.Comment.Body));
+            }
+
+            [IntegrationTest]
+            public void ForkEventPayloadDeserializesCorrectly()
+            {
+                var forkEvent = FindEventOfType("ForkEvent");
+                Assert.NotNull(forkEvent);
+                Assert.Equal(typeof(ForkEventPayload), forkEvent.Payload.GetType());
+                var forkPayload = forkEvent.Payload as ForkEventPayload;
+                Assert.NotNull(forkPayload);
+                Assert.NotNull(forkPayload.Forkee);
+                Assert.True(!string.IsNullOrEmpty(forkPayload.Forkee.FullName));
+            }
+
+            [IntegrationTest]
+            public void IssueCommentPayloadDeserializesCorrectly()
+            {
+                var commentEvent = FindEventOfType("IssueCommentEvent");
                 Assert.NotNull(commentEvent);
-                Assert.Equal("IssueCommentEvent", commentEvent.Type);
+                Assert.Equal(typeof(IssueCommentPayload), commentEvent.Payload.GetType());
                 var commentPayload = commentEvent.Payload as IssueCommentPayload;
                 Assert.NotNull(commentPayload);
                 Assert.Equal("created", commentPayload.Action);
                 Assert.NotNull(commentPayload.Comment);
-                Assert.Equal("@joshvera just going to give this a once-over to ensure it matches up with our other conventions before merging", commentPayload.Comment.Body);
+                Assert.NotNull(commentPayload.Comment.Body);
                 Assert.NotNull(commentPayload.Issue);
-                Assert.Equal(742, commentPayload.Issue.Number);
+                Assert.True(commentPayload.Issue.Number > 0);
             }
 
-            [IntegrationTest(Skip = "no longer able to access this event")]
-            public void PushEventPayloadDeserializesCorrectly()
+            [IntegrationTest]
+            public void IssueEventPayloadDeserializesCorrectly()
             {
-                var pushEvent = _events.FirstOrDefault(e => e.Id == "2628858765");
-                Assert.NotNull(pushEvent);
-                Assert.Equal("PushEvent", pushEvent.Type);
-                var pushPayload = pushEvent.Payload as PushEventPayload;
-                Assert.NotNull(pushPayload);
-                Assert.NotNull(pushPayload.Commits);
-                Assert.Equal(1, pushPayload.Commits.Count);
-                Assert.Equal("3cdcba0ccbea0e6d13ae94249fbb294d71648321", pushPayload.Commits.FirstOrDefault().Sha);
-                Assert.Equal("3cdcba0ccbea0e6d13ae94249fbb294d71648321", pushPayload.Head);
-                Assert.Equal("refs/heads/release-candidate", pushPayload.Ref);
-                Assert.Equal(1, pushPayload.Size);
+                var issueEvent = FindEventOfType("IssuesEvent");
+                Assert.NotNull(issueEvent);
+                Assert.Equal(typeof(IssueEventPayload), issueEvent.Payload.GetType());
+                var issuePayload = issueEvent.Payload as IssueEventPayload;
+                Assert.NotNull(issuePayload);
+                Assert.Contains(issuePayload.Action, new[] { "created", "closed" });
+                Assert.NotNull(issuePayload.Issue);
+                Assert.True(issuePayload.Issue.Number > 0);
             }
 
-            [IntegrationTest(Skip = "no longer able to access this event")]
-            public void PREventPayloadDeserializesCorrectly()
+            [IntegrationTest]
+            public void PullRequestCommentPayloadDeserializesCorrectly()
             {
-                var prEvent = _events.FirstOrDefault(e => e.Id == "2628718313");
-                Assert.NotNull(prEvent);
-                Assert.Equal("PullRequestEvent", prEvent.Type);
-                var prPayload = prEvent.Payload as PullRequestEventPayload;
-                Assert.NotNull(prPayload);
-                Assert.Equal("opened", prPayload.Action);
-                Assert.Equal(743, prPayload.Number);
-                Assert.NotNull(prPayload.PullRequest);
-                Assert.Equal(743, prPayload.PullRequest.Number);
-            }
-
-            [IntegrationTest(Skip = "no longer able to access this event")]
-            public void PRReviewCommentEventPayloadDeserializesCorrectly()
-            {
-                var prrcEvent = _events.First(e => e.Id == "2623246246");
+                var prrcEvent = FindEventOfType("PullRequestReviewCommentEvent");
                 Assert.NotNull(prrcEvent);
-                Assert.Equal("PullRequestReviewCommentEvent", prrcEvent.Type);
+                Assert.Equal(typeof(PullRequestCommentPayload), prrcEvent.Payload.GetType());
                 var prrcPayload = prrcEvent.Payload as PullRequestCommentPayload;
                 Assert.NotNull(prrcPayload);
                 Assert.Equal("created", prrcPayload.Action);
                 Assert.NotNull(prrcPayload.Comment);
-                Assert.Equal("Suuuuuuuuure :P", prrcPayload.Comment.Body);
+                Assert.True(!string.IsNullOrEmpty(prrcPayload.Comment.Body));
                 Assert.NotNull(prrcPayload.PullRequest);
-                Assert.Equal(737, prrcPayload.PullRequest.Number);
+                Assert.True(prrcPayload.PullRequest.Number > 0);
+            }
+
+            [IntegrationTest]
+            public void PullRequestEventPayloadDeserializesCorrectly()
+            {
+                var prEvent = FindEventOfType("PullRequestEvent");
+                Assert.NotNull(prEvent);
+                Assert.Equal(typeof(PullRequestEventPayload), prEvent.Payload.GetType());
+                var prPayload = prEvent.Payload as PullRequestEventPayload;
+                Assert.NotNull(prPayload);
+                Assert.Contains(prPayload.Action, new[] { "opened", "closed" });
+                Assert.True(prPayload.Number > 0);
+                Assert.NotNull(prPayload.PullRequest);
+                Assert.True(prPayload.PullRequest.Number > 0);
+            }
+
+            [IntegrationTest]
+            public void PushEventPayloadDeserializesCorrectly()
+            {
+                var pushEvent = FindEventOfType("PushEvent");
+                Assert.NotNull(pushEvent);
+                Assert.Equal(typeof(PushEventPayload), pushEvent.Payload.GetType());
+                var pushPayload = pushEvent.Payload as PushEventPayload;
+                Assert.NotNull(pushPayload);
+                Assert.True(!string.IsNullOrEmpty(pushPayload.Head));
+                Assert.True(!string.IsNullOrEmpty(pushPayload.Ref));
+                Assert.True(pushPayload.Size > 0);
+                Assert.NotNull(pushPayload.Commits);
+                Assert.True(pushPayload.Commits.Count > 0);
+                Assert.True(!string.IsNullOrEmpty(pushPayload.Commits.FirstOrDefault().Sha));
+            }
+
+            [IntegrationTest]
+            public void StarredEventPayloadDeserializesCorrectly()
+            {
+                var starredEvent = FindEventOfType("WatchEvent");
+                Assert.NotNull(starredEvent);
+                Assert.Equal(typeof(StarredEventPayload), starredEvent.Payload.GetType());
+                var starredPayload = starredEvent.Payload as StarredEventPayload;
+                Assert.NotNull(starredPayload);
+                Assert.Equal("started", starredPayload.Action);
+            }
+
+            [IntegrationTest]
+            public void UnsupportedEventPayloadDeserializesCorrectly()
+            {
+                var unsupportedEvent = FindEventOfType("DeleteEvent");
+                Assert.NotNull(unsupportedEvent);
+                Assert.Equal(typeof(ActivityPayload), unsupportedEvent.Payload.GetType());
+                var unsupportedPayload = unsupportedEvent.Payload;
+                Assert.NotNull(unsupportedPayload);
+                Assert.True(unsupportedEvent.PayloadJson.Contains("ref"));
+                Assert.True(unsupportedEvent.PayloadJson.Contains("ref_type"));
+                Assert.True(unsupportedEvent.PayloadJson.Contains("pusher_type"));
+            }
+
+            public Activity FindEventOfType(string eventType)
+            {
+                var page = 1;
+                Activity foundEvent = null;
+
+                while (foundEvent == null)
+                {
+                    var events = _github.Activity.Events.GetAllForRepository("octokit", "octokit.net", new ApiOptions { PageSize = 100, PageCount = 1, StartPage = page }).Result;
+                    foundEvent = events.FirstOrDefault(x => x.Type == eventType);
+                    page++;
+                }
+
+                return foundEvent;
             }
         }
     }

--- a/Octokit/Helpers/ParameterAttribute.cs
+++ b/Octokit/Helpers/ParameterAttribute.cs
@@ -18,5 +18,10 @@ namespace Octokit.Internal
         /// The name to use in place of the enum's value
         /// </summary>
         public string Value { get; set; }
+
+        /// <summary>
+        /// Whether to allow more than one response parameter to map to this same API value
+        /// </summary>
+        public bool AllowDuplicates { get; set; }
     }
 }

--- a/Octokit/Models/Response/Activity.cs
+++ b/Octokit/Models/Response/Activity.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -64,6 +65,9 @@ namespace Octokit
         /// The payload associated with the activity event.
         /// </summary>
         public ActivityPayload Payload { get; protected set; }
+
+        [Parameter(Key = "payload", AllowDuplicates = true)]
+        public string PayloadJson { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/ActivityPayloads/ActivityPayload.cs
+++ b/Octokit/Models/Response/ActivityPayloads/ActivityPayload.cs
@@ -10,7 +10,7 @@ namespace Octokit
 
         internal string DebuggerDisplay
         {
-            get { return Repository.FullName; }
+            get { return $"Type: {this.GetType().Name} Repo: {Repository?.FullName ?? "null"}"; }
         }
     }
 }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1480,7 +1480,12 @@ namespace Octokit
                             foreach (KeyValuePair<string, KeyValuePair<Type, ReflectionUtils.SetDelegate>> setter in SetCache[type])
                             {
                                 object jsonValue;
-                                if (jsonObject.TryGetValue(setter.Key, out jsonValue))
+                                var key = setter.Key;
+                                if (key.Contains("_octokit_"))
+                                {
+                                    key = key.Substring(0, key.IndexOf("_octokit_"));
+                                }
+                                if (jsonObject.TryGetValue(key, out jsonValue))
                                 {
                                     jsonValue = DeserializeObject(jsonValue, setter.Value.Key);
                                     setter.Value.Value(obj, jsonValue);

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1474,6 +1474,8 @@ namespace Octokit
                     {
                         if (type == typeof(object))
                             obj = value;
+                        else if (type == typeof(string))
+                            obj = value.ToString();
                         else
                         {
                             obj = ConstructorCache[type]();


### PR DESCRIPTION
## Background
As part of the [Events API](https://developer.github.com/v3/activity/events/types/), `Activity` responses are retrieved that contain a `Payload` field which varies according to the event in question.   In Octokit, we implement the `Payload` field of the `Activity` response model as a base type of `ActivityPayload` but [specific inherited payload classes](https://github.com/octokit/octokit.net/tree/34d13743e5bdf70b7e2ab6b3e44531050f63ee26/Octokit/Models/Response/ActivityPayloads) such as `IssueCommentPayload`, `PullRequestEventPayload` etc are assigned to this field via some deserializer ~~hackery~~ [MAGIC](https://github.com/octokit/octokit.net/blob/34d13743e5bdf70b7e2ab6b3e44531050f63ee26/Octokit/Http/SimpleJsonSerializer.cs#L132-L133) 😀 

## Problem
When GitHub API implements new event payloads, the payload cannot be obtained via Octokit until a response model class for the specific payload is added (and the [magic switch statement](https://github.com/octokit/octokit.net/blob/34d13743e5bdf70b7e2ab6b3e44531050f63ee26/Octokit/Http/SimpleJsonSerializer.cs#L159-L178) is updated).  

It actually turns out that GitHub API has currently [37 event payloads](https://developer.github.com/v3/activity/events/types/), and only 8 of these are implemented in Octokit.net! 🤔 

## What does this PR do?
Whilst we should implement all of these outstanding payload types (and any future ones!) (see #1646), this PR aims to add a generic "workaround" to Octokit so that in addition to the specific `Payload` response model classes, there is a `PayloadJson` field containing the raw json of the event payload.  This field can be used by consumers to obtain the payload of all events - regardless of whether they are yet implemented in Octokit or not.

A picture tells 1000 words so here is some debugger output showing what the `Payload` and `PayloadJson` fields look like for an implemented and unimplemented event type:

`IssueCommentEvent` (implemented in Octokit)
![image](https://user-images.githubusercontent.com/5425163/28867631-0c49a436-77ba-11e7-8a69-cfe8704dffe9.png)
The Payload is of explicit type `IssueCommentPayload` (and `PayloadJson` is also available)

`DeleteEvent` (not currently implemented in Octokit)
![image](https://user-images.githubusercontent.com/5425163/28867775-95d9525a-77ba-11e7-9a63-fbaa0752d7be.png)
The Payload is of base type `ActivityPayload` and doesn't provide anything useful, but the `PayloadJson` is now available and can be used by clients to at least understand this event prior to a Model for it being added to Octokit.net


## Implementation Notes
Implementing this required some tweaks to the deserializer so that we can have more than one response field that maps to the same API value (eg in this case the API field `payload` maps to both `ActivityPayload Payload` and `string PayloadJson`).  To limit the impact, I added a new field to the `[Parameter]` attribute we use, that explicitly marks the parameter declaration `AllowDuplicates`.  In the internals of the deserializer, it then appends a unique value to the api field (so it can be stored in the dictionary for the `SetterCache` along with other instances of the same api field).  In the case of `PayloadJson` it would end up in the `SetterCache` as `payload_octokit_payload_json`.  Then when populating models from the api response it removes this appended text from the dictionary key, so it can find the correct API field (`payload`).  It's a bit hacky but IMO no more so than the existing "magic" that was switching out the classes derived from `ActivityPayload` base class in the first place.

A 2nd deserializer tweak was needed so that an entire `JsonObject` could be written to a `string` property (by calling `.ToString()` on it) - this is used so that the `payload` API field (a `JsonObject` structure) can be mapped to our `string PayloadJson` field.

I also fixed up the existing Event payload integration tests which were previuosly skipped due to them looking for events that are too long ago.  I tweaked them to use our pagination support to keep searching until they find an event of the desired type.  We also now have an integration test for each of the 8 payload types octokit currently supports.  NOTE that there is a chance that these tests can fail if we hit the pagination limit of the events API before we encounter an event of the desired type but this is acceptable for the time being IMO