### PR TITLE
Fix broken JSON deserialization in .NET 4.5

### DIFF
--- a/Octokit.Tests.Conventions/ClientConstructorTests.cs
+++ b/Octokit.Tests.Conventions/ClientConstructorTests.cs
@@ -9,7 +9,7 @@ namespace Octokit.Tests.Conventions
     public class ClientConstructorTests
     {
         [Theory]
-        [MemberData("GetTestConstructorClasses")]
+        [MemberData(nameof(GetTestConstructorClasses))]
         public void CheckTestConstructorNames(Type type)
         {
             const string constructorTestClassName = "TheCtor";

--- a/Octokit.Tests.Conventions/ModelTests.cs
+++ b/Octokit.Tests.Conventions/ModelTests.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Conventions
         private static readonly Assembly Octokit = typeof(AuthorizationUpdate).GetTypeInfo().Assembly;
 
         [Theory]
-        [MemberData("ModelTypes")]
+        [MemberData(nameof(ModelTypes))]
         public void AllModelsHaveDebuggerDisplayAttribute(Type modelType)
         {
             var attribute = modelType.GetTypeInfo().GetCustomAttribute<DebuggerDisplayAttribute>(inherit: false);
@@ -41,7 +41,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("ResponseModelTypes")]
+        [MemberData(nameof(ResponseModelTypes))]
         public void AllResponseModelsHavePublicParameterlessCtors(Type modelType)
         {
             var ctor = modelType.GetConstructor(Type.EmptyTypes);
@@ -53,7 +53,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("ResponseModelTypes")]
+        [MemberData(nameof(ResponseModelTypes))]
         public void ResponseModelsHaveGetterOnlyProperties(Type modelType)
         {
             var mutableProperties = new List<PropertyInfo>();
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("ResponseModelTypes")]
+        [MemberData(nameof(ResponseModelTypes))]
         public void ResponseModelsHaveReadOnlyCollections(Type modelType)
         {
             var mutableCollectionProperties = new List<PropertyInfo>();
@@ -111,7 +111,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("ResponseModelTypes")]
+        [MemberData(nameof(ResponseModelTypes))]
         public void ResponseModelsUseStringEnumWrapper(Type modelType)
         {
             var enumProperties = modelType.GetProperties()
@@ -124,7 +124,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("ModelTypesWithUrlProperties")]
+        [MemberData(nameof(ModelTypesWithUrlProperties))]
         public void ModelsHaveUrlPropertiesOfTypeString(Type modelType)
         {
             var propertiesWithInvalidType = modelType
@@ -140,7 +140,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("EnumTypes")]
+        [MemberData(nameof(EnumTypes))]
         public void EnumMembersHaveParameterAttribute(Type enumType)
         {
             if (enumType == typeof(Language))

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -4,7 +4,7 @@
     <Description>Convention-based tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests.Conventions</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests.Conventions</AssemblyName>
     <PackageId>Octokit.Tests.Conventions</PackageId>
@@ -24,9 +24,12 @@
   <ItemGroup>
     <Compile Include="..\Octokit.Tests\Helpers\AssertEx.cs" />
     <None Include="app.config" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup>
     <ProjectReference Include="..\Octokit\Octokit.csproj" />
     <ProjectReference Include="..\Octokit.Reactive\Octokit.Reactive.csproj" />
     <ProjectReference Include="..\Octokit.Tests\Octokit.Tests.csproj" />

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -32,10 +32,6 @@
     <ProjectReference Include="..\Octokit.Tests\Octokit.Tests.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <DefineConstants>$(DefineConstants);NO_SERIALIZABLE;HAS_TYPEINFO</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -9,7 +9,7 @@ namespace Octokit.Tests.Conventions
     public class PaginationTests
     {
         [Theory(Skip = "Enable this to run it and find all the places where things break")]
-        [MemberData("GetClientInterfaces")]
+        [MemberData(nameof(GetClientInterfaces))]
         public void CheckObservableClients(Type clientInterface)
         {
             var methodsOrdered = clientInterface.GetMethodsOrdered();
@@ -28,7 +28,7 @@ namespace Octokit.Tests.Conventions
         }
 
         [Theory]
-        [MemberData("GetClientInterfaces")]
+        [MemberData(nameof(GetClientInterfaces))]
         public void CheckPaginationGetAllMethodNames(Type clientInterface)
         {
             var methodsOrdered = clientInterface.GetMethodsOrdered();

--- a/Octokit.Tests.Conventions/SyncObservableClients.cs
+++ b/Octokit.Tests.Conventions/SyncObservableClients.cs
@@ -11,7 +11,7 @@ namespace Octokit.Tests.Conventions
     public class SyncObservableClients
     {
         [Theory]
-        [MemberData("GetClientInterfaces")]
+        [MemberData(nameof(GetClientInterfaces))]
         public void CheckObservableClients(Type clientInterface)
         {
             var observableClient = clientInterface.GetObservableClientInterface();

--- a/Octokit.Tests.Conventions/xunit.runner.json
+++ b/Octokit.Tests.Conventions/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+    "appDomain": "denied"
+}

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -23,6 +23,9 @@
 
   <ItemGroup>
     <None Include="app.config" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -41,6 +41,11 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>Tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests</AssemblyName>
     <PackageId>Octokit.Tests</PackageId>
@@ -25,7 +25,7 @@
     <None Include="app.config" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup>
     <ProjectReference Include="..\Octokit\Octokit.csproj" />
     <ProjectReference Include="..\Octokit.Reactive\Octokit.Reactive.csproj" />
     <PackageReference Include="NSubstitute" Version="2.0.2" />

--- a/Octokit.Tests/xunit.runner.json
+++ b/Octokit.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+    "appDomain": "denied"
+}

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS;SIMPLE_JSON_INTERNAL,SIMPLE_JSON_OBJARRAYINTERNAL,SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -1,3 +1,6 @@
+using Cake.Common;
+using Cake.Common.Diagnostics;
+using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Frosting;
@@ -22,6 +25,26 @@ public class Context : FrostingContext
     public bool TravisCI { get; set; }
 
     public Project[] Projects { get; set; }
+
+    public DotNetCoreTestSettings GetTestSettings()
+    {
+        var settings = new DotNetCoreTestSettings
+        {
+            Configuration = Configuration,
+            NoBuild = true,
+            Verbose = false
+        };
+
+        if (!this.IsRunningOnWindows())
+        {
+            var testFramework = "netcoreapp1.0";
+
+            this.Information($"Running tests against {testFramework} only as we're not on Windows.");
+            settings.Framework = testFramework;
+        }
+
+        return settings;
+    }
 
     public Context(ICakeContext context)
         : base(context)

--- a/build/Tasks/ConventionTests.cs
+++ b/build/Tasks/ConventionTests.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Cake.Common.Diagnostics;
 using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Frosting;
 
 [Dependency(typeof(Build))]
@@ -12,12 +11,7 @@ public sealed class ConventionTests : FrostingTask<Context>
         foreach (var project in context.Projects.Where(x => x.ConventionTests))
         {
             context.Information("Executing Convention Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, new DotNetCoreTestSettings
-            {
-                Configuration = context.Configuration,
-                NoBuild = true,
-                Verbose = false
-            });
+            context.DotNetCoreTest(project.Path.FullPath, context.GetTestSettings());
         }
     }
 }

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Test;
@@ -9,15 +10,25 @@ public sealed class UnitTests : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
+        var testSettings = new DotNetCoreTestSettings
+        {
+            Configuration = context.Configuration,
+            NoBuild = true,
+            Verbose = false
+        };
+
+        if (!context.IsRunningOnWindows())
+        {
+            var testFramework = "netcoreapp1.0";
+
+            context.Information($"Running tests against {testFramework} only as we're not on Windows.");
+            testSettings.Framework = testFramework;
+        }
+
         foreach (var project in context.Projects.Where(x => x.UnitTests))
         {
             context.Information("Executing Unit Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, new DotNetCoreTestSettings
-            {
-                Configuration = context.Configuration,
-                NoBuild = true,
-                Verbose = false
-            });
+            context.DotNetCoreTest(project.Path.FullPath, testSettings);
         }
     }
 }

--- a/build/Tasks/UnitTests.cs
+++ b/build/Tasks/UnitTests.cs
@@ -1,8 +1,6 @@
 using System.Linq;
-using Cake.Common;
 using Cake.Common.Diagnostics;
 using Cake.Common.Tools.DotNetCore;
-using Cake.Common.Tools.DotNetCore.Test;
 using Cake.Frosting;
 
 [Dependency(typeof(Build))]
@@ -10,25 +8,10 @@ public sealed class UnitTests : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        var testSettings = new DotNetCoreTestSettings
-        {
-            Configuration = context.Configuration,
-            NoBuild = true,
-            Verbose = false
-        };
-
-        if (!context.IsRunningOnWindows())
-        {
-            var testFramework = "netcoreapp1.0";
-
-            context.Information($"Running tests against {testFramework} only as we're not on Windows.");
-            testSettings.Framework = testFramework;
-        }
-
         foreach (var project in context.Projects.Where(x => x.UnitTests))
         {
             context.Information("Executing Unit Tests Project {0}...", project.Name);
-            context.DotNetCoreTest(project.Path.FullPath, testSettings);
+            context.DotNetCoreTest(project.Path.FullPath, context.GetTestSettings());
         }
     }
 }


### PR DESCRIPTION
Fixes #1634 

One funny thing is that running tests with `dotnet test` against `net452` is *very* slow on my machine:

 - ~4 seconds for `netcoreapp1.0`
 - more than 2 minutes for `net452`

I want to see if the same thing happens on the build server.
If it does, I trialled using `dotnet xunit` and it was much faster, so that could be a workaround, but we'd have to change the Cake build script, and I don't if there's a wrapper for `dotnet xunit` already since it's pretty early days.

