### PR TITLE
Release v0.25 - She'll be Comin' Round the Mountain

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// Client for managing reviews.
         /// </summary>
         IObservablePullRequestReviewsClient Review { get; }
-       
+
         /// <summary>
         /// Client for managing review comments.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
@@ -35,7 +35,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(review, nameof(review));
             return _client.Create(owner, name, number, review).ToObservable();
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         public IObservable<Unit> Delete(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             return _client.Delete(owner, name, number, reviewId).ToObservable();
         }
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(dismissMessage, nameof(dismissMessage));
 
             return _client.Dismiss(owner, name, number, reviewId, dismissMessage).ToObservable();
@@ -125,7 +125,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             return GetAll(owner, name, number, ApiOptions.None);
         }
@@ -152,7 +152,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
             return _connection.GetAndFlattenAllPages<PullRequestReview>(ApiUrls.PullRequestReviews(owner, name, number), null, null, options);
@@ -183,7 +183,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> Get(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
             return _client.Get(owner, name, number, reviewId).ToObservable();
         }
@@ -212,7 +212,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(submitMessage, nameof(submitMessage));
 
             return _client.Submit(owner, name, number, reviewId, submitMessage).ToObservable();
@@ -269,7 +269,7 @@ namespace Octokit.Reactive
         public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name,nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
             return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(owner, name, number, reviewId), options);
@@ -286,7 +286,7 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number, reviewId),options);
+            return _connection.GetAndFlattenAllPages<PullRequestReviewComment>(ApiUrls.PullRequestReviewComments(repositoryId, number, reviewId), options);
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/OrganizationOutsideCollaboratorsClientTests.cs
@@ -258,7 +258,7 @@ namespace Octokit.Tests.Integration.Clients
             [OrganizationTest]
             public async Task CannotRemoveMemberOfOrganizationAsOutsideCollaborator()
             {
-                var ex = await Assert.ThrowsAsync<UserIsOrganizationMemberException>(() 
+                var ex = await Assert.ThrowsAsync<UserIsOrganizationMemberException>(()
                     => _gitHub.Organization.OutsideCollaborator.Delete(Helper.Organization, Helper.UserName));
 
                 Assert.True(string.Equals(

--- a/Octokit.Tests.Integration/Clients/ProjectsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ProjectsClientTests.cs
@@ -53,7 +53,7 @@ public class ProjectsClientTests
         {
             var project1 = await CreateRepositoryProjectHelper(_github, _context.RepositoryId);
             var project2 = await CreateRepositoryProjectHelper(_github, _context.RepositoryId);
-            
+
             // Make 2nd project closed
             var result = await _github.Repository.Project.Update(project2.Id, new ProjectUpdate { State = ItemState.Closed });
 
@@ -236,7 +236,7 @@ public class ProjectsClientTests
         public async Task GetsAllFilteredProjectsForRepository()
         {
             var project = await CreateOrganizationProjectHelper(_github, Helper.Organization);
-            
+
             // Make project closed
             var result = await _github.Repository.Project.Update(project.Id, new ProjectUpdate { State = ItemState.Closed });
 

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -87,7 +87,7 @@ public class PullRequestReviewRequestsClientTests
         public async Task ReturnsCorrectCountOfReviewRequestsWithStart()
         {
             var number = await CreateTheWorld(_github, _context);
-            
+
             var options = new ApiOptions
             {
                 PageSize = 1,
@@ -119,7 +119,7 @@ public class PullRequestReviewRequestsClientTests
         public async Task ReturnsDistinctResultsBasedOnStartPage()
         {
             var number = await CreateTheWorld(_github, _context);
-            
+
             var startOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -144,7 +144,7 @@ public class PullRequestReviewRequestsClientTests
         public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
         {
             var number = await CreateTheWorld(_github, _context);
-            
+
             var startOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -172,7 +172,7 @@ public class PullRequestReviewRequestsClientTests
         public async Task DeletesRequests()
         {
             var number = await CreateTheWorld(_github, _context);
-            
+
             var reviewRequestsBeforeDelete = await _client.GetAll(_context.RepositoryOwner, _context.RepositoryName, number);
             var reviewRequestToCreate = new PullRequestReviewRequest(_collaboratorLogins);
             await _client.Delete(_context.RepositoryOwner, _context.RepositoryName, number, reviewRequestToCreate);
@@ -186,11 +186,11 @@ public class PullRequestReviewRequestsClientTests
         public async Task DeletesRequestsWithRepositoryId()
         {
             var number = await CreateTheWorld(_github, _context);
-            
-            var reviewRequestsBeforeDelete = await _client.GetAll(_context.RepositoryId,  number);
+
+            var reviewRequestsBeforeDelete = await _client.GetAll(_context.RepositoryId, number);
             var reviewRequestToCreate = new PullRequestReviewRequest(_collaboratorLogins);
             await _client.Delete(_context.RepositoryId, number, reviewRequestToCreate);
-            var reviewRequestsAfterDelete = await _client.GetAll(_context.RepositoryId,  number);
+            var reviewRequestsAfterDelete = await _client.GetAll(_context.RepositoryId, number);
 
             Assert.NotEmpty(reviewRequestsBeforeDelete);
             Assert.Empty(reviewRequestsAfterDelete);

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -107,7 +107,7 @@ public class PullRequestReviewRequestsClientTests
             var options = new ApiOptions
             {
                 PageSize = 1,
-                PageCount = 2,
+                PageCount = 1,
                 StartPage = 2
             };
             var reviewRequests = await _client.GetAll(_context.RepositoryId, number, options);

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -788,7 +788,7 @@ public class ReleasesClientTests
 
             await _releaseClient.DeleteAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id);
 
-            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id));
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.GetAsset(_context.RepositoryOwner, _context.RepositoryName, result.Id));
         }
 
         [IntegrationTest]
@@ -806,7 +806,9 @@ public class ReleasesClientTests
 
             Assert.NotNull(asset);
 
-            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.DeleteAsset(_context.Repository.Id, result.Id));
+            await _releaseClient.DeleteAsset(_context.Repository.Id, result.Id);
+
+            await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.GetAsset(_context.Repository.Id, result.Id));
         }
     }
 

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -700,9 +700,9 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var repository = await github.Repository.Get("haacked", "libgit2sharp");
+            var repository = await github.Repository.Get("octokitnet-test1", "octokit.net");
 
-            Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
+            Assert.Equal("https://github.com/octokitnet-test1/octokit.net.git", repository.CloneUrl);
             Assert.True(repository.Fork);
         }
 
@@ -711,9 +711,9 @@ public class RepositoriesClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var repository = await github.Repository.Get(4550038);
+            var repository = await github.Repository.Get(100559458);
 
-            Assert.Equal("https://github.com/Haacked/libgit2sharp.git", repository.CloneUrl);
+            Assert.Equal("https://github.com/octokitnet-test1/octokit.net.git", repository.CloneUrl);
             Assert.True(repository.Fork);
         }
 

--- a/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryCollaboratorClientTests.cs
@@ -381,7 +381,7 @@ public class RepositoryCollaboratorClientTests
                 var fixture = github.Repository.Collaborator;
 
                 var permission = await fixture.ReviewPermission(context.RepositoryOwner, context.RepositoryName, "octokitnet-test1");
- 
+
                 Assert.Equal(PermissionLevel.None, permission.Permission);
             }
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableNotificationsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableNotificationsClientTests.cs
@@ -12,7 +12,7 @@ public class ObservableNotificationsClientTests
         public async Task MarksNotificationsRead()
         {
             var client = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
-            
+
             await client.Activity.Notifications.MarkAsRead();
         }
     }

--- a/Octokit.Tests.Integration/Reactive/ObservableProjectsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableProjectsClientTests.cs
@@ -55,7 +55,7 @@ public class ObservableProjectsClientTests
         {
             var project1 = await CreateRepositoryProjectHelper(_github, _context.RepositoryId);
             var project2 = await CreateRepositoryProjectHelper(_github, _context.RepositoryId);
-            
+
             // Make 2nd project closed
             var result = await _github.Repository.Project.Update(project2.Id, new ProjectUpdate { State = ItemState.Closed });
 
@@ -238,7 +238,7 @@ public class ObservableProjectsClientTests
         public async Task GetsAllFilteredProjectsForRepository()
         {
             var project = await CreateOrganizationProjectHelper(_github, Helper.Organization);
-            
+
             // Make project closed
             var result = await _github.Repository.Project.Update(project.Id, new ProjectUpdate { State = ItemState.Closed });
 

--- a/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableRepositoryCollaboratorClientTests.cs
@@ -141,7 +141,6 @@ public class ObservableRepositoryCollaboratorClientTests
     }
     public class TheReviewPermissionMethod
     {
-
         [IntegrationTest]
         public async Task ReturnsReadPermissionForNonCollaborator()
         {

--- a/Octokit.Tests/Clients/OrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/OrganizationOutsideCollaboratorsClientTests.cs
@@ -138,8 +138,8 @@ namespace Octokit.Tests.Clients
                 client.Delete("org", "user");
 
                 connection.Connection.Received().Delete(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators/user"), 
-                    Arg.Any<object>(), 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators/user"),
+                    Arg.Any<object>(),
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -150,7 +150,7 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "user"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("org", null));
-                
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("", "user"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Delete("org", ""));
             }

--- a/Octokit.Tests/Clients/ProjectCardsClientTests.cs
+++ b/Octokit.Tests/Clients/ProjectCardsClientTests.cs
@@ -75,7 +75,7 @@ namespace Octokit.Tests.Clients
                     newCard,
                     "application/vnd.github.inertia-preview+json");
             }
-                        
+
             [Fact]
             public async Task EnsuresNonNullArguments()
             {
@@ -151,7 +151,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ProjectCardsClient(Substitute.For<IApiConnection>());
-                
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Move(1, null));
             }
         }

--- a/Octokit.Tests/Clients/ProjectsClientTests.cs
+++ b/Octokit.Tests/Clients/ProjectsClientTests.cs
@@ -249,7 +249,7 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ProjectsClient(Substitute.For<IApiConnection>());
-                
+
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, null));
             }
         }

--- a/Octokit.Tests/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewRequestsClientTests.cs
@@ -123,7 +123,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestReviewRequestsClient(connection);
 
-                IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd"};
+                IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
                 var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
 
                 client.Create("fakeOwner", "fakeRepoName", 13, pullRequestReviewRequest);

--- a/Octokit.Tests/Clients/PullRequestReviewsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewsClientTests.cs
@@ -172,7 +172,7 @@ public class PullRequestReviewsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
-            
+
             var comment = new DraftPullRequestReviewComment("Comment content", "file.css", 7);
 
             var review = new PullRequestReviewCreate()
@@ -240,7 +240,7 @@ public class PullRequestReviewsClientTests
             await Assert.ThrowsAsync<ArgumentException>(() => client.Create("fakeOwner", "", 1, review));
         }
     }
-    
+
     public class TheDeleteMethod
     {
         [Fact]
@@ -257,7 +257,6 @@ public class PullRequestReviewsClientTests
         [Fact]
         public async Task PostsToCorrectUrlWithRepositoryId()
         {
-
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
 
@@ -285,7 +284,6 @@ public class PullRequestReviewsClientTests
         [Fact]
         public async Task PostsToCorrectUrl()
         {
-
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
 
@@ -301,7 +299,6 @@ public class PullRequestReviewsClientTests
         [Fact]
         public async Task PostsToCorrectUrlWithRepositoryId()
         {
-
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
 
@@ -341,7 +338,7 @@ public class PullRequestReviewsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
-            
+
             await client.GetAllComments("owner", "name", 13, 13);
 
             connection.Received().GetAll<PullRequestReviewComment>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/13/reviews/13/comments"), null, Args.ApiOptions);
@@ -399,7 +396,7 @@ public class PullRequestReviewsClientTests
         {
             var connection = Substitute.For<IApiConnection>();
             var client = new PullRequestReviewsClient(connection);
-            
+
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllComments(null, "name", 1, 1));
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllComments("owner", null, 1, 1));
 
@@ -418,7 +415,7 @@ public class PullRequestReviewsClientTests
 
             var submitMessage = new PullRequestReviewSubmit()
             {
-                Body = "string", 
+                Body = "string",
                 Event = PullRequestReviewEvent.Approve
             };
             await client.Submit("owner", "name", 13, 13, submitMessage);

--- a/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Clients/RepoCollaboratorsClientTests.cs
@@ -201,7 +201,7 @@ namespace Octokit.Tests.Clients
                 client.ReviewPermission("owner", "test", "user1");
                 connection.Received().Get<CollaboratorPermission>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/owner/test/collaborators/user1/permission"),
-                    Arg.Any<Dictionary<string, string>>(), 
+                    Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -214,7 +214,7 @@ namespace Octokit.Tests.Clients
                 client.ReviewPermission(1L, "user1");
                 connection.Received().Get<CollaboratorPermission>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/collaborators/user1/permission"),
-                    Arg.Any<Dictionary<string, string>>(), 
+                    Arg.Any<Dictionary<string, string>>(),
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -233,7 +233,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReviewPermission(1L, null));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.ReviewPermission(1L, ""));
             }
-
         }
 
         public class TheAddMethod

--- a/Octokit.Tests/Helpers/UriExtensionsTests.cs
+++ b/Octokit.Tests/Helpers/UriExtensionsTests.cs
@@ -92,7 +92,7 @@ namespace Octokit.Tests.Helpers
                 var uri = new Uri("https://api.github.com/repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2");
 
                 var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" }, { "per_page", "5" } };
-                
+
                 var actual = uri.ApplyParameters(parameters);
 
                 Assert.Equal(
@@ -106,7 +106,7 @@ namespace Octokit.Tests.Helpers
                 var uri = new Uri("repositories/1/milestones?state=closed&sort=due_date&direction=asc&page=2", UriKind.Relative);
 
                 var parameters = new Dictionary<string, string> { { "state", "open" }, { "sort", "other" }, { "per_page", "5" } };
-                
+
                 var actual = uri.ApplyParameters(parameters);
 
                 Assert.Equal(

--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -38,7 +38,7 @@ namespace Octokit.Tests.Models
             [Fact]
             public void ShouldThrowForInvalidEnumValue()
             {
-                Assert.Throws<ArgumentException>(() => new StringEnum<AccountType>((AccountType) 1337));
+                Assert.Throws<ArgumentException>(() => new StringEnum<AccountType>((AccountType)1337));
             }
         }
 
@@ -134,7 +134,7 @@ namespace Octokit.Tests.Models
             public void ShouldThrowForInvalidEnumValue()
             {
                 StringEnum<AccountType> stringEnum;
-                Assert.Throws<ArgumentException>(() => stringEnum = (AccountType) 1337);
+                Assert.Throws<ArgumentException>(() => stringEnum = (AccountType)1337);
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableOrganizationOutsideCollaboratorsClientTests.cs
@@ -51,8 +51,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org", options);
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"), 
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators"),
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2),
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -86,8 +86,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org", OrganizationMembersFilter.All);
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), 
-                    Args.EmptyDictionary, 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"),
+                    Args.EmptyDictionary,
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -107,8 +107,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org", OrganizationMembersFilter.All, options);
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"), 
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=all"),
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2),
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -121,8 +121,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled);
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), 
-                    Args.EmptyDictionary, 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"),
+                    Args.EmptyDictionary,
                     "application/vnd.github.korra-preview+json");
             }
 
@@ -142,8 +142,8 @@ namespace Octokit.Tests.Reactive
                 client.GetAll("org", OrganizationMembersFilter.TwoFactorAuthenticationDisabled, options);
 
                 gitHubClient.Connection.Received(1).Get<List<User>>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"), 
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), 
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/org/outside_collaborators?filter=2fa_disabled"),
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2),
                     "application/vnd.github.korra-preview+json");
             }
         }

--- a/Octokit.Tests/Reactive/ObservableProjectsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableProjectsClientTests.cs
@@ -185,7 +185,7 @@ namespace Octokit.Tests.Reactive
                 client.Get(1);
 
                 gitHubClient.Repository.Project.Received().Get(1);
-            }                     
+            }
         }
 
         public class TheCreateForRepositoryMethod
@@ -200,7 +200,7 @@ namespace Octokit.Tests.Reactive
                 client.CreateForRepository(1, newProject);
 
                 gitHubClient.Repository.Project.Received().CreateForRepository(1, newProject);
-            }          
+            }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
@@ -250,7 +250,7 @@ namespace Octokit.Tests.Reactive
                 client.Update(1, updateProject);
 
                 gitHubClient.Repository.Project.Received().Update(1, updateProject);
-            }            
+            }
 
             [Fact]
             public async Task EnsuresNonNullArguments()
@@ -273,7 +273,7 @@ namespace Octokit.Tests.Reactive
                 client.Delete(1);
 
                 gitHubClient.Repository.Project.Received().Delete(1);
-            }            
+            }
         }
     }
 }

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewsClientTests.cs
@@ -91,7 +91,6 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task RequestsCorrectUrlMulti()
             {
-
                 var firstPageUrl = new Uri("repos/owner/name/pulls/7/reviews", UriKind.Relative);
                 var secondPageUrl = new Uri("https://example.com/page/2");
                 var firstPageLinks = new Dictionary<string, Uri> { { "next", secondPageUrl } };
@@ -219,7 +218,6 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
-                
             }
         }
 
@@ -254,7 +252,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", 1, 1));
                 Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, 1, 1));
-                
+
                 Assert.Throws<ArgumentException>(() => client.Get("", "name", 1, 1));
                 Assert.Throws<ArgumentException>(() => client.Get("owner", "", 1, 1));
             }
@@ -365,7 +363,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", 1, 1));
                 Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, 1, 1));
-                             
+
                 Assert.Throws<ArgumentException>(() => client.Delete("", "name", 1, 1));
                 Assert.Throws<ArgumentException>(() => client.Delete("owner", "", 1, 1));
             }
@@ -584,7 +582,7 @@ namespace Octokit.Tests.Reactive
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Args.EmptyDictionary, null)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
-                
+
                 var client = new ObservablePullRequestReviewsClient(gitHubClient);
 
                 var results = await client.GetAllComments(1, 7, 1).ToArray();
@@ -615,7 +613,6 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => client.GetAllComments("", "name", 1, 1, ApiOptions.None));
                 Assert.Throws<ArgumentException>(() => client.GetAllComments("owner", "", 1, 1, ApiOptions.None));
-
             }
         }
 

--- a/Octokit/Clients/IProjectCardsClient.cs
+++ b/Octokit/Clients/IProjectCardsClient.cs
@@ -12,7 +12,6 @@ namespace Octokit
     /// </remarks>
     public interface IProjectCardsClient
     {
-
         /// <summary>
         /// Gets all cards.
         /// </summary>

--- a/Octokit/Clients/ProjectColumnsClient.cs
+++ b/Octokit/Clients/ProjectColumnsClient.cs
@@ -40,7 +40,7 @@ namespace Octokit
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
-            
+
             return ApiConnection.GetAll<ProjectColumn>(ApiUrls.ProjectColumns(projectId), new Dictionary<string, string>(), AcceptHeaders.ProjectsApiPreview, options);
         }
 
@@ -105,7 +105,7 @@ namespace Octokit
             {
                 return false;
             }
-        }        
+        }
 
         /// <summary>
         /// Moves a column.

--- a/Octokit/Clients/ProjectsClient.cs
+++ b/Octokit/Clients/ProjectsClient.cs
@@ -246,7 +246,7 @@ namespace Octokit
 
             return ApiConnection.Post<Project>(ApiUrls.OrganizationProjects(organization), newProject, AcceptHeaders.ProjectsApiPreview);
         }
-        
+
         /// <summary>
         /// Updates a project for this repository.
         /// </summary>
@@ -261,7 +261,7 @@ namespace Octokit
 
             return ApiConnection.Patch<Project>(ApiUrls.Project(id), projectUpdate, AcceptHeaders.ProjectsApiPreview);
         }
-        
+
         /// <summary>
         /// Deletes a project.
         /// </summary>

--- a/Octokit/Clients/PullRequestReviewsClient.cs
+++ b/Octokit/Clients/PullRequestReviewsClient.cs
@@ -30,7 +30,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return GetAll(owner, name, number,  ApiOptions.None);
+            return GetAll(owner, name, number, ApiOptions.None);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -172,7 +172,7 @@ namespace Octokit
             return ApiConnection
                 .Get<CollaboratorPermission>(ApiUrls.RepoCollaboratorPermission(repositoryId, user), null, AcceptHeaders.OrganizationMembershipPreview);
         }
-        
+
         /// <summary>
         /// Adds a new collaborator to the repository.
         /// </summary>
@@ -210,7 +210,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(user, "user");
 
             try
-            { 
+            {
                 var response = await Connection.Put<object>(ApiUrls.RepoCollaborator(owner, name, user), permission).ConfigureAwait(false);
                 return response.HttpResponse.IsTrue();
             }

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -536,7 +536,6 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
             return ApiConnection.Get<EnforceAdmins>(ApiUrls.RepoProtectedBranchAdminEnforcement(repositoryId, branch), null, AcceptHeaders.ProtectedBranchesApiPreview);
-
         }
 
         /// <summary>

--- a/Octokit/Exceptions/UserIsLastOwnerOfOrganizationException.cs
+++ b/Octokit/Exceptions/UserIsLastOwnerOfOrganizationException.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </summary>
         /// <param name="response">The HTTP payload from the server</param>
         /// <param name="innerException">The inner exception</param>
-        public UserIsLastOwnerOfOrganizationException(IResponse response, ApiException innerException) 
+        public UserIsLastOwnerOfOrganizationException(IResponse response, ApiException innerException)
             : base(response, innerException)
         {
             Debug.Assert(response != null && response.StatusCode == HttpStatusCode.Forbidden,

--- a/Octokit/Exceptions/UserIsNotMemberOfOrganizationException.cs
+++ b/Octokit/Exceptions/UserIsNotMemberOfOrganizationException.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </summary>
         /// <param name="response">The HTTP payload from the server</param>
         /// <param name="innerException">The inner exception</param>
-        public UserIsNotMemberOfOrganizationException(IResponse response, ApiException innerException) 
+        public UserIsNotMemberOfOrganizationException(IResponse response, ApiException innerException)
             : base(response, innerException)
         {
             Debug.Assert(response != null && response.StatusCode == HttpStatusCode.NotFound,

--- a/Octokit/Exceptions/UserIsOrganizationMemberException.cs
+++ b/Octokit/Exceptions/UserIsOrganizationMemberException.cs
@@ -32,7 +32,7 @@ namespace Octokit
         /// </summary>
         /// <param name="response">The HTTP payload from the server</param>
         /// <param name="innerException">The inner exception</param>
-        public UserIsOrganizationMemberException(IResponse response, ApiException innerException) 
+        public UserIsOrganizationMemberException(IResponse response, ApiException innerException)
             : base(response, innerException)
         {
             Debug.Assert(response != null && response.StatusCode == (HttpStatusCode)422,

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -205,7 +205,7 @@ namespace Octokit
         /// Refer to the API documentation for more information: https://developer.github.com/v3/pulls/
         /// </remarks>
         public IPullRequestsClient PullRequest { get; private set; }
-        
+
         /// <summary>
         /// Access GitHub's Repositories API.
         /// </summary>

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -48,6 +48,5 @@ namespace Octokit
         public const string ProjectsApiPreview = "application/vnd.github.inertia-preview+json";
 
         public const string OrganizationMembershipPreview = "application/vnd.github.korra-preview+json";
-
     }
 }

--- a/Octokit/Models/Request/PullRequestReviewCreate.cs
+++ b/Octokit/Models/Request/PullRequestReviewCreate.cs
@@ -35,7 +35,7 @@ namespace Octokit
         /// List of comments to include with this review
         /// </summary>
         public List<DraftPullRequestReviewComment> Comments { get; set; }
-        
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/PullRequestReviewSubmit.cs
+++ b/Octokit/Models/Request/PullRequestReviewSubmit.cs
@@ -14,7 +14,7 @@ namespace Octokit
         public PullRequestReviewSubmit()
         {
         }
-        
+
         /// <summary>
         /// The body of the review message
         /// </summary>
@@ -24,7 +24,7 @@ namespace Octokit
         /// The review event - Approve, Request Changes, Comment
         /// </summary>
         public PullRequestReviewEvent Event { get; set; }
-                
+
         internal string DebuggerDisplay
         {
             get

--- a/Octokit/Models/Request/RepositoryUpdate.cs
+++ b/Octokit/Models/Request/RepositoryUpdate.cs
@@ -12,7 +12,6 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryUpdate
     {
-
         /// <summary>
         /// Creates an object that describes an update to a repository on GitHub.
         /// </summary>

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReview(long id, string commitId,  User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state)
+        public PullRequestReview(long id, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state)
         {
             Id = id;
             CommitId = commitId;
@@ -25,7 +25,7 @@ namespace Octokit
             PullRequestUrl = pullRequestUrl;
             State = state;
         }
-        
+
         /// <summary>
         /// The review Id.
         /// </summary>
@@ -40,7 +40,7 @@ namespace Octokit
         /// The commit Id the review is associated with.
         /// </summary>
         public string CommitId { get; protected set; }
-        
+
         /// <summary>
         /// The user that created the review.
         /// </summary>
@@ -50,7 +50,7 @@ namespace Octokit
         /// The text of the review.
         /// </summary>
         public string Body { get; protected set; }
-        
+
         /// <summary>
         /// The URL for this review on Github.com
         /// </summary>
@@ -60,7 +60,7 @@ namespace Octokit
         /// The URL for the pull request via the API.
         /// </summary>
         public string PullRequestUrl { get; protected set; }
-        
+
         internal string DebuggerDisplay
         {
             get { return string.Format(CultureInfo.InvariantCulture, "Id: {0}, State: {1}, User: {2}", Id, State.DebuggerDisplay, User.DebuggerDisplay); }
@@ -71,7 +71,7 @@ namespace Octokit
     {
         [Parameter(Value = "APPROVED")]
         Approved,
-        
+
         [Parameter(Value = "CHANGES_REQUESTED")]
         ChangesRequested,
 

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -109,7 +109,7 @@ namespace Octokit
                 return false;
             }
 
-            return obj is StringEnum<TEnum> && Equals((StringEnum<TEnum>) obj);
+            return obj is StringEnum<TEnum> && Equals((StringEnum<TEnum>)obj);
         }
 
         public override int GetHashCode()

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,12 @@
-### New in 0.25.0 (released TBA)
+### New in 0.25.0 (released 23/8/2017)
+
+## Breaking Changes and Advisories
+
+- `IncludeAdmins` field is no longer present in `BranchProtectionRequiredStatusChecks` and `BranchProtectionRequiredStatusChecksUpdate` classes, instead use the new `EnforceAdmins` field on `BranchProtectionSettingsUpdate` or the new explicit APIs for configuring Admin Enforcement on protected branches.  This was an [upstream API breaking change](https://developer.github.com/changes/2017-05-02-adoption-of-admin-enforced/) so couldn't follow our normal deprecation schedule
+
+- `Enum` fields in Octokit response classes are now wrapped in an `EnumHelper<TEnum>` class to provide more robustness in dealing with new/unknown API values for these fields.  Whilst the changes are backwards compatible, please consult the guidance on [working with `StringEnum` members](https://github.com/octokit/octokit.net/blob/master/docs/working-with-enums.md) for more information
+
+## Release Notes
 
 ### Milestone: CAKE Builds
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,67 @@
+### New in 0.25.0 (released TBA)
+
+### Milestone: CAKE Builds
+
+**Features/Enhancements**
+
+- Add a build task to validate LINQPad samples - [#1551](https://github.com/octokit/octokit.net/pull/1551) via @mderriey
+- Add a code formatting task to CAKE - [#1550](https://github.com/octokit/octokit.net/pull/1550) via @mderriey
+- Add GitVersion configuration file - [#1555](https://github.com/octokit/octokit.net/pull/1555) via @mderriey
+
+
+### Milestone: dotnetcore Support
+
+**Features/Enhancements**
+
+- Port to .NET Core - [#1503](https://github.com/octokit/octokit.net/pull/1503) via @mderriey, @ryangribble
+- Remove unneeded files for .NET Core - [#1549](https://github.com/octokit/octokit.net/pull/1549) via @mderriey
+- Migrate dotnetcore to vs2017 tooling - [#1567](https://github.com/octokit/octokit.net/pull/1567) via @ryangribble, @mderriey
+- Provide [SourceLink](https://github.com/ctaggart/SourceLink) capability for Octokit and Octokit.Reactive assemblies - [#1574](https://github.com/octokit/octokit.net/pull/1574) via @ryangribble, @mderriey
+- Deliver the dotnetcore port and CAKE build framework changes - [#1581](https://github.com/octokit/octokit.net/pull/1581) via @ryangribble, @mderriey
+
+**Fixes**
+
+- Fix broken JSON deserialization in .NET 4.5 after VS2017 project update - [#1647](https://github.com/octokit/octokit.net/pull/1647) via @mderriey
+
+
+### Milestone: None
+
+**Features/Enhancements**
+
+- Add support for the newly resurrected `PullRequest.MergeCommitSha` property - [#1562](https://github.com/octokit/octokit.net/pull/1562) via @alexperovich
+- Enhance `RepositoryBranchesClient` to support Admin Enforcement changes - [#1598](https://github.com/octokit/octokit.net/pull/1598) via @M-Zuber
+- Implement [Pull Request Review Requests API (Preview)](https://developer.github.com/v3/pulls/review_requests/) - [#1588](https://github.com/octokit/octokit.net/pull/1588) via @gdziadkiewicz, @ryangribble
+- Provide a robust way to handle unknown enum values returned by GitHub API, to prevent deserialization errors until the enum values can be added to octokit - [#1595](https://github.com/octokit/octokit.net/pull/1595) via @khellang, @ryangribble
+- Implement support for [Projects API (Preview)](https://developer.github.com/v3/projects/) - [#1480](https://github.com/octokit/octokit.net/pull/1480) via @maddin2016, @ryangribble
+- Implement `ReviewPermission()` functionality for `OrganizationMembersClient` (Preview API) - [#1633](https://github.com/octokit/octokit.net/pull/1633) via @alfhenrik
+- Implement [Organization OutsideCollaborators API (Preview)](https://developer.github.com/v3/orgs/outside_collaborators/) - [#1639](https://github.com/octokit/octokit.net/pull/1639) via @alfhenrik, @ryangribble
+- Implement pagination support for `OrganizationOutsideCollaboratorsClient.GetAll()` method - [#1650](https://github.com/octokit/octokit.net/pull/1650) via @ryangribble
+- Implement `GetAllPendingInvitations()` functionality for `OrganizationMembersClient` and `TeamsClient` (Preview API) - [#1640](https://github.com/octokit/octokit.net/pull/1640) via @alfhenrik, @ryangribble
+- Implement [Pull Request Reviews API](https://developer.github.com/v3/pulls/reviews/) - [#1648](https://github.com/octokit/octokit.net/pull/1648) via @hartra344, @ryangribble
+
+**Fixes**
+
+- Fix `RepositoryTrafficClient` to handle upstream API change in timestamps from Unix epoch time to ISO8601 - [#1560](https://github.com/octokit/octokit.net/pull/1560) via @mderriey, @ryangribble
+- Fix more `IssueTimelineClient` deserialization exceptions by adding more new `EventInfoState` values - [#1563](https://github.com/octokit/octokit.net/pull/1563) via @ryangribble
+- Fix `NotificationsClient.MarkAsRead()` exception by specifying a payload body in the `PUT` request - [#1579](https://github.com/octokit/octokit.net/pull/1579) via @shiftkey, @ryangribble
+- Fix `connection.GetLastApiInfo()` was returning `null` in some situations - [#1580](https://github.com/octokit/octokit.net/pull/1580) via @ryangribble
+- Fix even more `IssueTimelineClient` deserialization exceptions by adding even more new `EventInfoState` values (this is getting old!) - [#1591](https://github.com/octokit/octokit.net/pull/1591) via @lynnfaraday, @ryangribble
+- `NewRepositoryWebHook.ToRequest()` no longer discards existing fields if they are set - [#1623](https://github.com/octokit/octokit.net/pull/1623) via @ctolkien
+- Fix pagination on API calls that use `Uri` parameters (typically for requests that include some form of filtering) - [#1649](https://github.com/octokit/octokit.net/pull/1649) via @ryangribble
+
+**Housekeeping**
+
+- Remove obsolete constructor of `RepositoryUpdate` request class - [#1569](https://github.com/octokit/octokit.net/pull/1569) via @eriawan
+- Remove unused Rx-Main dependency from LINQPad samples - [#1593](https://github.com/octokit/octokit.net/pull/1593) via @NickCraver
+- Change response models 'Url' properties from `Uri` to `string` - [#1585](https://github.com/octokit/octokit.net/pull/1585) via @mderriey
+- Remove obsolete branch protection methods/classes - [#1620](https://github.com/octokit/octokit.net/pull/1620) via @ryangribble
+- Remove methods and members that were marked `[Obsolete]` in 0.23 or earlier - [#1622](https://github.com/octokit/octokit.net/pull/1622) via @ryangribble
+
+**Documentation Updates**
+
+- Fix `Issue` documentation samples (`GetForRepository()` should be `GetForRepository()`) - [#1602](https://github.com/octokit/octokit.net/pull/1602) via @tnaoto
+- Fix `Release` documentation samples (`ReleaseUpdate` should be `NewRelease`) - [#1611](https://github.com/octokit/octokit.net/pull/1611) via @watsonlu
+
 ### New in 0.24.0 (released 17/1/2017)
 
 **Features/Enhancements**

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -32,7 +32,7 @@
 - Enhance `RepositoryBranchesClient` to support Admin Enforcement changes - [#1598](https://github.com/octokit/octokit.net/pull/1598) via @M-Zuber
 - Implement [Pull Request Review Requests API (Preview)](https://developer.github.com/v3/pulls/review_requests/) - [#1588](https://github.com/octokit/octokit.net/pull/1588) via @gdziadkiewicz, @ryangribble
 - Provide a robust way to handle unknown enum values returned by GitHub API, to prevent deserialization errors until the enum values can be added to octokit - [#1595](https://github.com/octokit/octokit.net/pull/1595) via @khellang, @ryangribble
-- Implement support for [Projects API (Preview)](https://developer.github.com/v3/projects/) - [#1480](https://github.com/octokit/octokit.net/pull/1480) via @maddin2016, @ryangribble
+- Implement [Projects API (Preview)](https://developer.github.com/v3/projects/) - [#1480](https://github.com/octokit/octokit.net/pull/1480) via @maddin2016, @ryangribble
 - Implement `ReviewPermission()` functionality for `OrganizationMembersClient` (Preview API) - [#1633](https://github.com/octokit/octokit.net/pull/1633) via @alfhenrik
 - Implement [Organization OutsideCollaborators API (Preview)](https://developer.github.com/v3/orgs/outside_collaborators/) - [#1639](https://github.com/octokit/octokit.net/pull/1639) via @alfhenrik, @ryangribble
 - Implement pagination support for `OrganizationOutsideCollaboratorsClient.GetAll()` method - [#1650](https://github.com/octokit/octokit.net/pull/1650) via @ryangribble

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -48,6 +48,7 @@
 - Fix even more `IssueTimelineClient` deserialization exceptions by adding even more new `EventInfoState` values (this is getting old!) - [#1591](https://github.com/octokit/octokit.net/pull/1591) via @lynnfaraday, @ryangribble
 - `NewRepositoryWebHook.ToRequest()` no longer discards existing fields if they are set - [#1623](https://github.com/octokit/octokit.net/pull/1623) via @ctolkien
 - Fix pagination on API calls that use `Uri` parameters (typically for requests that include some form of filtering) - [#1649](https://github.com/octokit/octokit.net/pull/1649) via @ryangribble
+- Fixed `RepositoryCommitsClient.GetSha1()` to correctly obtain the sha1 of the specified commit, after the API went from preview to official - [#1654](https://github.com/octokit/octokit.net/pull/1654) via @ryangribble
 
 **Housekeeping**
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,7 +6,7 @@
 
 - `Enum` fields in Octokit response classes are now wrapped in an `StringEnum<TEnum>` helper class, to provide more robustness in dealing with unknown API values for these fields.  Whilst the changes are backwards compatible, please consult the guidance on [working with Enums](https://github.com/octokit/octokit.net/blob/master/docs/working-with-enums.md) for more information
 
-- `IncludeAdmins` field is no longer present in `BranchProtectionRequiredStatusChecks` and `BranchProtectionRequiredStatusChecksUpdate` classes, instead use the new `EnforceAdmins` field on `BranchProtectionSettingsUpdate` or the [new explicit methods](https://github.com/octokit/octokit.net/blob/master/Octokit/Clients/IRepositoryBranchesClient.cs#L304-L365) for configuring Admin Enforcement on protected branches.  This was an [upstream API breaking change](https://developer.github.com/changes/2017-05-02-adoption-of-admin-enforced/) so couldn't follow our normal deprecation schedule
+- `IncludeAdmins` field is no longer present in `BranchProtectionRequiredStatusChecks` and `BranchProtectionRequiredStatusChecksUpdate` classes, instead use the new `EnforceAdmins` field on `BranchProtectionSettingsUpdate` or the [new explicit methods](https://github.com/octokit/octokit.net/blob/master/Octokit/Clients/IRepositoryBranchesClient.cs#L304-L365) for configuring Admin Enforcement on protected branches.  This was an [upstream API breaking change](https://developer.github.com/changes/2017-05-02-adoption-of-admin-enforced/) so we couldn't follow our normal deprecation schedule
 
 ## Release Notes
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,64 +4,64 @@
 
 **Features/Enhancements**
 
-- Add a build task to validate LINQPad samples - [#1551](https://github.com/octokit/octokit.net/pull/1551) via @mderriey
-- Add a code formatting task to CAKE - [#1550](https://github.com/octokit/octokit.net/pull/1550) via @mderriey
-- Add GitVersion configuration file - [#1555](https://github.com/octokit/octokit.net/pull/1555) via @mderriey
+- Add a build task to validate LINQPad samples - [#1551](https://github.com/octokit/octokit.net/pull/1551) via [@mderriey](https://github.com/mderriey)
+- Add a code formatting task to CAKE - [#1550](https://github.com/octokit/octokit.net/pull/1550) via [@mderriey](https://github.com/mderriey)
+- Add GitVersion configuration file - [#1555](https://github.com/octokit/octokit.net/pull/1555) via [@mderriey](https://github.com/mderriey)
 
 
 ### Milestone: dotnetcore Support
 
 **Features/Enhancements**
 
-- Port to .NET Core - [#1503](https://github.com/octokit/octokit.net/pull/1503) via @mderriey, @ryangribble
-- Remove unneeded files for .NET Core - [#1549](https://github.com/octokit/octokit.net/pull/1549) via @mderriey
-- Migrate dotnetcore to vs2017 tooling - [#1567](https://github.com/octokit/octokit.net/pull/1567) via @ryangribble, @mderriey
-- Provide [SourceLink](https://github.com/ctaggart/SourceLink) capability for Octokit and Octokit.Reactive assemblies - [#1574](https://github.com/octokit/octokit.net/pull/1574) via @ryangribble, @mderriey
-- Deliver the dotnetcore port and CAKE build framework changes - [#1581](https://github.com/octokit/octokit.net/pull/1581) via @ryangribble, @mderriey
+- Port to .NET Core - [#1503](https://github.com/octokit/octokit.net/pull/1503) via [@mderriey](https://github.com/mderriey), [@ryangribble](https://github.com/ryangribble)
+- Remove unneeded files for .NET Core - [#1549](https://github.com/octokit/octokit.net/pull/1549) via [@mderriey](https://github.com/mderriey)
+- Migrate dotnetcore to vs2017 tooling - [#1567](https://github.com/octokit/octokit.net/pull/1567) via [@ryangribble](https://github.com/ryangribble), [@mderriey](https://github.com/mderriey)
+- Provide [SourceLink](https://github.com/ctaggart/SourceLink) capability for Octokit and Octokit.Reactive assemblies - [#1574](https://github.com/octokit/octokit.net/pull/1574) via [@ryangribble](https://github.com/ryangribble), [@mderriey](https://github.com/mderriey)
+- Deliver the dotnetcore port and CAKE build framework changes - [#1581](https://github.com/octokit/octokit.net/pull/1581) via [@ryangribble](https://github.com/ryangribble), [@mderriey](https://github.com/mderriey)
 
 **Fixes**
 
-- Fix broken JSON deserialization in .NET 4.5 after VS2017 project update - [#1647](https://github.com/octokit/octokit.net/pull/1647) via @mderriey
+- Fix broken JSON deserialization in .NET 4.5 after VS2017 project update - [#1647](https://github.com/octokit/octokit.net/pull/1647) via [@mderriey](https://github.com/mderriey)
 
 
 ### Milestone: None
 
 **Features/Enhancements**
 
-- Add support for the newly resurrected `PullRequest.MergeCommitSha` property - [#1562](https://github.com/octokit/octokit.net/pull/1562) via @alexperovich
-- Enhance `RepositoryBranchesClient` to support Admin Enforcement changes - [#1598](https://github.com/octokit/octokit.net/pull/1598) via @M-Zuber
-- Implement [Pull Request Review Requests API (Preview)](https://developer.github.com/v3/pulls/review_requests/) - [#1588](https://github.com/octokit/octokit.net/pull/1588) via @gdziadkiewicz, @ryangribble
-- Provide a robust way to handle unknown enum values returned by GitHub API, to prevent deserialization errors until the enum values can be added to octokit - [#1595](https://github.com/octokit/octokit.net/pull/1595) via @khellang, @ryangribble
-- Implement [Projects API (Preview)](https://developer.github.com/v3/projects/) - [#1480](https://github.com/octokit/octokit.net/pull/1480) via @maddin2016, @ryangribble
-- Implement `ReviewPermission()` functionality for `OrganizationMembersClient` (Preview API) - [#1633](https://github.com/octokit/octokit.net/pull/1633) via @alfhenrik
-- Implement [Organization OutsideCollaborators API (Preview)](https://developer.github.com/v3/orgs/outside_collaborators/) - [#1639](https://github.com/octokit/octokit.net/pull/1639) via @alfhenrik, @ryangribble
-- Implement pagination support for `OrganizationOutsideCollaboratorsClient.GetAll()` method - [#1650](https://github.com/octokit/octokit.net/pull/1650) via @ryangribble
-- Implement `GetAllPendingInvitations()` functionality for `OrganizationMembersClient` and `TeamsClient` (Preview API) - [#1640](https://github.com/octokit/octokit.net/pull/1640) via @alfhenrik, @ryangribble
-- Implement [Pull Request Reviews API](https://developer.github.com/v3/pulls/reviews/) - [#1648](https://github.com/octokit/octokit.net/pull/1648) via @hartra344, @ryangribble
+- Add support for the newly resurrected `PullRequest.MergeCommitSha` property - [#1562](https://github.com/octokit/octokit.net/pull/1562) via [@alexperovich](https://github.com/alexperovich)
+- Enhance `RepositoryBranchesClient` to support Admin Enforcement changes - [#1598](https://github.com/octokit/octokit.net/pull/1598) via [@M-Zuber](https://github.com/M-Zuber)
+- Implement [Pull Request Review Requests API (Preview)](https://developer.github.com/v3/pulls/review_requests/) - [#1588](https://github.com/octokit/octokit.net/pull/1588) via [@gdziadkiewicz](https://github.com/gdziadkiewicz), [@ryangribble](https://github.com/ryangribble)
+- Provide a robust way to handle unknown enum values returned by GitHub API, to prevent deserialization errors until the enum values can be added to octokit - [#1595](https://github.com/octokit/octokit.net/pull/1595) via [@khellang](https://github.com/khellang), [@ryangribble](https://github.com/ryangribble)
+- Implement [Projects API (Preview)](https://developer.github.com/v3/projects/) - [#1480](https://github.com/octokit/octokit.net/pull/1480) via [@maddin2016](https://github.com/maddin2016), [@ryangribble](https://github.com/ryangribble)
+- Implement `ReviewPermission()` functionality for `OrganizationMembersClient` (Preview API) - [#1633](https://github.com/octokit/octokit.net/pull/1633) via [@alfhenrik](https://github.com/alfhenrik)
+- Implement [Organization OutsideCollaborators API (Preview)](https://developer.github.com/v3/orgs/outside_collaborators/) - [#1639](https://github.com/octokit/octokit.net/pull/1639) via [@alfhenrik](https://github.com/alfhenrik), [@ryangribble](https://github.com/ryangribble)
+- Implement pagination support for `OrganizationOutsideCollaboratorsClient.GetAll()` method - [#1650](https://github.com/octokit/octokit.net/pull/1650) via [@ryangribble](https://github.com/ryangribble)
+- Implement `GetAllPendingInvitations()` functionality for `OrganizationMembersClient` and `TeamsClient` (Preview API) - [#1640](https://github.com/octokit/octokit.net/pull/1640) via [@alfhenrik](https://github.com/alfhenrik), [@ryangribble](https://github.com/ryangribble)
+- Implement [Pull Request Reviews API](https://developer.github.com/v3/pulls/reviews/) - [#1648](https://github.com/octokit/octokit.net/pull/1648) via [@hartra344](https://github.com/hartra344), [@ryangribble](https://github.com/ryangribble)
 
 **Fixes**
 
-- Fix `RepositoryTrafficClient` to handle upstream API change in timestamps from Unix epoch time to ISO8601 - [#1560](https://github.com/octokit/octokit.net/pull/1560) via @mderriey, @ryangribble
-- Fix more `IssueTimelineClient` deserialization exceptions by adding more new `EventInfoState` values - [#1563](https://github.com/octokit/octokit.net/pull/1563) via @ryangribble
-- Fix `NotificationsClient.MarkAsRead()` exception by specifying a payload body in the `PUT` request - [#1579](https://github.com/octokit/octokit.net/pull/1579) via @shiftkey, @ryangribble
-- Fix `connection.GetLastApiInfo()` was returning `null` in some situations - [#1580](https://github.com/octokit/octokit.net/pull/1580) via @ryangribble
-- Fix even more `IssueTimelineClient` deserialization exceptions by adding even more new `EventInfoState` values (this is getting old!) - [#1591](https://github.com/octokit/octokit.net/pull/1591) via @lynnfaraday, @ryangribble
-- `NewRepositoryWebHook.ToRequest()` no longer discards existing fields if they are set - [#1623](https://github.com/octokit/octokit.net/pull/1623) via @ctolkien
-- Fix pagination on API calls that use `Uri` parameters (typically for requests that include some form of filtering) - [#1649](https://github.com/octokit/octokit.net/pull/1649) via @ryangribble
-- Fixed `RepositoryCommitsClient.GetSha1()` to correctly obtain the sha1 of the specified commit, after the API went from preview to official - [#1654](https://github.com/octokit/octokit.net/pull/1654) via @ryangribble
+- Fix `RepositoryTrafficClient` to handle upstream API change in timestamps from Unix epoch time to ISO8601 - [#1560](https://github.com/octokit/octokit.net/pull/1560) via [@mderriey](https://github.com/mderriey), [@ryangribble](https://github.com/ryangribble)
+- Fix more `IssueTimelineClient` deserialization exceptions by adding more new `EventInfoState` values - [#1563](https://github.com/octokit/octokit.net/pull/1563) via [@ryangribble](https://github.com/ryangribble)
+- Fix `NotificationsClient.MarkAsRead()` exception by specifying a payload body in the `PUT` request - [#1579](https://github.com/octokit/octokit.net/pull/1579) via [@shiftkey](https://github.com/shiftkey), [@ryangribble](https://github.com/ryangribble)
+- Fix `connection.GetLastApiInfo()` was returning `null` in some situations - [#1580](https://github.com/octokit/octokit.net/pull/1580) via [@ryangribble](https://github.com/ryangribble)
+- Fix even more `IssueTimelineClient` deserialization exceptions by adding even more new `EventInfoState` values (this is getting old!) - [#1591](https://github.com/octokit/octokit.net/pull/1591) via [@lynnfaraday](https://github.com/lynnfaraday), [@ryangribble](https://github.com/ryangribble)
+- `NewRepositoryWebHook.ToRequest()` no longer discards existing fields if they are set - [#1623](https://github.com/octokit/octokit.net/pull/1623) via [@ctolkien](https://github.com/ctolkien)
+- Fix pagination on API calls that use `Uri` parameters (typically for requests that include some form of filtering) - [#1649](https://github.com/octokit/octokit.net/pull/1649) via [@ryangribble](https://github.com/ryangribble)
+- Fixed `RepositoryCommitsClient.GetSha1()` to correctly obtain the sha1 of the specified commit, after the API went from preview to official - [#1654](https://github.com/octokit/octokit.net/pull/1654) via [@ryangribble](https://github.com/ryangribble)
 
 **Housekeeping**
 
-- Remove obsolete constructor of `RepositoryUpdate` request class - [#1569](https://github.com/octokit/octokit.net/pull/1569) via @eriawan
-- Remove unused Rx-Main dependency from LINQPad samples - [#1593](https://github.com/octokit/octokit.net/pull/1593) via @NickCraver
-- Change response models 'Url' properties from `Uri` to `string` - [#1585](https://github.com/octokit/octokit.net/pull/1585) via @mderriey
-- Remove obsolete branch protection methods/classes - [#1620](https://github.com/octokit/octokit.net/pull/1620) via @ryangribble
-- Remove methods and members that were marked `[Obsolete]` in 0.23 or earlier - [#1622](https://github.com/octokit/octokit.net/pull/1622) via @ryangribble
+- Remove obsolete constructor of `RepositoryUpdate` request class - [#1569](https://github.com/octokit/octokit.net/pull/1569) via [@eriawan](https://github.com/eriawan)
+- Remove unused Rx-Main dependency from LINQPad samples - [#1593](https://github.com/octokit/octokit.net/pull/1593) via [@NickCraver](https://github.com/NickCraver)
+- Change response models 'Url' properties from `Uri` to `string` - [#1585](https://github.com/octokit/octokit.net/pull/1585) via [@mderriey](https://github.com/mderriey)
+- Remove obsolete branch protection methods/classes - [#1620](https://github.com/octokit/octokit.net/pull/1620) via [@ryangribble](https://github.com/ryangribble)
+- Remove methods and members that were marked `[Obsolete]` in 0.23 or earlier - [#1622](https://github.com/octokit/octokit.net/pull/1622) via [@ryangribble](https://github.com/ryangribble)
 
 **Documentation Updates**
 
-- Fix `Issue` documentation samples (`GetForRepository()` should be `GetForRepository()`) - [#1602](https://github.com/octokit/octokit.net/pull/1602) via @tnaoto
-- Fix `Release` documentation samples (`ReleaseUpdate` should be `NewRelease`) - [#1611](https://github.com/octokit/octokit.net/pull/1611) via @watsonlu
+- Fix `Issue` documentation samples (`GetForRepository()` should be `GetForRepository()`) - [#1602](https://github.com/octokit/octokit.net/pull/1602) via [@tnaoto](https://github.com/tnaoto)
+- Fix `Release` documentation samples (`ReleaseUpdate` should be `NewRelease`) - [#1611](https://github.com/octokit/octokit.net/pull/1611) via [@watsonlu](https://github.com/watsonlu)
 
 ### New in 0.24.0 (released 17/1/2017)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,12 @@
 ### New in 0.25.0 (released 23/8/2017)
 
-## Breaking Changes and Advisories
+## Advisories and Breaking Changes
 
-- `IncludeAdmins` field is no longer present in `BranchProtectionRequiredStatusChecks` and `BranchProtectionRequiredStatusChecksUpdate` classes, instead use the new `EnforceAdmins` field on `BranchProtectionSettingsUpdate` or the new explicit APIs for configuring Admin Enforcement on protected branches.  This was an [upstream API breaking change](https://developer.github.com/changes/2017-05-02-adoption-of-admin-enforced/) so couldn't follow our normal deprecation schedule
+- Octokit.net has been ported to dotnetcore :tada: providing libraries targetting `netstandard1.1` and `net45` frameworks
 
-- `Enum` fields in Octokit response classes are now wrapped in an `EnumHelper<TEnum>` class to provide more robustness in dealing with new/unknown API values for these fields.  Whilst the changes are backwards compatible, please consult the guidance on [working with `StringEnum` members](https://github.com/octokit/octokit.net/blob/master/docs/working-with-enums.md) for more information
+- `Enum` fields in Octokit response classes are now wrapped in an `StringEnum<TEnum>` helper class, to provide more robustness in dealing with unknown API values for these fields.  Whilst the changes are backwards compatible, please consult the guidance on [working with Enums](https://github.com/octokit/octokit.net/blob/master/docs/working-with-enums.md) for more information
+
+- `IncludeAdmins` field is no longer present in `BranchProtectionRequiredStatusChecks` and `BranchProtectionRequiredStatusChecksUpdate` classes, instead use the new `EnforceAdmins` field on `BranchProtectionSettingsUpdate` or the [new explicit methods](https://github.com/octokit/octokit.net/blob/master/Octokit/Clients/IRepositoryBranchesClient.cs#L304-L365) for configuring Admin Enforcement on protected branches.  This was an [upstream API breaking change](https://developer.github.com/changes/2017-05-02-adoption-of-admin-enforced/) so couldn't follow our normal deprecation schedule
 
 ## Release Notes
 


### PR DESCRIPTION
This release has been long overdue 😭

Plenty of goodies in here including the dotnetcore port (netstandard 1.1) and moving to CAKE.Frosting as a build system... several bug fixes and several new API's implemented including Projects, Pull Request Reviews, Pull Request Review Requests and Organization Outside Collaborators!

Im also tweaking the release notes format a bit, and have been working on [a utility](https://github.com/ryangribble/Octokit.ReleaseNotes) to generate them, based on `release_notes` comments on the merged PR's.  Everything you see in ReleaseNotes.md was generated by this utility this time around, so any wording tweaks need to be done "at the source" and then I can regenerate the release notes.  Ultimately I'd like to do some more work so that creation of draft releases and generating release notes etc can be done in CAKE scripts and run by AppVeyor as appropriate.


All integration tests are passing so I'm pretty ready to 🚢 - will aim for tomorrow night.  I just need to go through things and see if there are any breaking changes that need to be called out.

- [x] initial release notes
- [x] version bump (need to see how AppVeyor and GitVersion will deal with this... I THINK once I tag master after mergint this PR, the resultant build should get the correct version!)
- [x] run `build FormatCode` to tidy up whitespace/formatting
- [x] integration tests all pass
- [x] tweak release notes to call out any breaking changes/special instructions
- [x] :thumbsup: from @shiftkey or @Haacked
- [x] :thumbsup: from key contributors @mderriey @alfhenrik  @M-Zuber etc
- [ ] :shipit: