### PR TITLE
Enable generation of XML doc files

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>Octokit.Reactive</AssemblyTitle>
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <AssemblyName>Octokit.Reactive</AssemblyName>
     <PackageId>Octokit.Reactive</PackageId>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>Octokit</AssemblyTitle>
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Octokit</PackageId>


### PR DESCRIPTION
Fixes #1673 

That post by Nate McMaster has saved my bacon a few times now: http://www.natemcmaster.com/blog/2017/01/19/project-json-to-csproj/#other-common-build-options

I think we lost the documentation files when we moved from the `project.json` project system to the new `.csproj` one.

I tested by running the `Package` build task and the XML files ended up in the `.nupkg`s which I suppose will fix this.