### PR TITLE
Fix AccountType enum Parameter values to match the sentence case used in API responses

### DIFF
--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -20,9 +20,9 @@ namespace Octokit.Tests.Models
             {
                 var stringEnum = new StringEnum<AccountType>(AccountType.Bot);
 
-                Assert.Equal("bot", stringEnum.StringValue);
+                Assert.Equal("Bot", stringEnum.StringValue);
                 Assert.Equal(AccountType.Bot, stringEnum.Value);
-                Assert.Equal("bot", stringEnum);
+                Assert.Equal("Bot", stringEnum);
                 Assert.Equal(AccountType.Bot, stringEnum);
             }
 
@@ -126,7 +126,7 @@ namespace Octokit.Tests.Models
             {
                 StringEnum<AccountType> stringEnum = AccountType.Bot;
 
-                Assert.Equal("bot", stringEnum.StringValue);
+                Assert.Equal("Bot", stringEnum.StringValue);
                 Assert.Equal(AccountType.Bot, stringEnum.Value);
             }
 

--- a/Octokit/Models/Response/AccountType.cs
+++ b/Octokit/Models/Response/AccountType.cs
@@ -7,19 +7,19 @@ namespace Octokit
         /// <summary>
         ///  User account
         /// </summary>
-        [Parameter(Value = "user")]
+        [Parameter(Value = "User")]
         User,
 
         /// <summary>
         /// Organization account
         /// </summary>
-        [Parameter(Value = "organization")]
+        [Parameter(Value = "Organization")]
         Organization,
 
         /// <summary>
         /// Bot account
         /// </summary>
-        [Parameter(Value = "bot")]
+        [Parameter(Value = "Bot")]
         Bot
     }
 }


### PR DESCRIPTION
While looking into another issue I found that the API responses for account type are `Bot` `User` `Organization` but we had these attributes in lower case on our enum.  This caused some cache misses in the deserializer enum field/attribute dictionary