### PR TITLE
add GraphQL Node ID's to response models

### DIFF
--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -123,7 +123,6 @@ public class TagsClientTests
                                             "\"object\":\"tag-object\"," +
                                             "\"type\":\"tree\"," +
                                             "\"tagger\":{" +
-                                                "\"node_id\":\"123ABC\"," +
                                                 "\"name\":\"tagger-name\"," +
                                                 "\"email\":\"tagger-email\"," +
                                                 "\"date\":\"2013-09-03T13:42:52Z\"" +

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -113,7 +113,7 @@ public class TagsClientTests
                 Tag = "tag-name",
                 Object = "tag-object",
                 Type = TaggedType.Tree,
-                Tagger = new Committer("123ABC", "tagger-name", "tagger-email", DateTimeOffset.Parse("2013-09-03T13:42:52Z"))
+                Tagger = new Committer("tagger-name", "tagger-email", DateTimeOffset.Parse("2013-09-03T13:42:52Z"))
             };
 
             var json = new SimpleJsonSerializer().Serialize(tag);

--- a/Octokit.Tests/Clients/TagsClientTests.cs
+++ b/Octokit.Tests/Clients/TagsClientTests.cs
@@ -113,7 +113,7 @@ public class TagsClientTests
                 Tag = "tag-name",
                 Object = "tag-object",
                 Type = TaggedType.Tree,
-                Tagger = new Committer("tagger-name", "tagger-email", DateTimeOffset.Parse("2013-09-03T13:42:52Z"))
+                Tagger = new Committer("123ABC", "tagger-name", "tagger-email", DateTimeOffset.Parse("2013-09-03T13:42:52Z"))
             };
 
             var json = new SimpleJsonSerializer().Serialize(tag);
@@ -123,6 +123,7 @@ public class TagsClientTests
                                             "\"object\":\"tag-object\"," +
                                             "\"type\":\"tree\"," +
                                             "\"tagger\":{" +
+                                                "\"node_id\":\"123ABC\"," +
                                                 "\"name\":\"tagger-name\"," +
                                                 "\"email\":\"tagger-email\"," +
                                                 "\"date\":\"2013-09-03T13:42:52Z\"" +

--- a/Octokit.Tests/Models/MigrationTests.cs
+++ b/Octokit.Tests/Models/MigrationTests.cs
@@ -110,20 +110,6 @@ namespace Octokit.Tests.Models
               ]
             }";
 
-        private static readonly Migration migration = new Migration(
-            id: 79,
-            guid: "0b989ba4-242f-11e5-81e1-c7b6966d2516",
-            state: Migration.MigrationState.Exported,
-            lockRepositories: true,
-            excludeAttachments: false,
-            url: "https://api.github.com/orgs/octo-org/migrations/79",
-            createdAt: "2015-07-06T15:33:38-07:00",
-            updatedAt: "2015-07-06T15:33:38-07:00",
-            repositories: new List<Repository>
-            {
-                new Repository(1296269)
-            });
-
         [Fact]
         public void CanBeDeserialized()
         {

--- a/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestsClientTests.cs
@@ -629,7 +629,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task FetchesAllCommitsForPullRequest()
             {
-                var commit = new PullRequestCommit(null, null, null, null, null, Enumerable.Empty<GitReference>(), null, null);
+                var commit = new PullRequestCommit("123ABC", null, null, null, null, null, Enumerable.Empty<GitReference>(), null, null);
                 var expectedUrl = "repos/fake/repo/pulls/42/commits";
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var connection = Substitute.For<IConnection>();
@@ -653,7 +653,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task FetchesAllCommitsForPullRequestWithRepositoryId()
             {
-                var commit = new PullRequestCommit(null, null, null, null, null, Enumerable.Empty<GitReference>(), null, null);
+                var commit = new PullRequestCommit("123ABC", null, null, null, null, null, Enumerable.Empty<GitReference>(), null, null);
                 var expectedUrl = "repositories/1/pulls/42/commits";
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var connection = Substitute.For<IConnection>();

--- a/Octokit/Models/Common/Committer.cs
+++ b/Octokit/Models/Common/Committer.cs
@@ -19,15 +19,22 @@ namespace Octokit
         /// <summary>
         /// Initializes a new instance of the <see cref="Committer"/> class.
         /// </summary>
+        /// <param name="nodeId">The GraphQL Node Id</param>
         /// <param name="name">The full name of the author or committer.</param>
         /// <param name="email">The email.</param>
         /// <param name="date">The date.</param>
-        public Committer(string name, string email, DateTimeOffset date)
+        public Committer(string nodeId, string name, string email, DateTimeOffset date)
         {
+            NodeId = nodeId;
             Name = name;
             Email = email;
             Date = date;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Gets the name of the author or committer.

--- a/Octokit/Models/Common/Committer.cs
+++ b/Octokit/Models/Common/Committer.cs
@@ -19,6 +19,19 @@ namespace Octokit
         /// <summary>
         /// Initializes a new instance of the <see cref="Committer"/> class.
         /// </summary>
+        /// <param name="name">The full name of the author or committer.</param>
+        /// <param name="email">The email.</param>
+        /// <param name="date">The date.</param>
+        public Committer(string name, string email, DateTimeOffset date)
+        {
+            Name = name;
+            Email = email;
+            Date = date;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Committer"/> class.
+        /// </summary>
         /// <param name="nodeId">The GraphQL Node Id</param>
         /// <param name="name">The full name of the author or committer.</param>
         /// <param name="email">The email.</param>

--- a/Octokit/Models/Response/Account.cs
+++ b/Octokit/Models/Response/Account.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         protected Account() { }
 
-        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, AccountType type, string url)
+        protected Account(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, AccountType type, string url)
         {
             AvatarUrl = avatarUrl;
             Bio = bio;
@@ -28,6 +28,7 @@ namespace Octokit
             Location = location;
             Login = login;
             Name = name;
+            NodeId = nodeId;
             OwnedPrivateRepos = ownedPrivateRepos;
             Plan = plan;
             PrivateGists = privateGists;
@@ -102,6 +103,11 @@ namespace Octokit
         /// The account's system-wide unique Id.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The account's geographic location.

--- a/Octokit/Models/Response/Author.cs
+++ b/Octokit/Models/Response/Author.cs
@@ -9,10 +9,11 @@ namespace Octokit
     {
         public Author() { }
 
-        public Author(string login, int id, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
+        public Author(string login, int id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin)
         {
             Login = login;
             Id = id;
+            NodeId = nodeId;
             AvatarUrl = avatarUrl;
             Url = url;
             HtmlUrl = htmlUrl;
@@ -32,6 +33,11 @@ namespace Octokit
         public string Login { get; protected set; }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public string AvatarUrl { get; protected set; }
 

--- a/Octokit/Models/Response/Blob.cs
+++ b/Octokit/Models/Response/Blob.cs
@@ -9,13 +9,19 @@ namespace Octokit
     {
         public Blob() { }
 
-        public Blob(string content, EncodingType encoding, string sha, int size)
+        public Blob(string nodeId, string content, EncodingType encoding, string sha, int size)
         {
+            NodeId = nodeId;
             Content = content;
             Encoding = encoding;
             Sha = sha;
             Size = size;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The content of the blob.

--- a/Octokit/Models/Response/Commit.cs
+++ b/Octokit/Models/Response/Commit.cs
@@ -11,11 +11,10 @@ namespace Octokit
         public Commit() { }
 
         public Commit(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, string message, Committer author, Committer committer, GitReference tree, IEnumerable<GitReference> parents, int commentCount, Verification verification)
-            : base(url, label, @ref, sha, user, repository)
+            : base(nodeId, url, label, @ref, sha, user, repository)
         {
             Ensure.ArgumentNotNull(parents, nameof(parents));
 
-            NodeId = nodeId;
             Message = message;
             Author = author;
             Committer = committer;
@@ -24,11 +23,6 @@ namespace Octokit
             CommentCount = commentCount;
             Verification = verification;
         }
-
-        /// <summary>
-        /// GraphQL Node Id
-        /// </summary>
-        public string NodeId { get; protected set; }
 
         public string Message { get; protected set; }
 

--- a/Octokit/Models/Response/Commit.cs
+++ b/Octokit/Models/Response/Commit.cs
@@ -10,11 +10,12 @@ namespace Octokit
     {
         public Commit() { }
 
-        public Commit(string url, string label, string @ref, string sha, User user, Repository repository, string message, Committer author, Committer committer, GitReference tree, IEnumerable<GitReference> parents, int commentCount, Verification verification)
+        public Commit(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, string message, Committer author, Committer committer, GitReference tree, IEnumerable<GitReference> parents, int commentCount, Verification verification)
             : base(url, label, @ref, sha, user, repository)
         {
             Ensure.ArgumentNotNull(parents, nameof(parents));
 
+            NodeId = nodeId;
             Message = message;
             Author = author;
             Committer = committer;
@@ -23,6 +24,11 @@ namespace Octokit
             CommentCount = commentCount;
             Verification = verification;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public string Message { get; protected set; }
 

--- a/Octokit/Models/Response/CommitComment.cs
+++ b/Octokit/Models/Response/CommitComment.cs
@@ -9,9 +9,10 @@ namespace Octokit
     {
         public CommitComment() { }
 
-        public CommitComment(int id, string url, string htmlUrl, string body, string path, int position, int? line, string commitId, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt, ReactionSummary reactions)
+        public CommitComment(int id, string nodeId, string url, string htmlUrl, string body, string path, int position, int? line, string commitId, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt, ReactionSummary reactions)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             HtmlUrl = htmlUrl;
             Body = body;
@@ -29,6 +30,11 @@ namespace Octokit
         /// The issue comment Id.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this repository comment.

--- a/Octokit/Models/Response/CommitStatus.cs
+++ b/Octokit/Models/Response/CommitStatus.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public CommitStatus() { }
 
-        public CommitStatus(DateTimeOffset createdAt, DateTimeOffset updatedAt, CommitState state, string targetUrl, string description, string context, long id, string url, User creator)
+        public CommitStatus(DateTimeOffset createdAt, DateTimeOffset updatedAt, CommitState state, string targetUrl, string description, string context, long id, string nodeId, string url, User creator)
         {
             CreatedAt = createdAt;
             UpdatedAt = updatedAt;
@@ -19,6 +19,7 @@ namespace Octokit
             Description = description;
             Context = context;
             Id = id;
+            NodeId = nodeId;
             Url = url;
             Creator = creator;
         }
@@ -58,6 +59,11 @@ namespace Octokit
         /// The unique identifier of the status.
         /// </summary>
         public long Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL of the status.

--- a/Octokit/Models/Response/Deployment.cs
+++ b/Octokit/Models/Response/Deployment.cs
@@ -13,9 +13,10 @@ namespace Octokit
     {
         public Deployment() { }
 
-        public Deployment(int id, string sha, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, bool transientEnvironment, bool productionEnvironment)
+        public Deployment(int id, string nodeId, string sha, string url, User creator, IReadOnlyDictionary<string, string> payload, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description, string statusesUrl, bool transientEnvironment, bool productionEnvironment)
         {
             Id = id;
+            NodeId = nodeId;
             Sha = sha;
             Url = url;
             Creator = creator;
@@ -32,6 +33,11 @@ namespace Octokit
         /// Id of this deployment.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// 

--- a/Octokit/Models/Response/DeploymentStatus.cs
+++ b/Octokit/Models/Response/DeploymentStatus.cs
@@ -11,9 +11,10 @@ namespace Octokit
     {
         public DeploymentStatus() { }
 
-        public DeploymentStatus(int id, string url, DeploymentState state, User creator, IReadOnlyDictionary<string, string> payload, string targetUrl, string logUrl, string environmentUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description)
+        public DeploymentStatus(int id, string nodeId, string url, DeploymentState state, User creator, IReadOnlyDictionary<string, string> payload, string targetUrl, string logUrl, string environmentUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, string description)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             State = state;
             Creator = creator;
@@ -30,6 +31,11 @@ namespace Octokit
         /// Id of this deployment status.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The API URL for this deployment status.

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -11,9 +11,10 @@ namespace Octokit
     {
         public EventInfo() { }
 
-        public EventInfo(int id, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt)
+        public EventInfo(int id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             Actor = actor;
             Assignee = assignee;
@@ -27,6 +28,11 @@ namespace Octokit
         /// The id of the issue/pull request event.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this event.

--- a/Octokit/Models/Response/Gist.cs
+++ b/Octokit/Models/Response/Gist.cs
@@ -10,10 +10,11 @@ namespace Octokit
     {
         public Gist() { }
 
-        public Gist(string url, string id, string description, bool @public, User owner, IReadOnlyDictionary<string, GistFile> files, int comments, string commentsUrl, string htmlUrl, string gitPullUrl, string gitPushUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, IReadOnlyList<GistFork> forks, IReadOnlyList<GistHistory> history)
+        public Gist(string url, string id, string nodeId, string description, bool @public, User owner, IReadOnlyDictionary<string, GistFile> files, int comments, string commentsUrl, string htmlUrl, string gitPullUrl, string gitPushUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt, IReadOnlyList<GistFork> forks, IReadOnlyList<GistHistory> history)
         {
             Url = url;
             Id = id;
+            NodeId = nodeId;
             Description = description;
             Public = @public;
             Owner = owner;
@@ -41,6 +42,11 @@ namespace Octokit
         /// Given a gist url of https://gist.github.com/UserName/1234 the Id would be '1234'.
         /// </remarks>
         public string Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// A description of the <see cref="Gist"/>.

--- a/Octokit/Models/Response/GistComment.cs
+++ b/Octokit/Models/Response/GistComment.cs
@@ -9,9 +9,10 @@ namespace Octokit
     {
         public GistComment() { }
 
-        public GistComment(int id, string url, string body, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
+        public GistComment(int id, string nodeId, string url, string body, User user, DateTimeOffset createdAt, DateTimeOffset? updatedAt)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             Body = body;
             User = user;
@@ -23,6 +24,11 @@ namespace Octokit
         /// The gist comment id.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this gist comment.

--- a/Octokit/Models/Response/GistFork.cs
+++ b/Octokit/Models/Response/GistFork.cs
@@ -9,12 +9,18 @@ namespace Octokit
     {
         public GistFork() { }
 
-        public GistFork(User user, string url, DateTimeOffset createdAt)
+        public GistFork(string nodeId, User user, string url, DateTimeOffset createdAt)
         {
+            NodeId = nodeId;
             User = user;
             Url = url;
             CreatedAt = createdAt;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The <see cref="User"/> that created this <see cref="GistFork"/>

--- a/Octokit/Models/Response/GitHubCommit.cs
+++ b/Octokit/Models/Response/GitHubCommit.cs
@@ -11,8 +11,8 @@ namespace Octokit
     {
         public GitHubCommit() { }
 
-        public GitHubCommit(string url, string label, string @ref, string sha, User user, Repository repository, Author author, string commentsUrl, Commit commit, Author committer, string htmlUrl, GitHubCommitStats stats, IReadOnlyList<GitReference> parents, IReadOnlyList<GitHubCommitFile> files)
-            : base(url, label, @ref, sha, user, repository)
+        public GitHubCommit(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, Author author, string commentsUrl, Commit commit, Author committer, string htmlUrl, GitHubCommitStats stats, IReadOnlyList<GitReference> parents, IReadOnlyList<GitHubCommitFile> files)
+            : base(nodeId, url, label, @ref, sha, user, repository)
         {
             Author = author;
             CommentsUrl = commentsUrl;

--- a/Octokit/Models/Response/GitReference.cs
+++ b/Octokit/Models/Response/GitReference.cs
@@ -9,8 +9,9 @@ namespace Octokit
     {
         public GitReference() { }
 
-        public GitReference(string url, string label, string @ref, string sha, User user, Repository repository)
+        public GitReference(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository)
         {
+            NodeId = nodeId;
             Url = url;
             Label = label;
             Ref = @ref;
@@ -18,6 +19,11 @@ namespace Octokit
             User = user;
             Repository = repository;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL associated with this reference.

--- a/Octokit/Models/Response/GitTag.cs
+++ b/Octokit/Models/Response/GitTag.cs
@@ -7,8 +7,8 @@ namespace Octokit
     {
         public GitTag() { }
 
-        public GitTag(string url, string label, string @ref, string sha, User user, Repository repository, string tag, string message, Committer tagger, TagObject @object, Verification verification)
-            : base(url, label, @ref, sha, user, repository)
+        public GitTag(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, string tag, string message, Committer tagger, TagObject @object, Verification verification)
+            : base(nodeId, url, label, @ref, sha, user, repository)
         {
             Tag = tag;
             Message = message;
@@ -16,6 +16,7 @@ namespace Octokit
             Object = @object;
             Verification = verification;
         }
+
 
         public string Tag { get; protected set; }
 

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -11,9 +11,10 @@ namespace Octokit
     {
         public Issue() { }
 
-        public Issue(string url, string htmlUrl, string commentsUrl, string eventsUrl, int number, ItemState state, string title, string body, User closedBy, User user, IReadOnlyList<Label> labels, User assignee, IReadOnlyList<User> assignees, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt, int id, bool locked, Repository repository, ReactionSummary reactions)
+        public Issue(string url, string htmlUrl, string commentsUrl, string eventsUrl, int number, ItemState state, string title, string body, User closedBy, User user, IReadOnlyList<Label> labels, User assignee, IReadOnlyList<User> assignees, Milestone milestone, int comments, PullRequest pullRequest, DateTimeOffset? closedAt, DateTimeOffset createdAt, DateTimeOffset? updatedAt, int id, string nodeId, bool locked, Repository repository, ReactionSummary reactions)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             HtmlUrl = htmlUrl;
             CommentsUrl = commentsUrl;
@@ -42,6 +43,11 @@ namespace Octokit
         /// The internal Id for this issue (not the issue number)
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this issue.

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -10,9 +10,10 @@ namespace Octokit
     {
         public IssueComment() { }
 
-        public IssueComment(int id, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions)
+        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             HtmlUrl = htmlUrl;
             Body = body;
@@ -26,6 +27,11 @@ namespace Octokit
         /// The issue comment Id.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this issue comment.

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,9 +9,10 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(int id, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
+        public IssueEvent(int id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             Actor = actor;
             Assignee = assignee;
@@ -27,6 +28,11 @@ namespace Octokit
         /// The id of the issue/pull request event.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this issue/pull request event.

--- a/Octokit/Models/Response/Label.cs
+++ b/Octokit/Models/Response/Label.cs
@@ -8,10 +8,11 @@ namespace Octokit
     {
         public Label() { }
 
-        public Label(string url, string name, string color, string description, bool @default)
+        public Label(string url, string name, string nodeId, string color, string description, bool @default)
         {
             Url = url;
             Name = name;
+            NodeId = nodeId;
             Color = color;
             Description = description;
             Default = @default;
@@ -26,6 +27,11 @@ namespace Octokit
         /// Name of the label
         /// </summary>
         public string Name { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Color of the label

--- a/Octokit/Models/Response/License.cs
+++ b/Octokit/Models/Response/License.cs
@@ -11,6 +11,7 @@ namespace Octokit
     {
         public License(
             string key,
+            string nodeId,
             string name,
             string spdxId,
             string url,
@@ -22,17 +23,8 @@ namespace Octokit
             string body,
             IEnumerable<string> required,
             IEnumerable<string> permitted,
-            IEnumerable<string> forbidden) : base(key, name, spdxId, url, featured)
+            IEnumerable<string> forbidden) : base(key, nodeId, name, spdxId, url, featured)
         {
-            Ensure.ArgumentNotNull(htmlUrl, nameof(htmlUrl));
-            Ensure.ArgumentNotNull(description, nameof(description));
-            Ensure.ArgumentNotNull(category, nameof(category));
-            Ensure.ArgumentNotNull(implementation, nameof(implementation));
-            Ensure.ArgumentNotNull(body, nameof(body));
-            Ensure.ArgumentNotNull(required, nameof(required));
-            Ensure.ArgumentNotNull(permitted, nameof(permitted));
-            Ensure.ArgumentNotNull(forbidden, nameof(forbidden));
-
             HtmlUrl = htmlUrl;
             Description = description;
             Category = category;

--- a/Octokit/Models/Response/LicenseMetadata.cs
+++ b/Octokit/Models/Response/LicenseMetadata.cs
@@ -6,14 +6,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class LicenseMetadata
     {
-        public LicenseMetadata(string key, string name, string spdxId, string url, bool featured)
+        public LicenseMetadata(string key, string nodeId, string name, string spdxId, string url, bool featured)
         {
-            Ensure.ArgumentNotNullOrEmptyString(key, nameof(key));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-            Ensure.ArgumentNotNullOrEmptyString(spdxId, nameof(spdxId));
-            Ensure.ArgumentNotNull(url, nameof(url));
-
             Key = key;
+            NodeId = nodeId;
             Name = name;
             SpdxId = spdxId;
             Url = url;
@@ -28,6 +24,11 @@ namespace Octokit
         /// The 
         /// </summary>
         public string Key { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Friendly name of the license.

--- a/Octokit/Models/Response/Merge.cs
+++ b/Octokit/Models/Response/Merge.cs
@@ -10,8 +10,8 @@ namespace Octokit
     {
         public Merge() { }
 
-        public Merge(string url, string label, string @ref, string sha, User user, Repository repository, Author author, Author committer, Commit commit, IEnumerable<GitReference> parents, string commentsUrl, int commentCount, string htmlUrl)
-            : base(url, label, @ref, sha, user, repository)
+        public Merge(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, Author author, Author committer, Commit commit, IEnumerable<GitReference> parents, string commentsUrl, int commentCount, string htmlUrl)
+            : base(nodeId, url, label, @ref, sha, user, repository)
         {
             Ensure.ArgumentNotNull(parents, nameof(parents));
 

--- a/Octokit/Models/Response/Migration.cs
+++ b/Octokit/Models/Response/Migration.cs
@@ -23,6 +23,7 @@ namespace Octokit
 
         public Migration(
             int id,
+            string nodeId,
             string guid,
             MigrationState state,
             bool lockRepositories,
@@ -33,6 +34,7 @@ namespace Octokit
             IReadOnlyList<Repository> repositories)
         {
             Id = id;
+            NodeId = nodeId;
             Guid = guid;
             State = state;
             LockRepositories = lockRepositories;
@@ -47,6 +49,11 @@ namespace Octokit
         /// Id of migration.
         /// </summary>
         public int Id { get; private set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Guid of migration.

--- a/Octokit/Models/Response/Milestone.cs
+++ b/Octokit/Models/Response/Milestone.cs
@@ -14,11 +14,12 @@ namespace Octokit
             Number = number;
         }
 
-        public Milestone(string url, string htmlUrl, int number, ItemState state, string title, string description, User creator, int openIssues, int closedIssues, DateTimeOffset createdAt, DateTimeOffset? dueOn, DateTimeOffset? closedAt, DateTimeOffset? updatedAt)
+        public Milestone(string url, string htmlUrl, int number, string nodeId, ItemState state, string title, string description, User creator, int openIssues, int closedIssues, DateTimeOffset createdAt, DateTimeOffset? dueOn, DateTimeOffset? closedAt, DateTimeOffset? updatedAt)
         {
             Url = url;
             HtmlUrl = htmlUrl;
             Number = number;
+            NodeId = nodeId;
             State = state;
             Title = title;
             Description = description;
@@ -45,6 +46,11 @@ namespace Octokit
         /// The milestone number.
         /// </summary>
         public int Number { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Whether the milestone is open or closed.

--- a/Octokit/Models/Response/Organization.cs
+++ b/Octokit/Models/Response/Organization.cs
@@ -10,8 +10,8 @@ namespace Octokit
     {
         public Organization() { }
 
-        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress)
-            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.Organization, url)
+        public Organization(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string nodeId, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, string billingAddress)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, nodeId, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.Organization, url)
         {
             BillingAddress = billingAddress;
         }

--- a/Octokit/Models/Response/OrganizationMembershipInvitation.cs
+++ b/Octokit/Models/Response/OrganizationMembershipInvitation.cs
@@ -12,9 +12,10 @@ namespace Octokit
         {
         }
 
-        public OrganizationMembershipInvitation(int id, string login, string email, OrganizationMembershipRole role, DateTimeOffset createdAt, User inviter)
+        public OrganizationMembershipInvitation(int id, string nodeId, string login, string email, OrganizationMembershipRole role, DateTimeOffset createdAt, User inviter)
         {
             Id = id;
+            NodeId = nodeId;
             Login = login;
             Email = email;
             Role = role;
@@ -23,6 +24,12 @@ namespace Octokit
         }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
+
         public string Login { get; protected set; }
         public string Email { get; protected set; }
         public StringEnum<OrganizationMembershipRole> Role { get; protected set; }

--- a/Octokit/Models/Response/Project.cs
+++ b/Octokit/Models/Response/Project.cs
@@ -9,11 +9,12 @@ namespace Octokit
     {
         public Project() { }
 
-        public Project(string ownerUrl, string url, int id, string name, string body, int number, ItemState state, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        public Project(string ownerUrl, string url, int id, string nodeId, string name, string body, int number, ItemState state, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt)
         {
             OwnerUrl = ownerUrl;
             Url = url;
             Id = id;
+            NodeId = nodeId;
             Name = name;
             Body = body;
             Number = number;
@@ -37,6 +38,11 @@ namespace Octokit
         /// The Id for this project.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The name for this project.

--- a/Octokit/Models/Response/ProjectCard.cs
+++ b/Octokit/Models/Response/ProjectCard.cs
@@ -9,11 +9,12 @@ namespace Octokit
     {
         public ProjectCard() { }
 
-        public ProjectCard(string columnUrl, string contentUrl, int id, string note, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        public ProjectCard(string columnUrl, string contentUrl, int id, string nodeId, string note, User creator, DateTimeOffset createdAt, DateTimeOffset updatedAt)
         {
             ColumnUrl = columnUrl;
             ContentUrl = contentUrl;
             Id = id;
+            NodeId = nodeId;
             Note = note;
             Creator = creator;
             CreatedAt = createdAt;
@@ -34,6 +35,11 @@ namespace Octokit
         /// The Id for this card.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The note for this card.

--- a/Octokit/Models/Response/ProjectColumn.cs
+++ b/Octokit/Models/Response/ProjectColumn.cs
@@ -9,9 +9,10 @@ namespace Octokit
     {
         public ProjectColumn() { }
 
-        public ProjectColumn(int id, string name, string projectUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt)
+        public ProjectColumn(int id, string nodeId, string name, string projectUrl, DateTimeOffset createdAt, DateTimeOffset updatedAt)
         {
             Id = id;
+            NodeId = nodeId;
             Name = name;
             ProjectUrl = projectUrl;
             CreatedAt = createdAt;
@@ -22,6 +23,11 @@ namespace Octokit
         /// The Id for this column.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The name for this column.

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -16,9 +16,10 @@ namespace Octokit
             Number = number;
         }
 
-        public PullRequest(long id, string url, string htmlUrl, string diffUrl, string patchUrl, string issueUrl, string statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool? mergeable, MergeableState? mergeableState, User mergedBy, string mergeCommitSha, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked, bool? maintainerCanModify, IReadOnlyList<User> requestedReviewers)
+        public PullRequest(long id, string nodeId, string url, string htmlUrl, string diffUrl, string patchUrl, string issueUrl, string statusesUrl, int number, ItemState state, string title, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, DateTimeOffset? closedAt, DateTimeOffset? mergedAt, GitReference head, GitReference @base, User user, User assignee, IReadOnlyList<User> assignees, bool? mergeable, MergeableState? mergeableState, User mergedBy, string mergeCommitSha, int comments, int commits, int additions, int deletions, int changedFiles, Milestone milestone, bool locked, bool? maintainerCanModify, IReadOnlyList<User> requestedReviewers)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             HtmlUrl = htmlUrl;
             DiffUrl = diffUrl;
@@ -57,6 +58,11 @@ namespace Octokit
         /// The internal Id for this pull request (not the pull request number)
         /// </summary>
         public long Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The URL for this pull request.

--- a/Octokit/Models/Response/PullRequestCommit.cs
+++ b/Octokit/Models/Response/PullRequestCommit.cs
@@ -11,10 +11,11 @@ namespace Octokit
     {
         public PullRequestCommit() { }
 
-        public PullRequestCommit(Committer author, string commentsUrl, Commit commit, Committer committer, string htmlUrl, IEnumerable<GitReference> parents, string sha, string url)
+        public PullRequestCommit(string nodeId, Committer author, string commentsUrl, Commit commit, Committer committer, string htmlUrl, IEnumerable<GitReference> parents, string sha, string url)
         {
             Ensure.ArgumentNotNull(parents, nameof(parents));
 
+            NodeId = nodeId;
             Author = author;
             CommentsUrl = commentsUrl;
             Commit = commit;
@@ -24,6 +25,11 @@ namespace Octokit
             Sha = sha;
             Url = url;
         }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public Committer Author { get; protected set; }
 

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -15,9 +15,10 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReview(long id, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state)
+        public PullRequestReview(long id, string nodeId, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state)
         {
             Id = id;
+            NodeId = nodeId;
             CommitId = commitId;
             User = user;
             Body = body;
@@ -30,6 +31,11 @@ namespace Octokit
         /// The review Id.
         /// </summary>
         public long Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The state of the review

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -15,11 +15,12 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReviewComment(string url, int id, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId)
+        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId)
         {
             PullRequestReviewId = pullRequestReviewId;
             Url = url;
             Id = id;
+            NodeId = nodeId;
             DiffHunk = diffHunk;
             Path = path;
             Position = position;
@@ -45,6 +46,11 @@ namespace Octokit
         /// The comment Id.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// The diff hunk the comment is about.

--- a/Octokit/Models/Response/Reaction.cs
+++ b/Octokit/Models/Response/Reaction.cs
@@ -30,9 +30,10 @@ namespace Octokit
     {
         public Reaction() { }
 
-        public Reaction(int id, User user, ReactionType content)
+        public Reaction(int id, string nodeId, User user, ReactionType content)
         {
             Id = id;
+            NodeId = nodeId;
             User = user;
             Content = content;
         }
@@ -41,6 +42,11 @@ namespace Octokit
         /// The Id for this reaction.
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// Information about the user.

--- a/Octokit/Models/Response/Reference.cs
+++ b/Octokit/Models/Response/Reference.cs
@@ -8,14 +8,20 @@ namespace Octokit
     {
         public Reference() { }
 
-        public Reference(string @ref, string url, TagObject @object)
+        public Reference(string @ref, string nodeId, string url, TagObject @object)
         {
             Ref = @ref;
+            NodeId = nodeId;
             Url = url;
             Object = @object;
         }
 
         public string Ref { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public string Url { get; protected set; }
 

--- a/Octokit/Models/Response/Release.cs
+++ b/Octokit/Models/Response/Release.cs
@@ -11,13 +11,14 @@ namespace Octokit
     {
         public Release() { }
 
-        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, int id, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt, Author author, string tarballUrl, string zipballUrl, IReadOnlyList<ReleaseAsset> assets)
+        public Release(string url, string htmlUrl, string assetsUrl, string uploadUrl, int id, string nodeId, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTimeOffset createdAt, DateTimeOffset? publishedAt, Author author, string tarballUrl, string zipballUrl, IReadOnlyList<ReleaseAsset> assets)
         {
             Url = url;
             HtmlUrl = htmlUrl;
             AssetsUrl = assetsUrl;
             UploadUrl = uploadUrl;
             Id = id;
+            NodeId = nodeId;
             TagName = tagName;
             TargetCommitish = targetCommitish;
             Name = name;
@@ -47,6 +48,11 @@ namespace Octokit
         public string UploadUrl { get; protected set; }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public string TagName { get; protected set; }
 

--- a/Octokit/Models/Response/ReleaseAsset.cs
+++ b/Octokit/Models/Response/ReleaseAsset.cs
@@ -9,10 +9,11 @@ namespace Octokit
     {
         public ReleaseAsset() { }
 
-        public ReleaseAsset(string url, int id, string name, string label, string state, string contentType, int size, int downloadCount, DateTimeOffset createdAt, DateTimeOffset updatedAt, string browserDownloadUrl, Author uploader)
+        public ReleaseAsset(string url, int id, string nodeId, string name, string label, string state, string contentType, int size, int downloadCount, DateTimeOffset createdAt, DateTimeOffset updatedAt, string browserDownloadUrl, Author uploader)
         {
             Url = url;
             Id = id;
+            NodeId = nodeId;
             Name = name;
             Label = label;
             State = state;
@@ -28,6 +29,11 @@ namespace Octokit
         public string Url { get; protected set; }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public string Name { get; protected set; }
 

--- a/Octokit/Models/Response/Repository.cs
+++ b/Octokit/Models/Response/Repository.cs
@@ -14,7 +14,7 @@ namespace Octokit
             Id = id;
         }
 
-        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit)
+        public Repository(string url, string htmlUrl, string cloneUrl, string gitUrl, string sshUrl, string svnUrl, string mirrorUrl, long id, string nodeId, User owner, string name, string fullName, string description, string homepage, string language, bool @private, bool fork, int forksCount, int stargazersCount, string defaultBranch, int openIssuesCount, DateTimeOffset? pushedAt, DateTimeOffset createdAt, DateTimeOffset updatedAt, RepositoryPermissions permissions, Repository parent, Repository source, LicenseMetadata license, bool hasIssues, bool hasWiki, bool hasDownloads, bool hasPages, int subscribersCount, long size, bool? allowRebaseMerge, bool? allowSquashMerge, bool? allowMergeCommit)
         {
             Url = url;
             HtmlUrl = htmlUrl;
@@ -24,6 +24,7 @@ namespace Octokit
             SvnUrl = svnUrl;
             MirrorUrl = mirrorUrl;
             Id = id;
+            NodeId = nodeId;
             Owner = owner;
             Name = name;
             FullName = fullName;
@@ -69,6 +70,11 @@ namespace Octokit
         public string MirrorUrl { get; protected set; }
 
         public long Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public User Owner { get; protected set; }
 

--- a/Octokit/Models/Response/RepositoryContributor.cs
+++ b/Octokit/Models/Response/RepositoryContributor.cs
@@ -10,8 +10,8 @@ namespace Octokit
     {
         public RepositoryContributor() { }
 
-        public RepositoryContributor(string login, int id, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, int contributions)
-            : base(login, id, avatarUrl, url, htmlUrl, followersUrl, followingUrl, gistsUrl, type, starredUrl, subscriptionsUrl, organizationsUrl, reposUrl, eventsUrl, receivedEventsUrl, siteAdmin)
+        public RepositoryContributor(string login, int id, string nodeId, string avatarUrl, string url, string htmlUrl, string followersUrl, string followingUrl, string gistsUrl, string type, string starredUrl, string subscriptionsUrl, string organizationsUrl, string reposUrl, string eventsUrl, string receivedEventsUrl, bool siteAdmin, int contributions)
+            : base(login, id, nodeId, avatarUrl, url, htmlUrl, followersUrl, followingUrl, gistsUrl, type, starredUrl, subscriptionsUrl, organizationsUrl, reposUrl, eventsUrl, receivedEventsUrl, siteAdmin)
         {
             Contributions = contributions;
         }

--- a/Octokit/Models/Response/RepositoryInvitation.cs
+++ b/Octokit/Models/Response/RepositoryInvitation.cs
@@ -22,9 +22,10 @@ namespace Octokit
     {
         public RepositoryInvitation() { }
 
-        public RepositoryInvitation(int id, Repository repository, User invitee, User inviter, InvitationPermissionType permissions, DateTimeOffset createdAt, string url, string htmlUrl)
+        public RepositoryInvitation(int id, string nodeId, Repository repository, User invitee, User inviter, InvitationPermissionType permissions, DateTimeOffset createdAt, string url, string htmlUrl)
         {
             Id = id;
+            NodeId = nodeId;
             Repository = repository;
             Invitee = invitee;
             Inviter = inviter;
@@ -35,6 +36,11 @@ namespace Octokit
         }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public Repository Repository { get; protected set; }
 

--- a/Octokit/Models/Response/RepositoryTag.cs
+++ b/Octokit/Models/Response/RepositoryTag.cs
@@ -11,15 +11,21 @@ namespace Octokit
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "tarball")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "zipball")]
-        public RepositoryTag(string name, GitReference commit, string zipballUrl, string tarballUrl)
+        public RepositoryTag(string name, string nodeId, GitReference commit, string zipballUrl, string tarballUrl)
         {
             Name = name;
+            NodeId = nodeId;
             Commit = commit;
             ZipballUrl = zipballUrl;
             TarballUrl = tarballUrl;
         }
 
         public string Name { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         public GitReference Commit { get; protected set; }
 

--- a/Octokit/Models/Response/TagObject.cs
+++ b/Octokit/Models/Response/TagObject.cs
@@ -9,8 +9,8 @@ namespace Octokit
     {
         public TagObject() { }
 
-        public TagObject(string url, string label, string @ref, string sha, User user, Repository repository, TaggedType type)
-            : base(url, label, @ref, sha, user, repository)
+        public TagObject(string nodeId, string url, string label, string @ref, string sha, User user, Repository repository, TaggedType type)
+            : base(nodeId, url, label, @ref, sha, user, repository)
         {
             Type = type;
         }

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -12,10 +12,11 @@ namespace Octokit
     {
         public Team() { }
 
-        public Team(string url, int id, string name, string description, TeamPrivacy privacy, Permission permission, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
+        public Team(string url, int id, string nodeId, string name, string description, TeamPrivacy privacy, Permission permission, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
         {
             Url = url;
             Id = id;
+            NodeId = nodeId;
             Name = name;
             Description = description;
             Privacy = privacy;
@@ -36,6 +37,11 @@ namespace Octokit
         /// team id
         /// </summary>
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
 
         /// <summary>
         /// team name

--- a/Octokit/Models/Response/TimelineEventInfo.cs
+++ b/Octokit/Models/Response/TimelineEventInfo.cs
@@ -9,9 +9,10 @@ namespace Octokit
     {
         public TimelineEventInfo() { }
 
-        public TimelineEventInfo(int id, string url, User actor, string commitId, EventInfoState @event, DateTimeOffset createdAt, Label label, User assignee, Milestone milestone, SourceInfo source, RenameInfo rename)
+        public TimelineEventInfo(int id, string nodeId, string url, User actor, string commitId, EventInfoState @event, DateTimeOffset createdAt, Label label, User assignee, Milestone milestone, SourceInfo source, RenameInfo rename)
         {
             Id = id;
+            NodeId = nodeId;
             Url = url;
             Actor = actor;
             CommitId = commitId;
@@ -25,6 +26,12 @@ namespace Octokit
         }
 
         public int Id { get; protected set; }
+
+        /// <summary>
+        /// GraphQL Node Id
+        /// </summary>
+        public string NodeId { get; protected set; }
+
         public string Url { get; protected set; }
         public User Actor { get; protected set; }
         public string CommitId { get; protected set; }

--- a/Octokit/Models/Response/User.cs
+++ b/Octokit/Models/Response/User.cs
@@ -14,8 +14,8 @@ namespace Octokit
     {
         public User() { }
 
-        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, DateTimeOffset updatedAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, RepositoryPermissions permissions, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
-            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
+        public User(string avatarUrl, string bio, string blog, int collaborators, string company, DateTimeOffset createdAt, DateTimeOffset updatedAt, int diskUsage, string email, int followers, int following, bool? hireable, string htmlUrl, int totalPrivateRepos, int id, string location, string login, string name, string nodeId, int ownedPrivateRepos, Plan plan, int privateGists, int publicGists, int publicRepos, string url, RepositoryPermissions permissions, bool siteAdmin, string ldapDistinguishedName, DateTimeOffset? suspendedAt)
+            : base(avatarUrl, bio, blog, collaborators, company, createdAt, diskUsage, email, followers, following, hireable, htmlUrl, totalPrivateRepos, id, location, login, name, nodeId, ownedPrivateRepos, plan, privateGists, publicGists, publicRepos, AccountType.User, url)
         {
             Permissions = permissions;
             SiteAdmin = siteAdmin;


### PR DESCRIPTION
Now that the inclusion of GraphQL Node ID's is [out of preview](https://developer.github.com/changes/2018-05-30-end-jean-grey-preview/), we can add the new field all the affected response models without worrying about preview header complexities 😌  

Fixes #1741 

Checklist of endpoints that need their response objects updated (from [initial announcement](https://developer.github.com/changes/2017-12-19-graphql-node-id/))
- [x] Deployments
- [x] Gists
- [x] Git Blobs
- [x] Git Commits
- [x] Git References
- [x] Git Tags
- [x] Issues
- [x] Labels
- [x] Milestones
- [x] Organizations
- [x] Projects
- [x] Pull Requests
- [x] Reactions
- [x] Releases
- [x] Repositories
- [x] Statuses
- [x] Teams
- [x] Users