### PR TITLE
Add possibility to configure GitHubClient timeout (#963)

### DIFF
--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -14,7 +14,7 @@ namespace Octokit.Reactive
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
         /// <param name="timeout">The Timeout value</param>
-        void SetRequestsTimeout(TimeSpan timeout);
+        void SetRequestTimeout(TimeSpan timeout);
         
         IObservableAuthorizationsClient Authorization { get; }
         IObservableActivitiesClient Activity { get; }

--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -6,6 +6,16 @@ namespace Octokit.Reactive
     {
         IConnection Connection { get; }
 
+        /// <summary>
+        /// Set the GitHub Api request timeout.
+        /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
+        /// </summary>
+        /// <remarks>
+        /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
+        /// </remarks>
+        /// <param name="timeout">The Timeout value</param>
+        void SetRequestsTimeout(TimeSpan timeout);
+        
         IObservableAuthorizationsClient Authorization { get; }
         IObservableActivitiesClient Activity { get; }
         IObservableIssuesClient Issue { get; }

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -54,10 +54,18 @@ namespace Octokit.Reactive
             get { return _gitHubClient.Connection; }
         }
 
-        public void SetRequestsTimeout(TimeSpan timeout)
+        /// <summary>
+        /// Set the GitHub Api request timeout.
+        /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
+        /// </summary>
+        /// <remarks>
+        /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
+        /// </remarks>
+        /// <param name="timeout">The Timeout value</param>
+        public void SetRequestTimeout(TimeSpan timeout)
         {
             
-            _gitHubClient.SetRequestsTimeout(timeout);
+            _gitHubClient.SetRequestTimeout(timeout);
         }
 
         public IObservableAuthorizationsClient Authorization { get; private set; }

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -54,6 +54,12 @@ namespace Octokit.Reactive
             get { return _gitHubClient.Connection; }
         }
 
+        public void SetRequestsTimeout(TimeSpan timeout)
+        {
+            
+            _gitHubClient.SetRequestsTimeout(timeout);
+        }
+
         public IObservableAuthorizationsClient Authorization { get; private set; }
         public IObservableActivitiesClient Activity { get; private set; }
         public IObservableIssuesClient Issue { get; private set; }

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -132,21 +132,6 @@ namespace Octokit.Tests
             }
         }
 
-        public class SettingRequestsTimeout
-        {
-            [Fact]
-            public void WhenSettingTimeoutThatSetTheRequestsTimeoutOnTheUnderlyingHttpClient()
-            {
-                var httpClient = Substitute.For<IHttpClient>();
-                var client = new GitHubClient(new Connection(new ProductHeaderValue("OctokitTests"), httpClient));
-
-                client.SetRequestsTimeout(TimeSpan.FromSeconds(15));
-
-
-                httpClient.Received(1).SetRequestsTimeout(TimeSpan.FromSeconds(15));
-            }
-        }
-
         public class TheLastApiInfoProperty
         {
             [Fact]
@@ -209,6 +194,21 @@ namespace Octokit.Tests
                 Assert.NotNull(result);
 
                 var temp = connection.Received(1).GetLastApiInfo();
+            }
+        }
+
+        public class TheSetRequestTimeoutMethod
+        {
+            [Fact]
+            public void SetsTheTimeoutOnTheUnderlyingHttpClient()
+            {
+                var httpClient = Substitute.For<IHttpClient>();
+                var client = new GitHubClient(new Connection(new ProductHeaderValue("OctokitTests"), httpClient));
+
+                client.SetRequestTimeout(TimeSpan.FromSeconds(15));
+
+
+                httpClient.Received(1).SetRequestTimeout(TimeSpan.FromSeconds(15));
             }
         }
     }

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -132,6 +132,21 @@ namespace Octokit.Tests
             }
         }
 
+        public class SettingRequestsTimeout
+        {
+            [Fact]
+            public void WhenSettingTimeoutThatSetTheRequestsTimeoutOnTheUnderlyingHttpClient()
+            {
+                var httpClient = Substitute.For<IHttpClient>();
+                var client = new GitHubClient(new Connection(new ProductHeaderValue("OctokitTests"), httpClient));
+
+                client.SetRequestsTimeout(TimeSpan.FromSeconds(15));
+
+
+                httpClient.Received(1).SetRequestsTimeout(TimeSpan.FromSeconds(15));
+            }
+        }
+
         public class TheLastApiInfoProperty
         {
             [Fact]

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -107,9 +107,9 @@ namespace Octokit
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
         /// <param name="timeout">The Timeout value</param>
-        public void SetRequestsTimeout(TimeSpan timeout)
+        public void SetRequestTimeout(TimeSpan timeout)
         {
-            Connection.SetRequestsTimeout(timeout);
+            Connection.SetRequestTimeout(timeout);
         }
 
         /// <summary>

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -100,6 +100,19 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Set the GitHub Api request timeout.
+        /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
+        /// </summary>
+        /// <remarks>
+        /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
+        /// </remarks>
+        /// <param name="timeout">The Timeout value</param>
+        public void SetRequestsTimeout(TimeSpan timeout)
+        {
+            Connection.SetRequestsTimeout(timeout);
+        }
+
+        /// <summary>
         /// Gets the latest API Info - this will be null if no API calls have been made
         /// </summary>
         /// <returns><seealso cref="ApiInfo"/> representing the information returned as part of an Api call</returns>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -752,5 +752,14 @@ namespace Octokit
 
             return _versionInformation;
         }
+
+        /// <summary>
+        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// </summary>
+        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
+        public void SetRequestsTimeout(TimeSpan timeout)
+        {
+            _httpClient.SetRequestsTimeout(timeout);
+        }
     }
 }

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -754,12 +754,12 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// Set the GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
-        public void SetRequestsTimeout(TimeSpan timeout)
+        /// <param name="timeout">The Timeout value</param>
+        public void SetRequestTimeout(TimeSpan timeout)
         {
-            _httpClient.SetRequestsTimeout(timeout);
+            _httpClient.SetRequestTimeout(timeout);
         }
     }
 }

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -264,6 +264,11 @@ namespace Octokit.Internal
 
             return newRequest;
         }
+
+        public void SetRequestsTimeout(TimeSpan timeout)
+        {
+            _http.Timeout = timeout;
+        }
     }
 
     internal class RedirectHandler : DelegatingHandler

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -265,7 +265,11 @@ namespace Octokit.Internal
             return newRequest;
         }
 
-        public void SetRequestsTimeout(TimeSpan timeout)
+        /// <summary>
+        /// Set the GitHub Api request timeout.
+        /// </summary>
+        /// <param name="timeout">The Timeout value</param>
+        public void SetRequestTimeout(TimeSpan timeout)
         {
             _http.Timeout = timeout;
         }

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -292,5 +292,11 @@ namespace Octokit
         /// the default <see cref="InMemoryCredentialStore"/> with just these credentials.
         /// </remarks>
         Credentials Credentials { get; set; }
+
+        /// <summary>
+        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// </summary>
+        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
+        void SetRequestsTimeout(TimeSpan timeout);
     }
 }

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -294,9 +294,9 @@ namespace Octokit
         Credentials Credentials { get; set; }
 
         /// <summary>
-        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// Set the GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
-        void SetRequestsTimeout(TimeSpan timeout);
+        /// <param name="timeout">The Timeout value</param>
+        void SetRequestTimeout(TimeSpan timeout);
     }
 }

--- a/Octokit/Http/IHttpClient.cs
+++ b/Octokit/Http/IHttpClient.cs
@@ -19,5 +19,12 @@ namespace Octokit.Internal
         /// <param name="cancellationToken">Used to cancel the request</param>
         /// <returns>A <see cref="Task" /> of <see cref="IResponse"/></returns>
         Task<IResponse> Send(IRequest request, CancellationToken cancellationToken);
+
+
+        /// <summary>
+        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// </summary>
+        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
+        void SetRequestsTimeout(TimeSpan timeout);
     }
 }

--- a/Octokit/Http/IHttpClient.cs
+++ b/Octokit/Http/IHttpClient.cs
@@ -22,9 +22,9 @@ namespace Octokit.Internal
 
 
         /// <summary>
-        /// Set the timespan to wait before the requests to GitHub api times out.
+        /// Set the GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">the timespan to wait before a request to GitHub api times out</param>
-        void SetRequestsTimeout(TimeSpan timeout);
+        /// <param name="timeout">The Timeout value</param>
+        void SetRequestTimeout(TimeSpan timeout);
     }
 }

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -8,6 +8,16 @@ namespace Octokit
     public interface IGitHubClient : IApiInfoProvider
     {
         /// <summary>
+        /// Set the GitHub Api request timeout.
+        /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
+        /// </summary>
+        /// <remarks>
+        /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
+        /// </remarks>
+        /// <param name="timeout">The Timeout value</param>
+        void SetRequestsTimeout(TimeSpan timeout);
+        
+        /// <summary>
         /// Provides a client connection to make rest requests to HTTP endpoints.
         /// </summary>
         IConnection Connection { get; }

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -15,7 +15,7 @@ namespace Octokit
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
         /// <param name="timeout">The Timeout value</param>
-        void SetRequestsTimeout(TimeSpan timeout);
+        void SetRequestTimeout(TimeSpan timeout);
         
         /// <summary>
         /// Provides a client connection to make rest requests to HTTP endpoints.


### PR DESCRIPTION
A first attempt to fix the problem describe in #963 by adding a possibility to extend the default timeout value (100s) that is too short to be able to post assets in github release.

Fixes #963

/ cc @ryangribble 