### PR TITLE
Fix Uri.ApplyParameters() to handle relative Uri's that have existing parameters

### DIFF
--- a/Octokit.Tests/Helpers/UriExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/UriExtensionsTests.cs
@@ -23,6 +23,20 @@ namespace Octokit.Tests.Helpers
             }
 
             [Fact]
+            public void AppendsParametersAsQueryStringWithRelativeUri()
+            {
+                var uri = new Uri("issues", UriKind.Relative);
+
+                var uriWithParameters = uri.ApplyParameters(new Dictionary<string, string>
+                {
+                    {"foo", "fooval"},
+                    {"bar", "barval"}
+                });
+
+                Assert.Equal(new Uri("issues?foo=fooval&bar=barval", UriKind.Relative), uriWithParameters);
+            }
+
+            [Fact]
             public void ThrowsExceptionWhenNullValueProvided()
             {
                 var uri = new Uri("https://example.com");
@@ -36,17 +50,16 @@ namespace Octokit.Tests.Helpers
             }
 
             [Fact]
-            public void AppendsParametersAsQueryStringToRelativeUri()
+            public void ThrowsExceptionWhenNullValueProvidedWithRelativeUri()
             {
-                var uri = new Uri("issues", UriKind.Relative);
+                var uri = new Uri("api/example", UriKind.Relative);
 
-                var uriWithParameters = uri.ApplyParameters(new Dictionary<string, string>
+                var parameters = new Dictionary<string, string>
                 {
-                    {"foo", "fooval"},
-                    {"bar", "barval"}
-                });
+                    {"foo", null }
+                };
 
-                Assert.Equal(new Uri("issues?foo=fooval&bar=barval", UriKind.Relative), uriWithParameters);
+                Assert.Throws<ArgumentNullException>(() => uri.ApplyParameters(parameters));
             }
 
             [Fact]
@@ -62,24 +75,61 @@ namespace Octokit.Tests.Helpers
             }
 
             [Fact]
+            public void DoesNotChangeUrlWhenParametersEmptyWithRelativeUri()
+            {
+                var uri = new Uri("api/example", UriKind.Relative);
+
+                var uriWithEmptyParameters = uri.ApplyParameters(new Dictionary<string, string>());
+                var uriWithNullParameters = uri.ApplyParameters(null);
+
+                Assert.Equal(uri, uriWithEmptyParameters);
+                Assert.Equal(uri, uriWithNullParameters);
+            }
+
+            [Fact]
             public void CombinesExistingParametersWithNewParameters()
             {
                 var uri = new Uri("https://api.github.com/repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2");
 
-                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" } };
-
+                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" }, { "per_page", "5" } };
+                
                 var actual = uri.ApplyParameters(parameters);
 
-                Assert.True(actual.Query.Contains("state=open"));
-                Assert.True(actual.Query.Contains("sort=other"));
-                Assert.True(actual.Query.Contains("direction=asc"));
-                Assert.True(actual.Query.Contains("page=2"));
+                Assert.Equal(
+                    new Uri("https://api.github.com/repositories/1/milestones?state=open&sort=other&per_page=5&direction=asc&page=2"),
+                    actual);
+            }
+
+            [Fact]
+            public void CombinesExistingParametersWithNewParametersToRelativeUri()
+            {
+                var uri = new Uri("repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2", UriKind.Relative);
+
+                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" }, { "per_page", "5" } };
+                
+                var actual = uri.ApplyParameters(parameters);
+
+                Assert.Equal(
+                    new Uri("repositories/1/milestones?state=open&sort=other&per_page=5&direction=asc&page=2", UriKind.Relative),
+                    actual);
             }
 
             [Fact]
             public void DoesNotChangePassedInDictionary()
             {
                 var uri = new Uri("https://api.github.com/repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2");
+
+                var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" } };
+
+                uri.ApplyParameters(parameters);
+
+                Assert.Equal(2, parameters.Count);
+            }
+
+            [Fact]
+            public void DoesNotChangePassedInDictionaryForRelativeUri()
+            {
+                var uri = new Uri("/repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2", UriKind.Relative);
 
                 var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" } };
 

--- a/Octokit/Helpers/UriExtensions.cs
+++ b/Octokit/Helpers/UriExtensions.cs
@@ -25,6 +25,12 @@ namespace Octokit
             // use a temporary dictionary which combines new and existing parameters
             IDictionary<string, string> p = new Dictionary<string, string>(parameters);
 
+            var hasQueryString = uri.OriginalString.IndexOf("?", StringComparison.Ordinal);
+
+            string uriWithoutQuery = hasQueryString == -1
+                    ? uri.ToString()
+                    : uri.OriginalString.Substring(0, hasQueryString);
+
             string queryString;
             if (uri.IsAbsoluteUri)
             {
@@ -32,7 +38,6 @@ namespace Octokit
             }
             else
             {
-                var hasQueryString = uri.OriginalString.IndexOf("?", StringComparison.Ordinal);
                 queryString = hasQueryString == -1
                     ? ""
                     : uri.OriginalString.Substring(hasQueryString);
@@ -65,7 +70,7 @@ namespace Octokit
                 return uriBuilder.Uri;
             }
 
-            return new Uri(uri + "?" + query, UriKind.Relative);
+            return new Uri(uriWithoutQuery + "?" + query, UriKind.Relative);
         }
     }
 }


### PR DESCRIPTION
While investigating why pagination didn't seem to be working on #1639 I discovered a bug in the `Uri.ApplyParameters()` extension method.

When the passed in `Uri` is a relative type and already includes query parameters, the resulting `Uri` generated by this function contains the existing parameters then an additional `?` character followed by the actual set of existing+new parameters.  

This was resulting in the pagination parameters being ignored by the upstream API 
(note the 2 occurrences of `?` and both the "existing" and "new+existing" parameter sets present):

Actual: `orgs/testorg/outside_collaborators?filter=all?per_page=1&page=1&filter=all`
Expected: `orgs/testorg/outside_collaborators?per_page=1&page=1&filter=all`

Unit tests have been extended to cover relative `Uri`'s, which reveals the failure case and confirms the fix.
