### PR TITLE
A missing event state: comment_deleted

### DIFF
--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -284,6 +284,12 @@ namespace Octokit
         /// An issue that a user had previously marked as a duplicate of another issue is no longer considered a duplicate.
         /// </summary>
         [Parameter(Value = "unmarked_as_duplicate")]
-        UnmarkedAsDuplicate
+        UnmarkedAsDuplicate,
+        
+        /// <summary>
+        /// An issue comment was deleted.
+        /// </summary>
+        [Parameter(Value = "comment_deleted")]
+        CommentDeleted
     }
 }

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -275,9 +275,15 @@ namespace Octokit
         CommitCommented,
         
         /// <summary>
-        /// A commit comment was made.
+        /// A user with write permissions marked an issue as a duplicate of another issue or a pull request as a duplicate of another pull request.
         /// </summary>
-        [Parameter(Value = "comment_deleted")]
-        CommentDeleted
+        [Parameter(Value = "marked_as_duplicate")]
+        MarkedAsDuplicate,
+        
+        /// <summary>
+        /// An issue that a user had previously marked as a duplicate of another issue is no longer considered a duplicate.
+        /// </summary>
+        [Parameter(Value = "unmarked_as_duplicate")]
+        UnmarkedAsDuplicate
     }
 }

--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -272,6 +272,12 @@ namespace Octokit
         /// A commit comment was made.
         /// </summary>
         [Parameter(Value = "commit-commented")]
-        CommitCommented
+        CommitCommented,
+        
+        /// <summary>
+        /// A commit comment was made.
+        /// </summary>
+        [Parameter(Value = "comment_deleted")]
+        CommentDeleted
     }
 }


### PR DESCRIPTION
Currently, Octokit does not support the comment_deleted event status. As an example, I was unable to get the Event.Value of one of the [VSCode issues](https://api.github.com/repos/Microsoft/vscode/issues/events/1246084209) and i recieved the following error:

> Requested value 'comment_deleted' was not found.

I'm using the latest version, which is 0.30.0