### PR TITLE
Implement pagination on Organization Outside Collaborators Client GetAll() method

### DIFF
--- a/Octokit.Reactive/Clients/IObservableOrganizationOutsideCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOrganizationOutsideCollaboratorsClient.cs
@@ -27,9 +27,36 @@ namespace Octokit.Reactive
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        IObservable<User> GetAll(string org, ApiOptions options);
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
         IObservable<User> GetAll(string org, OrganizationMembersFilter filter);
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        IObservable<User> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options);
 
         /// <summary>
         /// Removes a user as an outside collaborator from the organization, this will remove them from all repositories

--- a/Octokit.Reactive/Clients/ObservableOrganizationOutsideCollaboratorsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOrganizationOutsideCollaboratorsClient.cs
@@ -35,7 +35,26 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.OutsideCollaborators(org), null, AcceptHeaders.OrganizationMembershipPreview);
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public IObservable<User> GetAll(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.OutsideCollaborators(org), null, AcceptHeaders.OrganizationMembershipPreview, options);
         }
 
         /// <summary>
@@ -53,7 +72,27 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.OutsideCollaborators(org, filter), null, AcceptHeaders.OrganizationMembershipPreview);
+            return GetAll(org, filter, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public IObservable<User> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.OutsideCollaborators(org, filter), null, AcceptHeaders.OrganizationMembershipPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
@@ -126,7 +126,7 @@ namespace Octokit.Tests.Integration.Clients
                     var options = new ApiOptions
                     {
                         PageCount = 1,
-                        PageSize = 2
+                        PageSize = 1
                     };
 
                     var outsideCollaborators = await _gitHub.Organization
@@ -134,11 +134,11 @@ namespace Octokit.Tests.Integration.Clients
                         .GetAll(Helper.Organization, OrganizationMembersFilter.All, options);
 
                     Assert.NotNull(outsideCollaborators);
-                    Assert.Equal(2, outsideCollaborators.Count);
+                    Assert.Equal(1, outsideCollaborators.Count);
                 }
             }
 
-            [IntegrationTest(Skip = "It seems this API endpoint does not support pagination as page size/count are not adhered to")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterWithStart()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -171,6 +171,7 @@ namespace Octokit.Tests.Integration.Clients
 
                     Assert.Equal(1, firstPageOfOutsideCollaborators.Count);
                     Assert.Equal(1, secondPageOfOutsideCollaborators.Count);
+                    Assert.NotEqual(firstPageOfOutsideCollaborators[0].Login, secondPageOfOutsideCollaborators[0].Login);
                 }
             }
 
@@ -205,7 +206,7 @@ namespace Octokit.Tests.Integration.Clients
                     var options = new ApiOptions
                     {
                         PageCount = 1,
-                        PageSize = 2
+                        PageSize = 1
                     };
 
                     var outsideCollaborators = await _gitHub.Organization

--- a/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
@@ -49,6 +49,54 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithoutStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+
+                    var options = new ApiOptions
+                    {
+                        PageSize = 1,
+                        PageCount = 1
+                    };
+
+                    var outsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, options);
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageSize = 1,
+                        PageCount = 1,
+                        StartPage = 1
+                    };
+
+                    var outsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, options);
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilter()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -67,6 +115,66 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterAndApiOptions()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 2
+                    };
+
+                    var outsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, options);
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(2, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest(Skip = "It seems this API endpoint does not support pagination as page size/count are not adhered to")]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterWithStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var firstPageOptions = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 1,
+                        StartPage = 1
+                    };
+
+                    var firstPageOfOutsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, firstPageOptions);
+
+                    var secondPageOptions = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 1,
+                        StartPage = 2
+                    };
+
+                    var secondPageOfOutsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, secondPageOptions);
+
+                    Assert.Equal(1, firstPageOfOutsideCollaborators.Count);
+                    Assert.Equal(1, secondPageOfOutsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithTwoFactorFilter()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -78,6 +186,31 @@ namespace Octokit.Tests.Integration.Clients
                     var outsideCollaborators = await _gitHub.Organization
                         .OutsideCollaborator
                         .GetAll(Helper.Organization, OrganizationMembersFilter.TwoFactorAuthenticationDisabled);
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                    Assert.Equal(_fixtureCollaborator, outsideCollaborators[0].Login);
+                }
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithTwoFactorFilterAndApiOptions()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 2
+                    };
+
+                    var outsideCollaborators = await _gitHub.Organization
+                        .OutsideCollaborator
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
 
                     Assert.NotNull(outsideCollaborators);
                     Assert.Equal(1, outsideCollaborators.Count);

--- a/Octokit.Tests.Integration/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
@@ -121,18 +121,18 @@ namespace Octokit.Tests.Integration.Reactive
                     var options = new ApiOptions
                     {
                         PageCount = 1,
-                        PageSize = 2
+                        PageSize = 1
                     };
 
                     var outsideCollaborators = await _client
                         .GetAll(Helper.Organization, OrganizationMembersFilter.All, options).ToList();
 
                     Assert.NotNull(outsideCollaborators);
-                    Assert.Equal(2, outsideCollaborators.Count);
+                    Assert.Equal(1, outsideCollaborators.Count);
                 }
             }
 
-            [IntegrationTest(Skip = "It seems this API endpoint does not support pagination as page size/count are not adhered to")]
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterWithStart()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -163,6 +163,7 @@ namespace Octokit.Tests.Integration.Reactive
 
                     Assert.Equal(1, firstPageOfOutsideCollaborators.Count);
                     Assert.Equal(1, secondPageOfOutsideCollaborators.Count);
+                    Assert.NotEqual(firstPageOfOutsideCollaborators[0].Login, secondPageOfOutsideCollaborators[0].Login);
                 }
             }
 
@@ -196,7 +197,7 @@ namespace Octokit.Tests.Integration.Reactive
                     var options = new ApiOptions
                     {
                         PageCount = 1,
-                        PageSize = 2
+                        PageSize = 1
                     };
 
                     var outsideCollaborators = await _client

--- a/Octokit.Tests.Integration/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
@@ -47,6 +47,52 @@ namespace Octokit.Tests.Integration.Reactive
             }
 
             [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithoutStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+
+                    var options = new ApiOptions
+                    {
+                        PageSize = 1,
+                        PageCount = 1
+                    };
+
+                    var outsideCollaborators = await _client
+                        .GetAll(Helper.Organization, options).ToList();
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageSize = 1,
+                        PageCount = 1,
+                        StartPage = 1
+                    };
+
+                    var outsideCollaborators = await _client
+                        .GetAll(Helper.Organization, options).ToList();
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilter()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -64,6 +110,63 @@ namespace Octokit.Tests.Integration.Reactive
             }
 
             [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterAndApiOptions()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 2
+                    };
+
+                    var outsideCollaborators = await _client
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, options).ToList();
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(2, outsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest(Skip = "It seems this API endpoint does not support pagination as page size/count are not adhered to")]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithAllFilterWithStart()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var firstPageOptions = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 1,
+                        StartPage = 1
+                    };
+
+                    var firstPageOfOutsideCollaborators = await _client
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, firstPageOptions).ToList();
+
+                    var secondPageOptions = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 1,
+                        StartPage = 2
+                    };
+
+                    var secondPageOfOutsideCollaborators = await _client
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.All, secondPageOptions).ToList();
+
+                    Assert.Equal(1, firstPageOfOutsideCollaborators.Count);
+                    Assert.Equal(1, secondPageOfOutsideCollaborators.Count);
+                }
+            }
+
+            [IntegrationTest]
             public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithTwoFactorFilter()
             {
                 var repoName = Helper.MakeNameWithTimestamp("public-repo");
@@ -74,6 +177,30 @@ namespace Octokit.Tests.Integration.Reactive
 
                     var outsideCollaborators = await _client
                         .GetAll(Helper.Organization, OrganizationMembersFilter.TwoFactorAuthenticationDisabled).ToList();
+
+                    Assert.NotNull(outsideCollaborators);
+                    Assert.Equal(1, outsideCollaborators.Count);
+                    Assert.Equal("alfhenrik-test-2", outsideCollaborators[0].Login);
+                }
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsCorrectCountOfOutsideCollaboratorsWithTwoFactorFilterAndApiOptions()
+            {
+                var repoName = Helper.MakeNameWithTimestamp("public-repo");
+                using (var context = await _gitHub.CreateRepositoryContext(Helper.Organization, new NewRepository(repoName)))
+                {
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, _fixtureCollaborator);
+                    await _gitHub.Repository.Collaborator.Add(context.RepositoryOwner, context.RepositoryName, "alfhenrik");
+
+                    var options = new ApiOptions
+                    {
+                        PageCount = 1,
+                        PageSize = 2
+                    };
+
+                    var outsideCollaborators = await _client
+                        .GetAll(Helper.Organization, OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options).ToList();
 
                     Assert.NotNull(outsideCollaborators);
                     Assert.Equal(1, outsideCollaborators.Count);

--- a/Octokit.Tests/Clients/OrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationOutsideCollaboratorsClientTests.cs
@@ -26,7 +26,25 @@ namespace Octokit.Tests.Clients
 
                 client.GetAll("org");
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"), null, "application/vnd.github.korra-preview+json");
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"), null, "application/vnd.github.korra-preview+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationOutsideCollaboratorsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", options);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"), null, "application/vnd.github.korra-preview+json", options);
             }
 
             [Fact]
@@ -37,10 +55,17 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null));
 
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("org", null));
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll(""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, ApiOptions.None));
             }
 
             [Fact]
@@ -51,7 +76,25 @@ namespace Octokit.Tests.Clients
 
                 client.GetAll("org", OrganizationMembersFilter.All);
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), null, "application/vnd.github.korra-preview+json");
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), null, "application/vnd.github.korra-preview+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void AllFilterRequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationOutsideCollaboratorsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", OrganizationMembersFilter.All, options);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), null, "application/vnd.github.korra-preview+json", options);
             }
 
             [Fact]
@@ -62,7 +105,25 @@ namespace Octokit.Tests.Clients
 
                 client.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled);
 
-                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), null, "application/vnd.github.korra-preview+json");
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), null, "application/vnd.github.korra-preview+json", Args.ApiOptions);
+            }
+
+            [Fact]
+            public void TwoFactorFilterRequestsTheCorrectUrlWithApiOptions()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new OrganizationOutsideCollaboratorsClient(connection);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
+
+                connection.Received().GetAll<User>(Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), null, "application/vnd.github.korra-preview+json", options);
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
@@ -31,7 +31,28 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"),
-                    null,
+                    Args.EmptyDictionary,
+                    "application/vnd.github.korra-preview+json");
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationOutsideCollaboratorsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageCount = 1,
+                    PageSize = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", options);
+
+                gitHubClient.Connection.Received(1).Get<List<User>>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -43,10 +64,17 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null));
 
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("org", null));
+
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, OrganizationMembersFilter.All, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("org", OrganizationMembersFilter.All, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll(""));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All));
+                Assert.Throws<ArgumentException>(() => client.GetAll("", OrganizationMembersFilter.All, ApiOptions.None));
             }
 
             [Fact]
@@ -59,7 +87,28 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), 
-                    null, 
+                    Args.EmptyDictionary, 
+                    "application/vnd.github.korra-preview+json");
+            }
+
+            [Fact]
+            public void AllFilterRequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationOutsideCollaboratorsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", OrganizationMembersFilter.All, options);
+
+                gitHubClient.Connection.Received(1).Get<List<User>>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -73,7 +122,28 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), 
-                    null, 
+                    Args.EmptyDictionary, 
+                    "application/vnd.github.korra-preview+json");
+            }
+
+            [Fact]
+            public void TwoFactorFilterRequestsTheCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableOrganizationOutsideCollaboratorsClient(gitHubClient);
+
+                var options = new ApiOptions
+                {
+                    PageSize = 1,
+                    PageCount = 1,
+                    StartPage = 1
+                };
+
+                client.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
+
+                gitHubClient.Connection.Received(1).Get<List<User>>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
                     "application/vnd.github.korra-preview+json");
             }
         }

--- a/Octokit/Clients/IOrganizationOutsideCollaboratorsClient.cs
+++ b/Octokit/Clients/IOrganizationOutsideCollaboratorsClient.cs
@@ -26,9 +26,36 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options);
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
         Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter);
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options);
 
         /// <summary>
         /// Removes a user as an outside collaborator from the organization, this will remove them from all repositories

--- a/Octokit/Clients/OrganizationOutsideCollaboratorsClient.cs
+++ b/Octokit/Clients/OrganizationOutsideCollaboratorsClient.cs
@@ -36,7 +36,26 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
-            return ApiConnection.GetAll<User>(ApiUrls.OutsideCollaborators(org), null, AcceptHeaders.OrganizationMembershipPreview);
+            return GetAll(org, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return ApiConnection.GetAll<User>(ApiUrls.OutsideCollaborators(org), null, AcceptHeaders.OrganizationMembershipPreview, options);
         }
 
         /// <summary>
@@ -54,7 +73,27 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
 
-            return ApiConnection.GetAll<User>(ApiUrls.OutsideCollaborators(org, filter), null, AcceptHeaders.OrganizationMembershipPreview);
+            return GetAll(org, filter, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// List all users who are outside collaborators of an organization. An outside collaborator is a user that
+        /// is not a member of the organization.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/outside_collaborators/#list-outside-collaborators">API documentation</a>
+        /// for more information.
+        /// </remarks>
+        /// <param name="org">The login for the organization</param>
+        /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>The users</returns>
+        public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return ApiConnection.GetAll<User>(ApiUrls.OutsideCollaborators(org, filter), null, AcceptHeaders.OrganizationMembershipPreview, options);
         }
 
         /// <summary>


### PR DESCRIPTION
It appeared as though this API endpoint didnt support pagination, so `ApiOptions` overloads were dropped from the implementation in #1639 

After GitHub support confirmed pagination should be in place on this endpoint, some debugging revealed 
a bug in octokit (#1649 ) which was causing invalid Uri's that was affecting this endpoint (as it uses a query parameter to specify the filter in the `Uri`)

Once that fix is merged, pagination works OK, so this PR (re)implements the pagination support for the `GetAll()` outside collaborators function and associated integration tests

CC @alfhenrik 