### PR TITLE
Enable pagination convention tests

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
@@ -214,6 +214,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
         IObservable<string> GetRequiredStatusChecksContexts(string owner, string name, string branch);
 
         /// <summary>
@@ -224,7 +225,29 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
         IObservable<string> GetRequiredStatusChecksContexts(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<string> GetAllRequiredStatusChecksContexts(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<string> GetAllRequiredStatusChecksContexts(long repositoryId, string branch);
 
         /// <summary>
         /// Replace the required status checks contexts for the specified branch
@@ -472,6 +495,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         IObservable<Team> GetProtectedBranchTeamRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -482,7 +506,29 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         IObservable<Team> GetProtectedBranchTeamRestrictions(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<Team> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<Team> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch);
 
         /// <summary>
         /// Replace team restrictions for the specified branch (applies only to Organization owned repositories)
@@ -562,6 +608,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         IObservable<User> GetProtectedBranchUserRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -572,7 +619,29 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         IObservable<User> GetProtectedBranchUserRestrictions(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<User> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        IObservable<User> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch);
 
         /// <summary>
         /// Replace user restrictions for the specified branch (applies only to Organization owned repositories)

--- a/Octokit.Reactive/Clients/IObservableRepositoryTrafficClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryTrafficClient.cs
@@ -16,6 +16,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
         IObservable<RepositoryTrafficReferrer> GetReferrers(string owner, string name);
 
         /// <summary>
@@ -23,7 +24,23 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
         IObservable<RepositoryTrafficReferrer> GetReferrers(long repositoryId);
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        IObservable<RepositoryTrafficReferrer> GetAllReferrers(string owner, string name);
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        IObservable<RepositoryTrafficReferrer> GetAllReferrers(long repositoryId);
 
         /// <summary>
         /// List the top 10 popular contents over the last 14 days
@@ -31,6 +48,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
         IObservable<RepositoryTrafficPath> GetPaths(string owner, string name);
 
         /// <summary>
@@ -38,7 +56,23 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
         IObservable<RepositoryTrafficPath> GetPaths(long repositoryId);
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        IObservable<RepositoryTrafficPath> GetAllPaths(string owner, string name);
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        IObservable<RepositoryTrafficPath> GetAllPaths(long repositoryId);
 
         /// <summary>
         /// Get the total number of views and breakdown per day or week for the last 14 days

--- a/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
@@ -331,13 +331,10 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
         public IObservable<string> GetRequiredStatusChecksContexts(string owner, string name, string branch)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
-
-            return _client.GetRequiredStatusChecksContexts(owner, name, branch).ToObservable().SelectMany(x => x);
+            return GetAllRequiredStatusChecksContexts(owner, name, branch);
         }
 
         /// <summary>
@@ -348,11 +345,43 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
         public IObservable<string> GetRequiredStatusChecksContexts(long repositoryId, string branch)
+        {
+            return GetAllRequiredStatusChecksContexts(repositoryId, branch);
+        }
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<string> GetAllRequiredStatusChecksContexts(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.GetAllRequiredStatusChecksContexts(owner, name, branch).ToObservable().SelectMany(x => x);
+        }
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<string> GetAllRequiredStatusChecksContexts(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
-            return _client.GetRequiredStatusChecksContexts(repositoryId, branch).ToObservable().SelectMany(x => x);
+            return _client.GetAllRequiredStatusChecksContexts(repositoryId, branch).ToObservable().SelectMany(x => x);
         }
 
         /// <summary>
@@ -741,13 +770,10 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         public IObservable<Team> GetProtectedBranchTeamRestrictions(string owner, string name, string branch)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
-
-            return _client.GetProtectedBranchTeamRestrictions(owner, name, branch).ToObservable().SelectMany(x => x);
+            return GetAllProtectedBranchTeamRestrictions(owner, name, branch);
         }
 
         /// <summary>
@@ -758,11 +784,43 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         public IObservable<Team> GetProtectedBranchTeamRestrictions(long repositoryId, string branch)
+        {
+            return GetAllProtectedBranchTeamRestrictions(repositoryId, branch);
+        }
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<Team> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.GetAllProtectedBranchTeamRestrictions(owner, name, branch).ToObservable().SelectMany(x => x);
+        }
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<Team> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
-            return _client.GetProtectedBranchTeamRestrictions(repositoryId, branch).ToObservable().SelectMany(x => x);
+            return _client.GetAllProtectedBranchTeamRestrictions(repositoryId, branch).ToObservable().SelectMany(x => x);
         }
 
         /// <summary>
@@ -885,13 +943,10 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         public IObservable<User> GetProtectedBranchUserRestrictions(string owner, string name, string branch)
         {
-            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
-            Ensure.ArgumentNotNullOrEmptyString(name, "name");
-            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
-
-            return _client.GetProtectedBranchUserRestrictions(owner, name, branch).ToObservable().SelectMany(x => x);
+            return GetAllProtectedBranchUserRestrictions(owner, name, branch);
         }
 
         /// <summary>
@@ -902,11 +957,44 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
+
         public IObservable<User> GetProtectedBranchUserRestrictions(long repositoryId, string branch)
+        {
+            return GetAllProtectedBranchUserRestrictions(repositoryId, branch);
+        }
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<User> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
+            Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
+
+            return _client.GetAllProtectedBranchUserRestrictions(owner, name, branch).ToObservable().SelectMany(x => x);
+        }
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public IObservable<User> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
-            return _client.GetProtectedBranchUserRestrictions(repositoryId, branch).ToObservable().SelectMany(x => x);
+            return _client.GetAllProtectedBranchUserRestrictions(repositoryId, branch).ToObservable().SelectMany(x => x);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoryTrafficClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryTrafficClient.cs
@@ -20,9 +20,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
         public IObservable<RepositoryTrafficPath> GetPaths(long repositoryId)
         {
-            return _client.GetPaths(repositoryId).ToObservable().SelectMany(x => x);
+            return GetAllPaths(repositoryId);
         }
 
         /// <summary>
@@ -31,12 +32,34 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
         public IObservable<RepositoryTrafficPath> GetPaths(string owner, string name)
+        {
+            return GetAllPaths(owner, name);
+        }
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        public IObservable<RepositoryTrafficPath> GetAllPaths(long repositoryId)
+        {
+            return _client.GetAllPaths(repositoryId).ToObservable().SelectMany(x => x);
+        }
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        public IObservable<RepositoryTrafficPath> GetAllPaths(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.GetPaths(owner, name).ToObservable().SelectMany(x => x);
+            return _client.GetAllPaths(owner, name).ToObservable().SelectMany(x => x);
         }
 
         /// <summary>
@@ -44,9 +67,10 @@ namespace Octokit.Reactive
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
         public IObservable<RepositoryTrafficReferrer> GetReferrers(long repositoryId)
         {
-            return _client.GetReferrers(repositoryId).ToObservable().SelectMany(x => x);
+            return GetAllReferrers(repositoryId);
         }
 
         /// <summary>
@@ -55,12 +79,34 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
         public IObservable<RepositoryTrafficReferrer> GetReferrers(string owner, string name)
+        {
+            return GetAllReferrers(owner, name);
+        }
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        public IObservable<RepositoryTrafficReferrer> GetAllReferrers(long repositoryId)
+        {
+            return _client.GetAllReferrers(repositoryId).ToObservable().SelectMany(x => x);
+        }
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        public IObservable<RepositoryTrafficReferrer> GetAllReferrers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return _client.GetReferrers(owner, name).ToObservable().SelectMany(x => x);
+            return _client.GetAllReferrers(owner, name).ToObservable().SelectMany(x => x);
         }
 
         /// <summary>

--- a/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
+++ b/Octokit.Tests.Conventions/Exception/ApiOptionsMissingException.cs
@@ -14,7 +14,7 @@ namespace Octokit.Tests.Conventions
         static string CreateMessage(Type type, IEnumerable<MethodInfo> methods)
         {
             var methodsFormatted = String.Join("\r\n", methods.Select(FormatMethod));
-            return "Methods found on type {0} require an overload which accepts an parameter of type ApiOptions:\r\n{1}"
+            return "Methods found on type {0} require an overload which accepts a parameter of type ApiOptions:\r\n{1}"
                       .FormatWithNewLine(
                           type.Name,
                           methodsFormatted);

--- a/Octokit.Tests.Conventions/PaginationTests.cs
+++ b/Octokit.Tests.Conventions/PaginationTests.cs
@@ -8,14 +8,17 @@ namespace Octokit.Tests.Conventions
 {
     public class PaginationTests
     {
-        [Theory(Skip = "Enable this to run it and find all the places where things break")]
+        [Theory]
         [MemberData(nameof(GetClientInterfaces))]
-        public void CheckObservableClients(Type clientInterface)
+        public void CheckPaginationApiOptionsOverloads(Type clientInterface)
         {
             var methodsOrdered = clientInterface.GetMethodsOrdered();
 
             var methodsWhichCanPaginate = methodsOrdered
-                .Where(x => x.Name.StartsWith("GetAll") && !x.HasAttribute<ExcludeFromPaginationConventionTestAttribute>());
+                .Where(x => x.ReturnType.GetCustomTypeInfo().TypeCategory == TypeCategory.ReadOnlyList)
+                .Where(x => x.Name.StartsWith("Get"))
+                .Where(x => !x.HasAttribute<ExcludeFromPaginationApiOptionsConventionTestAttribute>())
+                .Where(x => !x.HasAttribute<ObsoleteAttribute>());
 
             var invalidMethods = methodsWhichCanPaginate
                 .Where(method => MethodHasAppropriateOverload(method, methodsOrdered) == null)
@@ -35,7 +38,9 @@ namespace Octokit.Tests.Conventions
 
             var methodsThatCanPaginate = methodsOrdered
                 .Where(x => x.ReturnType.GetCustomTypeInfo().TypeCategory == TypeCategory.ReadOnlyList)
-                .Where(x => x.Name.StartsWith("Get") && !x.HasAttribute<ExcludeFromPaginationConventionTestAttribute>());
+                .Where(x => x.Name.StartsWith("Get"))
+                .Where(x => !x.HasAttribute<ExcludeFromPaginationNamingConventionTestAttribute>())
+                .Where(x => !x.HasAttribute<ObsoleteAttribute>());
 
             var invalidMethods = methodsThatCanPaginate
                 .Where(x => !x.Name.StartsWith("GetAll"))
@@ -49,7 +54,7 @@ namespace Octokit.Tests.Conventions
 
         static MethodInfo MethodHasAppropriateOverload(MethodInfo method, MethodInfo[] methodsOrdered)
         {
-            var parameters = method.GetParametersOrdered();
+            var parameters = method.GetParameters();
             var name = method.Name;
             return methodsOrdered
                 .Where(x => x.Name == name)
@@ -60,7 +65,7 @@ namespace Octokit.Tests.Conventions
         {
             var actual = methodInfo.GetParameters();
 
-            if (actual.Length != expected.Length + 1)
+            if ((actual.Length != expected.Length) && (actual.Length != expected.Length + 1))
             {
                 return false;
             }
@@ -81,9 +86,10 @@ namespace Octokit.Tests.Conventions
                 }
             }
 
-            var lastParameter = actual.Last();
+            var lastParameter = actual.LastOrDefault();
 
-            return lastParameter.Name == "options"
+            return lastParameter != null
+                   && lastParameter.Name == "options"
                    && lastParameter.ParameterType == typeof(ApiOptions);
         }
 

--- a/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryBranchesClientTests.cs
@@ -1254,12 +1254,12 @@ public class RepositoryBranchesClientTests
         }
     }
 
-    public class TheGetProtectedBranchTeamRestrictionsMethod : IDisposable
+    public class TheGetAllProtectedBranchTeamRestrictionsMethod : IDisposable
     {
         IRepositoryBranchesClient _client;
         OrganizationRepositoryWithTeamContext _orgRepoContext;
 
-        public TheGetProtectedBranchTeamRestrictionsMethod()
+        public TheGetAllProtectedBranchTeamRestrictionsMethod()
         {
             var github = Helper.GetAuthenticatedClient();
             _client = github.Repository.Branch;
@@ -1272,7 +1272,7 @@ public class RepositoryBranchesClientTests
         {
             var repoOwner = _orgRepoContext.RepositoryContext.RepositoryOwner;
             var repoName = _orgRepoContext.RepositoryContext.RepositoryName;
-            var restrictions = await _client.GetProtectedBranchTeamRestrictions(repoOwner, repoName, "master");
+            var restrictions = await _client.GetAllProtectedBranchTeamRestrictions(repoOwner, repoName, "master");
 
             Assert.NotNull(restrictions);
             Assert.Equal(1, restrictions.Count);
@@ -1282,7 +1282,7 @@ public class RepositoryBranchesClientTests
         public async Task GetsProtectedBranchTeamRestrictionsForOrgRepoWithRepositoryId()
         {
             var repoId = _orgRepoContext.RepositoryContext.RepositoryId;
-            var restrictions = await _client.GetProtectedBranchTeamRestrictions(repoId, "master");
+            var restrictions = await _client.GetAllProtectedBranchTeamRestrictions(repoId, "master");
 
             Assert.NotNull(restrictions);
             Assert.Equal(1, restrictions.Count);
@@ -1470,12 +1470,12 @@ public class RepositoryBranchesClientTests
         }
     }
 
-    public class TheGetProtectedBranchUserRestrictionsMethod : IDisposable
+    public class TheGetAllProtectedBranchUserRestrictionsMethod : IDisposable
     {
         IRepositoryBranchesClient _client;
         OrganizationRepositoryWithTeamContext _orgRepoContext;
 
-        public TheGetProtectedBranchUserRestrictionsMethod()
+        public TheGetAllProtectedBranchUserRestrictionsMethod()
         {
             var github = Helper.GetAuthenticatedClient();
             _client = github.Repository.Branch;
@@ -1488,7 +1488,7 @@ public class RepositoryBranchesClientTests
         {
             var repoOwner = _orgRepoContext.RepositoryContext.RepositoryOwner;
             var repoName = _orgRepoContext.RepositoryContext.RepositoryName;
-            var restrictions = await _client.GetProtectedBranchUserRestrictions(repoOwner, repoName, "master");
+            var restrictions = await _client.GetAllProtectedBranchUserRestrictions(repoOwner, repoName, "master");
 
             Assert.NotNull(restrictions);
             Assert.Equal(0, restrictions.Count);
@@ -1498,7 +1498,7 @@ public class RepositoryBranchesClientTests
         public async Task GetsProtectedBranchUserRestrictionsForOrgRepoWithRepositoryId()
         {
             var repoId = _orgRepoContext.RepositoryContext.RepositoryId;
-            var restrictions = await _client.GetProtectedBranchUserRestrictions(repoId, "master");
+            var restrictions = await _client.GetAllProtectedBranchUserRestrictions(repoId, "master");
 
             Assert.NotNull(restrictions);
             Assert.Equal(0, restrictions.Count);

--- a/Octokit.Tests.Integration/Clients/RepositoryTrafficClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryTrafficClientTests.cs
@@ -21,12 +21,12 @@ public class RepositoryTrafficClientTests
         _repoId = _github.Repository.Get(_owner, _repo).Result.Id;
     }
 
-    public class TheGetReferrersMethod : RepositoryTrafficClientTests
+    public class TheGetAllReferrersMethod : RepositoryTrafficClientTests
     {
         [IntegrationTest(Skip = "This test needs to be an administrator of the Octokit.net repository")]
         public async Task GetsReferrers()
         {
-            var referrers = await _fixture.GetReferrers(_owner, _repo);
+            var referrers = await _fixture.GetAllReferrers(_owner, _repo);
 
             Assert.True(referrers.Count > 0);
         }
@@ -34,18 +34,18 @@ public class RepositoryTrafficClientTests
         [IntegrationTest(Skip = "This test needs to be an administrator of the Octokit.net repository")]
         public async Task GetsReferrersWithRepositoryId()
         {
-            var referrers = await _fixture.GetReferrers(_repoId);
+            var referrers = await _fixture.GetAllReferrers(_repoId);
 
             Assert.True(referrers.Count > 0);
         }
     }
 
-    public class TheGetPathsMethod : RepositoryTrafficClientTests
+    public class TheGetAllPathsMethod : RepositoryTrafficClientTests
     {
         [IntegrationTest(Skip = "This test needs to be an administrator of the Octokit.net repository")]
         public async Task GetsPaths()
         {
-            var paths = await _fixture.GetPaths(_owner, _repo);
+            var paths = await _fixture.GetAllPaths(_owner, _repo);
 
             Assert.True(paths.Count > 0);
         }
@@ -53,7 +53,7 @@ public class RepositoryTrafficClientTests
         [IntegrationTest(Skip = "This test needs to be an administrator of the Octokit.net repository")]
         public async Task GetsPathsWithRepositoryId()
         {
-            var paths = await _fixture.GetPaths(_repoId);
+            var paths = await _fixture.GetAllPaths(_repoId);
 
             Assert.True(paths.Count > 0);
         }

--- a/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryBranchesClientTests.cs
@@ -445,7 +445,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetRequiredStatusChecksContextsMethod
+        public class TheGetAllRequiredStatusChecksContextsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -454,7 +454,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetRequiredStatusChecksContexts("owner", "repo", "branch");
+                client.GetAllRequiredStatusChecksContexts("owner", "repo", "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<string>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/required_status_checks/contexts"), null, previewAcceptsHeader);
@@ -467,7 +467,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetRequiredStatusChecksContexts(1, "branch");
+                client.GetAllRequiredStatusChecksContexts(1, "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<string>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/required_status_checks/contexts"), null, previewAcceptsHeader);
@@ -478,17 +478,17 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts(null, "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts("owner", null, "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts("owner", "repo", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts("owner", "repo", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts(1, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRequiredStatusChecksContexts("", "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRequiredStatusChecksContexts("owner", "", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRequiredStatusChecksContexts("owner", "repo", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("owner", "repo", ""));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRequiredStatusChecksContexts(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts(1, ""));
             }
         }
 
@@ -1030,7 +1030,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetProtectedBranchTeamRestrictionsMethod
+        public class TheGetAllProtectedBranchTeamRestrictionsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -1039,7 +1039,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetProtectedBranchTeamRestrictions("owner", "repo", "branch");
+                client.GetAllProtectedBranchTeamRestrictions("owner", "repo", "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<Team>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/restrictions/teams"), null, previewAcceptsHeader);
@@ -1052,7 +1052,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetProtectedBranchTeamRestrictions(1, "branch");
+                client.GetAllProtectedBranchTeamRestrictions(1, "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<Team>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/restrictions/teams"), null, previewAcceptsHeader);
@@ -1063,17 +1063,17 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions(null, "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions("owner", null, "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions("owner", "repo", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "repo", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions(1, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("", "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("owner", "", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("owner", "repo", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "repo", ""));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions(1, ""));
             }
         }
 
@@ -1233,7 +1233,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetProtectedBranchUserRestrictionsMethod
+        public class TheGetAllProtectedBranchUserRestrictionsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -1242,7 +1242,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetProtectedBranchUserRestrictions("owner", "repo", "branch");
+                client.GetAllProtectedBranchUserRestrictions("owner", "repo", "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<User>>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/branches/branch/protection/restrictions/users"), null, previewAcceptsHeader);
@@ -1255,7 +1255,7 @@ namespace Octokit.Tests.Clients
                 var client = new RepositoryBranchesClient(connection);
                 const string previewAcceptsHeader = "application/vnd.github.loki-preview+json";
 
-                client.GetProtectedBranchUserRestrictions(1, "branch");
+                client.GetAllProtectedBranchUserRestrictions(1, "branch");
 
                 connection.Received()
                     .Get<IReadOnlyList<User>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/branches/branch/protection/restrictions/users"), null, previewAcceptsHeader);
@@ -1266,17 +1266,17 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryBranchesClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions(null, "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions("owner", null, "branch"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions("owner", "repo", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions(null, "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions("owner", null, "branch"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "repo", null));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions(1, null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("", "repo", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("owner", "", "branch"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("owner", "repo", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("", "repo", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "", "branch"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "repo", ""));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetProtectedBranchUserRestrictions(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions(1, ""));
             }
         }
 

--- a/Octokit.Tests/Clients/RepositoryTrafficClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryTrafficClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryTrafficClient(connection);
 
-                await client.GetReferrers("fake", "repo");
+                await client.GetAllReferrers("fake", "repo");
 
                 connection.Received().GetAll<RepositoryTrafficReferrer>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/traffic/popular/referrers"), "application/vnd.github.spiderman-preview");
             }
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryTrafficClient(connection);
 
-                await client.GetReferrers(1);
+                await client.GetAllReferrers(1);
 
                 connection.Received().GetAll<RepositoryTrafficReferrer>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/traffic/popular/referrers"), "application/vnd.github.spiderman-preview");
             }
@@ -47,11 +47,11 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryTrafficClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReferrers(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetReferrers("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllReferrers(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllReferrers("owner", null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReferrers("", "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetReferrers("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllReferrers("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllReferrers("owner", ""));
             }
         }
 
@@ -63,7 +63,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryTrafficClient(connection);
 
-                await client.GetPaths("fake", "repo");
+                await client.GetAllPaths("fake", "repo");
 
                 connection.Received().GetAll<RepositoryTrafficPath>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/traffic/popular/paths"), "application/vnd.github.spiderman-preview");
             }
@@ -74,7 +74,7 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoryTrafficClient(connection);
 
-                await client.GetPaths(1);
+                await client.GetAllPaths(1);
 
                 connection.Received().GetAll<RepositoryTrafficPath>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/traffic/popular/paths"), "application/vnd.github.spiderman-preview");
             }
@@ -84,11 +84,11 @@ namespace Octokit.Tests.Clients
             {
                 var client = new RepositoryTrafficClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetPaths(null, "name"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetPaths("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPaths(null, "name"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllPaths("owner", null));
 
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetPaths("", "name"));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetPaths("owner", ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPaths("", "name"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllPaths("owner", ""));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryBranchesClientTests.cs
@@ -429,7 +429,7 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetRequiredStatusChecksContextsMethod
+        public class TheGetAllRequiredStatusChecksContextsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -437,10 +437,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetRequiredStatusChecksContexts("owner", "repo", "branch");
+                client.GetAllRequiredStatusChecksContexts("owner", "repo", "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetRequiredStatusChecksContexts("owner", "repo", "branch");
+                    .GetAllRequiredStatusChecksContexts("owner", "repo", "branch");
             }
 
             [Fact]
@@ -449,10 +449,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetRequiredStatusChecksContexts(1, "branch");
+                client.GetAllRequiredStatusChecksContexts(1, "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetRequiredStatusChecksContexts(1, "branch");
+                    .GetAllRequiredStatusChecksContexts(1, "branch");
             }
 
             [Fact]
@@ -460,17 +460,17 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts(null, "repo", "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts("owner", null, "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts("owner", "repo", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetRequiredStatusChecksContexts(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllRequiredStatusChecksContexts(1, null));
 
-                Assert.Throws<ArgumentException>(() => client.GetRequiredStatusChecksContexts("", "repo", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetRequiredStatusChecksContexts("owner", "", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetRequiredStatusChecksContexts("owner", "repo", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts("owner", "repo", ""));
 
-                Assert.Throws<ArgumentException>(() => client.GetRequiredStatusChecksContexts(1, ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllRequiredStatusChecksContexts(1, ""));
             }
         }
 
@@ -977,7 +977,7 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetProtectedBranchTeamRestrictionsMethod
+        public class TheGetAllProtectedBranchTeamRestrictionsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -985,10 +985,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetProtectedBranchTeamRestrictions("owner", "repo", "branch");
+                client.GetAllProtectedBranchTeamRestrictions("owner", "repo", "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetProtectedBranchTeamRestrictions("owner", "repo", "branch");
+                    .GetAllProtectedBranchTeamRestrictions("owner", "repo", "branch");
             }
 
             [Fact]
@@ -997,10 +997,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetProtectedBranchTeamRestrictions(1, "branch");
+                client.GetAllProtectedBranchTeamRestrictions(1, "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetProtectedBranchTeamRestrictions(1, "branch");
+                    .GetAllProtectedBranchTeamRestrictions(1, "branch");
             }
 
             [Fact]
@@ -1008,17 +1008,17 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions(null, "repo", "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions("owner", null, "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "repo", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchTeamRestrictions(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchTeamRestrictions(1, null));
 
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("", "repo", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("owner", "", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions("owner", "repo", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions("owner", "repo", ""));
 
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchTeamRestrictions(1, ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchTeamRestrictions(1, ""));
             }
         }
 
@@ -1172,7 +1172,7 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheGetProtectedBranchUserRestrictionsMethod
+        public class TheGetAllProtectedBranchUserRestrictionsMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -1180,10 +1180,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetProtectedBranchUserRestrictions("owner", "repo", "branch");
+                client.GetAllProtectedBranchUserRestrictions("owner", "repo", "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetProtectedBranchUserRestrictions("owner", "repo", "branch");
+                    .GetAllProtectedBranchUserRestrictions("owner", "repo", "branch");
             }
 
             [Fact]
@@ -1192,10 +1192,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryBranchesClient(gitHubClient);
 
-                client.GetProtectedBranchUserRestrictions(1, "branch");
+                client.GetAllProtectedBranchUserRestrictions(1, "branch");
 
                 gitHubClient.Repository.Branch.Received()
-                    .GetProtectedBranchUserRestrictions(1, "branch");
+                    .GetAllProtectedBranchUserRestrictions(1, "branch");
             }
 
             [Fact]
@@ -1203,17 +1203,17 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoryBranchesClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions(null, "repo", "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions("owner", null, "branch"));
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions("owner", "repo", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions(null, "repo", "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions("owner", null, "branch"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "repo", null));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetProtectedBranchUserRestrictions(1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllProtectedBranchUserRestrictions(1, null));
 
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("", "repo", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("owner", "", "branch"));
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchUserRestrictions("owner", "repo", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("", "repo", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "", "branch"));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions("owner", "repo", ""));
 
-                Assert.Throws<ArgumentException>(() => client.GetProtectedBranchUserRestrictions(1, ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllProtectedBranchUserRestrictions(1, ""));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryTrafficClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryTrafficClientTests.cs
@@ -24,9 +24,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryTrafficClient(gitHubClient);
 
-                client.GetReferrers("fake", "repo");
+                client.GetAllReferrers("fake", "repo");
 
-                gitHubClient.Received().Repository.Traffic.GetReferrers("fake", "repo");
+                gitHubClient.Received().Repository.Traffic.GetAllReferrers("fake", "repo");
             }
 
             [Fact]
@@ -35,9 +35,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryTrafficClient(gitHubClient);
 
-                client.GetReferrers(1);
+                client.GetAllReferrers(1);
 
-                gitHubClient.Received().Repository.Traffic.GetReferrers(1);
+                gitHubClient.Received().Repository.Traffic.GetAllReferrers(1);
             }
 
             [Fact]
@@ -45,11 +45,11 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoryTrafficClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetReferrers(null, "name"));
-                Assert.Throws<ArgumentNullException>(() => client.GetReferrers("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllReferrers(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllReferrers("owner", null));
 
-                Assert.Throws<ArgumentException>(() => client.GetReferrers("", "name"));
-                Assert.Throws<ArgumentException>(() => client.GetReferrers("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllReferrers("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllReferrers("owner", ""));
             }
         }
 
@@ -61,9 +61,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryTrafficClient(gitHubClient);
 
-                client.GetPaths("fake", "repo");
+                client.GetAllPaths("fake", "repo");
 
-                gitHubClient.Received().Repository.Traffic.GetPaths("fake", "repo");
+                gitHubClient.Received().Repository.Traffic.GetAllPaths("fake", "repo");
             }
 
             [Fact]
@@ -72,9 +72,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableRepositoryTrafficClient(gitHubClient);
 
-                client.GetPaths(1);
+                client.GetAllPaths(1);
 
-                gitHubClient.Received().Repository.Traffic.GetPaths(1);
+                gitHubClient.Received().Repository.Traffic.GetAllPaths(1);
             }
 
             [Fact]
@@ -82,11 +82,11 @@ namespace Octokit.Tests.Reactive
             {
                 var client = new ObservableRepositoryTrafficClient(Substitute.For<IGitHubClient>());
 
-                Assert.Throws<ArgumentNullException>(() => client.GetPaths(null, "name"));
-                Assert.Throws<ArgumentNullException>(() => client.GetPaths("owner", null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllPaths(null, "name"));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllPaths("owner", null));
 
-                Assert.Throws<ArgumentException>(() => client.GetPaths("", "name"));
-                Assert.Throws<ArgumentException>(() => client.GetPaths("owner", ""));
+                Assert.Throws<ArgumentException>(() => client.GetAllPaths("", "name"));
+                Assert.Throws<ArgumentException>(() => client.GetAllPaths("owner", ""));
             }
         }
 

--- a/Octokit/Clients/ICommitCommentReactionsClient.cs
+++ b/Octokit/Clients/ICommitCommentReactionsClient.cs
@@ -40,6 +40,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -49,6 +50,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IIssueCommentReactionsClient.cs
@@ -37,6 +37,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -45,6 +46,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
     }
 }

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -18,6 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,6 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>

--- a/Octokit/Clients/IMigrationsClient.cs
+++ b/Octokit/Clients/IMigrationsClient.cs
@@ -35,6 +35,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The organization of which to list migrations.</param>
         /// <returns>List of most recent <see cref="Migration"/>s.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<List<Migration>> GetAll(
             string org);
 

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -18,6 +18,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<Emoji>> GetAllEmojis();
 
         /// <summary>
@@ -41,6 +42,7 @@ namespace Octokit
         /// </summary>
         /// <returns>A list of template names</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates();
 
         /// <summary>

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -57,6 +57,7 @@ namespace Octokit
         /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
 
         /// <summary>

--- a/Octokit/Clients/IOrganizationsClient.cs
+++ b/Octokit/Clients/IOrganizationsClient.cs
@@ -97,6 +97,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Organization"/>s.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("This API call uses the OrganizationRequest.Since parameter for pagination")]
         Task<IReadOnlyList<Organization>> GetAll();
 
         /// <summary>
@@ -105,6 +106,7 @@ namespace Octokit
         /// <param name="request">Search parameters of the last organization seen</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Organization"/>s.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("This API call uses the OrganizationRequest.Since parameter for pagination")]
         Task<IReadOnlyList<Organization>> GetAll(OrganizationRequest request);
 
         /// <summary>

--- a/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewCommentReactionsClient.cs
@@ -18,6 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number);
 
         /// <summary>
@@ -26,6 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>        
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number);
 
         /// <summary>

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -48,6 +48,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(string owner, string name);
 
         /// <summary>
@@ -58,6 +59,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(long repositoryId);
 
         /// <summary>
@@ -70,6 +72,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace);
 
         /// <summary>
@@ -81,6 +84,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -137,6 +137,7 @@ namespace Octokit
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate",
              Justification = "Makes a network request")]
+        [ExcludeFromPaginationApiOptionsConventionTest("This API call uses the PublicRepositoryRequest.Since parameter for pagination")]
         Task<IReadOnlyList<Repository>> GetAllPublic();
 
         /// <summary>
@@ -150,6 +151,7 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("This API call uses the PublicRepositoryRequest.Since parameter for pagination")]
         Task<IReadOnlyList<Repository>> GetAllPublic(PublicRepositoryRequest request);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -425,6 +425,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(string owner, string name);
 
         /// <summary>
@@ -435,6 +436,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(long repositoryId);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -151,7 +151,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
         Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(string owner, string name, string branch);
 
         /// <summary>
@@ -162,7 +161,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
         Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(long repositoryId, string branch);
 
         /// <summary>
@@ -219,6 +217,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(string owner, string name, string branch);
 
         /// <summary>
@@ -230,6 +229,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(long repositoryId, string branch);
 
         /// <summary>
@@ -479,6 +479,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -490,6 +491,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(long repositoryId, string branch);
 
         /// <summary>
@@ -571,6 +573,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -582,6 +585,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(long repositoryId, string branch);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -216,7 +216,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(string owner, string name, string branch);
 
@@ -228,7 +228,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(long repositoryId, string branch);
 
@@ -478,7 +478,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(string owner, string name, string branch);
 
@@ -490,7 +490,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(long repositoryId, string branch);
 
@@ -572,7 +572,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(string owner, string name, string branch);
 
@@ -584,7 +584,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationConventionTest]
+        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(long repositoryId, string branch);
 

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -216,8 +216,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllRequiredStatusCheckContexts instead")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(string owner, string name, string branch);
 
         /// <summary>
@@ -228,9 +227,31 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllRequiredStatusCheckContexts instead")]
         Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(long repositoryId, string branch);
 
         /// <summary>
         /// Replace the required status checks contexts for the specified branch
@@ -478,8 +499,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -490,9 +510,31 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch);
 
         /// <summary>
         /// Replace team restrictions for the specified branch (applies only to Organization owned repositories)
@@ -572,8 +614,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(string owner, string name, string branch);
 
         /// <summary>
@@ -584,9 +625,31 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        [ExcludeFromPaginationNamingConventionTest("TODO: Rename method to GetAll")]
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(long repositoryId, string branch);
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch);
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch);
 
         /// <summary>
         /// Replace user restrictions for the specified branch (applies only to Organization owned repositories)

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -22,6 +22,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path);
 
         /// <summary>
@@ -32,6 +33,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId, string path);
 
         /// <summary>
@@ -42,6 +44,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name);
 
         /// <summary>
@@ -51,6 +54,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId);
 
         /// <summary>
@@ -63,6 +67,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
 
         /// <summary>
@@ -74,6 +79,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference);
 
         /// <summary>
@@ -86,6 +92,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference);
 
         /// <summary>
@@ -97,6 +104,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryInvitationsClient.cs
+++ b/Octokit/Clients/IRepositoryInvitationsClient.cs
@@ -51,6 +51,7 @@ namespace Octokit
         /// </remarks>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent();
 
         /// <summary>
@@ -61,6 +62,7 @@ namespace Octokit
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoryTrafficClient.cs
+++ b/Octokit/Clients/IRepositoryTrafficClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -17,7 +18,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ExcludeFromPaginationConventionTest]
+        [Obsolete("Please use GetAllReferrers instead")]
         Task<IReadOnlyList<RepositoryTrafficReferrer>> GetReferrers(string owner, string name);
 
         /// <summary>
@@ -25,8 +26,25 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        [ExcludeFromPaginationConventionTest]
+        [Obsolete("Please use GetAllReferrers instead")]
         Task<IReadOnlyList<RepositoryTrafficReferrer>> GetReferrers(long repositoryId);
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(string owner, string name);
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(long repositoryId);
 
         /// <summary>
         /// List the top 10 popular contents over the last 14 days
@@ -34,7 +52,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        [ExcludeFromPaginationConventionTest]
+        [Obsolete("Please use GetAllPaths instead")]
         Task<IReadOnlyList<RepositoryTrafficPath>> GetPaths(string owner, string name);
 
         /// <summary>
@@ -42,8 +60,25 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        [ExcludeFromPaginationConventionTest]
+        [Obsolete("Please use GetAllPaths instead")]
         Task<IReadOnlyList<RepositoryTrafficPath>> GetPaths(long repositoryId);
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(string owner, string name);
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(long repositoryId);
 
         /// <summary>
         /// Get the total number of views and breakdown per day or week for the last 14 days

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -370,7 +370,36 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
         public Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(string owner, string name, string branch)
+        {
+            return GetAllRequiredStatusChecksContexts(owner, name, branch);
+        }
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllRequiredStatusChecksContexts instead")]
+        public Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(long repositoryId, string branch)
+        {
+            return GetAllRequiredStatusChecksContexts(repositoryId, branch);
+        }
+
+        /// <summary>
+        /// Get the required status checks contexts for the specified branch
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -387,7 +416,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public Task<IReadOnlyList<string>> GetRequiredStatusChecksContexts(long repositoryId, string branch)
+        public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
@@ -840,7 +869,36 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
         public Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(string owner, string name, string branch)
+        {
+            return GetAllProtectedBranchTeamRestrictions(owner, name, branch);
+        }
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchTeamRestrictions instead")]
+        public Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(long repositoryId, string branch)
+        {
+            return GetAllProtectedBranchTeamRestrictions(repositoryId, branch);   
+        }
+
+        /// <summary>
+        /// Get team restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -857,7 +915,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public Task<IReadOnlyList<Team>> GetProtectedBranchTeamRestrictions(long repositoryId, string branch)
+        public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 
@@ -984,7 +1042,36 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
         public Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(string owner, string name, string branch)
+        {
+            return GetAllProtectedBranchUserRestrictions(owner, name, branch);
+        }
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        [Obsolete("Please use GetAllProtectedBranchUserRestrictions instead")]
+        public Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(long repositoryId, string branch)
+        {
+            return GetAllProtectedBranchUserRestrictions(repositoryId, branch);
+        }
+
+        /// <summary>
+        /// Get user restrictions for the specified branch (applies only to Organization owned repositories)
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch">API documentation</a> for more details
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="branch">The name of the branch</param>
+        public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -1001,7 +1088,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
-        public Task<IReadOnlyList<User>> GetProtectedBranchUserRestrictions(long repositoryId, string branch)
+        public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");
 

--- a/Octokit/Clients/RepositoryTrafficClient.cs
+++ b/Octokit/Clients/RepositoryTrafficClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -14,7 +15,30 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
         public Task<IReadOnlyList<RepositoryTrafficPath>> GetPaths(long repositoryId)
+        {
+            return GetAllPaths(repositoryId);
+        }
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllPaths instead")]
+        public Task<IReadOnlyList<RepositoryTrafficPath>> GetPaths(string owner, string name)
+        {
+            return GetAllPaths(owner, name);
+        }
+
+        /// <summary>
+        /// List the top 10 popular contents over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        public Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(long repositoryId)
         {
             return ApiConnection.GetAll<RepositoryTrafficPath>(ApiUrls.RepositoryTrafficPaths(repositoryId), AcceptHeaders.RepositoryTrafficApiPreview);
         }
@@ -25,7 +49,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        public Task<IReadOnlyList<RepositoryTrafficPath>> GetPaths(string owner, string name)
+        public Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
@@ -38,7 +62,30 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
         public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetReferrers(long repositoryId)
+        {
+            return GetAllReferrers(repositoryId);
+        }
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        [Obsolete("Please use GetAllReferrers instead")]
+        public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetReferrers(string owner, string name)
+        {
+            return GetAllReferrers(owner, name);
+        }
+
+        /// <summary>
+        /// List the top 10 referrers over the last 14 days
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
+        /// <param name="repositoryId">The owner of the repository</param>
+        public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(long repositoryId)
         {
             return ApiConnection.GetAll<RepositoryTrafficReferrer>(ApiUrls.RepositoryTrafficReferrers(repositoryId), AcceptHeaders.RepositoryTrafficApiPreview);
         }
@@ -49,7 +96,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetReferrers(string owner, string name)
+        public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");

--- a/Octokit/Helpers/ExcludeFromPaginationApiOptionsConventionTestAttribute.cs
+++ b/Octokit/Helpers/ExcludeFromPaginationApiOptionsConventionTestAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Octokit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ExcludeFromPaginationApiOptionsConventionTestAttribute : Attribute
+    {
+        public ExcludeFromPaginationApiOptionsConventionTestAttribute(string note)
+        {
+            Note = note;
+        }
+
+        public string Note { get; private set; }
+    }
+}

--- a/Octokit/Helpers/ExcludeFromPaginationConventionTest.cs
+++ b/Octokit/Helpers/ExcludeFromPaginationConventionTest.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Octokit
-{
-    [AttributeUsage(AttributeTargets.Method)]
-    public sealed class ExcludeFromPaginationConventionTestAttribute : Attribute
-    {
-    }
-}

--- a/Octokit/Helpers/ExcludeFromPaginationNamingConventionTest.cs
+++ b/Octokit/Helpers/ExcludeFromPaginationNamingConventionTest.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Octokit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ExcludeFromPaginationNamingConventionTestAttribute : Attribute
+    {
+        public ExcludeFromPaginationNamingConventionTestAttribute()
+        {
+        }
+
+        public ExcludeFromPaginationNamingConventionTestAttribute(string note)
+        {
+            Note = note;
+        }
+
+        public string Note { get; private set; }
+    }
+}


### PR DESCRIPTION
Unskip and tweak the existing pagination tests so we can use them to enforce pagination conventions going forward

- ApiOptions overload pagination implemtation
For items that failed tests, probed upstream API and flagged the method as either requiring pagination implementation or API not supporting pagination.  Issues will be raised for each client/method where pagination needs to be implemented

- GetAll naming for methods returning `IReadonlyList<T>`
Renamed offending methods in `RepositoryTrafficClient` and `RepositoryBranchesClient` and flagged old ones as `[Obsolete]` so they can be removed in the future