### PR TITLE
Implement Team Membership changes

### DIFF
--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -123,13 +123,23 @@ namespace Octokit.Reactive
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use AddOrEditMembership instead")]
         IObservable<TeamMembership> AddMembership(int id, string login);
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <param name="request">Additional parameters for the request</param>
+        IObservable<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -158,8 +158,19 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use GetMembershipDetails instead")]
         IObservable<TeamMembership> GetMembership(int id, string login);
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        IObservable<TeamMembershipDetails> GetMembershipDetails(int id, string login);
 
         /// <summary>
         /// Returns all team's repositories.

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -164,6 +164,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
+        /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -65,8 +65,6 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         IObservable<User> GetAllMembers(int id);
 
         /// <summary>
@@ -77,9 +75,28 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         IObservable<User> GetAllMembers(int id, ApiOptions options);
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        IObservable<User> GetAllMembers(int id, TeamMembersRequest request);
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        IObservable<User> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -254,6 +254,7 @@ namespace Octokit.Reactive
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
+        /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -243,12 +243,28 @@ namespace Octokit.Reactive
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use GetMembershipDetails instead")]
         public IObservable<TeamMembership> GetMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
             return _client.GetMembership(id, login).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        public IObservable<TeamMembershipDetails> GetMembershipDetails(int id, string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, "login");
+
+            return _client.GetMembershipDetails(id, login).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -122,6 +122,38 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        public IObservable<User> GetAllMembers(int id, TeamMembersRequest request)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+            
+            return GetAllMembers(id, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        public IObservable<User> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _connection.GetAndFlattenAllPages<User>(ApiUrls.TeamMembers(id), request.ToParametersDictionary(), options);
+        }
+
+        /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -192,17 +192,33 @@ namespace Octokit.Reactive
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use AddOrEditMembership instead")]
         public IObservable<TeamMembership> AddMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
 
             return _client.AddMembership(id, login).ToObservable();
+        }
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <param name="request">Additional parameters for the request</param>
+        public IObservable<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return _client.AddOrEditMembership(id, login, request).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
+++ b/Octokit.Tests.Integration/Helpers/ObservableGithubClientExtensions.cs
@@ -28,7 +28,7 @@ namespace Octokit.Tests.Integration.Helpers
             return new RepositoryContext(client.Connection, repo);
         }
 
-        internal static async Task<TeamContext> CreateEnterpriseTeamContext(this IObservableGitHubClient client, string organization, NewTeam newTeam)
+        internal static async Task<TeamContext> CreateTeamContext(this IObservableGitHubClient client, string organization, NewTeam newTeam)
         {
             var team = await client.Organization.Team.Create(organization, newTeam);
 

--- a/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/Enterprise/ObservableEnterpriseLdapClientTests.cs
@@ -23,7 +23,7 @@ namespace Octokit.Tests.Integration
             _github = new ObservableGitHubClient(EnterpriseHelper.GetAuthenticatedClient());
 
             NewTeam newTeam = new NewTeam(Helper.MakeNameWithTimestamp("test-team")) { Description = "Test Team" };
-            _context = _github.CreateEnterpriseTeamContext(EnterpriseHelper.Organization, newTeam).Result;
+            _context = _github.CreateTeamContext(EnterpriseHelper.Organization, newTeam).Result;
         }
 
         [GitHubEnterpriseTest]

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -10,6 +10,95 @@ using Xunit;
 
 public class ObservableTeamsClientTests
 {
+    public class TheAddOrEditMembershipMethod : IDisposable
+    {
+        private readonly IObservableGitHubClient _github;
+        private readonly TeamContext _teamContext;
+
+        public TheAddOrEditMembershipMethod()
+        {
+            _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
+
+            var newTeam = new NewTeam(Helper.MakeNameWithTimestamp("team-fixture"));
+            newTeam.Maintainers.Add(Helper.UserName);
+
+            _teamContext = _github.CreateTeamContext(Helper.Organization, newTeam).Result;
+        }
+
+        [OrganizationTest]
+        public async Task AddsMembership()
+        {
+            var login = "octokitnet-test1";
+
+            var membership = await _github.Organization.Team.AddOrEditMembership(_teamContext.TeamId, login, new UpdateTeamMembership(TeamRole.Member));
+
+            Assert.Equal(TeamRole.Member, membership.Role);
+            Assert.Equal(MembershipState.Pending, membership.State);
+        }
+
+        [OrganizationTest]
+        public async Task EditsMembership()
+        {
+            var login = "octokitnet-test1";
+
+            // Add as member
+            await _github.Organization.Team.AddOrEditMembership(_teamContext.TeamId, login, new UpdateTeamMembership(TeamRole.Member));
+
+            // Update to maintainer
+            var membership = await _github.Organization.Team.AddOrEditMembership(_teamContext.TeamId, login, new UpdateTeamMembership(TeamRole.Maintainer));
+
+            Assert.Equal(TeamRole.Maintainer, membership.Role);
+            Assert.Equal(MembershipState.Pending, membership.State);
+        }
+
+        public void Dispose()
+        {
+            if (_teamContext != null)
+            {
+                _teamContext.Dispose();
+            }
+        }
+    }
+
+    public class TheGetMembershipDetailsMethod : IDisposable
+    {
+        private readonly IObservableGitHubClient _github;
+        private readonly TeamContext _teamContext;
+
+        public TheGetMembershipDetailsMethod()
+        {
+            _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
+
+            var newTeam = new NewTeam(Helper.MakeNameWithTimestamp("team-fixture"));
+            newTeam.Maintainers.Add(Helper.UserName);
+
+            _teamContext = _github.CreateTeamContext(Helper.Organization, newTeam).Result;
+        }
+
+        [OrganizationTest]
+        public async Task GetsMembershipDetails()
+        {
+            var membership = await _github.Organization.Team.GetMembershipDetails(_teamContext.TeamId, Helper.UserName);
+
+            Assert.Equal(TeamRole.Maintainer, membership.Role);
+            Assert.Equal(MembershipState.Active, membership.State);
+        }
+
+        [OrganizationTest]
+        public void ThrowsWhenNotAMember()
+        {
+            Assert.Throws<NotFoundException>(() => _github.Organization.Team.GetMembershipDetails(_teamContext.TeamId, "foo"));
+        }
+
+        public void Dispose()
+        {
+            if (_teamContext != null)
+            {
+                _teamContext.Dispose();
+            }
+        }
+    }
+
     public class TheGetAllMembersMethod : IDisposable
     {
         private readonly IObservableGitHubClient _github;

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -85,9 +85,9 @@ public class ObservableTeamsClientTests
         }
 
         [OrganizationTest]
-        public void ThrowsWhenNotAMember()
+        public async Task ThrowsWhenNotAMember()
         {
-            Assert.Throws<NotFoundException>(() => _github.Organization.Team.GetMembershipDetails(_teamContext.TeamId, "foo"));
+            Assert.ThrowsAsync<NotFoundException>(async () => await _github.Organization.Team.GetMembershipDetails(_teamContext.TeamId, "foo"));
         }
 
         public void Dispose()

--- a/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableTeamsClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Octokit;
@@ -9,28 +10,43 @@ using Xunit;
 
 public class ObservableTeamsClientTests
 {
-    public class TheGetAllMembersMethod
+    public class TheGetAllMembersMethod : IDisposable
     {
-        readonly Team _team;
+        private readonly IObservableGitHubClient _github;
+        private readonly TeamContext _teamContext;
 
         public TheGetAllMembersMethod()
         {
-            var github = Helper.GetAuthenticatedClient();
+            _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
 
-            _team = github.Organization.Team.GetAll(Helper.Organization).Result.First();
+            var newTeam = new NewTeam(Helper.MakeNameWithTimestamp("team-fixture"));
+            newTeam.Maintainers.Add(Helper.UserName);
+
+            _teamContext = _github.CreateTeamContext(Helper.Organization, newTeam).Result;
         }
 
         [OrganizationTest]
-        public async Task GetsAllMembersWhenAuthenticated()
+        public async Task GetsAllMembers()
         {
-            var github = Helper.GetAuthenticatedClient();
-            var client = new ObservableTeamsClient(github);
+            var members = await _github.Organization.Team.GetAllMembers(_teamContext.TeamId).ToList();
 
-            var observable = client.GetAllMembers(_team.Id, ApiOptions.None);
-            var members = await observable.ToList();
+            Assert.Contains(Helper.UserName, members.Select(u => u.Login));
+        }
 
-            Assert.True(members.Count > 0);
-            Assert.True(members.Any(x => x.Login == Helper.UserName));
+        [OrganizationTest]
+        public async Task GetsAllMembersWithRequest()
+        {
+            var members = await _github.Organization.Team.GetAllMembers(_teamContext.TeamId, new TeamMembersRequest(TeamRoleFilter.Member)).ToList();
+
+            Assert.Empty(members);
+        }
+
+        public void Dispose()
+        {
+            if (_teamContext != null)
+            {
+                _teamContext.Dispose();
+            }
         }
     }
 

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -279,6 +279,30 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetMembershipDetailsMethod
+        {
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+                await client.GetMembershipDetails(1, "user");
+
+                connection.Received().Get<TeamMembershipDetails>(Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullOrEmptyArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetMembershipDetails(1, null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetMembershipDetails(1, ""));
+            }
+        }
+
         public class TheRemoveMembershipMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetMembersMethod
+        public class TheGetAllMembersMethod
         {
             [Fact]
             public void RequestsTheCorrectUrl()
@@ -74,6 +74,34 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<User>(
                     Arg.Is<Uri>(u => u.ToString() == "teams/1/members"),
                     Args.ApiOptions);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRequest()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                client.GetAllMembers(1, new TeamMembersRequest(TeamRoleFilter.Maintainer));
+
+                connection.Received().GetAll<User>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/members"),
+                    Arg.Is<Dictionary<string, string>>(d => d["role"] == "maintainer"),
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllMembers(1, (TeamMembersRequest)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllMembers(1, (ApiOptions)null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllMembers(1, null, ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllMembers(1, new TeamMembersRequest(TeamRoleFilter.All), null));
             }
         }
 

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -212,6 +212,36 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheAddOrEditMembershipMethod
+        {
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+                var request = new UpdateTeamMembership(TeamRole.Maintainer);
+
+                await client.AddOrEditMembership(1, "user", request);
+
+                connection.Received().Put<TeamMembershipDetails>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/memberships/user"),
+                    Arg.Is<UpdateTeamMembership>(x => x.Role == TeamRole.Maintainer));
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullOrEmptyArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+                var request = new UpdateTeamMembership(TeamRole.Maintainer);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddOrEditMembership(1, null, request));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.AddOrEditMembership(1, "user", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.AddOrEditMembership(1, "", request));
+            }
+        }
+
         public class TheGetAllForCurrentMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -46,6 +46,51 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheGetAllMembersMethod
+        {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                client.GetAllMembers(1);
+
+                github.Connection.Received().Get<List<User>>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/members"),
+                    Args.EmptyDictionary,
+                    null);
+            }
+
+            [Fact]
+            public void RequestsTheCorrectUrlWithRequest()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                client.GetAllMembers(1, new TeamMembersRequest(TeamRoleFilter.Maintainer));
+
+                github.Connection.Received().Get<List<User>>(
+                    Arg.Is<Uri>(u => u.ToString() == "teams/1/members"),
+                    Arg.Is<Dictionary<string, string>>(d => d["role"] == "maintainer"),
+                    null);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllMembers(1, (TeamMembersRequest)null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllMembers(1, (ApiOptions)null));
+
+                Assert.Throws<ArgumentNullException>(() => client.GetAllMembers(1, null, ApiOptions.None));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllMembers(1, new TeamMembersRequest(TeamRoleFilter.All), null));
+            }
+        }
+
         public class TheGetAllPendingInvitationsMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -91,6 +91,34 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheAddOrEditMembershipMethod
+        {
+            [Fact]
+            public async Task RequestsTheCorrectUrl()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+                var request = new UpdateTeamMembership(TeamRole.Maintainer);
+
+                client.AddOrEditMembership(1, "user", request);
+
+                github.Organization.Team.Received().AddOrEditMembership(1, "user", request);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullOrEmptyArguments()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+                var request = new UpdateTeamMembership(TeamRole.Maintainer);
+
+                Assert.Throws<ArgumentNullException>(() => client.AddOrEditMembership(1, null, request));
+                Assert.Throws<ArgumentNullException>(() => client.AddOrEditMembership(1, "user", null));
+
+                Assert.Throws<ArgumentException>(() => client.AddOrEditMembership(1, "", request));
+            }
+        }
+
         public class TheGetAllPendingInvitationsMethod
         {
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableTeamsClientTests.cs
@@ -11,6 +11,15 @@ namespace Octokit.Tests.Reactive
 {
     public class ObservableTeamsClientTests
     {
+        public class TheCtor
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                Assert.Throws<ArgumentNullException>(() => new ObservableTeamsClient(null));
+            }
+        }
+
         public class TheCreateMethod
         {
             [Fact]
@@ -37,12 +46,28 @@ namespace Octokit.Tests.Reactive
             }
         }
 
-        public class TheCtor
+        public class TheGetMembershipDetailsMethod
         {
+            [Fact]
+            public void RequestsTheCorrectUrl()
+            {
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                client.GetMembershipDetails(1, "user");
+
+                github.Organization.Team.Received().GetMembershipDetails(1, "user");
+            }
+
             [Fact]
             public void EnsuresNonNullArguments()
             {
-                Assert.Throws<ArgumentNullException>(() => new ObservableTeamsClient(null));
+                var github = Substitute.For<IGitHubClient>();
+                var client = new ObservableTeamsClient(github);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetMembershipDetails(1, null));
+
+                Assert.Throws<ArgumentException>(() => client.GetMembershipDetails(1, ""));
             }
         }
 

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -124,13 +124,23 @@ namespace Octokit
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use AddOrEditMembership instead")]
         Task<TeamMembership> AddMembership(int id, string login);
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <param name="request">Additional parameters for the request</param>
+        Task<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request);
 
         /// <summary>
         /// Removes a <see cref="User"/> from a <see cref="Team"/>.

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -62,23 +62,42 @@ namespace Octokit
         /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        /// <param name="id">The team identifier</param>
         Task<IReadOnlyList<User>> GetAllMembers(int id);
 
         /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
-        /// <param name="id">The team identifier</param>
-        /// <param name="options">Options to change API behaviour.</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
         Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options);
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request);
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options);
 
         /// <summary>
         /// Returns newly created <see cref="Team" /> for the current org.

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -165,6 +165,7 @@ namespace Octokit
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
+        /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -159,8 +159,19 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use GetMembershipDetails instead")]
         Task<TeamMembership> GetMembership(int id, string login);
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        Task<TeamMembershipDetails> GetMembershipDetails(int id, string login);
 
         /// <summary>
         /// Returns all team's repositories.

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -92,11 +92,10 @@ namespace Octokit
         /// <summary>
         /// Returns all members of the given team. 
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
+        /// <param name="id">The team identifier</param>
         public Task<IReadOnlyList<User>> GetAllMembers(int id)
         {
             return GetAllMembers(id, ApiOptions.None);
@@ -110,7 +109,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
-        /// <returns>A list of the team's member <see cref="User"/>s.</returns>
         public Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -118,6 +116,40 @@ namespace Octokit
             var endpoint = ApiUrls.TeamMembers(id);
 
             return ApiConnection.GetAll<User>(endpoint, options);
+        }
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        public Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return GetAllMembers(id, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns all members with the specified role in the given team of the given role.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#list-team-members
+        /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="request">The request filter</param>
+        /// <param name="options">Options to change API behaviour.</param>
+        public Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            var endpoint = ApiUrls.TeamMembers(id);
+
+            return ApiConnection.GetAll<User>(endpoint, request.ToParametersDictionary(), options);
         }
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -184,6 +184,7 @@ namespace Octokit
         /// <summary>
         /// Gets whether the user with the given <paramref name="login"/> 
         /// is a member of the team with the given <paramref name="id"/>.
+        /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -158,7 +158,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use GetMembershipDetails instead")]
         public async Task<TeamMembership> GetMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
@@ -179,6 +179,24 @@ namespace Octokit
             return response["state"] == "active"
                 ? TeamMembership.Active
                 : TeamMembership.Pending;
+        }
+
+        /// <summary>
+        /// Gets whether the user with the given <paramref name="login"/> 
+        /// is a member of the team with the given <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team to check.</param>
+        /// <param name="login">The user to check.</param>
+        public Task<TeamMembershipDetails> GetMembershipDetails(int id, string login)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
+
+            var endpoint = ApiUrls.TeamMember(id, login);
+
+            return ApiConnection.Get<TeamMembershipDetails>(endpoint);
         }
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -224,12 +224,11 @@ namespace Octokit
         /// Adds a <see cref="User"/> to a <see cref="Team"/>.
         /// </summary>
         /// <remarks>
-        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-team-member">API documentation</a> for more information.
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
-        /// <exception cref="ApiValidationException">Thrown if you attempt to add an organization to a team.</exception>
-        /// <returns>A <see cref="TeamMembership"/> result indicating the membership status</returns>
+        [Obsolete("Please use AddOrEditMembership instead")]
         public async Task<TeamMembership> AddMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, "login");
@@ -255,6 +254,25 @@ namespace Octokit
             return response["state"] == "active"
                 ? TeamMembership.Active
                 : TeamMembership.Pending;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="User"/> to a <see cref="Team"/>.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/orgs/teams/#add-or-update-team-membership">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="id">The team identifier.</param>
+        /// <param name="login">The user to add to the team.</param>
+        /// <param name="request">Additional parameters for the request</param>
+        public Task<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            var endpoint = ApiUrls.TeamMember(id, login);
+
+            return ApiConnection.Put<TeamMembershipDetails>(endpoint, request);
         }
 
         /// <summary>

--- a/Octokit/Models/Request/TeamMembersRequest.cs
+++ b/Octokit/Models/Request/TeamMembersRequest.cs
@@ -1,0 +1,55 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to filter requests for team members
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class TeamMembersRequest : RequestParameters
+    {
+        public TeamMembersRequest(TeamRoleFilter role)
+        {
+            Role = role;
+        }
+
+        /// <summary>
+        /// Which membership roles to get
+        /// </summary>
+        public TeamRoleFilter Role { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Role {0} ", Role);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Filtering by Roles within a Team
+    /// </summary>
+    public enum TeamRoleFilter
+    {
+        /// <summary>
+        /// Regular Team Member
+        /// </summary>
+        [Parameter(Value = "member")]
+        Member,
+
+        /// <summary>
+        ///  Team Maintainer
+        /// </summary>
+        [Parameter(Value = "maintainer")]
+        Maintainer,
+
+        /// <summary>
+        /// All Roles
+        /// </summary>
+        [Parameter(Value = "all")]
+        All
+    }
+}

--- a/Octokit/Models/Request/UpdateTeamMembership.cs
+++ b/Octokit/Models/Request/UpdateTeamMembership.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Used to filter requests for team members
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class UpdateTeamMembership
+    {
+        public UpdateTeamMembership(TeamRole role)
+        {
+            Role = role;
+        }
+
+        /// <summary>
+        /// Which membership roles to get
+        /// </summary>
+        public TeamRole Role { get; private set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Role {0}", Role);
+            }
+        }
+    }
+}

--- a/Octokit/Models/Response/MembershipState.cs
+++ b/Octokit/Models/Response/MembershipState.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// States of a Team/Organization Membership
+    /// </summary>
+    public enum MembershipState
+    {
+        /// <summary>
+        /// The membership is pending
+        /// </summary>
+        [Parameter(Value = "pending")]
+        Pending,
+
+        /// <summary>
+        /// The membership is active
+        /// </summary>
+        [Parameter(Value = "active")]
+        Active
+    }
+}

--- a/Octokit/Models/Response/TeamMembership.cs
+++ b/Octokit/Models/Response/TeamMembership.cs
@@ -2,7 +2,7 @@
 
 namespace Octokit
 {
-    [Obsolete("This enum will be replaced with a response class TeamMembershipDetails")]
+    [Obsolete("Please use TeamMembershipDetails response class instead")]
     public enum TeamMembership
     {
         NotFound = 0,

--- a/Octokit/Models/Response/TeamMembership.cs
+++ b/Octokit/Models/Response/TeamMembership.cs
@@ -1,5 +1,8 @@
-﻿namespace Octokit
+﻿using System;
+
+namespace Octokit
 {
+    [Obsolete("This enum will be replaced with a response class TeamMembershipDetails")]
     public enum TeamMembership
     {
         NotFound = 0,

--- a/Octokit/Models/Response/TeamMembershipDetails.cs
+++ b/Octokit/Models/Response/TeamMembershipDetails.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class TeamMembershipDetails
+    {
+        public StringEnum<TeamRole> Role { get; protected set; }
+
+        public StringEnum<MembershipState> State { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Role: {0} State: {1}", Role, State);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Roles within a Team
+    /// </summary>
+    public enum TeamRole
+    {
+        /// <summary>
+        /// Regular Team Member
+        /// </summary>
+        [Parameter(Value = "member")]
+        Member,
+
+        /// <summary>
+        ///  Team Maintainer
+        /// </summary>
+        [Parameter(Value = "maintainer")]
+        Maintainer
+    }
+}


### PR DESCRIPTION
Fixes #1676 

- Implement `TeamsClient.AddOrEditMembership` taking a request parameter to indicate the `role` of the member to be added/updated (Member or Maintainer)
- Implement role filter on `TeamsClient.GetAllmembers()` so that the query can be filtered based on the member roles (Member, Maintainer or All)
- Introduce new response type for Team membership which includes the `Role` (Member or Maintainer) and `Status` (Active or Pending) of the membership.

Due to needing to safely deprecate the old `GetMembership` method following our normal deprecation schedule, the new method has been named `GetMembershipDetails` as the method signature was the same except for the return type. 

The `AddMembership` method has been deprecated, replaced with `AddOrEditMembership`