### PR TITLE
Add missing fields to Team response, and NewTeam/UpdateTeam requests

### DIFF
--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -12,29 +12,7 @@ public class TeamsClientTests
     public class TheCreateMethod
     {
         [OrganizationTest]
-        public async Task FailsWhenNotAuthenticated()
-        {
-            var github = Helper.GetAnonymousClient();
-            var newTeam = new NewTeam("Test");
-
-            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.Create(Helper.Organization, newTeam));
-
-            Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
-        }
-
-        [OrganizationTest]
-        public async Task FailsWhenAuthenticatedWithBadCredentials()
-        {
-            var github = Helper.GetBadCredentialsClient();
-
-            var newTeam = new NewTeam("Test");
-
-            var e = await Assert.ThrowsAsync<AuthorizationException>(() => github.Organization.Team.Create(Helper.Organization, newTeam));
-            Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
-        }
-
-        [OrganizationTest]
-        public async Task SucceedsWhenAuthenticated()
+        public async Task CreatesTeam()
         {
             var github = Helper.GetAuthenticatedClient();
 
@@ -47,6 +25,7 @@ public class TeamsClientTests
                     Description = teamDescription,
                     Privacy = TeamPrivacy.Closed
                 };
+                newTeam.Maintainers.Add(Helper.UserName);
                 newTeam.RepoNames.Add(context.Repository.FullName);
 
                 var team = await github.Organization.Team.Create(Helper.Organization, newTeam);
@@ -54,6 +33,7 @@ public class TeamsClientTests
                 Assert.Equal(teamName, team.Name);
                 Assert.Equal(teamDescription, team.Description);
                 Assert.Equal(TeamPrivacy.Closed, team.Privacy);
+                Assert.Equal(1, team.MembersCount);
                 Assert.Equal(1, team.ReposCount);
 
                 await github.Organization.Team.Delete(team.Id);
@@ -287,7 +267,7 @@ public class TeamsClientTests
 
     public class TheUpdateMethod
     {
-        private IGitHubClient _github;
+        private readonly IGitHubClient _github;
 
         public TheUpdateMethod()
         {

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -22,7 +22,7 @@ public class TeamsClientTests
             Assert.Equal(HttpStatusCode.Unauthorized, e.StatusCode);
         }
 
-        [OrganizationTest(Skip = "see https://github.com/octokit/octokit.net/issues/533 for the resolution to this failing test")]
+        [OrganizationTest]
         public async Task FailsWhenAuthenticatedWithBadCredentials()
         {
             var github = Helper.GetBadCredentialsClient();

--- a/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/TeamsClientTests.cs
@@ -38,11 +38,26 @@ public class TeamsClientTests
         {
             var github = Helper.GetAuthenticatedClient();
 
-            var newTeam = new NewTeam(Guid.NewGuid().ToString());
+            var teamName = Helper.MakeNameWithTimestamp("new-team");
+            var teamDescription = Helper.MakeNameWithTimestamp("team description");
+            using (var context = await github.CreateRepositoryContext(Helper.Organization, new NewRepository(Helper.MakeNameWithTimestamp("org-repo"))))
+            {
+                var newTeam = new NewTeam(teamName)
+                {
+                    Description = teamDescription,
+                    Privacy = TeamPrivacy.Closed
+                };
+                newTeam.RepoNames.Add(context.Repository.FullName);
 
-            var team = await github.Organization.Team.Create(Helper.Organization, newTeam);
+                var team = await github.Organization.Team.Create(Helper.Organization, newTeam);
 
-            Assert.Equal(newTeam.Name, team.Name);
+                Assert.Equal(teamName, team.Name);
+                Assert.Equal(teamDescription, team.Description);
+                Assert.Equal(TeamPrivacy.Closed, team.Privacy);
+                Assert.Equal(1, team.ReposCount);
+
+                await github.Organization.Team.Delete(team.Id);
+            }
         }
     }
 
@@ -266,6 +281,37 @@ public class TeamsClientTests
                 Assert.Equal(1, secondPagePendingInvitations.Count);
 
                 Assert.NotEqual(firstPagePendingInvitations[0].Login, secondPagePendingInvitations[0].Login);
+            }
+        }
+    }
+
+    public class TheUpdateMethod
+    {
+        private IGitHubClient _github;
+
+        public TheUpdateMethod()
+        {
+            _github = Helper.GetAuthenticatedClient();
+        }
+
+        [OrganizationTest]
+        public async Task UpdatesTeam()
+        {
+            using (var teamContext = await _github.CreateTeamContext(Helper.Organization, new NewTeam(Helper.MakeNameWithTimestamp("team-fixture"))))
+            {
+                var teamName = Helper.MakeNameWithTimestamp("updated-team");
+                var teamDescription = Helper.MakeNameWithTimestamp("updated description");
+                var update = new UpdateTeam(teamName)
+                {
+                    Description = teamDescription,
+                    Privacy = TeamPrivacy.Closed
+                };
+
+                var team = await _github.Organization.Team.Update(teamContext.TeamId, update);
+
+                Assert.Equal(teamName, team.Name);
+                Assert.Equal(teamDescription, team.Description);
+                Assert.Equal(TeamPrivacy.Closed, team.Privacy);
             }
         }
     }

--- a/Octokit/Models/Request/NewTeam.cs
+++ b/Octokit/Models/Request/NewTeam.cs
@@ -24,7 +24,6 @@ namespace Octokit
         {
             Name = name;
             RepoNames = new Collection<string>();
-            Permission = Permission.Pull;
         }
 
         /// <summary>
@@ -33,28 +32,35 @@ namespace Octokit
         public string Name { get; private set; }
 
         /// <summary>
-        /// Gets or sets the description of the team
+        /// The description of the team.
         /// </summary>
-        /// <value>
-        /// The description.
-        /// </value>
         public string Description { get; set; }
 
         /// <summary>
-        /// permission associated to this team
+        /// The logins of organization members to add as maintainers of the team
         /// </summary>
-        public Permission Permission { get; set; }
+        public Collection<string> Maintainers { get; protected set; }
 
         /// <summary>
-        /// array of repo_names this team has permissions to
+        /// The full name (e.g., "organization-name/repository-name") of repositories to add the team to
         /// </summary>
-        public Collection<string> RepoNames { get; private set; }
+        public Collection<string> RepoNames { get; protected set; }
+
+        /// <summary>
+        /// The level of privacy this team should have (default: Secret)
+        /// </summary>
+        public TeamPrivacy? Privacy { get; set; }
+
+        /// <summary>
+        /// The permission that new repositories will be added to the team with when none is specified (default: Pull)
+        /// </summary>
+        public Permission? Permission { get; set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "Name: {0} Permission: {1}", Name, Permission);
+                return string.Format(CultureInfo.InvariantCulture, "Name: {0} Privacy: {1} Permission: {2}", Name, Privacy?.ToString() ?? "Default", Permission?.ToString() ?? "Default" );
             }
         }
     }

--- a/Octokit/Models/Request/NewTeam.cs
+++ b/Octokit/Models/Request/NewTeam.cs
@@ -23,6 +23,7 @@ namespace Octokit
         public NewTeam(string name)
         {
             Name = name;
+            Maintainers = new Collection<string>();
             RepoNames = new Collection<string>();
         }
 

--- a/Octokit/Models/Request/UpdateTeam.cs
+++ b/Octokit/Models/Request/UpdateTeam.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -12,30 +13,41 @@ namespace Octokit
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateTeam"/> class.
         /// </summary>
-        /// <param name="team">The team.</param>
-        public UpdateTeam(string team)
+        /// <param name="name">The updated team name.</param>
+        public UpdateTeam(string name)
         {
-            Name = team;
+            Name = name;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateTeam"/> class.
         /// </summary>
-        /// <param name="team">The team.</param>
+        /// <param name="name">The updated team name.</param>
         /// <param name="permission">The permission.</param>
-        public UpdateTeam(string team, Permission permission)
+        [Obsolete("This constructor will be removed for housekeeping purposes")]
+        public UpdateTeam(string name, Permission permission)
         {
-            Name = team;
+            Name = name;
             Permission = permission;
         }
 
         /// <summary>
-        /// team name
+        /// The name of the team (required).
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; private set; }
 
         /// <summary>
-        /// permission for this team
+        /// The description of the team.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The level of privacy this team should have (default: Secret)
+        /// </summary>
+        public TeamPrivacy? Privacy { get; set; }
+
+        /// <summary>
+        /// The permission that new repositories will be added to the team with when none is specified (default: Pull)
         /// </summary>
         public Permission? Permission { get; set; }
 
@@ -43,7 +55,7 @@ namespace Octokit
         {
             get
             {
-                return string.Format(CultureInfo.InvariantCulture, "Team: {0} Permission: {1}", Name, Permission.GetValueOrDefault());
+                return string.Format(CultureInfo.InvariantCulture, "Team: {0} Privacy: {1} Permission: {2}", Name, Privacy?.ToString() ?? "Default", Permission?.ToString() ?? "Default");
             }
         }
     }

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -12,11 +12,13 @@ namespace Octokit
     {
         public Team() { }
 
-        public Team(string url, int id, string name, Permission permission, int membersCount, int reposCount, Organization organization, string ldapDistinguishedName)
+        public Team(string url, int id, string name, string description, TeamPrivacy privacy, Permission permission, int membersCount, int reposCount, Organization organization, string ldapDistinguishedName)
         {
             Url = url;
             Id = id;
             Name = name;
+            Description = description;
+            Privacy = privacy;
             Permission = permission;
             MembersCount = membersCount;
             ReposCount = reposCount;
@@ -38,6 +40,16 @@ namespace Octokit
         /// team name
         /// </summary>
         public string Name { get; protected set; }
+
+        /// <summary>
+        /// team description
+        /// </summary>
+        public string Description { get; protected set; }
+
+        /// <summary>
+        /// team privacy
+        /// </summary>
+        public StringEnum<TeamPrivacy> Privacy { get; protected set; }
 
         /// <summary>
         /// permission attached to this team
@@ -69,5 +81,23 @@ namespace Octokit
         {
             get { return string.Format(CultureInfo.InvariantCulture, "Name: {0} ", Name); }
         }
+    }
+
+    /// <summary>
+    /// Used to describe a team's privacy level.
+    /// </summary>
+    public enum TeamPrivacy
+    {
+        /// <summary>
+        /// Only visible to organization owners and members of the team.
+        /// </summary>
+        [Parameter(Value = "secret")]
+        Secret,
+
+        /// <summary>
+        /// Visible to all members of the organization.
+        /// </summary>
+        [Parameter(Value = "closed")]
+        Closed
     }
 }


### PR DESCRIPTION
Fixes #1675 

- Add `TeamPrivacy` enum (Closed, Secret)
- Add `Description` and `Privacy` fields to `Team` response object
- Add `Privacy` and `Maintainers` fields to `NewTeam` request object
- Add `Description` and `Privacy` field to `UpdateTeam` request object

NOTE: `Permission` field on `NewTeam` request has been changed to a nullable type, eg  `Permission? Permission`, since it is optional and should not be sent to the API when the consumer has not set a value.

Ensured new fields are exercised in integration tests