### PR TITLE
Tidy up compiler warnings

### DIFF
--- a/Octokit.Reactive/Clients/IObservableProjectsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableProjectsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         IObservable<Project> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         IObservable<Project> GetAllForRepository(string owner, string name, ProjectRequest request);
 
@@ -58,7 +58,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         IObservable<Project> GetAllForRepository(string owner, string name, ApiOptions options);
 
@@ -69,7 +69,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
         IObservable<Project> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options);

--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewsClient.cs
@@ -173,6 +173,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        /// <param name="options">Options for changing the API response</param>
         IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options);
 
         /// <summary>
@@ -182,6 +183,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        /// <param name="options">Options for changing the API response</param>
         IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryBranchesClient.cs
@@ -348,6 +348,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         IObservable<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update);
 
         /// <summary>
@@ -358,6 +359,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         IObservable<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableTeamsClient.cs
@@ -61,19 +61,20 @@ namespace Octokit.Reactive
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
         IObservable<Team> GetAllChildTeams(int id);
 
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options for changing the API response</param>
         IObservable<Team> GetAllChildTeams(int id, ApiOptions options);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableProjectsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableProjectsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         public IObservable<Project> GetAllForRepository(string owner, string name)
         {
             return GetAllForRepository(owner, name, ApiOptions.None);
@@ -47,7 +47,8 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<Project> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -66,7 +67,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         public IObservable<Project> GetAllForRepository(string owner, string name, ProjectRequest request)
         {
@@ -80,7 +81,7 @@ namespace Octokit.Reactive
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Project> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options)
@@ -113,8 +114,7 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         public IObservable<Project> GetAllForRepository(long repositoryId, ApiOptions options)
         {

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewsClient.cs
@@ -266,6 +266,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<PullRequestReviewComment> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -282,6 +283,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        /// <param name="options">Options for changing the API response</param>
         public IObservable<PullRequestReviewComment> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryBranchesClient.cs
@@ -537,6 +537,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         public IObservable<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -555,6 +556,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         public IObservable<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit.Reactive/Clients/ObservableTeamsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableTeamsClient.cs
@@ -105,10 +105,11 @@ namespace Octokit.Reactive
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
         public IObservable<Team> GetAllChildTeams(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -18,6 +18,10 @@
     <Copyright>Copyright GitHub 2017</Copyright>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>1591;1701;1702;1705</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Octokit\Helpers\Ensure.cs;..\Octokit\Helpers\Pagination.cs" />
     <None Include="app.config" />

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Octokit.Tests\Helpers\AssertEx.cs" />
     <None Include="app.config" />
     <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/AssigneesClientTests.cs
@@ -10,7 +10,6 @@ public class AssigneesClientTests
 {
     readonly IGitHubClient _github;
     readonly RepositoryContext _context;
-    readonly IIssuesClient _issuesClient;
 
     public AssigneesClientTests()
     {

--- a/Octokit/Clients/IProjectsClient.cs
+++ b/Octokit/Clients/IProjectsClient.cs
@@ -19,7 +19,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request);
 
@@ -59,7 +59,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ApiOptions options);
 
@@ -70,7 +70,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
         Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options);

--- a/Octokit/Clients/IRepositoryBranchesClient.cs
+++ b/Octokit/Clients/IRepositoryBranchesClient.cs
@@ -352,6 +352,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update);
 
         /// <summary>
@@ -362,6 +363,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update);
 
         /// <summary>

--- a/Octokit/Clients/ITeamsClient.cs
+++ b/Octokit/Clients/ITeamsClient.cs
@@ -62,19 +62,20 @@ namespace Octokit
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
         Task<IReadOnlyList<Team>> GetAllChildTeams(int id);
 
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
         Task<IReadOnlyList<Team>> GetAllChildTeams(int id, ApiOptions options);
 
         /// <summary>

--- a/Octokit/Clients/ProjectsClient.cs
+++ b/Octokit/Clients/ProjectsClient.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name)
         {
             return GetAllForRepository(owner, name, ApiOptions.None);
@@ -40,7 +40,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
@@ -58,7 +58,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request)
         {
@@ -72,7 +72,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
-        /// <param name="repo">The name of the repository</param>
+        /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options)

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -576,6 +576,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
@@ -594,6 +595,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        /// <param name="update">The required pull request review settings</param>
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, "branch");

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -104,10 +104,11 @@ namespace Octokit
         /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
-        /// <param name="id">The team identifier</param>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        /// <param name="id">The team identifier</param>
+        /// <param name="options">Options to change API behaviour.</param>
         public Task<IReadOnlyList<Team>> GetAllChildTeams(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -26,6 +26,10 @@
     <DefineConstants>$(DefineConstants);HAS_ENVIRONMENT;HAS_REGEX_COMPILED_OPTIONS;SIMPLE_JSON_INTERNAL;SIMPLE_JSON_OBJARRAYINTERNAL;SIMPLE_JSON_READONLY_COLLECTIONS;HAS_SERVICEPOINTMANAGER</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>1591;1701;1702;1705</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.Net.Http" />
     <Reference Include="System" />


### PR DESCRIPTION
- Suppress "missing XmlComment for publicly visible member" warning as it floods the build logs and we don't actually need XmlComments on _every_ public member
- Fix warnings regarding incorrect xml param comments
- Fix other compiler warnings