### PR TITLE
Fix RepositoryCommitsClient.GetSha1 API call after preview period ended

### DIFF
--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -1062,7 +1062,7 @@ namespace Octokit.Tests.Clients
                 client.GetSha1("owner", "name", "reference");
 
                 connection.Received()
-                    .Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/commits/reference"), null, AcceptHeaders.CommitReferenceSha1Preview);
+                    .Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/commits/reference"), null, "application/vnd.github.v3.sha");
             }
         }
     }

--- a/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
+++ b/Octokit.Tests/Clients/RespositoryCommitsClientTests.cs
@@ -318,7 +318,7 @@ namespace Octokit.Tests.Clients
                 await client.GetSha1("fake", "repo", "ref");
 
                 connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/ref"),
-                    null, "application/vnd.github.chitauri-preview+sha");
+                    null, "application/vnd.github.v3.sha");
             }
 
             [Fact]
@@ -330,7 +330,7 @@ namespace Octokit.Tests.Clients
                 await client.GetSha1(1, "ref");
 
                 connection.Received().Get<string>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/ref"),
-                    null, "application/vnd.github.chitauri-preview+sha");
+                    null, "application/vnd.github.v3.sha");
             }
 
             [Fact]

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -190,7 +190,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(owner, name, reference), null, AcceptHeaders.CommitReferenceSha1Preview);
+            return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(owner, name, reference), null, AcceptHeaders.CommitReferenceSha1MediaType);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, "reference");
 
-            return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(repositoryId, reference), null, AcceptHeaders.CommitReferenceSha1Preview);
+            return ApiConnection.Get<string>(ApiUrls.RepositoryCommit(repositoryId, reference), null, AcceptHeaders.CommitReferenceSha1MediaType);
         }
     }
 }

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -10,6 +10,8 @@ namespace Octokit
 
         public const string RedirectsPreviewThenStableVersionJson = "application/vnd.github.quicksilver-preview+json; charset=utf-8, application/vnd.github.v3+json; charset=utf-8";
 
+        public const string CommitReferenceSha1MediaType = "application/vnd.github.v3.sha";
+
         public const string OrganizationPermissionsPreview = "application/vnd.github.ironman-preview+json";
 
         public const string LicensesApiPreview = "application/vnd.github.drax-preview+json";
@@ -19,9 +21,7 @@ namespace Octokit
         public const string StarCreationTimestamps = "application/vnd.github.v3.star+json";
 
         public const string IssueLockingUnlockingApiPreview = "application/vnd.github.the-key-preview+json";
-
-        public const string CommitReferenceSha1Preview = "application/vnd.github.chitauri-preview+sha";
-
+        
         public const string SquashCommitPreview = "application/vnd.github.polaris-preview+json";
 
         public const string MigrationsApiPreview = "application/vnd.github.wyandotte-preview+json";


### PR DESCRIPTION
While running integration tests prepping for a release, I found that the `client.Repository.Commit.GetSha1()` call was returning `null` rather than the expected `string` sha1.

This turned out to be a situation where when the API went from preview to official ([announced here](https://developer.github.com/changes/2016-04-12-commit-reference-sha-api-is-now-official/)], the old preview header is no longer able to be used (despite the blog post saying it is!).

I contacted GitHub support who informed me that the blog post was incorrect in saying the preview header would still work - unlike normal API previews where the accepts header just enables additional/changed json response fields, this particular API call actually had an entirely new media type response (a string SHA1 rather than a json payload) and therefore it required the proper header once it was out of preview.  They also allayed my fears that we need to not send preview headers once things are official, as for the "normal" cases it doesnt matter if we keep sending preview headers, since the new response formats will be returned anyway (and the preview headers help us support older GitHub Enterprise versions, where the feature is still in preview).  

Long story short, this PR fixes the `GetSha1` call to use the official media type `Accepts` header, and updates unit tests to match.  Integration test is now passing