### PR TITLE
Added get release by tag endpoint

### DIFF
--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -66,7 +66,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
         IObservable<Release> Get(string owner, string name, int id);
 
         /// <summary>
@@ -79,7 +78,6 @@ namespace Octokit.Reactive
         /// <param name="name">The repository's name</param>
         /// <param name="tag">The tag of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
         IObservable<Release> Get(string owner, string name, string tag);
 
         /// <summary>
@@ -91,8 +89,18 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
         IObservable<Release> Get(long repositoryId, int id);
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        IObservable<Release> Get(long repositoryId, string tag);
 
         /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.

--- a/Octokit.Reactive/Clients/IObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableReleasesClient.cs
@@ -73,6 +73,19 @@ namespace Octokit.Reactive
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
+        IObservable<Release> Get(string owner, string name, string tag);
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -141,6 +141,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public IObservable<Release> Get(long repositoryId, string tag)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(tag, nameof(tag));
+
+            return _client.Get(repositoryId, tag).ToObservable();
+        }
+
+        /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit.Reactive/Clients/ObservableReleasesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReleasesClient.cs
@@ -111,6 +111,25 @@ namespace Octokit.Reactive
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public IObservable<Release> Get(string owner, string name, string tag)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(tag, nameof(tag));
+
+            return _client.Get(owner, name, tag).ToObservable();
+        }
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -190,9 +190,25 @@ public class ReleasesClientTests
         }
 
         [IntegrationTest]
+        public async Task ReturnsReleaseWithRepositoryIdByTag()
+        {
+            var releaseByTag = await _releaseClient.Get(7528679, "v0.28.0");
+
+            Assert.Equal(releaseByTag.Id, 8396883);
+            Assert.Equal(releaseByTag.Name, "v0.28 - Get to the Chopper!!!");
+            Assert.Equal(releaseByTag.TagName, "v0.28.0");
+        }
+
+        [IntegrationTest]
         public async Task ThrowsWhenTagNotFound()
         {
             await Assert.ThrowsAsync<NotFoundException>(() => _releaseClient.Get("octokit", "octokit.net", "0.0"));
+        }
+
+        [IntegrationTest]
+        public async Task ThrowsWhenTagNotFoundWithRepositoryId()
+        {
+            await Assert.ThrowsAsync<NotFoundException>(() => _releaseClient.Get(7528679, "0.0"));
         }
     }
 

--- a/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/ReleasesClientTests.cs
@@ -168,39 +168,29 @@ public class ReleasesClientTests
         }
     }
 
-    public class TheGetReleaseByTagMethod
+    public class TheGetMethod
     {
         private readonly IReleasesClient _releaseClient;
         private readonly IGitHubClient _client;
 
-        public TheGetReleaseByTagMethod()
+        public TheGetMethod()
         {
             _client = Helper.GetAuthenticatedClient();
             _releaseClient = _client.Repository.Release;
         }
 
         [IntegrationTest]
-        public async Task ReturnsLatestRelease()
+        public async Task ReturnsReleaseByTag()
         {
-            var lastReleaseFromGetAll = (await _releaseClient.GetAll("octokit", "octokit.net")).OrderBy(r => r.CreatedAt).Last();
-            var releaseByTag = await _releaseClient.Get("octokit", "octokit.net", lastReleaseFromGetAll.TagName);
+            var releaseByTag = await _releaseClient.Get("octokit", "octokit.net", "v0.28.0");
 
-            Assert.Equal(lastReleaseFromGetAll.Id, releaseByTag.Id);
+            Assert.Equal(releaseByTag.Id, 8396883);
+            Assert.Equal(releaseByTag.Name, "v0.28 - Get to the Chopper!!!");
+            Assert.Equal(releaseByTag.TagName, "v0.28.0");
         }
 
         [IntegrationTest]
-        public async Task NoReleaseOnRepo()
-        {
-            var repoName = Helper.MakeNameWithTimestamp("public-repo");
-            await _client.Repository.Create(new NewRepository(repoName));
-
-            await Assert.ThrowsAsync<NotFoundException>(() => _releaseClient.Get(Helper.UserName, repoName, "0.0"));
-
-            await _client.Repository.Delete(Helper.UserName, repoName);
-        }
-
-        [IntegrationTest]
-        public async Task NoReleaseWithTag()
+        public async Task ThrowsWhenTagNotFound()
         {
             await Assert.ThrowsAsync<NotFoundException>(() => _releaseClient.Get("octokit", "octokit.net", "0.0"));
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
@@ -107,9 +107,25 @@ namespace Octokit.Tests.Integration.Reactive
             }
 
             [IntegrationTest]
+            public async Task ReturnsReleaseWithRepositoryIdByTag()
+            {
+                var releaseByTag = await _releaseClient.Get(7528679, "v0.28.0");
+
+                Assert.Equal(releaseByTag.Id, 8396883);
+                Assert.Equal(releaseByTag.Name, "v0.28 - Get to the Chopper!!!");
+                Assert.Equal(releaseByTag.TagName, "v0.28.0");
+            }
+
+            [IntegrationTest]
             public async Task ThrowsWhenTagNotFound()
             {
                 await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get("octokit", "octokit.net", "0.0"));
+            }
+
+            [IntegrationTest]
+            public async Task ThrowsWhenTagNotFoundWithRepositoryId()
+            {
+                await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get(7528679, "0.0"));
             }
         }
     }

--- a/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableReleaseClientTests.cs
@@ -84,5 +84,33 @@ namespace Octokit.Tests.Integration.Reactive
                 Assert.NotEqual(firstPage[4].Id, secondPage[4].Id);
             }
         }
+
+        public class TheGetMethod
+        {
+            readonly ObservableReleasesClient _releaseClient;
+            
+            public TheGetMethod()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                _releaseClient = new ObservableReleasesClient(github);
+            }
+
+            [IntegrationTest]
+            public async Task ReturnsReleaseByTag()
+            {
+                var releaseByTag = await _releaseClient.Get("octokit", "octokit.net", "v0.28.0");
+
+                Assert.Equal(releaseByTag.Id, 8396883);
+                Assert.Equal(releaseByTag.Name, "v0.28 - Get to the Chopper!!!");
+                Assert.Equal(releaseByTag.TagName, "v0.28.0");
+            }
+
+            [IntegrationTest]
+            public async Task ThrowsWhenTagNotFound()
+            {
+                await Assert.ThrowsAsync<NotFoundException>(async () => await _releaseClient.Get("octokit", "octokit.net", "0.0"));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -124,6 +124,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsTheCorrectUrlByTag()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReleasesClient(connection);
+
+                await client.Get("fake", "repo", "tag");
+
+                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/releases/tags/tag"));
+            }
+
+            [Fact]
             public async Task RequestsTheCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -144,6 +155,13 @@ namespace Octokit.Tests.Clients
 
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("owner", "", 1));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Get("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("owner", "name", ""));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Get(null, "name", "tag"));
+                await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("", "name", "tag"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Get("owner", null, "tag"));
+                await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("owner", "", "tag"));
             }
         }
 

--- a/Octokit.Tests/Clients/ReleasesClientTests.cs
+++ b/Octokit.Tests/Clients/ReleasesClientTests.cs
@@ -146,6 +146,17 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsTheCorrectUrlWithRepositoryIdByTag()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReleasesClient(connection);
+
+                await client.Get(1, "tag");
+
+                connection.Received().Get<Release>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/releases/tags/tag"));
+            }
+
+            [Fact]
             public async Task EnsuresNonNullArguments()
             {
                 var releasesClient = new ReleasesClient(Substitute.For<IApiConnection>());
@@ -162,6 +173,9 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("", "name", "tag"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Get("owner", null, "tag"));
                 await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get("owner", "", "tag"));
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => releasesClient.Get(1, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => releasesClient.Get(1, ""));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -138,6 +138,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithRepositoryIdByTag()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReleasesClient(gitHubClient);
+
+                client.Get(1, "tag");
+
+                gitHubClient.Repository.Release.Received(1).Get(1, "tag");
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var releasesClient = new ObservableReleasesClient(Substitute.For<IGitHubClient>());

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -127,7 +127,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsTheCorrectUrlWithTag()
+            public void RequestsTheCorrectUrlByTag()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableReleasesClient(gitHubClient);

--- a/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableReleasesClientTests.cs
@@ -127,6 +127,17 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
+            public void RequestsTheCorrectUrlWithTag()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableReleasesClient(gitHubClient);
+
+                client.Get("fake", "repo", "tag");
+
+                gitHubClient.Repository.Release.Received(1).Get("fake", "repo", "tag");
+            }
+
+            [Fact]
             public void EnsuresNonNullArguments()
             {
                 var releasesClient = new ObservableReleasesClient(Substitute.For<IGitHubClient>());
@@ -136,6 +147,13 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentException>(() => releasesClient.Get("", "name", 1));
                 Assert.Throws<ArgumentException>(() => releasesClient.Get("owner", "", 1));
+
+                Assert.Throws<ArgumentNullException>(() => releasesClient.Get(null, "name", "tag"));
+                Assert.Throws<ArgumentException>(() => releasesClient.Get("", "name", "tag"));
+                Assert.Throws<ArgumentNullException>(() => releasesClient.Get("owner", null, "tag"));
+                Assert.Throws<ArgumentException>(() => releasesClient.Get("owner", "", "tag"));
+                Assert.Throws<ArgumentNullException>(() => releasesClient.Get("owner", "name", null));
+                Assert.Throws<ArgumentException>(() => releasesClient.Get("owner", "name", ""));
             }
         }
 

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -66,7 +66,6 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
         Task<Release> Get(string owner, string name, int id);
 
         /// <summary>
@@ -90,8 +89,18 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get", Justification = "Method makes a network request")]
         Task<Release> Get(long repositoryId, int id);
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        Task<Release> Get(long repositoryId, string tag);
 
         /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.

--- a/Octokit/Clients/IReleasesClient.cs
+++ b/Octokit/Clients/IReleasesClient.cs
@@ -73,6 +73,18 @@ namespace Octokit
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        Task<Release> Get(string owner, string name, string tag);
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -141,6 +141,23 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public Task<Release> Get(long repositoryId, string tag)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(tag, nameof(tag));
+
+            var endpoint = ApiUrls.Releases(repositoryId, tag);
+            return ApiConnection.Get<Release>(endpoint);
+        }
+
+        /// <summary>
         /// Gets the latest <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -109,6 +109,26 @@ namespace Octokit
         /// Gets a single <see cref="Release"/> for the specified repository.
         /// </summary>
         /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The repository's owner</param>
+        /// <param name="name">The repository's name</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        public Task<Release> Get(string owner, string name, string tag)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(tag, nameof(tag));
+
+            var endpoint = ApiUrls.Releases(owner, name, tag);
+            return ApiConnection.Get<Release>(endpoint);
+        }
+
+        /// <summary>
+        /// Gets a single <see cref="Release"/> for the specified repository.
+        /// </summary>
+        /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/releases/#get-a-single-release">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -3053,6 +3053,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns a single release for the specified repository
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <returns>The <see cref="Uri"/> that returns a single release for the specified repository</returns>
+        public static Uri Releases(long repositoryId, string tag)
+        {
+            return "repositories/{0}/releases/tags/{1}".FormatUri(repositoryId, tag);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for a repository branch.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -216,6 +216,18 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that returns a single release for the specified repository
+        /// </summary>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="tag">The tag of the release</param>
+        /// <returns></returns>
+        public static Uri Releases(string owner, string name, string tag)
+        {
+            return "repos/{0}/{1}/releases/tags/{2}".FormatUri(owner, name, tag);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that returns the latest release for the specified repository
         /// </summary>
         /// <param name="owner">The owner of the repository</param>


### PR DESCRIPTION
This adds the endpoint to retrieve a release by owner, repo, and tag. [https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name](https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name)