### PR TITLE
Docs: appClient - add GitHubApps subclass to method calls

### DIFF
--- a/docs/github-apps.md
+++ b/docs/github-apps.md
@@ -54,13 +54,13 @@ Now we have an authenticated `GitHubApp` (`appClient`), we can query various top
 
 ``` csharp
 // Get the current authenticated GitHubApp
-var app = await appClient.GetCurrent();
+var app = await appClient.GitHubApps.GetCurrent();
 
 // Get a list of installations for the authenticated GitHubApp
-var installations = await appClient.GetAllInstallationsForCurrent();
+var installations = await appClient.GitHubApps.GetAllInstallationsForCurrent();
 
 // Get a specific installation of the authenticated GitHubApp by it's installation Id
-var installation = await appClient.GetInstallation(123);
+var installation = await appClient.GitHubApps.GetInstallation(123);
 
 ```
 
@@ -72,7 +72,7 @@ In order to do more than top level calls, a `GitHubApp` needs to authenticate as
 
 ``` csharp
 // Create an Installation token for Insallation Id 123
-var response = await appClient.CreateInstallationToken(123);
+var response = await appClient.GitHubApps.CreateInstallationToken(123);
 
 // NOTE - the token will expire in 1 hour!
 response.ExpiresAt;


### PR DESCRIPTION
In implementing this, I found that `appClient.GetCurrent()` (etc.) don't work.
Appears that all the GitHub Apps methods were moved into a subclass called `GitHubApps`, so that `appClient.GitHubApps.GetCurrent()` etc does work. 

Could also be written by adding the `.GitHubApps` onto the end of the `appClient` constructor; not sure which would be better from a documentation standpoint.

Anyway, took me a while to figure it out, thought that updated docs might help others.