### PR TITLE
Release v0.26 - In the Nick of Time

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,7 @@
 
 ## Advisories and Breaking Changes
 
-- This release contains the necessary Octokit changes to ensure that we send the `required-pull-request-reviews` field which becomes mandatory  when the Protected Branches API [graduates from preview mode](https://developer.github.com/changes/2017-06-16-loki-preview-ending-soon/) on the 1st September
+- This release contains the necessary Octokit changes to ensure we specify the `required_pull_request_reviews` field on Branch Protection updates, which becomes mandatory when the Protected Branches API [graduates from preview mode](https://developer.github.com/changes/2017-06-16-loki-preview-ending-soon/) on the 1st September
 
 **Features/Enhancements**
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,13 @@
+### New in 0.26.0 (released 31/8/2017)
+
+## Advisories and Breaking Changes
+
+- This release contains the necessary Octokit changes to ensure that we send the `required-pull-request-reviews` field which becomes mandatory  when the Protected Branches API [graduates from preview mode](https://developer.github.com/changes/2017-06-16-loki-preview-ending-soon/) on the 1st September
+
+**Features/Enhancements**
+
+- Implement `RequiredPullRequestReviews` support in `IRepositoryBranchesClient.UpdateBranchProtection` and additional granular methods to `GetReviewEnforcement`, `UpdateReviewEnforcement` and `RemoveReviewEnforcement` via [@M-Zuber](https://github.com/M-Zuber), [@ryangribble](https://github.com/ryangribble)
+
 ### New in 0.25.0 (released 23/8/2017)
 
 ## Advisories and Breaking Changes

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,7 @@
 
 ## Advisories and Breaking Changes
 
-- This release contains the necessary Octokit changes to ensure we specify the `required_pull_request_reviews` field on Branch Protection updates, which becomes mandatory when the Protected Branches API [graduates from preview mode](https://developer.github.com/changes/2017-06-16-loki-preview-ending-soon/) on the 1st September
+- This release contains the necessary Octokit changes to specify the `required_pull_request_reviews` field on Branch Protection updates, which becomes mandatory when the Protected Branches API [graduates from preview mode](https://developer.github.com/changes/2017-06-16-loki-preview-ending-soon/) on the 1st September
 
 **Features/Enhancements**
 


### PR DESCRIPTION
We need to get #1523 shipped prior to the Branch Protection API Preview period ending on the 1st September

Given it's hot on the heels of v0.25 I have only run the integration tests for `RepositoryBranchesClient` and `ObservableRepositoryBranchesClient` and will aim to ship tomorrow.

- [x] initial release notes
- [x] run `build FormatCode` to tidy up whitespace/formatting
- [x] ~~integration tests all pass~~ `RepositoryBranchesClient` and `ObservableRepositoryBranchesClient` integration tests all pass
- [x] tweak release notes to call out any breaking changes/special instructions
- [x] :thumbsup: from @shiftkey or @Haacked
- [x] :thumbsup: from key contributors @mderriey @alfhenrik  @M-Zuber etc
- [ ] :shipit: