### PR TITLE
Change integration tests configuration script test account warning color to yellow.

### DIFF
--- a/script/configure-integration-tests.ps1
+++ b/script/configure-integration-tests.ps1
@@ -74,8 +74,8 @@ function VerifyEnvironmentVariable([string]$friendlyName, [string]$key, [bool]$o
 }
 
 Write-Host
-Write-Host "BIG FREAKING WARNING!!!!!" 
-Write-Host "You should use a test account when running the Octokit integration tests!"
+Write-Warning "BIG FREAKING WARNING!!!!!" 
+Write-Warning "You should use a test account when running the Octokit integration tests!"
 Write-Host
 Write-Host
 


### PR DESCRIPTION
The warning in configuration script can be easily overlooked. I changed it's color to yellow to make it more visible.

How it looks after the change:
![image](https://user-images.githubusercontent.com/8547855/32695082-8b4dc05e-c752-11e7-9926-222cf7adee52.png)
