### PR TITLE
Fix SearchRepository forks qualifier

### DIFF
--- a/Octokit.Tests.Integration/Clients/SearchClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/SearchClientTests.cs
@@ -24,6 +24,30 @@ public class SearchClientTests
     }
 
     [IntegrationTest]
+    public async Task SearchForForkedRepositories()
+    {
+        var request = new SearchRepositoriesRequest("octokit")
+        {
+            Fork = ForkQualifier.IncludeForks
+        };
+        var repos = await _gitHubClient.Search.SearchRepo(request);
+
+        Assert.True(repos.Items.Any(x => x.Fork));
+    }
+
+    [IntegrationTest]
+    public async Task SearchForOnlyForkedRepositories()
+    {
+        var request = new SearchRepositoriesRequest("octokit")
+        {
+            Fork = ForkQualifier.OnlyForks
+        };
+        var repos = await _gitHubClient.Search.SearchRepo(request);
+
+        Assert.True(repos.Items.All(x => x.Fork));
+    }
+
+    [IntegrationTest]
     public async Task SearchForGitHub()
     {
         var request = new SearchUsersRequest("github");

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -428,7 +428,7 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
-            public void TestingTheForkQualifier()
+            public void TestingTheIncludeForkQualifier()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
@@ -437,7 +437,20 @@ namespace Octokit.Tests.Clients
                 request.Fork = ForkQualifier.IncludeForks;
                 client.SearchRepo(request);
                 connection.Received().Get<SearchRepositoryResult>(Arg.Is<Uri>(u => u.ToString() == "search/repositories"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "github+fork:IncludeForks"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "github+fork:true"));
+            }
+
+            [Fact]
+            public void TestingTheOnlyForkQualifier()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+                //search repos that contains rails and forks are included in the search
+                var request = new SearchRepositoriesRequest("github");
+                request.Fork = ForkQualifier.OnlyForks;
+                client.SearchRepo(request);
+                connection.Received().Get<SearchRepositoryResult>(Arg.Is<Uri>(u => u.ToString() == "search/repositories"),
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "github+fork:only"));
             }
 
             [Fact]

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -133,7 +133,7 @@ namespace Octokit
 
             if (Fork != null)
             {
-                parameters.Add(string.Format(CultureInfo.InvariantCulture, "fork:{0}", Fork));
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "fork:{0}", Fork.ToParameter()));
             }
 
             if (Stars != null)
@@ -780,12 +780,12 @@ namespace Octokit
         /// <summary>
         /// only search for forked repos
         /// </summary>
-        [Parameter(Value = "Only")]
+        [Parameter(Value = "only")]
         OnlyForks,
         /// <summary>
         /// include forked repos into the search
         /// </summary>
-        [Parameter(Value = "True")]
+        [Parameter(Value = "true")]
         IncludeForks
     }
 }


### PR DESCRIPTION
Fixes #1677 

The forks qualifier should be `fork:true` or `fork:only` and was incorrectly being set to the enum member `.ToString()` rather than the decorated `[Parameter()]` values.

- Changed the `MergedQualifiers` function to use the decorated `[Parameter]` attribute value for the enum members
- Changed the values to lowercase for consistency
- Added unit and integration tests for both Forks values (Include and Only)