### PR TITLE
[WIP] Fixes #1718 Implement Repository Transfer functionality

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -49,6 +49,8 @@ namespace Octokit.Reactive
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
         IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
+        
+        IObservable<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer);
 
         /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -39,6 +39,18 @@ namespace Octokit.Reactive
         IObservable<Unit> Delete(long repositoryId);
 
         /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
+        IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
+
+        /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -44,11 +44,11 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
-        IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
+        IObservable<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer);
 
         /// <summary>
         /// Transfers the ownership of the specified repository.

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -49,7 +49,16 @@ namespace Octokit.Reactive
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
         IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
-        
+
+        /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
         IObservable<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer);
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -111,6 +111,15 @@ namespace Octokit.Reactive
             return _client.Transfer(currentOwner, name, repositoryTransfer).ToObservable();
         }
 
+        /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
         public IObservable<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
         {
             return _client.Transfer(repositoryId, repositoryTransfer).ToObservable();

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -102,13 +102,13 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
-        public IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
+        public IObservable<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer)
         {
-            return _client.Transfer(currentOwner, name, repositoryTransfer).ToObservable();
+            return _client.Transfer(owner, name, repositoryTransfer).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -108,6 +108,10 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="Repository"/></returns>
         public IObservable<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer)
         {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
+
             return _client.Transfer(owner, name, repositoryTransfer).ToObservable();
         }
 
@@ -122,6 +126,8 @@ namespace Octokit.Reactive
         /// <returns>A <see cref="Repository"/></returns>
         public IObservable<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
         {
+            Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
+            
             return _client.Transfer(repositoryId, repositoryTransfer).ToObservable();
         }
 

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -95,6 +95,21 @@ namespace Octokit.Reactive
         {
             return _client.Delete(repositoryId).ToObservable();
         }
+        
+        /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
+        public IObservable<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
+        {
+            return _client.Transfer(currentOwner, name, repositoryTransfer).ToObservable();
+        }
 
         /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -111,6 +111,11 @@ namespace Octokit.Reactive
             return _client.Transfer(currentOwner, name, repositoryTransfer).ToObservable();
         }
 
+        public IObservable<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
+        {
+            return _client.Transfer(repositoryId, repositoryTransfer).ToObservable();
+        }
+
         /// <summary>
         /// Retrieves the <see cref="Repository"/> for the specified owner and name.
         /// </summary>

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -1699,7 +1699,7 @@ public class RepositoriesClientTests
         }
         
         [IntegrationTest]
-        public async Task TransfersFromOrgToUserWithId()
+        public async Task TransfersFromOrgToUserById()
         {
             var github = Helper.GetAuthenticatedClient();
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1682,10 +1682,10 @@ public class RepositoriesClientTests
         }
     }
 
-    public class TheTransferByNameMethod
+    public class TheTransferMethod
     {
         [IntegrationTest]
-        public async Task CanTransferOrgRepoToUser()
+        public async Task TransfersFromOrgToUser()
         {
             var github = Helper.GetAuthenticatedClient();
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
@@ -1697,9 +1697,23 @@ public class RepositoriesClientTests
                 var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
             }
         }
+        
+        [IntegrationTest]
+        public async Task TransfersFromOrgToUserWithId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
+            var newOwner = Helper.UserName;
+            using (var context = await github.CreateRepositoryContext(Helper.Organization, newRepo))
+            {
+                var transfer = new RepositoryTransfer(newOwner);
+                await github.Repository.Transfer(context.RepositoryId, transfer);
+                var transferred = await github.Repository.Get(context.RepositoryId);
+            }
+        }
 
         [IntegrationTest]
-        public async Task CanTransferUserRepoToOrg()
+        public async Task TransfersFromUserToOrg()
         {
             var github = Helper.GetAuthenticatedClient();
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
@@ -1711,9 +1725,23 @@ public class RepositoriesClientTests
                 var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
             }
         }
+        
+        [IntegrationTest]
+        public async Task TransfersFromUserToOrgById()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
+            var newOwner = Helper.Organization;
+            using (var context = await github.CreateRepositoryContext(newRepo))
+            {
+                var transfer = new RepositoryTransfer(newOwner);
+                await github.Repository.Transfer(context.RepositoryId, transfer);
+                var transferred = await github.Repository.Get(context.RepositoryId);
+            }
+        }
 
         [IntegrationTest]
-        public async Task CanTransferToOrgWithTeams()
+        public async Task TransfersFromUserToOrgWithTeams()
         {
             // FIXME API doesn't add teams when transferring to an organization
             var github = Helper.GetAuthenticatedClient();
@@ -1737,40 +1765,9 @@ public class RepositoriesClientTests
                         repoTeams.Select(t => t.Id)));
             }
         }
-    }
-
-    public class TheTransferByIdMethod
-    {
+        
         [IntegrationTest]
-        public async Task CanTransferOrgRepoToUser()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
-            var newOwner = Helper.UserName;
-            using (var context = await github.CreateRepositoryContext(Helper.Organization, newRepo))
-            {
-                var transfer = new RepositoryTransfer(newOwner);
-                await github.Repository.Transfer(context.RepositoryId, transfer);
-                var transferred = await github.Repository.Get(context.RepositoryId);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task CanTransferUserRepoToOrg()
-        {
-            var github = Helper.GetAuthenticatedClient();
-            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
-            var newOwner = Helper.Organization;
-            using (var context = await github.CreateRepositoryContext(newRepo))
-            {
-                var transfer = new RepositoryTransfer(newOwner);
-                await github.Repository.Transfer(context.RepositoryId, transfer);
-                var transferred = await github.Repository.Get(context.RepositoryId);
-            }
-        }
-
-        [IntegrationTest]
-        public async Task CanTransferToOrgWithTeams()
+        public async Task TransfersFromUserToOrgWithTeamsById()
         {
             // FIXME API doesn't add teams when transferring to an organization
             var github = Helper.GetAuthenticatedClient();

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1697,5 +1697,19 @@ public class RepositoriesClientTests
                 var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
             }
         }
+
+        [IntegrationTest]
+        public async Task CanTransferUserRepoToOrg()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
+            var newOwner = Helper.Organization;
+            using (var context = await github.CreateRepositoryContext(newRepo))
+            {
+                var transfer = new RepositoryTransfer(newOwner);
+                await github.Repository.Transfer(context.RepositoryOwner, context.RepositoryName, transfer);
+                var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1748,21 +1748,21 @@ public class RepositoriesClientTests
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
             var newOwner = Helper.Organization;
 
-            Random rand = new Random();
-            IReadOnlyList<Team> teams = await github.Organization.Team.GetAll(Helper.Organization);
-            var randomTeam = teams[rand.Next(teams.Count)];
-            var transferTeamIds = new int[] { randomTeam.Id };
-
-            using (var context = await github.CreateRepositoryContext(newRepo))
+            using (var repositoryContext = await github.CreateRepositoryContext(newRepo))
             {
-                var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
-                await github.Repository.Transfer(context.RepositoryOwner, context.RepositoryName, transfer);
-                var repoTeams = await github.Repository.GetAllTeams(context.RepositoryId);
+                NewTeam team = new NewTeam(Helper.MakeNameWithTimestamp("transfer-team"));
+                using (var teamContext = await github.CreateTeamContext(Helper.Organization, team)) {
+                    var transferTeamIds = new int[] { teamContext.TeamId };
+                    var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
+                    await github.Repository.Transfer(
+                        repositoryContext.RepositoryOwner, repositoryContext.RepositoryName, transfer);
+                    var repoTeams = await github.Repository.GetAllTeams(repositoryContext.RepositoryId);
 
-                // transferTeamIds is a subset of repoTeams
-                Assert.Empty(
-                    transferTeamIds.Except(
-                        repoTeams.Select(t => t.Id)));
+                    // transferTeamIds is a subset of repoTeams
+                    Assert.Empty(
+                        transferTeamIds.Except(
+                            repoTeams.Select(t => t.Id)));
+                }
             }
         }
         
@@ -1774,21 +1774,20 @@ public class RepositoriesClientTests
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
             var newOwner = Helper.Organization;
 
-            Random rand = new Random();
-            IReadOnlyList<Team> teams = await github.Organization.Team.GetAll(Helper.Organization);
-            var randomTeam = teams[rand.Next(teams.Count)];
-            var transferTeamIds = new int[] { randomTeam.Id };
-
-            using (var context = await github.CreateRepositoryContext(newRepo))
+            using (var repositoryContext = await github.CreateRepositoryContext(newRepo))
             {
-                var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
-                await github.Repository.Transfer(context.RepositoryId, transfer);
-                var repoTeams = await github.Repository.GetAllTeams(context.RepositoryId);
+                NewTeam team = new NewTeam(Helper.MakeNameWithTimestamp("transfer-team"));
+                using (var teamContext = await github.CreateTeamContext(Helper.Organization, team)) {
+                    var transferTeamIds = new int[] { teamContext.TeamId };
+                    var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
+                    await github.Repository.Transfer(repositoryContext.RepositoryId, transfer);
+                    var repoTeams = await github.Repository.GetAllTeams(repositoryContext.RepositoryId);
 
-                // transferTeamIds is a subset of repoTeams
-                Assert.Empty(
-                    transferTeamIds.Except(
-                        repoTeams.Select(t => t.Id)));
+                    // transferTeamIds is a subset of repoTeams
+                    Assert.Empty(
+                        transferTeamIds.Except(
+                            repoTeams.Select(t => t.Id)));
+                }
             }
         }
     }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1715,6 +1715,7 @@ public class RepositoriesClientTests
         [IntegrationTest]
         public async Task CanTransferToOrgWithTeams()
         {
+            // FIXME API doesn't add teams when transferring to an organization
             var github = Helper.GetAuthenticatedClient();
             var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
             var newOwner = Helper.Organization;

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1681,4 +1681,21 @@ public class RepositoriesClientTests
             Assert.Equal("MIT License", license.License.Name);
         }
     }
+
+    public class TheTransferMethod
+    {
+        [IntegrationTest]
+        public async Task CanTransferOrgRepoToUser()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            var newRepo = new NewRepository(Helper.MakeNameWithTimestamp("transferred-repo"));
+            var newOwner = Helper.UserName;
+            using (var context = await github.CreateRepositoryContext(Helper.Organization, newRepo))
+            {
+                var transfer = new RepositoryTransfer(newOwner);
+                await github.Repository.Transfer(context.RepositoryOwner, context.RepositoryName, transfer);
+                var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
+            }
+        }
+    }
 }

--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -1695,6 +1695,8 @@ public class RepositoriesClientTests
                 var transfer = new RepositoryTransfer(newOwner);
                 await github.Repository.Transfer(context.RepositoryOwner, context.RepositoryName, transfer);
                 var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
+                
+                Assert.Equal(newOwner, transferred.Owner.Login);
             }
         }
         
@@ -1709,6 +1711,8 @@ public class RepositoriesClientTests
                 var transfer = new RepositoryTransfer(newOwner);
                 await github.Repository.Transfer(context.RepositoryId, transfer);
                 var transferred = await github.Repository.Get(context.RepositoryId);
+
+                Assert.Equal(newOwner, transferred.Owner.Login);
             }
         }
 
@@ -1723,6 +1727,8 @@ public class RepositoriesClientTests
                 var transfer = new RepositoryTransfer(newOwner);
                 await github.Repository.Transfer(context.RepositoryOwner, context.RepositoryName, transfer);
                 var transferred = await github.Repository.Get(newOwner, context.RepositoryName);
+                
+                Assert.Equal(newOwner, transferred.Owner.Login);
             }
         }
         
@@ -1737,6 +1743,8 @@ public class RepositoriesClientTests
                 var transfer = new RepositoryTransfer(newOwner);
                 await github.Repository.Transfer(context.RepositoryId, transfer);
                 var transferred = await github.Repository.Get(context.RepositoryId);
+
+                Assert.Equal(newOwner, transferred.Owner.Login);
             }
         }
 
@@ -1756,8 +1764,10 @@ public class RepositoriesClientTests
                     var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
                     await github.Repository.Transfer(
                         repositoryContext.RepositoryOwner, repositoryContext.RepositoryName, transfer);
+                    var transferred = await github.Repository.Get(repositoryContext.RepositoryId);
                     var repoTeams = await github.Repository.GetAllTeams(repositoryContext.RepositoryId);
 
+                    Assert.Equal(newOwner, transferred.Owner.Login);
                     // transferTeamIds is a subset of repoTeams
                     Assert.Empty(
                         transferTeamIds.Except(
@@ -1781,8 +1791,10 @@ public class RepositoriesClientTests
                     var transferTeamIds = new int[] { teamContext.TeamId };
                     var transfer = new RepositoryTransfer(newOwner, transferTeamIds);
                     await github.Repository.Transfer(repositoryContext.RepositoryId, transfer);
+                    var transferred = await github.Repository.Get(repositoryContext.RepositoryId);
                     var repoTeams = await github.Repository.GetAllTeams(repositoryContext.RepositoryId);
 
+                    Assert.Equal(newOwner, transferred.Owner.Login);
                     // transferTeamIds is a subset of repoTeams
                     Assert.Empty(
                         transferTeamIds.Except(

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -214,43 +214,43 @@ namespace Octokit.Tests.Clients
         public class TheTransferMethod
         {
             [Fact]
-            public void EnsuresNonNullArguments()
+            public async Task EnsuresNonNullArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
                 var transfer = new RepositoryTransfer("newOwner");
 
-                Assert.ThrowsAsync<ArgumentNullException>(
-                    async () => await client.Transfer(null, "name", transfer));
-                Assert.ThrowsAsync<ArgumentNullException>(
-                    async () => await client.Transfer("owner", null, transfer));
-                Assert.ThrowsAsync<ArgumentNullException>(
-                    async () => await client.Transfer("owner", "name", null));
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer(null, "name", transfer));
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer("owner", null, transfer));
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer("owner", "name", null));
             }
             
             [Fact]
-            public void EnsuresNonNullArgumentsById()
+            public async Task EnsuresNonNullArgumentsById()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
                 var transfer = new RepositoryTransfer("newOwner");
                 var repositoryId = 1;
 
-                Assert.ThrowsAsync<ArgumentNullException>(
-                    async () => await client.Transfer(repositoryId, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer(repositoryId, null));
             }
 
             [Fact]
-            public void EnsuresNonEmptyArguments()
+            public async Task EnsuresNonEmptyArguments()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new RepositoriesClient(connection);
                 var transfer = new RepositoryTransfer("newOwner");
 
-                Assert.ThrowsAsync<ArgumentException>(
-                    async () => await client.Transfer("", "name", transfer));
-                Assert.ThrowsAsync<ArgumentException>(
-                    async () => await client.Transfer("owner", "", transfer));
+                await Assert.ThrowsAsync<ArgumentException>(
+                    () => client.Transfer("", "name", transfer));
+                await Assert.ThrowsAsync<ArgumentException>(
+                    () => client.Transfer("owner", "", transfer));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -240,6 +240,59 @@ namespace Octokit.Tests.Clients
                 Assert.ThrowsAsync<ArgumentException>(
                     () => client.Transfer("owner", "", transfer));
             }
+
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var teamId = new int[2] {35, 42};
+                var transfer = new RepositoryTransfer("newOwner", teamId);
+
+                await client.Transfer("owner", "name", transfer);
+
+                connection.Received()
+                    .Post<Repository>(
+                        Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/transfer"),
+                        Arg.Any<RepositoryTransfer>(),
+                        Arg.Any<string>());
+            }
+
+            [Fact]
+            public async Task SendsCorrectRequest()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var teamId = new int[2] {35, 42};
+                var transfer = new RepositoryTransfer("newOwner", teamId);
+
+                await client.Transfer("owner", "name", transfer);
+
+                connection.Received()
+                    .Post<Repository>(
+                        Arg.Any<Uri>(),
+                        Arg.Is<RepositoryTransfer>(
+                            t => t.NewOwner == "newOwner" && object.Equals(teamId, t.TeamId)),
+                        Arg.Any<string>());
+            }
+
+            [Fact]
+            public async Task SendsPreviewHeader()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var teamId = new int[2] {35, 42};
+                var transfer = new RepositoryTransfer("newOwner", teamId);
+
+                await client.Transfer("owner", "name", transfer);
+
+                connection.Received()
+                    .Post<Repository>(
+                        Arg.Any<Uri>(),
+                        Arg.Any<RepositoryTransfer>(),
+                        Arg.Is<string>(
+                            s => s.Contains(AcceptHeaders.RepositoryTransferPreview)));
+            }
         }
 
         public class TheDeleteMethod

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -211,6 +211,37 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheTransferMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer(null, "name", transfer));
+                Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer("owner", null, transfer));
+                Assert.ThrowsAsync<ArgumentNullException>(
+                    () => client.Transfer("owner", "name", null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoriesClient(connection);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                Assert.ThrowsAsync<ArgumentException>(
+                    () => client.Transfer("", "name", transfer));
+                Assert.ThrowsAsync<ArgumentException>(
+                    () => client.Transfer("owner", "", transfer));
+            }
+        }
+
         public class TheDeleteMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -221,11 +221,11 @@ namespace Octokit.Tests.Clients
                 var transfer = new RepositoryTransfer("newOwner");
 
                 Assert.ThrowsAsync<ArgumentNullException>(
-                    () => client.Transfer(null, "name", transfer));
+                    async () => await client.Transfer(null, "name", transfer));
                 Assert.ThrowsAsync<ArgumentNullException>(
-                    () => client.Transfer("owner", null, transfer));
+                    async () => await client.Transfer("owner", null, transfer));
                 Assert.ThrowsAsync<ArgumentNullException>(
-                    () => client.Transfer("owner", "name", null));
+                    async () => await client.Transfer("owner", "name", null));
             }
             
             [Fact]
@@ -237,7 +237,7 @@ namespace Octokit.Tests.Clients
                 var repositoryId = 1;
 
                 Assert.ThrowsAsync<ArgumentNullException>(
-                    () => client.Transfer(repositoryId, null));
+                    async () => await client.Transfer(repositoryId, null));
             }
 
             [Fact]
@@ -248,9 +248,9 @@ namespace Octokit.Tests.Clients
                 var transfer = new RepositoryTransfer("newOwner");
 
                 Assert.ThrowsAsync<ArgumentException>(
-                    () => client.Transfer("", "name", transfer));
+                    async () => await client.Transfer("", "name", transfer));
                 Assert.ThrowsAsync<ArgumentException>(
-                    () => client.Transfer("owner", "", transfer));
+                    async () => await client.Transfer("owner", "", transfer));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoriesClientTests.cs
@@ -302,7 +302,7 @@ namespace Octokit.Tests.Clients
                     .Post<Repository>(
                         Arg.Any<Uri>(),
                         Arg.Is<RepositoryTransfer>(
-                            t => t.NewOwner == "newOwner" && object.Equals(teamId, t.TeamId)),
+                            t => t.NewOwner == "newOwner" && object.Equals(teamId, t.TeamIds)),
                         Arg.Any<string>());
             }
             
@@ -321,7 +321,7 @@ namespace Octokit.Tests.Clients
                     .Post<Repository>(
                         Arg.Any<Uri>(),
                         Arg.Is<RepositoryTransfer>(
-                            t => t.NewOwner == "newOwner" && object.Equals(teamId, t.TeamId)),
+                            t => t.NewOwner == "newOwner" && object.Equals(teamId, t.TeamIds)),
                         Arg.Any<string>());
             }
 

--- a/Octokit.Tests/Models/RepositoryTransferTest.cs
+++ b/Octokit.Tests/Models/RepositoryTransferTest.cs
@@ -1,0 +1,94 @@
+using Xunit;
+using System;
+
+namespace Octokit.Tests.Models
+{
+    public class RepositoryTransferTest
+    {
+        public static readonly string emptyName = "";
+        public static readonly string nonemptyName = "name";
+        public static readonly int[] emptyTeamId = new int[] {};
+        public static readonly int[] nonemptyTeamId = new int[] {1, 2, 3};
+
+        public class TheSingleArgumentConstructor
+        {
+            [Fact]
+            public void ChecksForEmptyName()
+            {
+                Assert.Throws<ArgumentException>(() => {new RepositoryTransfer(emptyName);});
+            }
+
+            [Fact]
+            public void ChecksForNullName()
+            {
+                Assert.Throws<ArgumentNullException>(() => {new RepositoryTransfer(null);});
+            }
+
+            [Fact]
+            public void StoresGivenName()
+            {
+                string testName = nonemptyName;
+                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(testName);
+                Assert.Equal(repositoryTransfer.NewOwner, testName);
+            }
+
+            [Fact]
+            public void SetsTeamIdToNull()
+            {
+                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName);
+                Assert.Null(repositoryTransfer.TeamId);
+            }
+        }
+
+        public class TheFullConstructor
+        {
+            [Fact]
+            public void ChecksForEmptyName()
+            {
+                Assert.Throws<ArgumentException>(() => {new RepositoryTransfer(emptyName, nonemptyTeamId);});
+            }
+
+            [Fact]
+            public void ChecksForNullName()
+            {
+                Assert.Throws<ArgumentNullException>(() => {new RepositoryTransfer(null, nonemptyTeamId);});
+            }
+
+            [Fact]
+            public void ChecksForEmptyTeamId()
+            {
+                Assert.Throws<ArgumentException>(() => {new RepositoryTransfer(nonemptyName, emptyTeamId);});
+            }
+
+            [Fact]
+            public void ChecksForNullTeamId()
+            {
+                Assert.Throws<ArgumentNullException>(() => {new RepositoryTransfer(nonemptyName, null);});
+            }
+
+            [Fact]
+            public void StoresGivenName()
+            {
+                string testName = nonemptyName;
+                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(testName, nonemptyTeamId);
+                Assert.Equal(repositoryTransfer.NewOwner, testName);
+            }
+
+            [Fact]
+            public void StoresGivenTeamId()
+            {
+                int[] testTeamId = nonemptyTeamId;
+                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
+                Assert.Equal(repositoryTransfer.TeamId, testTeamId);
+            }
+
+            [Fact]
+            public void DoesntKeepReferenceToTeamId()
+            {
+                int[] testTeamId = nonemptyTeamId;
+                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
+                Assert.False(Object.ReferenceEquals(repositoryTransfer.TeamId, testTeamId));
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Models/RepositoryTransferTest.cs
+++ b/Octokit.Tests/Models/RepositoryTransferTest.cs
@@ -36,7 +36,7 @@ namespace Octokit.Tests.Models
             public void SetsTeamIdToNull()
             {
                 RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName);
-                Assert.Null(repositoryTransfer.TeamId);
+                Assert.Null(repositoryTransfer.TeamIds);
             }
         }
 
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Models
             {
                 int[] testTeamId = nonemptyTeamId;
                 RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
-                Assert.Equal(repositoryTransfer.TeamId, testTeamId);
+                Assert.Equal(repositoryTransfer.TeamIds, testTeamId);
             }
         }
     }

--- a/Octokit.Tests/Models/RepositoryTransferTest.cs
+++ b/Octokit.Tests/Models/RepositoryTransferTest.cs
@@ -81,14 +81,6 @@ namespace Octokit.Tests.Models
                 RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
                 Assert.Equal(repositoryTransfer.TeamId, testTeamId);
             }
-
-            [Fact]
-            public void DoesntKeepReferenceToTeamId()
-            {
-                int[] testTeamId = nonemptyTeamId;
-                RepositoryTransfer repositoryTransfer = new RepositoryTransfer(nonemptyName, testTeamId);
-                Assert.False(Object.ReferenceEquals(repositoryTransfer.TeamId, testTeamId));
-            }
         }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoriesClientTests.cs
@@ -21,6 +21,71 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheTransferMethod
+        {
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                Assert.Throws<ArgumentNullException>(
+                    () => client.Transfer(null, "name", transfer));
+                Assert.Throws<ArgumentNullException>(
+                    () => client.Transfer("owner", null, transfer));
+                Assert.Throws<ArgumentNullException>(
+                    () => client.Transfer("owner", "name", null));
+            }
+            
+            [Fact]
+            public void EnsuresNonNullArgumentsById()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var transfer = new RepositoryTransfer("newOwner");
+                var repositoryId = 1;
+
+                Assert.Throws<ArgumentNullException>(
+                    () => client.Transfer(repositoryId, null));
+            }
+
+            [Fact]
+            public void EnsuresNonEmptyArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                Assert.Throws<ArgumentException>(
+                    () => client.Transfer("", "name", transfer));
+                Assert.Throws<ArgumentException>(
+                    () => client.Transfer("owner", "", transfer));
+            }
+
+            [Fact]
+            public void CallsIntoClient()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                client.Transfer("owner", "name", transfer);
+                gitHubClient.Repository.Received().Transfer("owner", "name", transfer);
+            }
+
+            [Fact]
+            public void CallsIntoClientById()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoriesClient(gitHubClient);
+                var transfer = new RepositoryTransfer("newOwner");
+
+                client.Transfer(1, transfer);
+                gitHubClient.Repository.Received().Transfer(1, transfer);
+            }
+        }
+
         public class TheDeleteMethod
         {
             [Fact]

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -106,11 +106,11 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
-        Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
+        Task<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer);
 
         /// <summary>
         /// Transfers the ownership of the specified repository.

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -112,6 +112,8 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
 
+        Task<Repository> Transfer(long id, RepositoryTransfer repositoryTransfer);
+
         /// <summary>
         /// Gets the specified repository.
         /// </summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -112,7 +112,7 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
 
-        Task<Repository> Transfer(long id, RepositoryTransfer repositoryTransfer);
+        Task<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer);
 
         /// <summary>
         /// Gets the specified repository.

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -108,7 +108,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="currentOwner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="repositoryTransfer">Reposoitory transfer information</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
         Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -112,6 +112,15 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
 
+        /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
         Task<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer);
 
         /// <summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -101,6 +101,17 @@ namespace Octokit
         Task Delete(long repositoryId);
 
         /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryTransfer">Reposoitory transfer information</param>
+        Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
+
+        /// <summary>
         /// Gets the specified repository.
         /// </summary>
         /// <remarks>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -109,6 +109,7 @@ namespace Octokit
         /// <param name="currentOwner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
         Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer);
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -169,17 +169,17 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
         /// </remarks>
-        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
-        public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
+        public Task<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer)
         {
-            Ensure.ArgumentNotNullOrEmptyString(currentOwner, nameof(currentOwner));
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
 
-            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(owner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -172,6 +172,7 @@ namespace Octokit
         /// <param name="currentOwner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
         public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
         {
             return ApiConnection.Post<Repository>(ApiUrls.Repository(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -178,9 +178,18 @@ namespace Octokit
             return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
-        public Task<Repository> Transfer(long id, RepositoryTransfer repositoryTransfer)
+        /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
+        /// <returns>A <see cref="Repository"/></returns>
+        public Task<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
         {
-            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(id), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(repositoryId), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -164,6 +164,20 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Transfers the ownership of the specified repository.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/#transfer-a-repository">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="repositoryTransfer">Reposoitory transfer information</param>
+        public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
+        {
+            return ApiConnection.Post<Repository>(ApiUrls.Repository(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
+        }
+
+        /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -175,6 +175,10 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
         {
+            Ensure.ArgumentNotNullOrEmptyString(currentOwner, nameof(currentOwner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
+
             return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
@@ -189,6 +193,8 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         public Task<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
         {
+            Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
+
             return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(repositoryId), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -175,7 +175,7 @@ namespace Octokit
         /// <returns>A <see cref="Repository"/></returns>
         public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
         {
-            return ApiConnection.Post<Repository>(ApiUrls.Repository(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -178,6 +178,11 @@ namespace Octokit
             return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
         }
 
+        public Task<Repository> Transfer(long id, RepositoryTransfer repositoryTransfer)
+        {
+            return ApiConnection.Post<Repository>(ApiUrls.RepositoryTransfer(id), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);
+        }
+
         /// <summary>
         /// Updates the specified repository with the values given in <paramref name="update"/>
         /// </summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -171,7 +171,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="currentOwner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="repositoryTransfer">Reposoitory transfer information</param>
+        /// <param name="repositoryTransfer">Repository transfer information</param>
         public Task<Repository> Transfer(string currentOwner, string name, RepositoryTransfer repositoryTransfer)
         {
             return ApiConnection.Post<Repository>(ApiUrls.Repository(currentOwner, name), repositoryTransfer, AcceptHeaders.RepositoryTransferPreview);

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -61,6 +61,8 @@ namespace Octokit
 
         public const string LabelsApiPreview = "application/vnd.github.symmetra-preview+json";
 
+        public const string RepositoryTransferPreview = "application/vnd.github.nightshade-preview+json";
+
         /// <summary>
         /// Combines multiple preview headers. GitHub API supports Accept header with multiple
         /// values separated by comma.

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1845,6 +1845,11 @@ namespace Octokit
             return "repos/{0}/{1}/transfer".FormatUri(currentOwner, name);
         }
 
+        /// <summary>
+        /// Returns the <see cref="Uri"/> for a repository transfer.
+        /// </summary>
+        /// <param name="repositoryId">The id of the repository</param>
+        /// <returns></returns>
         public static Uri RepositoryTransfer(long repositoryId)
         {
             return "repositories/{0}/transfer".FormatUri(repositoryId);

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1835,6 +1835,17 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> for a repository transfer.
+        /// </summary>
+        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <returns></returns>
+        public static Uri RepositoryTransfer(string currentOwner, string name)
+        {
+            return "repos/{0}/{1}/transfer".FormatUri(currentOwner, name);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> for repository commits.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1845,6 +1845,11 @@ namespace Octokit
             return "repos/{0}/{1}/transfer".FormatUri(currentOwner, name);
         }
 
+        public static Uri RepositoryTransfer(long id)
+        {
+            return "repositories/{0}/transfer".FormatUri(id);
+        }
+
         /// <summary>
         /// Returns the <see cref="Uri"/> for repository commits.
         /// </summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1837,12 +1837,12 @@ namespace Octokit
         /// <summary>
         /// Returns the <see cref="Uri"/> for a repository transfer.
         /// </summary>
-        /// <param name="currentOwner">The current owner of the repository</param>
+        /// <param name="owner">The current owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
-        public static Uri RepositoryTransfer(string currentOwner, string name)
+        public static Uri RepositoryTransfer(string owner, string name)
         {
-            return "repos/{0}/{1}/transfer".FormatUri(currentOwner, name);
+            return "repos/{0}/{1}/transfer".FormatUri(owner, name);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -1845,9 +1845,9 @@ namespace Octokit
             return "repos/{0}/{1}/transfer".FormatUri(currentOwner, name);
         }
 
-        public static Uri RepositoryTransfer(long id)
+        public static Uri RepositoryTransfer(long repositoryId)
         {
-            return "repositories/{0}/transfer".FormatUri(id);
+            return "repositories/{0}/transfer".FormatUri(repositoryId);
         }
 
         /// <summary>

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -50,15 +51,15 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Checks a list argument to ensure it isn't null or empty.
+        /// Checks an enumerable argument to ensure it isn't null or empty.
         /// </summary>
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
-        public static void ArgumentNotNullOrEmptyList<T>([ValidatedNotNull]IReadOnlyList<T> value, string name)
+        public static void ArgumentNotNullOrEmptyEnumerable<T>([ValidatedNotNull]IEnumerable<T> value, string name)
         {
             ArgumentNotNull(value, name);
-            if (value.Count > 0) return;
-
+            if (Enumerable.Any(value)) return;
+            
             throw new ArgumentException("List cannot be empty", name);
         }
     }

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -47,6 +47,14 @@ namespace Octokit
 
             throw new ArgumentException("Timespan must be greater than zero", name);
         }
+
+        public static void ArgumentNotNullOrEmptyArray<T>([ValidatedNotNull]T[] array, string name)
+        {
+            ArgumentNotNull(array, name);
+            if (array.Length > 0) return;
+
+            throw new ArgumentException("Array cannot be empty", name);
+        }
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -48,6 +48,11 @@ namespace Octokit
             throw new ArgumentException("Timespan must be greater than zero", name);
         }
 
+        /// <summary>
+        /// Checks an array argument to ensure it isn't null or empty.
+        /// </summary>
+        /// <param name = "value">The argument value to check</param>
+        /// <param name = "name">The name of the argument</param>
         public static void ArgumentNotNullOrEmptyArray<T>([ValidatedNotNull]T[] value, string name)
         {
             ArgumentNotNull(value, name);

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -48,10 +48,10 @@ namespace Octokit
             throw new ArgumentException("Timespan must be greater than zero", name);
         }
 
-        public static void ArgumentNotNullOrEmptyArray<T>([ValidatedNotNull]T[] array, string name)
+        public static void ArgumentNotNullOrEmptyArray<T>([ValidatedNotNull]T[] value, string name)
         {
-            ArgumentNotNull(array, name);
-            if (array.Length > 0) return;
+            ArgumentNotNull(value, name);
+            if (value.Length > 0) return;
 
             throw new ArgumentException("Array cannot be empty", name);
         }

--- a/Octokit/Helpers/Ensure.cs
+++ b/Octokit/Helpers/Ensure.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit
@@ -49,16 +50,16 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Checks an array argument to ensure it isn't null or empty.
+        /// Checks a list argument to ensure it isn't null or empty.
         /// </summary>
         /// <param name = "value">The argument value to check</param>
         /// <param name = "name">The name of the argument</param>
-        public static void ArgumentNotNullOrEmptyArray<T>([ValidatedNotNull]T[] value, string name)
+        public static void ArgumentNotNullOrEmptyList<T>([ValidatedNotNull]IReadOnlyList<T> value, string name)
         {
             ArgumentNotNull(value, name);
-            if (value.Length > 0) return;
+            if (value.Count > 0) return;
 
-            throw new ArgumentException("Array cannot be empty", name);
+            throw new ArgumentException("List cannot be empty", name);
         }
     }
 

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -32,21 +32,8 @@ namespace Octokit
         {
             get
             {
-                StringBuilder strBuilder = new StringBuilder();
-                strBuilder.AppendFormat(CultureInfo.InvariantCulture, "NewOwner: {0}", NewOwner);
-                strBuilder.Append(", TeamId: ");
-                if (TeamId == null) {
-                    strBuilder.Append("null");
-                    return strBuilder.ToString();
-                }
-
-                strBuilder.Append("[ ");
-                foreach (int id in TeamId)
-                {
-                    strBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0} ", id.ToString());
-                }
-                strBuilder.Append("]");
-                return strBuilder.ToString();
+                string teamIdStr = string.Join(", ", TeamId ?? new int[0]);
+                return string.Format(CultureInfo.InvariantCulture, "NewOwner: {0}, TeamId: [{1}]", NewOwner, teamIdStr);
             }
         }
     }

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -36,12 +36,12 @@ namespace Octokit
         /// Teams can only be added to organization-owned repositories, so this constructor
         /// will create an invalid description if that is not the case.
         /// </remarks>
-        public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamId)
+        public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamIds)
             : this(newOwner)
         {
-            Ensure.ArgumentNotNullOrEmptyEnumerable(teamId, nameof(teamId));
+            Ensure.ArgumentNotNullOrEmptyEnumerable(teamIds, nameof(teamIds));
 
-            TeamId = teamId;
+            TeamIds = teamIds;
         }
 
         /// <summary>
@@ -56,14 +56,14 @@ namespace Octokit
         /// Teams can only be added to organization-owned repositories, so this constructor
         /// will create an invalid description if that is not the case.
         /// </remarks>
-        public IReadOnlyList<int> TeamId { get; set; }
+        public IReadOnlyList<int> TeamIds { get; set; }
 
         internal string DebuggerDisplay
         {
             get
             {
-                string teamIdStr = string.Join(", ", TeamId ?? new int[0]);
-                return string.Format(CultureInfo.InvariantCulture, "NewOwner: {0}, TeamId: [{1}]", NewOwner, teamIdStr);
+                string teamIdsStr = string.Join(", ", TeamIds ?? new int[0]);
+                return string.Format(CultureInfo.InvariantCulture, "NewOwner: {0}, TeamIds: [{1}]", NewOwner, teamIdsStr);
             }
         }
     }

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -13,9 +13,13 @@ namespace Octokit
     public class RepositoryTransfer
     {
         /// <summary>
-        /// Creates a new repository transfer description where TeamId is empty.
+        /// Creates a new repository transfer description with no team Ids.
         /// </summary>
         /// <param name="newOwner">The new owner of the repository after the transfer.</param>
+        /// <remarks>
+        /// This is the only valid constructor for repositories whose current owner is not an
+        /// organization.
+        /// </remarks>
         public RepositoryTransfer(string newOwner)
         {
             Ensure.ArgumentNotNullOrEmptyString(newOwner, nameof(newOwner));

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -14,8 +14,7 @@ namespace Octokit
         public RepositoryTransfer(string newOwner, int[] teamId)
             : this(newOwner)
         {
-            // TODO Create Ensure method to check for empty arrays
-            // Ensure.ArgumentNotNullOrEmptyArray(teamId, nameof(teamId));
+            Ensure.ArgumentNotNullOrEmptyArray(teamId, nameof(teamId));
 
             TeamId = new int[teamId.Length];
             Array.Copy(teamId, TeamId, teamId.Length);

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Text;
+using System.Diagnostics;
+using System.Globalization;
 
 namespace Octokit
 {
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryTransfer
     {
         public RepositoryTransfer(string newOwner)
@@ -23,5 +27,27 @@ namespace Octokit
         public string NewOwner { get; set; }
 
         public int[] TeamId { get; set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                StringBuilder strBuilder = new StringBuilder();
+                strBuilder.AppendFormat(CultureInfo.InvariantCulture, "NewOwner: {0}", NewOwner);
+                strBuilder.Append(", TeamId: ");
+                if (TeamId == null) {
+                    strBuilder.Append("null");
+                    return strBuilder.ToString();
+                }
+
+                strBuilder.Append("[ ");
+                foreach (int id in TeamId)
+                {
+                    strBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0} ", id.ToString());
+                }
+                strBuilder.Append("]");
+                return strBuilder.ToString();
+            }
+        }
     }
 }

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Octokit
+{
+    public class RepositoryTransfer
+    {
+        public RepositoryTransfer(string newOwner)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(newOwner, nameof(newOwner));
+
+            NewOwner = newOwner;
+        }
+
+        public RepositoryTransfer(string newOwner, int[] teamId)
+            : this(newOwner)
+        {
+            // TODO Create Ensure method to check for empty arrays
+            // Ensure.ArgumentNotNullOrEmptyArray(teamId, nameof(teamId));
+
+            TeamId = new int[teamId.Length];
+            Array.Copy(teamId, TeamId, teamId.Length);
+        }
+
+        public string NewOwner { get; set; }
+
+        public int[] TeamId { get; set; }
+    }
+}

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Diagnostics;
 using System.Globalization;
+using System.Collections.Generic;
 
 namespace Octokit
 {
@@ -15,18 +16,17 @@ namespace Octokit
             NewOwner = newOwner;
         }
 
-        public RepositoryTransfer(string newOwner, int[] teamId)
+        public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamId)
             : this(newOwner)
         {
-            Ensure.ArgumentNotNullOrEmptyArray(teamId, nameof(teamId));
+            Ensure.ArgumentNotNullOrEmptyList(teamId, nameof(teamId));
 
-            TeamId = new int[teamId.Length];
-            Array.Copy(teamId, TeamId, teamId.Length);
+            TeamId = teamId;
         }
 
         public string NewOwner { get; set; }
 
-        public int[] TeamId { get; set; }
+        public IReadOnlyList<int> TeamId { get; set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -6,9 +6,16 @@ using System.Collections.Generic;
 
 namespace Octokit
 {
+    /// <summary>
+    /// Describes the transfer of a repository to a new owner.
+    /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class RepositoryTransfer
     {
+        /// <summary>
+        /// Creates a new repository transfer description where TeamId is empty.
+        /// </summary>
+        /// <param name="newOwner">The new owner of the repository after the transfer.</param>
         public RepositoryTransfer(string newOwner)
         {
             Ensure.ArgumentNotNullOrEmptyString(newOwner, nameof(newOwner));
@@ -16,6 +23,15 @@ namespace Octokit
             NewOwner = newOwner;
         }
 
+        /// <summary>
+        /// Creates a new repository transfer description.
+        /// </summary>
+        /// <param name="newOwner">The new owner of the repository after the transfer.</param>
+        /// <param name="teamId">A list of team Ids to add to the repository after the transfer.</param>
+        /// <remarks>
+        /// Teams can only be added to organization-owned repositories, so this constructor
+        /// will create an invalid description if that is not the case.
+        /// </remarks>
         public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamId)
             : this(newOwner)
         {
@@ -24,8 +40,18 @@ namespace Octokit
             TeamId = teamId;
         }
 
+        /// <summary>
+        /// The new owner of the repository after the transfer.
+        /// </summary>
         public string NewOwner { get; set; }
 
+        /// <summary>
+        /// A list of team Ids to add to the repository after the transfer.
+        /// </summary>
+        /// <remarks>
+        /// Teams can only be added to organization-owned repositories, so this constructor
+        /// will create an invalid description if that is not the case.
+        /// </remarks>
         public IReadOnlyList<int> TeamId { get; set; }
 
         internal string DebuggerDisplay

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -19,7 +19,7 @@ namespace Octokit
         public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamId)
             : this(newOwner)
         {
-            Ensure.ArgumentNotNullOrEmptyList(teamId, nameof(teamId));
+            Ensure.ArgumentNotNullOrEmptyEnumerable(teamId, nameof(teamId));
 
             TeamId = teamId;
         }

--- a/Octokit/Models/Request/RepositoryTransfer.cs
+++ b/Octokit/Models/Request/RepositoryTransfer.cs
@@ -16,10 +16,6 @@ namespace Octokit
         /// Creates a new repository transfer description with no team Ids.
         /// </summary>
         /// <param name="newOwner">The new owner of the repository after the transfer.</param>
-        /// <remarks>
-        /// This is the only valid constructor for repositories whose current owner is not an
-        /// organization.
-        /// </remarks>
         public RepositoryTransfer(string newOwner)
         {
             Ensure.ArgumentNotNullOrEmptyString(newOwner, nameof(newOwner));
@@ -31,11 +27,7 @@ namespace Octokit
         /// Creates a new repository transfer description.
         /// </summary>
         /// <param name="newOwner">The new owner of the repository after the transfer.</param>
-        /// <param name="teamId">A list of team Ids to add to the repository after the transfer.</param>
-        /// <remarks>
-        /// Teams can only be added to organization-owned repositories, so this constructor
-        /// will create an invalid description if that is not the case.
-        /// </remarks>
+        /// <param name="teamIds">A list of team Ids to add to the repository after the transfer (only applies to transferring to an Organization).</param>
         public RepositoryTransfer(string newOwner, IReadOnlyList<int> teamIds)
             : this(newOwner)
         {
@@ -50,12 +42,8 @@ namespace Octokit
         public string NewOwner { get; set; }
 
         /// <summary>
-        /// A list of team Ids to add to the repository after the transfer.
+        /// A list of team Ids to add to the repository after the transfer (only applies to transferring to an Organization).
         /// </summary>
-        /// <remarks>
-        /// Teams can only be added to organization-owned repositories, so this constructor
-        /// will create an invalid description if that is not the case.
-        /// </remarks>
         public IReadOnlyList<int> TeamIds { get; set; }
 
         internal string DebuggerDisplay


### PR DESCRIPTION
Pull request addressing #1718 
- [x] (From issue) Repository transfer should be implemented as a ```Transfer``` method on the ```IRepositoriesClient``` and ```IObservableRepositoriesClient``` clients
- [x] (From issue) Accept header ```application/vnd.github.nightshade-preview+json``` is required, to enable the preview functionality
- [x] (From issue) The ```TeamId``` field on the request object only applies to organisation owned repositories, so the ```ctor``` of the request object class should reflect this by oferring an overload that doesn't require this input, and the xmldoc should also make mention of the fact the ```team_id``` only applies to org repositories
- [x] (From ```CONTRIBUTING.md```) XML documentation on the new methods
- [x] (From ```CONTRIBUTING.md```) Run convention tests successfully
- [x] (From ```CONTRIBUTING.md```) Create new unit tests for request object constructor
- [x] (From ```CONTRIBUTING.md```) Integration tests
- [x] Add unit tests for the ```Transfer``` client methods in [RepositoriesClientTest](https://github.com/octokit/octokit.net/blob/master/Octokit.Tests/Clients/RepositoriesClientTests.cs)
- [x] Implement 2nd endpoint (if it exists (it probably does)) that takes the repository Id ```/repositories/:id/transfer```
- [x] Use IReadOnlyList<int> rather than a normal int[] array for TeamId
- [x] Do something more succinct for ```DebuggerDisplay``` property in ```RepositoryTransfer```
- [x] Make Ensure.NotNullOrEmptyList into Ensure.NotNullOrEmptyEnumerable
- [x] XmlDoc comments should be added to RepositoryTransfer
- [x] Add XmlDoc for second endpoint
- [x] Implement integration tests
- [x] Debug integration tests for transferring with team ids
---
Points of concern:
- I'm not sure if I'm the one supposed to implement and/or run the integration tests, but if it is me then I have no idea of what to do. Could someone please point me in the right direction?
- Unit tests were all successful, but I'm not sure they've covered everything they were supposed to.

---
Edit: Updated "to do" list in replies
Edit 2: Update main "to do" list