### PR TITLE
Remove extra space before close ticks.

### DIFF
--- a/docs/http-client.md
+++ b/docs/http-client.md
@@ -22,7 +22,7 @@ The rules we currently follow:
  - MUST use the original request's authentication credentials when following a redirect where the original host matches the redirect host.
  - MUST NOT use the original request's authentication credentials when following a redirect where the original host does not match the redirect host.
  - SHOULD only follow 3 redirects.
- ```
+```
 
 ### Proxy Support
 


### PR DESCRIPTION
This is breaking the layout at http://octokitnet.readthedocs.io/en/latest/http-client/.