### PR TITLE
Add pagination support to ReferencesClient.

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReferencesClient.cs
@@ -56,9 +56,32 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/git/refs/#get-all-references
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAll(string owner, string name, ApiOptions options);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
         IObservable<Reference> GetAll(long repositoryId);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -78,10 +101,35 @@ namespace Octokit.Reactive
         /// <remarks>
         /// http://developer.github.com/v3/git/refs/#get-all-references
         /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
         IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Creates a reference for a given repository

--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -70,10 +70,26 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAll(string owner, string name)
         {
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAll(string owner, string name, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name));
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name), options);
         }
 
         /// <summary>
@@ -86,7 +102,23 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAll(long repositoryId)
         {
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId));
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAll(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId), options);
         }
 
         /// <summary>
@@ -101,11 +133,28 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
+            return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name, subNamespace));
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
 
         /// <summary>
@@ -119,9 +168,25 @@ namespace Octokit.Reactive
         /// <returns></returns>
         public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
-            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            return GetAllForSubNamespace(repositoryId, subNamespace, ApiOptions.None);
+        }
 
-            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
+
+            return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }
 
         /// <summary>

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -63,11 +63,121 @@ public class ReferencesClientTests : IDisposable
         Assert.NotEmpty(list);
     }
 
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAll("octokit", "octokit.net", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAll("octokit", "octokit.net", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAll("octokit", "octokit.net", startOptions);
+        var secondRefsPage = await _fixture.GetAll("octokit", "octokit.net", skipStartOptions);
+
+        foreach (var r1 in firstRefsPage)
+        foreach (var r2 in secondRefsPage)
+        {
+            Assert.NotEqual(r1.Ref, r2.Ref);
+        }
+    }
+
     [IntegrationTest(Skip = "This is paging for a long long time")]
     public async Task CanGetListOfReferencesWithRepositoryId()
     {
         var list = await _fixture.GetAll(7528679);
         Assert.NotEmpty(list);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithRepositoryIdWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAll(7528679, options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesWithRepositoryIdWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAll(7528679, options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesWithRepositoryIdBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAll(7528679, startOptions);
+        var secondRefsPage = await _fixture.GetAll(7528679, skipStartOptions);
+
+        foreach (var r1 in firstRefsPage)
+        foreach (var r2 in secondRefsPage)
+        {
+            Assert.NotEqual(r1.Ref, r2.Ref);
+        }
     }
 
     [IntegrationTest]
@@ -78,10 +188,120 @@ public class ReferencesClientTests : IDisposable
     }
 
     [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesInNamespaceBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", startOptions);
+        var secondRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", skipStartOptions);
+
+        foreach (var r1 in firstRefsPage)
+        foreach (var r2 in secondRefsPage)
+        {
+            Assert.NotEqual(r1.Ref, r2.Ref);
+        }
+    }
+
+    [IntegrationTest]
     public async Task CanGetListOfReferencesInNamespaceWithRepositoryId()
     {
         var list = await _fixture.GetAllForSubNamespace(7528679, "heads");
         Assert.NotEmpty(list);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithRepositoryIdWithStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var references = await _fixture.GetAllForSubNamespace(7528679, "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsCorrectCountOfReferencesInNamespaceWithRepositoryIdWithoutStart()
+    {
+        var options = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var references = await _fixture.GetAllForSubNamespace(7528679, "heads", options);
+
+        Assert.Equal(5, references.Count);
+    }
+
+    [IntegrationTest]
+    public async Task ReturnsDistinctReferencesInNamespaceWithRepositoryIdBasedOnStartPage()
+    {
+        var startOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1
+        };
+
+        var skipStartOptions = new ApiOptions
+        {
+            PageSize = 5,
+            PageCount = 1,
+            StartPage = 2
+        };
+
+        var firstRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", startOptions);
+        var secondRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", skipStartOptions);
+
+        foreach (var r1 in firstRefsPage)
+        foreach (var r2 in secondRefsPage)
+        {
+            Assert.NotEqual(r1.Ref, r2.Ref);
+        }
     }
 
     [IntegrationTest]

--- a/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReferencesClientTests.cs
@@ -111,11 +111,7 @@ public class ReferencesClientTests : IDisposable
         var firstRefsPage = await _fixture.GetAll("octokit", "octokit.net", startOptions);
         var secondRefsPage = await _fixture.GetAll("octokit", "octokit.net", skipStartOptions);
 
-        foreach (var r1 in firstRefsPage)
-        foreach (var r2 in secondRefsPage)
-        {
-            Assert.NotEqual(r1.Ref, r2.Ref);
-        }
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest(Skip = "This is paging for a long long time")]
@@ -173,11 +169,7 @@ public class ReferencesClientTests : IDisposable
         var firstRefsPage = await _fixture.GetAll(7528679, startOptions);
         var secondRefsPage = await _fixture.GetAll(7528679, skipStartOptions);
 
-        foreach (var r1 in firstRefsPage)
-        foreach (var r2 in secondRefsPage)
-        {
-            Assert.NotEqual(r1.Ref, r2.Ref);
-        }
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest]
@@ -235,11 +227,7 @@ public class ReferencesClientTests : IDisposable
         var firstRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", startOptions);
         var secondRefsPage = await _fixture.GetAllForSubNamespace("octokit", "octokit.net", "heads", skipStartOptions);
 
-        foreach (var r1 in firstRefsPage)
-        foreach (var r2 in secondRefsPage)
-        {
-            Assert.NotEqual(r1.Ref, r2.Ref);
-        }
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest]
@@ -297,11 +285,7 @@ public class ReferencesClientTests : IDisposable
         var firstRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", startOptions);
         var secondRefsPage = await _fixture.GetAllForSubNamespace(7528679, "heads", skipStartOptions);
 
-        foreach (var r1 in firstRefsPage)
-        foreach (var r2 in secondRefsPage)
-        {
-            Assert.NotEqual(r1.Ref, r2.Ref);
-        }
+        Assert.False(firstRefsPage.Any(x => secondRefsPage.Contains(x)));
     }
 
     [IntegrationTest]

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -68,6 +68,9 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
@@ -75,6 +78,9 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", ApiOptions.None));
             }
 
             [Fact]
@@ -110,16 +116,27 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", "heads", null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, "subnamespace", null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", ""));
 
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads", ApiOptions.None));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "name", "", ApiOptions.None));
+
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace(1, ""));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace(1, "", ApiOptions.None));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -68,6 +68,10 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(1, null));
+
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", ""));
@@ -81,7 +85,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("owner", "repo");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs"), Args.ApiOptions);
             }
 
             [Fact]
@@ -92,7 +96,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1);
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs"), Args.ApiOptions);
             }
         }
 
@@ -106,8 +110,10 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(null, "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", null, "heads"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace("owner", "name", "heads", null));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForSubNamespace(1, "subnamespace", null));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("", "name", "heads"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForSubNamespace("owner", "", "heads"));
@@ -124,7 +130,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForSubNamespace("owner", "repo", "heads");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"), Args.ApiOptions);
             }
 
             [Fact]
@@ -135,7 +141,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForSubNamespace(1, "heads");
 
-                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"));
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"), Args.ApiOptions);
             }
         }
 

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -48,8 +48,19 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(string owner, string name);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options);
 
         /// <summary>
         /// Gets all references for a given repository
@@ -59,8 +70,18 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAll(long repositoryId);
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAll(long repositoryId, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -72,8 +93,20 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
@@ -84,8 +117,19 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace);
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options);
 
         /// <summary>
         /// Creates a reference for a given repository

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -66,10 +66,26 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name)
         {
+            return GetAll(owner, name, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
+            Ensure.ArgumentNotNull(options, "options");
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name), options);
         }
 
         /// <summary>
@@ -82,7 +98,23 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAll(long repositoryId)
         {
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId));
+            return GetAll(repositoryId, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets all references for a given repository
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAll(long repositoryId, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId), options);
         }
 
         /// <summary>
@@ -97,13 +129,30 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
+            return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
             // TODO: Handle 404 when subNamespace cannot be found
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, subNamespace));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
 
         /// <summary>
@@ -117,11 +166,27 @@ namespace Octokit
         /// <returns></returns>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
+            return GetAllForSubNamespace(repositoryId, subNamespace, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets references for a given repository by sub-namespace, i.e. "tags" or "heads"
+        /// </summary>
+        /// <remarks>
+        /// http://developer.github.com/v3/git/refs/#get-all-references
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="subNamespace">The sub-namespace to get references for</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns></returns>
+        public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
+        {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, "subNamespace");
+            Ensure.ArgumentNotNull(options, "options");
 
             // TODO: Handle 404 when subNamespace cannot be found
 
-            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace));
+            return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1664 

- [x] Remove convention test exclusion

- [x] Add `ApiOptions` overload
  - make existing methods call new overload with `ApiOptions.None`

- [x] Update unit tests
  - Adjust for `ApiOptions` parameter
  - Add `null`/`""` checks for `ApiOptions` overloads

- [x] Add pagination Integration tests
  - `ReturnsCorrectCountOfXWithoutStart`
  - `ReturnsCorrectCountOfXWithStart`
  - `ReturnsDistinctXBasedOnStartPage`

- [x] Decide what to do with `GetAllForSubNamespace` endpoint