### PR TITLE
Add TLS1.2 to enabled security protocols (.NET Framework 4.5 only)

### DIFF
--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -4,7 +4,7 @@
     <Description>Integration tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests.Integration</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests.Integration</AssemblyName>
     <PackageId>Octokit.Tests.Integration</PackageId>
@@ -27,7 +27,7 @@
     <None Include="app.config" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup>
     <ProjectReference Include="..\Octokit\Octokit.csproj" />
     <ProjectReference Include="..\Octokit.Reactive\Octokit.Reactive.csproj" />
     <ProjectReference Include="..\Octokit.Tests\Octokit.Tests.csproj" />

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -27,6 +27,10 @@ namespace Octokit.Internal
         {
             Ensure.ArgumentNotNull(getHandler, "getHandler");
 
+#if HAS_SERVICEPOINTMANAGER
+            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
+#endif
+
             _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });
         }
 

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -28,7 +28,7 @@ namespace Octokit.Internal
             Ensure.ArgumentNotNull(getHandler, "getHandler");
 
 #if HAS_SERVICEPOINTMANAGER
-            ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 #endif
 
             _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS;SIMPLE_JSON_INTERNAL,SIMPLE_JSON_OBJARRAYINTERNAL,SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;HAS_SERVICEPOINTMANAGER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Fixes #1756 

TLS1.2 will be required to connect to the GitHub API when [GitHub deprecates weak cryptographic algorithms on 22nd February](https://developer.github.com/changes/2018-02-01-weak-crypto-removal-notice/)

.NET Frameworks less than 4.6 do not have TLS1.2 enabled by default, so Octokit will now enable this protocol (on the `net45` target framework build only).

Notes
- `ServicePointManager.SecurityProtocol` is the mechanism used to enable the protocol... which isn't actually available on .NET Core until 2.0 anyway (but we don't need it since TLS1.2 is already enabled in .NET Core anyway)
- Added a `net452` target to the integration test project (bringing it into line with the other multi targeted test projects) in order to manually test that this value was set on .NET 4.5x 