### PR TITLE
CommitStatus IDs are 64bit, not 32bit

### DIFF
--- a/Octokit/Models/Response/CommitStatus.cs
+++ b/Octokit/Models/Response/CommitStatus.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public CommitStatus() { }
 
-        public CommitStatus(DateTimeOffset createdAt, DateTimeOffset updatedAt, CommitState state, string targetUrl, string description, string context, int id, string url, User creator)
+        public CommitStatus(DateTimeOffset createdAt, DateTimeOffset updatedAt, CommitState state, string targetUrl, string description, string context, long id, string url, User creator)
         {
             CreatedAt = createdAt;
             UpdatedAt = updatedAt;
@@ -57,7 +57,7 @@ namespace Octokit
         /// <summary>
         /// The unique identifier of the status.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// The URL of the status.


### PR DESCRIPTION
  * The API returns 64bit values for commit status. For example
  '4299360515'. This is larger than uint32.MaxValue so i assume
  this type *should* be a long.