### PR TITLE
Fix exception in RepositoriesClient.GetAllLanguages() when no languages exist

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoriesClientTests.cs
@@ -1343,6 +1343,30 @@ public class RepositoriesClientTests
             Assert.NotEmpty(languages);
             Assert.True(languages.Any(l => l.Name == "C#"));
         }
+
+        [IntegrationTest]
+        public async Task GetsEmptyLanguagesWhenNone()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var languages = await github.Repository.GetAllLanguages(context.RepositoryOwner, context.RepositoryName);
+
+                Assert.Empty(languages);
+            }
+        }
+
+        [IntegrationTest]
+        public async Task GetsEmptyLanguagesWhenNoneWithRepositoryId()
+        {
+            var github = Helper.GetAuthenticatedClient();
+            using (var context = await github.CreateRepositoryContext(Helper.MakeNameWithTimestamp("public-repo")))
+            {
+                var languages = await github.Repository.GetAllLanguages(context.RepositoryId);
+
+                Assert.Empty(languages);
+            }
+        }
     }
 
     public class TheGetAllTagsMethod

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -693,7 +693,8 @@ namespace Octokit
             var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
 
             return new ReadOnlyCollection<RepositoryLanguage>(
-                data.Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());
+                (data ?? new Dictionary<string, long>())
+                .Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());
         }
 
         /// <summary>
@@ -710,7 +711,8 @@ namespace Octokit
             var data = await ApiConnection.Get<Dictionary<string, long>>(endpoint).ConfigureAwait(false);
 
             return new ReadOnlyCollection<RepositoryLanguage>(
-                data.Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());
+                (data ?? new Dictionary<string, long>())
+                .Select(kvp => new RepositoryLanguage(kvp.Key, kvp.Value)).ToList());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1820 

This endpoint is a bit "special" as it returns an object hash which we deserialize as a `Dictionary<string, long>` and then convert into a `ReadOnlyList`.  When no languages exist, the API returns `null` which then throws an exception in our conversion process.

This fix handles this situation by returning an empty list.