### PR TITLE
[WIP]: Share state between tests for the PR review requests tests

### DIFF
--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -111,31 +111,6 @@ public class PullRequestReviewRequestsClientTests
         }
     }
 
-    public class PullRequestReviewRequestClientTestsBase : IDisposable
-    {
-        internal readonly IGitHubClient _github;
-        internal readonly IPullRequestReviewRequestsClient _client;
-        internal readonly RepositoryContext _context;
-
-        public PullRequestReviewRequestClientTestsBase()
-        {
-            _github = Helper.GetAuthenticatedClient();
-
-            _client = _github.PullRequest.ReviewRequest;
-
-            _context = _github.CreateRepositoryContext("test-repo").Result;
-
-            Task.WaitAll(_collaboratorLogins.Select(AddCollaborator).ToArray());
-        }
-
-        private Task AddCollaborator(string collaborator) => _github.Repository.Collaborator.Add(_context.RepositoryOwner, _context.RepositoryName, collaborator);
-
-        public void Dispose()
-        {
-            _context.Dispose();
-        }
-    }
-
     public class WhenNoRequestsExistFixture : PullRequestReviewRequestClientFixtureBase
     {
         protected override Task<int> CreatePullRequest() =>

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -124,17 +124,17 @@ public class PullRequestReviewRequestsClientTests
         }
     }
 
-    public class WhenNoRequestsExistFixture : PullRequestReviewRequestClientFixtureBase
+    public class WhenNoRequestExists : PullRequestReviewRequestClientFixtureBase
     {
         protected override Task<int> CreatePullRequest() =>
             CreateTheWorld(createReviewRequests: false);
     }
 
-    public class WhenNoRequestsExistTheGetAllMethod : IClassFixture<WhenNoRequestsExistFixture>
+    public class WhenNoRequestExistsTheGetAllMethod : IClassFixture<WhenNoRequestExists>
     {
-        private readonly WhenNoRequestsExistFixture _fixture;
+        private readonly WhenNoRequestExists _fixture;
 
-        public WhenNoRequestsExistTheGetAllMethod(WhenNoRequestsExistFixture fixture)
+        public WhenNoRequestExistsTheGetAllMethod(WhenNoRequestExists fixture)
         {
             _fixture = fixture;
         }

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -73,7 +73,7 @@ public class PullRequestReviewRequestsClientTests
             return createdPullRequest.Number;
         }
 
-        protected async Task<TreeResponse> CreateTree(IEnumerable<KeyValuePair<string, string>> treeContents)
+        private async Task<TreeResponse> CreateTree(IEnumerable<KeyValuePair<string, string>> treeContents)
         {
             var collection = new List<NewTreeItem>();
 
@@ -104,7 +104,7 @@ public class PullRequestReviewRequestsClientTests
             return await GitHub.Git.Tree.Create(Context.RepositoryOwner, Context.RepositoryName, newTree);
         }
 
-        protected Task<Commit> CreateCommit(string message, string sha, string parent)
+        private Task<Commit> CreateCommit(string message, string sha, string parent)
         {
             var newCommit = new NewCommit(message, sha, parent);
             return GitHub.Git.Commit.Create(Context.RepositoryOwner, Context.RepositoryName, newCommit);

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -325,7 +325,7 @@ public class PullRequestReviewRequestsClientTests
         }
     }
 
-    public class TheCreateMethod : WhenRequestsExistFixture
+    public class TheCreateMethod : WhenNoRequestExists
     {
         [DualAccountTest]
         public async Task CreatesRequests()

--- a/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestReviewRequestsClientTests.cs
@@ -169,35 +169,41 @@ public class PullRequestReviewRequestsClientTests
             CreateTheWorld();
     }
 
-    public class WhenRequestsExistTheGetAllMethod : IClassFixture<WhenRequestsExistFixture>
+    public class WhenRequestsExistTheGetAllMethod
     {
-        private readonly WhenRequestsExistFixture _fixture;
+        private const string _repositoryName = "pr-review-request";
+        private const string _repositoryOwner = "octokitnet-test";
+        private const long _repositoryId = 102994692;
+        private const int _pullRequestNumber = 1;
 
-        public WhenRequestsExistTheGetAllMethod(WhenRequestsExistFixture fixture)
+        private static readonly IEnumerable<string> _expectedCollaborators = new[] { "ryangribble-test2", "octokitnet-test2" };
+        private readonly IPullRequestReviewRequestsClient _client;
+
+        public WhenRequestsExistTheGetAllMethod()
         {
-            _fixture = fixture;
+            _client = Helper.GetAuthenticatedClient().PullRequest.ReviewRequest;
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task GetsRequests()
         {
-            var reviewRequests = await _fixture.Client.GetAll(
-                _fixture.Context.RepositoryOwner,
-                _fixture.Context.RepositoryName,
-                _fixture.Number);
+            var reviewRequests = await _client.GetAll(
+                _repositoryOwner,
+                _repositoryName,
+                _pullRequestNumber);
 
-            Assert.Equal(_fixture.CollaboratorLoginAsList, reviewRequests.Select(rr => rr.Login));
+            Assert.Equal(_expectedCollaborators, reviewRequests.Select(rr => rr.Login));
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task GetsRequestsWithRepositoryId()
         {
-            var reviewRequests = await _fixture.Client.GetAll(_fixture.Context.RepositoryId, _fixture.Number);
+            var reviewRequests = await _client.GetAll(_repositoryId, _pullRequestNumber);
 
-            Assert.Equal(_fixture.CollaboratorLoginAsList, reviewRequests.Select(rr => rr.Login));
+            Assert.Equal(_expectedCollaborators, reviewRequests.Select(rr => rr.Login));
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task ReturnsCorrectCountOfReviewRequestsWithStart()
         {
             var options = new ApiOptions
@@ -207,12 +213,12 @@ public class PullRequestReviewRequestsClientTests
                 StartPage = 2
             };
 
-            var reviewRequests = await _fixture.Client.GetAll(_fixture.Context.RepositoryOwner, _fixture.Context.RepositoryName, _fixture.Number, options);
+            var reviewRequests = await _client.GetAll(_repositoryOwner, _repositoryName, _pullRequestNumber, options);
 
             Assert.Equal(1, reviewRequests.Count);
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task ReturnsCorrectCountOfReviewRequestsWithStartWithRepositoryId()
         {
             var options = new ApiOptions
@@ -222,12 +228,12 @@ public class PullRequestReviewRequestsClientTests
                 StartPage = 2
             };
 
-            var reviewRequests = await _fixture.Client.GetAll(_fixture.Context.RepositoryId, _fixture.Number, options);
+            var reviewRequests = await _client.GetAll(_repositoryId, _pullRequestNumber, options);
 
             Assert.Equal(1, reviewRequests.Count);
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task ReturnsDistinctResultsBasedOnStartPage()
         {
             var startOptions = new ApiOptions
@@ -236,10 +242,10 @@ public class PullRequestReviewRequestsClientTests
                 PageCount = 1
             };
 
-            var firstPage = await _fixture.Client.GetAll(
-                _fixture.Context.RepositoryOwner,
-                _fixture.Context.RepositoryName,
-                _fixture.Number,
+            var firstPage = await _client.GetAll(
+                _repositoryOwner,
+                _repositoryName,
+                _pullRequestNumber,
                 startOptions);
 
             var skipStartOptions = new ApiOptions
@@ -249,10 +255,10 @@ public class PullRequestReviewRequestsClientTests
                 StartPage = 2
             };
 
-            var secondPage = await _fixture.Client.GetAll(
-                _fixture.Context.RepositoryOwner,
-                _fixture.Context.RepositoryName,
-                _fixture.Number,
+            var secondPage = await _client.GetAll(
+                _repositoryOwner,
+                _repositoryName,
+                _pullRequestNumber,
                 skipStartOptions);
 
             Assert.Equal(1, firstPage.Count);
@@ -260,7 +266,7 @@ public class PullRequestReviewRequestsClientTests
             Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
         }
 
-        [DualAccountTest]
+        [Fact]
         public async Task ReturnsDistinctResultsBasedOnStartPageWithRepositoryId()
         {
             var startOptions = new ApiOptions
@@ -269,9 +275,9 @@ public class PullRequestReviewRequestsClientTests
                 PageCount = 1
             };
 
-            var firstPage = await _fixture.Client.GetAll(
-                _fixture.Context.RepositoryId,
-                _fixture.Number,
+            var firstPage = await _client.GetAll(
+                _repositoryId,
+                _pullRequestNumber,
                 startOptions);
 
             var skipStartOptions = new ApiOptions
@@ -281,9 +287,9 @@ public class PullRequestReviewRequestsClientTests
                 StartPage = 2
             };
 
-            var secondPage = await _fixture.Client.GetAll(
-                _fixture.Context.RepositoryId,
-                _fixture.Number,
+            var secondPage = await _client.GetAll(
+                _repositoryId,
+                _pullRequestNumber,
                 skipStartOptions);
 
             Assert.Equal(1, firstPage.Count);

--- a/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
+++ b/Octokit.Tests.Integration/Helpers/RepositoryContext.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Octokit.Reactive;
 
 namespace Octokit.Tests.Integration.Helpers
 {
-    internal sealed class RepositoryContext : IDisposable
+    public sealed class RepositoryContext : IDisposable
     {
         internal RepositoryContext(IConnection connection, Repository repo)
         {


### PR DESCRIPTION
Fixes #1667 

That's a first go at trying to share state between some integration tests.

It got a bit crazy with the inheritance to differentiate cases where we want to create the review request and when we don't, so I'm more than happy to get feedback on the _design_.

Unfortunately, I couldn't test they worked as after inviting the test accounts as collaborators to the test repository, they need to accept the invitation before they can be added as PR reviewers.

Let's try to identify a list of areas where we can do the same thing:

 - [ ] PR review requests