### PR TITLE
Deserializer should handle nullable StringEnum<T>

### DIFF
--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -8,9 +8,11 @@ namespace Octokit.Tests.Models
         public class TheCtor
         {
             [Fact]
-            public void ShouldThrowForNullStringValue()
+            public void ShouldThrowForNullOrEmptyStringValues()
             {
                 Assert.Throws<ArgumentNullException>(() => new StringEnum<AccountType>(null));
+
+                Assert.Throws<ArgumentException>(() => new StringEnum<AccountType>(""));
             }
 
             [Fact]
@@ -50,12 +52,10 @@ namespace Octokit.Tests.Models
 
         public class TheValueProperty
         {
-            [Theory]
-            [InlineData("")]
-            [InlineData("Cow")]
-            public void ShouldThrowForInvalidValue(string value)
+            [Fact]
+            public void ShouldThrowForInvalidValue()
             {
-                var stringEnum = new StringEnum<AccountType>(value);
+                var stringEnum = new StringEnum<AccountType>("Cow");
                 Assert.Throws<ArgumentException>(() => stringEnum.Value);
             }
 
@@ -100,12 +100,10 @@ namespace Octokit.Tests.Models
                 Assert.True(result);
             }
 
-            [Theory]
-            [InlineData("")]
-            [InlineData("Cow")]
-            public void ShouldReturnFalseForInvalidValue(string value)
+            [Fact]
+            public void ShouldReturnFalseForInvalidValue()
             {
-                var stringEnum = new StringEnum<AccountType>(value);
+                var stringEnum = new StringEnum<AccountType>("Cow");
 
                 AccountType type;
                 var result = stringEnum.TryParse(out type);

--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -46,12 +46,10 @@ namespace Octokit.Tests.Models
         {
             [Theory]
             [InlineData("")]
-            [InlineData(null)]
             [InlineData("Cow")]
             public void ShouldThrowForInvalidValue(string value)
             {
                 var stringEnum = new StringEnum<AccountType>(value);
-
                 Assert.Throws<ArgumentException>(() => stringEnum.Value);
             }
 
@@ -110,7 +108,6 @@ namespace Octokit.Tests.Models
 
             [Theory]
             [InlineData("")]
-            [InlineData(null)]
             [InlineData("Cow")]
             public void ShouldReturnFalseForInvalidValue(string value)
             {

--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -55,6 +55,18 @@ namespace Octokit.Tests.Models
                 Assert.Throws<ArgumentException>(() => stringEnum.Value);
             }
 
+            public class SomeObject
+            {
+                public StringEnum<AccountType> SomeEnumProperty { get; set; }
+            }
+
+            [Fact]
+            public void ShouldReturnDefaultWhenUninitialized()
+            {
+                var test = new SomeObject();
+                Assert.Equal(AccountType.User, test.SomeEnumProperty.Value);
+            }
+
             [Fact]
             public void ShouldHandleUnderscores()
             {

--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -48,7 +48,7 @@ namespace Octokit.Tests.Models
             }
         }
 
-        public class TheParsedValueProperty
+        public class TheValueProperty
         {
             [Theory]
             [InlineData("")]
@@ -57,18 +57,6 @@ namespace Octokit.Tests.Models
             {
                 var stringEnum = new StringEnum<AccountType>(value);
                 Assert.Throws<ArgumentException>(() => stringEnum.Value);
-            }
-
-            public class SomeObject
-            {
-                public StringEnum<AccountType> SomeEnumProperty { get; set; }
-            }
-
-            [Fact]
-            public void ShouldReturnDefaultWhenUninitialized()
-            {
-                var test = new SomeObject();
-                Assert.Equal(AccountType.User, test.SomeEnumProperty.Value);
             }
 
             [Fact]

--- a/Octokit.Tests/Models/StringEnumTests.cs
+++ b/Octokit.Tests/Models/StringEnumTests.cs
@@ -8,6 +8,12 @@ namespace Octokit.Tests.Models
         public class TheCtor
         {
             [Fact]
+            public void ShouldThrowForNullStringValue()
+            {
+                Assert.Throws<ArgumentNullException>(() => new StringEnum<AccountType>(null));
+            }
+
+            [Fact]
             public void ShouldSetValue()
             {
                 var stringEnum = new StringEnum<AccountType>("user");

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -132,7 +132,9 @@ namespace Octokit.Tests
             {
                 var item = new ObjectWithEnumProperty
                 {
-                    Name = "Ferris Bueller"
+                    Name = "Ferris Bueller",
+                    SomeEnum = SomeEnum.PlusOne,
+                    StringEnum = SomeEnum.PlusOne
                 };
 
                 var json = new SimpleJsonSerializer().Serialize(item);

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -117,12 +117,14 @@ namespace Octokit.Tests
                 {
                     Name = "Ferris Bueller",
                     SomeEnum = SomeEnum.Unicode,
-                    StringEnum = SomeEnum.SomethingElse
+                    SomeEnumNullable = SomeEnum.Unicode,
+                    StringEnum = SomeEnum.SomethingElse,
+                    StringEnumNullable = SomeEnum.SomethingElse
                 };
 
                 var json = new SimpleJsonSerializer().Serialize(item);
 
-                Assert.Equal("{\"name\":\"Ferris Bueller\",\"some_enum\":\"utf-8\",\"string_enum\":\"something_else\"}", json);
+                Assert.Equal("{\"name\":\"Ferris Bueller\",\"some_enum\":\"unicode\",\"some_enum_nullable\":\"unicode\",\"string_enum\":\"something else\",\"string_enum_nullable\":\"something else\"}", json);
             }
 
             [Fact]

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -301,7 +301,7 @@ namespace Octokit.Tests
             }
 
             [Fact]
-            public void DeserializesEnumWithParameterAttribute()
+            public void DeserializesEnums()
             {
                 const string json1 = @"{""some_enum"":""+1""}";
                 const string json2 = @"{""some_enum"":""utf-8""}";
@@ -320,6 +320,78 @@ namespace Octokit.Tests
                 Assert.Equal(SomeEnum.SomethingElse, sample3.SomeEnum);
                 Assert.Equal(SomeEnum.AnotherExample, sample4.SomeEnum);
                 Assert.Equal(SomeEnum.Unicode, sample5.SomeEnum);
+            }
+
+            [Fact]
+            public void DeserializesNullableEnums()
+            {
+                const string json1 = @"{""some_enum_nullable"":""+1""}";
+                const string json2 = @"{""some_enum_nullable"":""utf-8""}";
+                const string json3 = @"{""some_enum_nullable"":""something else""}";
+                const string json4 = @"{""some_enum_nullable"":""another_example""}";
+                const string json5 = @"{""some_enum_nullable"":""unicode""}";
+                const string json6 = @"{""some_enum_nullable"":null}";
+
+                var sample1 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json1);
+                var sample2 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json2);
+                var sample3 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json3);
+                var sample4 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json4);
+                var sample5 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json5);
+                var sample6 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json6);
+
+                Assert.Equal(SomeEnum.PlusOne, sample1.SomeEnumNullable);
+                Assert.Equal(SomeEnum.Utf8, sample2.SomeEnumNullable);
+                Assert.Equal(SomeEnum.SomethingElse, sample3.SomeEnumNullable);
+                Assert.Equal(SomeEnum.AnotherExample, sample4.SomeEnumNullable);
+                Assert.Equal(SomeEnum.Unicode, sample5.SomeEnumNullable);
+                Assert.False(sample6.SomeEnumNullable.HasValue);
+            }
+
+            [Fact]
+            public void DeserializesStringEnums()
+            {
+                const string json1 = @"{""string_enum"":""+1""}";
+                const string json2 = @"{""string_enum"":""utf-8""}";
+                const string json3 = @"{""string_enum"":""something else""}";
+                const string json4 = @"{""string_enum"":""another_example""}";
+                const string json5 = @"{""string_enum"":""unicode""}";
+
+                var sample1 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json1);
+                var sample2 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json2);
+                var sample3 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json3);
+                var sample4 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json4);
+                var sample5 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json5);
+
+                Assert.Equal(SomeEnum.PlusOne, sample1.StringEnum);
+                Assert.Equal(SomeEnum.Utf8, sample2.StringEnum);
+                Assert.Equal(SomeEnum.SomethingElse, sample3.StringEnum);
+                Assert.Equal(SomeEnum.AnotherExample, sample4.StringEnum);
+                Assert.Equal(SomeEnum.Unicode, sample5.StringEnum);
+            }
+
+            [Fact]
+            public void DeserializesNullableStringEnums()
+            {
+                const string json1 = @"{""string_enum_nullable"":""+1""}";
+                const string json2 = @"{""string_enum_nullable"":""utf-8""}";
+                const string json3 = @"{""string_enum_nullable"":""something else""}";
+                const string json4 = @"{""string_enum_nullable"":""another_example""}";
+                const string json5 = @"{""string_enum_nullable"":""unicode""}";
+                const string json6 = @"{""string_enum_nullable"":null}";
+
+                var sample1 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json1);
+                var sample2 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json2);
+                var sample3 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json3);
+                var sample4 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json4);
+                var sample5 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json5);
+                var sample6 = new SimpleJsonSerializer().Deserialize<ObjectWithEnumProperty>(json6);
+
+                Assert.Equal(SomeEnum.PlusOne, sample1.StringEnumNullable);
+                Assert.Equal(SomeEnum.Utf8, sample2.StringEnumNullable);
+                Assert.Equal(SomeEnum.SomethingElse, sample3.StringEnumNullable);
+                Assert.Equal(SomeEnum.AnotherExample, sample4.StringEnumNullable);
+                Assert.Equal(SomeEnum.Unicode, sample5.StringEnumNullable);
+                Assert.False(sample6.StringEnumNullable.HasValue);
             }
 
             [Fact]
@@ -369,6 +441,12 @@ namespace Octokit.Tests
         public string Name { get; set; }
 
         public SomeEnum SomeEnum { get; set; }
+
+        public SomeEnum? SomeEnumNullable { get; set; }
+
+        public StringEnum<SomeEnum> StringEnum { get; set; }
+
+        public StringEnum<SomeEnum>? StringEnumNullable { get; set; }
     }
 
     public enum SomeEnum

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -116,12 +116,26 @@ namespace Octokit.Tests
                 var item = new ObjectWithEnumProperty
                 {
                     Name = "Ferris Bueller",
-                    SomeEnum = SomeEnum.PlusOne
+                    SomeEnum = SomeEnum.Unicode,
+                    StringEnum = SomeEnum.SomethingElse
                 };
 
                 var json = new SimpleJsonSerializer().Serialize(item);
 
-                Assert.Equal("{\"name\":\"Ferris Bueller\",\"some_enum\":\"+1\"}", json);
+                Assert.Equal("{\"name\":\"Ferris Bueller\",\"some_enum\":\"utf-8\",\"string_enum\":\"something_else\"}", json);
+            }
+
+            [Fact]
+            public void HandlesEnumDefaults()
+            {
+                var item = new ObjectWithEnumProperty
+                {
+                    Name = "Ferris Bueller"
+                };
+
+                var json = new SimpleJsonSerializer().Serialize(item);
+
+                Assert.Equal("{\"name\":\"Ferris Bueller\",\"some_enum\":\"+1\",\"string_enum\":\"+1\"}", json);
             }
         }
 

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -144,20 +144,17 @@ namespace Octokit.Internal
 
                 if (stringValue != null)
                 {
+                    // If it's a nullable type, use the underlying type
+                    if (ReflectionUtils.IsNullableType(type))
+                    {
+                        type = Nullable.GetUnderlyingType(type);
+                    }
+
                     var typeInfo = ReflectionUtils.GetTypeInfo(type);
 
                     if (typeInfo.IsEnum)
                     {
                         return DeserializeEnumHelper(stringValue, type);
-                    }
-
-                    if (ReflectionUtils.IsNullableType(type))
-                    {
-                        var underlyingType = Nullable.GetUnderlyingType(type);
-                        if (ReflectionUtils.GetTypeInfo(underlyingType).IsEnum)
-                        {
-                            return DeserializeEnumHelper(stringValue, underlyingType);
-                        }
                     }
 
                     if (ReflectionUtils.IsTypeGenericeCollectionInterface(type))

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -65,8 +65,21 @@ namespace Octokit.Internal
                 Ensure.ArgumentNotNull(input, "input");
 
                 var type = input.GetType();
-                var jsonObject = new JsonObject();
                 var getters = GetCache[type];
+
+                if (ReflectionUtils.IsStringEnumWrapper(type))
+                {
+                    // Handle StringEnum<T> by getting the underlying enum value, then using the enum serializer
+                    // Note this will throw if the StringEnum<T> was initialised using a string that is not a valid enum member
+                    var inputEnum = (getters["value"](input) as Enum);
+                    if (inputEnum != null)
+                    {
+                        output = SerializeEnum(inputEnum);
+                        return true;
+                    }
+                }
+
+                var jsonObject = new JsonObject();
                 foreach (var getter in getters)
                 {
                     if (getter.Value != null)

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -168,14 +168,9 @@ namespace Octokit.Internal
                         }
                     }
 
-                    if (typeInfo.IsGenericType)
+                    if (ReflectionUtils.IsStringEnumWrapper(type))
                     {
-                        var typeDefinition = typeInfo.GetGenericTypeDefinition();
-
-                        if (typeof(StringEnum<>).IsAssignableFrom(typeDefinition))
-                        {
-                            return Activator.CreateInstance(type, stringValue);
-                        }
+                        return Activator.CreateInstance(type, stringValue);
                     }
                 }
                 else if (jsonValue != null)

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -29,7 +29,7 @@ namespace Octokit
 
         public StringEnum(string stringValue)
         {
-            Ensure.ArgumentNotNull(stringValue, nameof(stringValue));
+            Ensure.ArgumentNotNullOrEmptyString(stringValue, nameof(stringValue));
 
             _stringValue = stringValue;
             _parsedValue = null;

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -144,6 +144,11 @@ namespace Octokit
 
         private TEnum ParseValue()
         {
+            if (string.IsNullOrEmpty(_stringValue))
+            {
+                return default(TEnum);
+            }
+
             TEnum value;
             if (TryParse(out value))
             {

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -68,12 +68,6 @@ namespace Octokit
                 return true;
             }
 
-            if (StringValue == null)
-            {
-                value = default(TEnum);
-                return false;
-            }
-
             try
             {
                 // Use the SimpleJsonSerializer to parse the string to Enum according to the GitHub Api strategy
@@ -146,11 +140,6 @@ namespace Octokit
 
         private TEnum ParseValue()
         {
-            if (_stringValue == null)
-            {
-                return default(TEnum);
-            }
-
             TEnum value;
             if (TryParse(out value))
             {

--- a/Octokit/Models/Response/StringEnum.cs
+++ b/Octokit/Models/Response/StringEnum.cs
@@ -29,7 +29,9 @@ namespace Octokit
 
         public StringEnum(string stringValue)
         {
-            _stringValue = stringValue ?? string.Empty;
+            Ensure.ArgumentNotNull(stringValue, nameof(stringValue));
+
+            _stringValue = stringValue;
             _parsedValue = null;
         }
 
@@ -66,7 +68,7 @@ namespace Octokit
                 return true;
             }
 
-            if (string.IsNullOrEmpty(StringValue))
+            if (StringValue == null)
             {
                 value = default(TEnum);
                 return false;
@@ -144,7 +146,7 @@ namespace Octokit
 
         private TEnum ParseValue()
         {
-            if (string.IsNullOrEmpty(_stringValue))
+            if (_stringValue == null)
             {
                 return default(TEnum);
             }

--- a/Octokit/SimpleJson.cs
+++ b/Octokit/SimpleJson.cs
@@ -1772,6 +1772,18 @@ namespace Octokit
                 return GetTypeInfo(type1).IsAssignableFrom(GetTypeInfo(type2));
             }
 
+            public static bool IsStringEnumWrapper(Type type)
+            {
+                var typeInfo = ReflectionUtils.GetTypeInfo(type);
+                if (typeInfo.IsGenericType)
+                {
+                    var typeDefinition = typeInfo.GetGenericTypeDefinition();
+
+                    return typeof(StringEnum<>).IsAssignableFrom(typeDefinition);
+                }
+                return false;
+            }
+
             public static IEnumerable<Type> GetInterfaces(Type type)
             {
 #if SIMPLE_JSON_TYPEINFO


### PR DESCRIPTION
When a nullable `StringEnum<T>?` member was added to a class, the deserializer failed to deserialize "good" values into the field as it tries to do a type conversion to the `Nullable<T>` wrapper.  This change ensures that when deserializing a non empty string value, we use the underlying type of any `Nullable` type.  We already were doing this for regular `enum`s but not `StringEnum<>`s

Added tests for enum, nullable enum, StringEnum and nullable StringEnum to capture the failing state, then proved the fix :+1: