### PR TITLE
Update MiscellaneousClient to ApiClient approach and add pagination support to GetAllLicenses.

### DIFF
--- a/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
@@ -47,7 +47,6 @@ namespace Octokit.Reactive
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         IObservable<LicenseMetadata> GetAllLicenses();
@@ -56,7 +55,6 @@ namespace Octokit.Reactive
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
         IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options);

--- a/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/IObservableMiscellaneousClient.cs
@@ -53,6 +53,15 @@ namespace Octokit.Reactive
         IObservable<LicenseMetadata> GetAllLicenses();
 
         /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options);
+
+        /// <summary>
         /// Retrieves a license based on the license key such as "MIT"
         /// </summary>
         /// <param name="key"></param>

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -74,7 +74,19 @@ namespace Octokit.Reactive
         /// <returns>A list of licenses available on the site</returns>
         public IObservable<LicenseMetadata> GetAllLicenses()
         {
-            return _client.GetAllLicenses().ToObservable().SelectMany(l => l);
+            return GetAllLicenses(ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        public IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options)
+        {
+            return _client.GetAllLicenses(options).ToObservable().SelectMany(l => l);
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMiscellaneousClient.cs
@@ -70,7 +70,6 @@ namespace Octokit.Reactive
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         public IObservable<LicenseMetadata> GetAllLicenses()
         {
@@ -81,7 +80,6 @@ namespace Octokit.Reactive
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
         public IObservable<LicenseMetadata> GetAllLicenses(ApiOptions options)

--- a/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
@@ -72,6 +72,31 @@ public class MiscellaneousClientTests
 
             Assert.Equal(5, result.Count);
         }
+
+        [IntegrationTest]
+        public async Task CanRetrieveDistinctListOfLicensesBasedOnPageStart()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var startOptions = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1
+            };
+
+            var firstPage = await github.Miscellaneous.GetAllLicenses(startOptions);
+
+            var skipStartOptions = new ApiOptions
+            {
+                PageSize = 1,
+                PageCount = 1,
+                StartPage = 2
+            };
+
+            var secondPage = await github.Miscellaneous.GetAllLicenses(skipStartOptions);
+
+            Assert.NotEqual(firstPage[0].Key, secondPage[0].Key);
+        }
     }
 
     public class TheGetLicenseMethod

--- a/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MiscellaneousClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
 
@@ -55,6 +56,22 @@ public class MiscellaneousClientTests
             Assert.True(result.Count > 2);
             Assert.Contains(result, license => license.Key == "mit");
         }
+
+        [IntegrationTest]
+        public async Task CanRetrieveListOfLicensesWithPagination()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            var options = new ApiOptions
+            {
+                PageCount = 1,
+                PageSize = 5,
+            };
+
+            var result = await github.Miscellaneous.GetAllLicenses(options);
+
+            Assert.Equal(5, result.Count);
+        }
     }
 
     public class TheGetLicenseMethod
@@ -68,6 +85,14 @@ public class MiscellaneousClientTests
 
             Assert.Equal("mit", result.Key);
             Assert.Equal("MIT License", result.Name);
+        }
+
+        [IntegrationTest]
+        public async Task ReportsErrorWhenInvalidLicenseProvided()
+        {
+            var github = Helper.GetAuthenticatedClient();
+
+            await Assert.ThrowsAsync<NotFoundException>(() => github.Miscellaneous.GetLicense("purple-monkey-dishwasher"));
         }
     }
 

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -184,11 +184,11 @@ namespace Octokit.Tests.Clients
         public class TheGetAllLicensesMethod
         {
             [Fact]
-            public async void EnsuresNonNullArguments()
+            public void EnsuresNonNullArguments()
             {
                 var client = new MiscellaneousClient(Substitute.For<IApiConnection>());
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllLicenses(null));
+                Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllLicenses(null));
             }
 
             [Fact]
@@ -196,8 +196,8 @@ namespace Octokit.Tests.Clients
             {
                 IReadOnlyList<LicenseMetadata> response = new ReadOnlyCollection<LicenseMetadata>(new List<LicenseMetadata>()
                 {
-                    new LicenseMetadata("foo1", "foo2", "http://example.com/foo1" ),
-                    new LicenseMetadata("bar1", "bar2", "http://example.com/bar1" )
+                    new LicenseMetadata("foo1", "node-id-1", "foo2", "http://example.com/foo1", "something", true),
+                    new LicenseMetadata("bar1", "node-id-1", "bar2", "http://example.com/bar1", "something else", false )
                 });
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetAll<LicenseMetadata>(Args.Uri, null, AcceptHeaders.LicensesApiPreview, Args.ApiOptions)

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -15,16 +15,20 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheEmojiEndpoint()
             {
-                IApiResponse<string> response = new ApiResponse<string>(new Response(), "<strong>Test</strong>");
-                var connection = Substitute.For<IConnection>();
-                connection.Post<string>(Args.Uri, "**Test**", "text/html", "text/plain")
+                var response = "<strong>Test</strong>";
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Post<string>(
+                        Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
+                        Arg.Is<string>(s => s == "**Test**"),
+                        "text/html",
+                        "text/plain")
                     .Returns(Task.FromResult(response));
-                var client = new MiscellaneousClient(connection);
+                var client = new MiscellaneousClient(apiConnection);
 
                 var html = await client.RenderRawMarkdown("**Test**");
 
                 Assert.Equal("<strong>Test</strong>", html);
-                connection.Received()
+                apiConnection.Received()
                     .Post<string>(Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
                     "**Test**",
                     "text/html",
@@ -34,20 +38,23 @@ namespace Octokit.Tests.Clients
         public class TheRenderArbitraryMarkdownMethod
         {
             [Fact]
-            public async Task RequestsTheEmojiEndpoint()
+            public async Task RequestsTheMarkdownEndpoint()
             {
-                IApiResponse<string> response = new ApiResponse<string>(new Response(), "<strong>Test</strong>");
-                var connection = Substitute.For<IConnection>();
-                var forTest = new NewArbitraryMarkdown("testMarkdown", "gfm", "testContext");
-                connection.Post<string>(Args.Uri, forTest, "text/html", "text/plain")
-                    .Returns(Task.FromResult(response));
-                var client = new MiscellaneousClient(connection);
+                var response = "<strong>Test</strong>";
 
-                var html = await client.RenderArbitraryMarkdown(forTest);
+                var payload = new NewArbitraryMarkdown("testMarkdown", "gfm", "testContext");
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Post<string>(Args.Uri, payload, "text/html", "text/plain")
+                    .Returns(Task.FromResult(response));
+
+                var client = new MiscellaneousClient(apiConnection);
+
+                var html = await client.RenderArbitraryMarkdown(payload);
                 Assert.Equal("<strong>Test</strong>", html);
-                connection.Received()
+                apiConnection.Received()
                     .Post<string>(Arg.Is<Uri>(u => u.ToString() == "markdown"),
-                    forTest,
+                    payload,
                     "text/html",
                     "text/plain");
             }
@@ -57,25 +64,24 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheEmojiEndpoint()
             {
-                IApiResponse<Dictionary<string, string>> response = new ApiResponse<Dictionary<string, string>>
-                (
-                    new Response(),
-                    new Dictionary<string, string>
-                    {
-                        { "foo", "http://example.com/foo.gif" },
-                        { "bar", "http://example.com/bar.gif" }
-                    }
-                );
-                var connection = Substitute.For<IConnection>();
-                connection.Get<Dictionary<string, string>>(Args.Uri, null, null).Returns(Task.FromResult(response));
-                var client = new MiscellaneousClient(connection);
+                IReadOnlyList<Emoji> response = new List<Emoji>
+                {
+                    { new Emoji("foo", "http://example.com/foo.gif") },
+                    { new Emoji("bar", "http://example.com/bar.gif") }
+                };
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.GetAll<Emoji>(Args.Uri)
+                          .Returns(Task.FromResult(response));
+
+                var client = new MiscellaneousClient(apiConnection);
 
                 var emojis = await client.GetAllEmojis();
 
                 Assert.Equal(2, emojis.Count);
                 Assert.Equal("foo", emojis[0].Name);
-                connection.Received()
-                    .Get<Dictionary<string, string>>(Arg.Is<Uri>(u => u.ToString() == "emojis"), null, null);
+                apiConnection.Received()
+                    .GetAll<Emoji>(Arg.Is<Uri>(u => u.ToString() == "emojis"));
             }
         }
 
@@ -84,20 +90,17 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheResourceRateLimitEndpoint()
             {
-                IApiResponse<MiscellaneousRateLimit> response = new ApiResponse<MiscellaneousRateLimit>
-                (
-                    new Response(),
-                    new MiscellaneousRateLimit(
-                        new ResourceRateLimit(
-                            new RateLimit(5000, 4999, 1372700873),
-                            new RateLimit(30, 18, 1372700873)
-                        ),
-                        new RateLimit(100, 75, 1372700873)
-                    )
-                );
-                var connection = Substitute.For<IConnection>();
-                connection.Get<MiscellaneousRateLimit>(Args.Uri, null, null).Returns(Task.FromResult(response));
-                var client = new MiscellaneousClient(connection);
+                var rateLimit = new MiscellaneousRateLimit(
+                     new ResourceRateLimit(
+                         new RateLimit(5000, 4999, 1372700873),
+                         new RateLimit(30, 18, 1372700873)
+                     ),
+                     new RateLimit(100, 75, 1372700873)
+                 );
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<MiscellaneousRateLimit>(Arg.Is<Uri>(u => u.ToString() == "rate_limit")).Returns(Task.FromResult(rateLimit));
+
+                var client = new MiscellaneousClient(apiConnection);
 
                 var result = await client.GetRateLimits();
 
@@ -131,8 +134,8 @@ namespace Octokit.Tests.Clients
                     CultureInfo.InvariantCulture);
                 Assert.Equal(expectedReset, result.Rate.Reset);
 
-                connection.Received()
-                    .Get<MiscellaneousRateLimit>(Arg.Is<Uri>(u => u.ToString() == "rate_limit"), null, null);
+                apiConnection.Received()
+                    .Get<MiscellaneousRateLimit>(Arg.Is<Uri>(u => u.ToString() == "rate_limit"));
             }
         }
 
@@ -141,22 +144,18 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task RequestsTheMetadataEndpoint()
             {
-                IApiResponse<Meta> response = new ApiResponse<Meta>
-                (
-                    new Response(),
-                    new Meta(
-                        false,
-                        "12345ABCDE",
-                        new[] { "1.1.1.1/24", "1.1.1.2/24" },
-                        new[] { "1.1.2.1/24", "1.1.2.2/24" },
-                        new[] { "1.1.3.1/24", "1.1.3.2/24" },
-                        new[] { "1.1.4.1", "1.1.4.2" }
-                    )
-                );
-                var connection = Substitute.For<IConnection>();
-                connection.Get<Meta>(Args.Uri, null, null)
-                    .Returns(Task.FromResult(response));
-                var client = new MiscellaneousClient(connection);
+                var meta = new Meta(
+                     false,
+                     "12345ABCDE",
+                     new[] { "1.1.1.1/24", "1.1.1.2/24" },
+                     new[] { "1.1.2.1/24", "1.1.2.2/24" },
+                     new[] { "1.1.3.1/24", "1.1.3.2/24" },
+                     new[] { "1.1.4.1", "1.1.4.2" }
+                 );
+
+                var apiConnection = Substitute.For<IApiConnection>();
+                apiConnection.Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta")).Returns(Task.FromResult(meta));
+                var client = new MiscellaneousClient(apiConnection);
 
                 var result = await client.GetMetadata();
 
@@ -167,8 +166,8 @@ namespace Octokit.Tests.Clients
                 Assert.Equal(result.Pages, new[] { "1.1.3.1/24", "1.1.3.2/24" });
                 Assert.Equal(result.Importer, new[] { "1.1.4.1", "1.1.4.2" });
 
-                connection.Received()
-                    .Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta"), null, null);
+                apiConnection.Received()
+                    .Get<Meta>(Arg.Is<Uri>(u => u.ToString() == "meta"));
             }
         }
 

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -196,11 +196,12 @@ namespace Octokit.Tests.Clients
             {
                 IReadOnlyList<LicenseMetadata> response = new ReadOnlyCollection<LicenseMetadata>(new List<LicenseMetadata>()
                 {
-                    new LicenseMetadata("foo1", "node-id-1", "foo2", "http://example.com/foo1", "something", true),
-                    new LicenseMetadata("bar1", "node-id-1", "bar2", "http://example.com/bar1", "something else", false )
+                    new LicenseMetadata("foo1", "node-id-1", "foo2", "something", "http://example.com/foo1",  true),
+                    new LicenseMetadata("bar1", "node-id-1", "bar2", "something else", "http://example.com/bar1", false)
                 });
+
                 var connection = Substitute.For<IApiConnection>();
-                connection.GetAll<LicenseMetadata>(Args.Uri, null, AcceptHeaders.LicensesApiPreview, Args.ApiOptions)
+                connection.GetAll<LicenseMetadata>(Arg.Is<Uri>(u => u.ToString() == "licenses"), null, "application/vnd.github.drax-preview+json", Args.ApiOptions)
                     .Returns(Task.FromResult(response));
                 var client = new MiscellaneousClient(connection);
 

--- a/Octokit.Tests/Clients/MiscellaneousClientTests.cs
+++ b/Octokit.Tests/Clients/MiscellaneousClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using NSubstitute;
 using Octokit.Internal;
@@ -13,24 +14,25 @@ namespace Octokit.Tests.Clients
         public class TheRenderRawMarkdownMethod
         {
             [Fact]
-            public async Task RequestsTheEmojiEndpoint()
+            public async Task RequestsTheRawMarkdownEndpoint()
             {
+                var markdown = "**Test**";
                 var response = "<strong>Test</strong>";
                 var apiConnection = Substitute.For<IApiConnection>();
                 apiConnection.Post<string>(
                         Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
-                        Arg.Is<string>(s => s == "**Test**"),
+                        markdown,
                         "text/html",
                         "text/plain")
                     .Returns(Task.FromResult(response));
                 var client = new MiscellaneousClient(apiConnection);
 
-                var html = await client.RenderRawMarkdown("**Test**");
+                var html = await client.RenderRawMarkdown(markdown);
 
                 Assert.Equal("<strong>Test</strong>", html);
                 apiConnection.Received()
                     .Post<string>(Arg.Is<Uri>(u => u.ToString() == "markdown/raw"),
-                    "**Test**",
+                    markdown,
                     "text/html",
                     "text/plain");
             }

--- a/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableMiscellaneousClientTests.cs
@@ -87,7 +87,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllLicenses();
 
-                gitHubClient.Miscellaneous.Received(1).GetAllLicenses();
+                gitHubClient.Miscellaneous.Received(1).GetAllLicenses(Args.ApiOptions);
             }
         }
 

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -59,8 +59,16 @@ namespace Octokit
         /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        [ExcludeFromPaginationApiOptionsConventionTest("TODO: Implement pagination for this method")]
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
+
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options);
 
         /// <summary>
         /// Retrieves a license based on the license key such as "MIT"

--- a/Octokit/Clients/IMiscellaneousClient.cs
+++ b/Octokit/Clients/IMiscellaneousClient.cs
@@ -56,7 +56,6 @@ namespace Octokit
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses();
@@ -65,7 +64,6 @@ namespace Octokit
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
         Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options);
@@ -73,7 +71,7 @@ namespace Octokit
         /// <summary>
         /// Retrieves a license based on the license key such as "MIT"
         /// </summary>
-        /// <param name="key"></param>
+        /// <param name="key">The license identifier to look for</param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
         Task<License> GetLicense(string key);
 

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -79,7 +79,6 @@ namespace Octokit
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
         {
@@ -90,7 +89,6 @@ namespace Octokit
         /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
         /// list of all possible OSS licenses.
         /// </summary>
-        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options)

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
-using System.Collections.ObjectModel;
 
 namespace Octokit
 {
@@ -13,19 +11,15 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="http://developer.github.com/v3/misc/">Miscellaneous API documentation</a> for more details.
     /// </remarks>
-    public class MiscellaneousClient : IMiscellaneousClient
+    public class MiscellaneousClient : ApiClient, IMiscellaneousClient
     {
-        readonly IConnection _connection;
-
         /// <summary>
         ///     Initializes a new GitHub miscellaneous API client.
         /// </summary>
-        /// <param name="connection">An API connection</param>
-        public MiscellaneousClient(IConnection connection)
+        /// <param name="apiConnection">An API connection.</param>
+        public MiscellaneousClient(IApiConnection apiConnection)
+            : base(apiConnection)
         {
-            Ensure.ArgumentNotNull(connection, nameof(connection));
-
-            _connection = connection;
         }
 
         /// <summary>
@@ -33,12 +27,9 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
-        public async Task<IReadOnlyList<Emoji>> GetAllEmojis()
+        public Task<IReadOnlyList<Emoji>> GetAllEmojis()
         {
-            var endpoint = new Uri("emojis", UriKind.Relative);
-            var response = await _connection.Get<Dictionary<string, string>>(endpoint, null, null).ConfigureAwait(false);
-            return new ReadOnlyCollection<Emoji>(
-                response.Body.Select(kvp => new Emoji(kvp.Key, kvp.Value)).ToArray());
+            return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
         }
 
         /// <summary>
@@ -47,11 +38,9 @@ namespace Octokit
         /// <param name="markdown">A plain-text Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
-        public async Task<string> RenderRawMarkdown(string markdown)
+        public Task<string> RenderRawMarkdown(string markdown)
         {
-            var endpoint = new Uri("markdown/raw", UriKind.Relative);
-            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain").ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Post<string>(ApiUrls.RawMarkdown(), markdown, "text/html", "text/plain");
         }
 
         /// <summary>
@@ -60,23 +49,18 @@ namespace Octokit
         /// <param name="markdown">An arbitrary Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
-        public async Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
+        public Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
         {
-            var endpoint = new Uri("markdown", UriKind.Relative);
-            var response = await _connection.Post<string>(endpoint, markdown, "text/html", "text/plain").ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Post<string>(ApiUrls.Markdown(), markdown, "text/html", "text/plain");
         }
 
         /// <summary>
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>A list of template names</returns>
-        public async Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
+        public Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
         {
-            var endpoint = new Uri("gitignore/templates", UriKind.Relative);
-
-            var response = await _connection.Get<string[]>(endpoint, null, null).ConfigureAwait(false);
-            return new ReadOnlyCollection<string>(response.Body);
+            return ApiConnection.GetAll<string>(ApiUrls.GitIgnoreTemplates());
         }
 
         /// <summary>
@@ -84,14 +68,11 @@ namespace Octokit
         /// </summary>
         /// <param name="templateName"></param>
         /// <returns>A template and its source</returns>
-        public async Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
+        public Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
         {
             Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));
 
-            var endpoint = new Uri("gitignore/templates/" + Uri.EscapeUriString(templateName), UriKind.Relative);
-
-            var response = await _connection.Get<GitIgnoreTemplate>(endpoint, null, null).ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Get<GitIgnoreTemplate>(ApiUrls.GitIgnoreTemplates(templateName));
         }
 
         /// <summary>
@@ -100,12 +81,23 @@ namespace Octokit
         /// </summary>
         /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
         /// <returns>A list of licenses available on the site</returns>
-        public async Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
+        public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
         {
-            var endpoint = new Uri("licenses", UriKind.Relative);
+            return GetAllLicenses(ApiOptions.None);
+        }
 
-            var response = await _connection.Get<LicenseMetadata[]>(endpoint, null, AcceptHeaders.LicensesApiPreview).ConfigureAwait(false);
-            return new ReadOnlyCollection<LicenseMetadata>(response.Body);
+        /// <summary>
+        /// Returns a list of the licenses shown in the license picker on GitHub.com. This is not a comprehensive
+        /// list of all possible OSS licenses.
+        /// </summary>
+        /// <remarks>This is a PREVIEW API! Use it at your own risk.</remarks>
+        /// <param name="options">Options for changing the API response</param>
+        /// <returns>A list of licenses available on the site</returns>
+        public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(options, "options");
+
+            return ApiConnection.GetAll<LicenseMetadata>(ApiUrls.Licenses(), null, AcceptHeaders.LicensesApiPreview, options);
         }
 
         /// <summary>
@@ -113,12 +105,9 @@ namespace Octokit
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
-        public async Task<License> GetLicense(string key)
+        public Task<License> GetLicense(string key)
         {
-            var endpoint = new Uri("licenses/" + Uri.EscapeUriString(key), UriKind.Relative);
-
-            var response = await _connection.Get<License>(endpoint, null, AcceptHeaders.LicensesApiPreview).ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Get<License>(ApiUrls.Licenses(key), null, AcceptHeaders.LicensesApiPreview);
         }
 
         /// <summary>
@@ -127,11 +116,9 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public async Task<MiscellaneousRateLimit> GetRateLimits()
+        public Task<MiscellaneousRateLimit> GetRateLimits()
         {
-            var endpoint = new Uri("rate_limit", UriKind.Relative);
-            var response = await _connection.Get<MiscellaneousRateLimit>(endpoint, null, null).ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Get<MiscellaneousRateLimit>(ApiUrls.RateLimit());
         }
 
         /// <summary>
@@ -140,11 +127,9 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public async Task<Meta> GetMetadata()
+        public Task<Meta> GetMetadata()
         {
-            var endpoint = new Uri("meta", UriKind.Relative);
-            var response = await _connection.Get<Meta>(endpoint, null, null).ConfigureAwait(false);
-            return response.Body;
+            return ApiConnection.Get<Meta>(ApiUrls.Meta());
         }
     }
 }

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -102,7 +102,7 @@ namespace Octokit
             GitHubApps = new GitHubAppsClient(apiConnection);
             Issue = new IssuesClient(apiConnection);
             Migration = new MigrationClient(apiConnection);
-            Miscellaneous = new MiscellaneousClient(connection);
+            Miscellaneous = new MiscellaneousClient(apiConnection);
             Oauth = new OauthClient(connection);
             Organization = new OrganizationsClient(apiConnection);
             PullRequest = new PullRequestsClient(apiConnection);

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -4156,5 +4156,97 @@ namespace Octokit
         {
             return "repos/{0}/{1}/check-suites/preferences".FormatUri(owner, repo);
         }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all emojis in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> for emojis.</returns>
+        public static Uri Emojis()
+        {
+            return "emojis".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns rendered markdown in
+        /// response to a POST request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to render markdown.</returns>
+        public static Uri RawMarkdown()
+        {
+            return "markdown/raw".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns rendered markdown in
+        /// response to a POST request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to render markdown.</returns>
+        public static Uri Markdown()
+        {
+            return "markdown".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all git ignore templates in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to git ignore templates.</returns>
+        public static Uri GitIgnoreTemplates()
+        {
+            return "gitignore/templates".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns specified git ignore templates in
+        /// response to a GET request.
+        /// </summary>
+        /// <param name="templateName">The name of the template to retrieve</param>
+        /// <returns>The <see cref="Uri"/> to git ignore template.</returns>
+        public static Uri GitIgnoreTemplates(string templateName)
+        {
+            return "gitignore/templates/{0}".FormatUri(templateName);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns all licenses in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to licenses.</returns>
+        public static Uri Licenses()
+        {
+            return "licenses".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns specified license in
+        /// response to a GET request.
+        /// </summary>
+        /// <param name="key">The key of the license to retrieve</param>
+        /// <returns>The <see cref="Uri"/> to license.</returns>
+        public static Uri Licenses(string key)
+        {
+            return "licenses/{0}".FormatUri(key);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns rate limit in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to rate limit.</returns>
+        public static Uri RateLimit()
+        {
+            return "rate_limit".FormatUri();
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that returns meta in
+        /// response to a GET request.
+        /// </summary>
+        /// <returns>The <see cref="Uri"/> to meta.</returns>
+        public static Uri Meta()
+        {
+            return "meta".FormatUri();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1663 

- [x] Remove convention test exclusion
- [x] Add `ApiOptions` overload
  -  [x] make existing methods call new overload with `ApiOptions.None`
- [x] Update unit tests
  -  [x] Adjust for `ApiOptions` parameter
  -  [x] Add `null`/`""` checks for `ApiOptions` overloads
- [x] Add pagination Integration tests
