### PR TITLE
Implement changes to Checks API for Annotations models and re-request endpoint

### DIFF
--- a/Octokit.Reactive/Clients/IObservableCheckSuitesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCheckSuitesClient.cs
@@ -151,6 +151,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         IObservable<bool> Request(string owner, string name, CheckSuiteTriggerRequest request);
 
         /// <summary>
@@ -161,6 +162,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         IObservable<bool> Request(long repositoryId, CheckSuiteTriggerRequest request);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableCheckSuitesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableCheckSuitesClient.cs
@@ -164,5 +164,26 @@ namespace Octokit.Reactive
         /// <param name="request">Details of the Check Suite request</param>
         [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         IObservable<bool> Request(long repositoryId, CheckSuiteTriggerRequest request);
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        IObservable<bool> Rerequest(string owner, string name, long checkSuiteId);
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        IObservable<bool> Rerequest(long repositoryId, long checkSuiteId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCheckSuitesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCheckSuitesClient.cs
@@ -268,5 +268,35 @@ namespace Octokit.Reactive
 
             return _client.Request(repositoryId, request).ToObservable();
         }
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        public IObservable<bool> Rerequest(string owner, string name, long checkSuiteId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            return _client.Rerequest(owner, name, checkSuiteId).ToObservable();
+        }
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        public IObservable<bool> Rerequest(long repositoryId, long checkSuiteId)
+        {
+            return _client.Rerequest(repositoryId, checkSuiteId).ToObservable();
+        }
     }
 }

--- a/Octokit.Reactive/Clients/ObservableCheckSuitesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableCheckSuitesClient.cs
@@ -243,6 +243,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public IObservable<bool> Request(string owner, string name, CheckSuiteTriggerRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -260,7 +261,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
-
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public IObservable<bool> Request(long repositoryId, CheckSuiteTriggerRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));

--- a/Octokit.Tests.Integration/Clients/CheckRunsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CheckRunsClientTests.cs
@@ -409,7 +409,7 @@ namespace Octokit.Tests.Integration.Clients
                         {
                             Annotations = new[]
                             {
-                                new NewCheckRunAnnotation("file.txt", "blob", 1, 1, CheckWarningLevel.Warning, "this is a warning")
+                                new NewCheckRunAnnotation("file.txt", 1, 1, CheckAnnotationLevel.Warning, "this is a warning")
                             }
                         }
                     };
@@ -421,7 +421,7 @@ namespace Octokit.Tests.Integration.Clients
                     // Check result
                     Assert.Equal(1, annotations.Count);
                     Assert.Equal("this is a warning", annotations.First().Message);
-                    Assert.Equal(CheckWarningLevel.Warning, annotations.First().WarningLevel);
+                    Assert.Equal(CheckAnnotationLevel.Warning, annotations.First().AnnotationLevel);
                 }
             }
 
@@ -442,7 +442,7 @@ namespace Octokit.Tests.Integration.Clients
                         {
                             Annotations = new[]
                             {
-                                new NewCheckRunAnnotation("file.txt", "blob", 1, 1, CheckWarningLevel.Warning, "this is a warning")
+                                new NewCheckRunAnnotation("file.txt", 1, 1, CheckAnnotationLevel.Warning, "this is a warning")
                             }
                         }
                     };
@@ -454,7 +454,7 @@ namespace Octokit.Tests.Integration.Clients
                     // Check result
                     Assert.Equal(1, annotations.Count);
                     Assert.Equal("this is a warning", annotations.First().Message);
-                    Assert.Equal(CheckWarningLevel.Warning, annotations.First().WarningLevel);
+                    Assert.Equal(CheckAnnotationLevel.Warning, annotations.First().AnnotationLevel);
                 }
             }
         }

--- a/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
@@ -213,6 +213,7 @@ namespace Octokit.Tests.Integration.Clients
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public class TheRequestMethod
         {
             IGitHubClient _github;
@@ -252,5 +253,6 @@ namespace Octokit.Tests.Integration.Clients
                 }
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
@@ -213,48 +213,6 @@ namespace Octokit.Tests.Integration.Clients
             }
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        public class TheRequestMethod
-        {
-            IGitHubClient _github;
-            IGitHubClient _githubAppInstallation;
-
-            public TheRequestMethod()
-            {
-                _github = Helper.GetAuthenticatedClient();
-
-                // Authenticate as a GitHubApp Installation
-                _githubAppInstallation = Helper.GetAuthenticatedGitHubAppInstallationForOwner(Helper.UserName);
-            }
-
-            [GitHubAppsTest]
-            public async Task RequestsCheckSuite()
-            {
-                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
-                {
-                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryOwner, repoContext.RepositoryName, "master");
-
-                    var result = await _githubAppInstallation.Check.Suite.Request(repoContext.RepositoryOwner, repoContext.RepositoryName, new CheckSuiteTriggerRequest(headCommit.Sha));
-
-                    Assert.True(result);
-                }
-            }
-
-            [GitHubAppsTest]
-            public async Task RequestsCheckSuiteWithRepositoryId()
-            {
-                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
-                {
-                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
-
-                    var result = await _githubAppInstallation.Check.Suite.Request(repoContext.RepositoryId, new CheckSuiteTriggerRequest(headCommit.Sha));
-
-                    Assert.True(result);
-                }
-            }
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
-
         public class TheRerequestMethod
         {
             IGitHubClient _github;

--- a/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CheckSuitesClientTests.cs
@@ -254,5 +254,51 @@ namespace Octokit.Tests.Integration.Clients
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        public class TheRerequestMethod
+        {
+            IGitHubClient _github;
+            IGitHubClient _githubAppInstallation;
+
+            public TheRerequestMethod()
+            {
+                _github = Helper.GetAuthenticatedClient();
+
+                // Authenticate as a GitHubApp Installation
+                _githubAppInstallation = Helper.GetAuthenticatedGitHubAppInstallationForOwner(Helper.UserName);
+            }
+
+            [GitHubAppsTest]
+            public async Task RerequestsCheckSuite()
+            {
+                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
+                {
+                    // Need to get a CheckSuiteId so we can test the Get method
+                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
+                    var checkSuite = (await _githubAppInstallation.Check.Suite.GetAllForReference(repoContext.RepositoryId, headCommit.Sha)).CheckSuites.First();
+
+                    // Get Check Suite by Id
+                    var result = await _githubAppInstallation.Check.Suite.Rerequest(repoContext.RepositoryOwner, repoContext.RepositoryName, checkSuite.Id);
+
+                    Assert.True(result);
+                }
+            }
+
+            [GitHubAppsTest]
+            public async Task RerequestsCheckSuiteWithRepositoryId()
+            {
+                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
+                {
+                    // Need to get a CheckSuiteId so we can test the Get method
+                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
+                    var checkSuite = (await _githubAppInstallation.Check.Suite.GetAllForReference(repoContext.RepositoryId, headCommit.Sha)).CheckSuites.First();
+
+                    // Get Check Suite by Id
+                    var result = await _githubAppInstallation.Check.Suite.Rerequest(repoContext.RepositoryId, checkSuite.Id);
+
+                    Assert.True(result);
+                }
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableCheckRunsClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCheckRunsClientTests.cs
@@ -410,7 +410,7 @@ namespace Octokit.Tests.Integration.Reactive
                         {
                             Annotations = new[]
                             {
-                                new NewCheckRunAnnotation("file.txt", "blob", 1, 1, CheckWarningLevel.Warning, "this is a warning")
+                                new NewCheckRunAnnotation("file.txt", 1, 1, CheckAnnotationLevel.Warning, "this is a warning")
                             }
                         }
                     };
@@ -422,7 +422,7 @@ namespace Octokit.Tests.Integration.Reactive
                     // Check result
                     Assert.Equal(1, annotations.Count);
                     Assert.Equal("this is a warning", annotations.First().Message);
-                    Assert.Equal(CheckWarningLevel.Warning, annotations.First().WarningLevel);
+                    Assert.Equal(CheckAnnotationLevel.Warning, annotations.First().AnnotationLevel);
                 }
             }
 
@@ -443,7 +443,7 @@ namespace Octokit.Tests.Integration.Reactive
                         {
                             Annotations = new[]
                             {
-                                new NewCheckRunAnnotation("file.txt", "blob", 1, 1, CheckWarningLevel.Warning, "this is a warning")
+                                new NewCheckRunAnnotation("file.txt", 1, 1, CheckAnnotationLevel.Warning, "this is a warning")
                             }
                         }
                     };
@@ -455,7 +455,7 @@ namespace Octokit.Tests.Integration.Reactive
                     // Check result
                     Assert.Equal(1, annotations.Count);
                     Assert.Equal("this is a warning", annotations.First().Message);
-                    Assert.Equal(CheckWarningLevel.Warning, annotations.First().WarningLevel);
+                    Assert.Equal(CheckAnnotationLevel.Warning, annotations.First().AnnotationLevel);
                 }
             }
         }

--- a/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
@@ -215,48 +215,6 @@ namespace Octokit.Tests.Integration.Reactive
             }
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        public class TheRequestMethod
-        {
-            IObservableGitHubClient _github;
-            IObservableGitHubClient _githubAppInstallation;
-
-            public TheRequestMethod()
-            {
-                _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
-
-                // Authenticate as a GitHubApp Installation
-                _githubAppInstallation = new ObservableGitHubClient(Helper.GetAuthenticatedGitHubAppInstallationForOwner(Helper.UserName));
-            }
-
-            [GitHubAppsTest]
-            public async Task RequestsCheckSuite()
-            {
-                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
-                {
-                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryOwner, repoContext.RepositoryName, "master");
-
-                    var result = await _githubAppInstallation.Check.Suite.Request(repoContext.RepositoryOwner, repoContext.RepositoryName, new CheckSuiteTriggerRequest(headCommit.Sha));
-
-                    Assert.True(result);
-                }
-            }
-
-            [GitHubAppsTest]
-            public async Task RequestsCheckSuiteWithRepositoryId()
-            {
-                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
-                {
-                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
-
-                    var result = await _githubAppInstallation.Check.Suite.Request(repoContext.RepositoryId, new CheckSuiteTriggerRequest(headCommit.Sha));
-
-                    Assert.True(result);
-                }
-            }
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
-
         public class TheRerequestMethod
         {
             IObservableGitHubClient _github;

--- a/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
@@ -215,6 +215,7 @@ namespace Octokit.Tests.Integration.Reactive
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public class TheRequestMethod
         {
             IObservableGitHubClient _github;
@@ -254,5 +255,6 @@ namespace Octokit.Tests.Integration.Reactive
                 }
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
+++ b/Octokit.Tests.Integration/Reactive/ObservableCheckSuitesClientTests.cs
@@ -256,5 +256,49 @@ namespace Octokit.Tests.Integration.Reactive
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        public class TheRerequestMethod
+        {
+            IObservableGitHubClient _github;
+            IObservableGitHubClient _githubAppInstallation;
+
+            public TheRerequestMethod()
+            {
+                _github = new ObservableGitHubClient(Helper.GetAuthenticatedClient());
+
+                // Authenticate as a GitHubApp Installation
+                _githubAppInstallation = new ObservableGitHubClient(Helper.GetAuthenticatedGitHubAppInstallationForOwner(Helper.UserName));
+            }
+
+            [GitHubAppsTest]
+            public async Task RerequestsCheckSuite()
+            {
+                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
+                {
+                    // Need to get a CheckSuiteId so we can test the Get method
+                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
+                    var checkSuite = (await _githubAppInstallation.Check.Suite.GetAllForReference(repoContext.RepositoryId, headCommit.Sha)).CheckSuites.First();
+
+                    var result = await _githubAppInstallation.Check.Suite.Rerequest(repoContext.RepositoryOwner, repoContext.RepositoryName, checkSuite.Id);
+
+                    Assert.True(result);
+                }
+            }
+
+            [GitHubAppsTest]
+            public async Task RerequestsCheckSuiteWithRepositoryId()
+            {
+                using (var repoContext = await _github.CreateRepositoryContext(new NewRepository(Helper.MakeNameWithTimestamp("public-repo")) { AutoInit = true }))
+                {
+                    // Need to get a CheckSuiteId so we can test the Get method
+                    var headCommit = await _github.Repository.Commit.Get(repoContext.RepositoryId, "master");
+                    var checkSuite = (await _githubAppInstallation.Check.Suite.GetAllForReference(repoContext.RepositoryId, headCommit.Sha)).CheckSuites.First();
+
+                    var result = await _githubAppInstallation.Check.Suite.Rerequest(repoContext.RepositoryId, checkSuite.Id);
+
+                    Assert.True(result);
+                }
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/CheckSuitesClientTests.cs
+++ b/Octokit.Tests/Clients/CheckSuitesClientTests.cs
@@ -332,6 +332,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public class TheRequestMethod
         {
             [Fact]
@@ -393,5 +394,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.Request("fake", "", request));
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit.Tests/Clients/CheckSuitesClientTests.cs
+++ b/Octokit.Tests/Clients/CheckSuitesClientTests.cs
@@ -395,5 +395,56 @@ namespace Octokit.Tests.Clients
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        public class TheRerequestMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var connection = MockedIApiConnection.PostReturnsHttpStatus(HttpStatusCode.Created);
+                var client = new CheckSuitesClient(connection);
+
+                await client.Rerequest("fake", "repo", 1);
+
+                connection.Connection.Received().Post(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/check-suites/1/rerequest"),
+                    Args.Object,
+                    "application/vnd.github.antiope-preview+json");
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var connection = MockedIApiConnection.PostReturnsHttpStatus(HttpStatusCode.Created);
+                var client = new CheckSuitesClient(connection);
+
+                await client.Rerequest(1, 1);
+
+                connection.Connection.Received().Post(
+                    Arg.Is<Uri>(u => u.ToString() == "repositories/1/check-suites/1/rerequest"),
+                    Args.Object,
+                    "application/vnd.github.antiope-preview+json");
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CheckSuitesClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Rerequest(null, "repo", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Rerequest("fake", null, 1));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new CheckSuitesClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Rerequest("", "repo", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Rerequest("fake", "", 1));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Clients/ProjectCardsClientTests.cs
+++ b/Octokit.Tests/Clients/ProjectCardsClientTests.cs
@@ -115,7 +115,10 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ProjectCardsClient(connection);
-                var updateCard = new ProjectCardUpdate("someNewNote");
+                var updateCard = new ProjectCardUpdate
+                {
+                    Note = "someNewNote"
+                };
 
                 await client.Update(1, updateCard);
 
@@ -129,7 +132,10 @@ namespace Octokit.Tests.Clients
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ProjectCardsClient(Substitute.For<IApiConnection>());
-                var updateCard = new ProjectCardUpdate("someNewNote");
+                var updateCard = new ProjectCardUpdate
+                {
+                    Note = "someNewNote"
+                };
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, null));
             }

--- a/Octokit.Tests/Reactive/ObservableCheckSuitesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCheckSuitesClientTests.cs
@@ -370,5 +370,50 @@ namespace Octokit.Tests.Clients
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        public class TheRerequestMethod
+        {
+            [Fact]
+            public async Task RequestsCorrectUrl()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCheckSuitesClient(gitHubClient);
+
+                client.Rerequest("fake", "repo", 1);
+
+                gitHubClient.Check.Suite.Received().Rerequest("fake", "repo", 1);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryId()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCheckSuitesClient(gitHubClient);
+
+                client.Rerequest(1, 1);
+
+                gitHubClient.Check.Suite.Received().Rerequest(1, 1);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCheckSuitesClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.Rerequest(null, "repo", 1));
+                Assert.Throws<ArgumentNullException>(() => client.Rerequest("fake", null, 1));
+            }
+
+            [Fact]
+            public async Task EnsuresNonEmptyArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableCheckSuitesClient(gitHubClient);
+
+                Assert.Throws<ArgumentException>(() => client.Rerequest("", "repo", 1));
+                Assert.Throws<ArgumentException>(() => client.Rerequest("fake", "", 1));
+            }
+        }
     }
 }

--- a/Octokit.Tests/Reactive/ObservableCheckSuitesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableCheckSuitesClientTests.cs
@@ -313,6 +313,7 @@ namespace Octokit.Tests.Clients
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public class TheRequestMethod
         {
             [Fact]
@@ -368,5 +369,6 @@ namespace Octokit.Tests.Clients
                 Assert.Throws<ArgumentException>(() => client.Request("fake", "", request));
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit.Tests/Reactive/ObservableProjectCardsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableProjectCardsClientTests.cs
@@ -113,7 +113,10 @@ namespace Octokit.Tests.Reactive
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableProjectCardsClient(gitHubClient);
-                var updateCard = new ProjectCardUpdate("someNewNote");
+                var updateCard = new ProjectCardUpdate
+                {
+                    Note = "someNewNote"
+                };
 
                 client.Update(1, updateCard);
 
@@ -124,7 +127,10 @@ namespace Octokit.Tests.Reactive
             public async Task EnsuresNonNullArguments()
             {
                 var client = new ObservableProjectCardsClient(Substitute.For<IGitHubClient>());
-                var updateCard = new ProjectCardUpdate("someNewNote");
+                var updateCard = new ProjectCardUpdate
+                {
+                    Note = "someNewNote"
+                };
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Update(1, null).ToTask());
             }

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -244,6 +245,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public async Task<bool> Request(string owner, string name, CheckSuiteTriggerRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -268,6 +270,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public async Task<bool> Request(long repositoryId, CheckSuiteTriggerRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -284,5 +284,49 @@ namespace Octokit
 
             return httpStatusCode == HttpStatusCode.Created;
         }
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        public async Task<bool> Rerequest(string owner, string name, long checkSuiteId)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+
+            var httpStatusCode = await Connection.Post(ApiUrls.CheckSuiteRerequest(owner, name, checkSuiteId), null, AcceptHeaders.ChecksApiPreview).ConfigureAwait(false);
+
+            if (httpStatusCode != HttpStatusCode.Created)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode);
+            }
+
+            return httpStatusCode == HttpStatusCode.Created;
+        }
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        public async Task<bool> Rerequest(long repositoryId, long checkSuiteId)
+        {
+            var httpStatusCode = await Connection.Post(ApiUrls.CheckSuiteRerequest(repositoryId, checkSuiteId), null, AcceptHeaders.ChecksApiPreview).ConfigureAwait(false);
+
+            if (httpStatusCode != HttpStatusCode.Created)
+            {
+                throw new ApiException("Invalid Status Code returned. Expected a 201", httpStatusCode);
+            }
+
+            return httpStatusCode == HttpStatusCode.Created;
+        }
     }
 }

--- a/Octokit/Clients/ICheckSuitesClient.cs
+++ b/Octokit/Clients/ICheckSuitesClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Octokit
 {
@@ -151,6 +152,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         Task<bool> Request(string owner, string name, CheckSuiteTriggerRequest request);
 
         /// <summary>
@@ -161,6 +163,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Details of the Check Suite request</param>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         Task<bool> Request(long repositoryId, CheckSuiteTriggerRequest request);
     }
 }

--- a/Octokit/Clients/ICheckSuitesClient.cs
+++ b/Octokit/Clients/ICheckSuitesClient.cs
@@ -165,5 +165,26 @@ namespace Octokit
         /// <param name="request">Details of the Check Suite request</param>
         [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         Task<bool> Request(long repositoryId, CheckSuiteTriggerRequest request);
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        Task<bool> Rerequest(string owner, string name, long checkSuiteId);
+
+        /// <summary>
+        /// Triggers GitHub to rerequest an existing check suite, without pushing new code to a repository
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/checks/suites/#request-check-suites">Check Suites API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        Task<bool> Rerequest(long repositoryId, long checkSuiteId);
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -4033,6 +4033,29 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Uri"/> that handles the check suite requests for the repository.
+        /// </summary>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        /// <returns>The <see cref="Uri"/> that handles the check suite requests for the repository.</returns>
+        public static Uri CheckSuiteRerequest(long repositoryId, long checkSuiteId)
+        {
+            return "repositories/{0}/check-suites/{1}/rerequest".FormatUri(repositoryId, checkSuiteId);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> that handles the check suite requests for the repository.
+        /// </summary>
+        /// <param name="owner">The owner of repo</param>
+        /// <param name="repo">The name of repo</param>
+        /// <param name="checkSuiteId">The Id of the check suite</param>
+        /// <returns>The <see cref="Uri"/> that handles the check suite requests for the repository.</returns>
+        public static Uri CheckSuiteRerequest(string owner, string repo, long checkSuiteId)
+        {
+            return "repos/{0}/{1}/check-suites/{2}/rerequest".FormatUri(owner, repo, checkSuiteId);
+        }
+
+        /// <summary>
         /// Returns the <see cref="Uri"/> that handles the check suite preferences for the repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -4014,6 +4014,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>The <see cref="Uri"/> that handles the check suite requests for the repository.</returns>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public static Uri CheckSuiteRequests(long repositoryId)
         {
             return "repositories/{0}/check-suite-requests".FormatUri(repositoryId);
@@ -4025,6 +4026,7 @@ namespace Octokit
         /// <param name="owner">The owner of repo</param>
         /// <param name="repo">The name of repo</param>
         /// <returns>The <see cref="Uri"/> that handles the check suite requests for the repository.</returns>
+        [Obsolete("This method has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
         public static Uri CheckSuiteRequests(string owner, string repo)
         {
             return "repos/{0}/{1}/check-suite-requests".FormatUri(owner, repo);

--- a/Octokit/Models/Common/CheckStatus.cs
+++ b/Octokit/Models/Common/CheckStatus.cs
@@ -1,4 +1,5 @@
-﻿using Octokit.Internal;
+﻿using System;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -35,6 +36,19 @@ namespace Octokit
         ActionRequired,
     }
 
+    public enum CheckAnnotationLevel
+    {
+        [Parameter(Value = "notice")]
+        Notice,
+
+        [Parameter(Value = "warning")]
+        Warning,
+
+        [Parameter(Value = "failure")]
+        Failure,
+    }
+
+    [Obsolete("This enum is replaced with CheckAnnotationLevel but may still be required on GitHub Enterprise 2.14")]
     public enum CheckWarningLevel
     {
         [Parameter(Value = "notice")]

--- a/Octokit/Models/Request/CheckSuiteTriggerRequest.cs
+++ b/Octokit/Models/Request/CheckSuiteTriggerRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -6,6 +7,7 @@ namespace Octokit
     /// <summary>
     /// Request to trigger the creation of a check suite
     /// </summary>
+    [Obsolete("This request has been deprecated in the GitHub Api, however can still be used on GitHub Enterprise 2.14")]
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class CheckSuiteTriggerRequest
     {

--- a/Octokit/Models/Request/NewCheckRunAnnotation.cs
+++ b/Octokit/Models/Request/NewCheckRunAnnotation.cs
@@ -83,6 +83,16 @@ namespace Octokit
         public int EndLine { get; protected set; }
 
         /// <summary>
+        /// Required. The start line of the annotation
+        /// </summary>
+        public int? StartColumn { get; set; }
+
+        /// <summary>
+        /// Required. The end line of the annotation
+        /// </summary>
+        public int? EndColumn { get; set; }
+
+        /// <summary>
         /// Required. The warning level of the annotation. Can be one of notice, warning, or failure
         /// </summary>
         [Obsolete("This property is replaced with AnnotationLevel but may still be required on GitHub Enterprise 2.14")]

--- a/Octokit/Models/Request/NewCheckRunAnnotation.cs
+++ b/Octokit/Models/Request/NewCheckRunAnnotation.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -9,12 +10,37 @@ namespace Octokit
         /// <summary>
         /// Constructs a CheckRunCreateAnnotation request object
         /// </summary>
+        /// <param name="path">Required. The path of the file to add an annotation to. For example, assets/css/main.css</param>
+        /// <param name="startLine">Required. The start line of the annotation</param>
+        /// <param name="endLine">Required. The end line of the annotation</param>
+        /// <param name="annotationLevel">Required. The level of the annotation. Can be one of notice, warning, or failure</param>
+        /// <param name="message">Required. A short description of the feedback for these lines of code. The maximum size is 64 KB</param>
+        public NewCheckRunAnnotation(string path, int startLine, int endLine, CheckAnnotationLevel annotationLevel, string message)
+        {
+            Path = path;
+            StartLine = startLine;
+            EndLine = endLine;
+            AnnotationLevel = annotationLevel;
+            Message = message;
+
+            // Ensure legacy properties are explicitly null
+#pragma warning disable CS0618 // Type or member is obsolete
+            Filename = null;
+            BlobHref = null;
+            WarningLevel = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>
+        /// Constructs a CheckRunCreateAnnotation request object (using Filename, BlobHref and WarningLevel)
+        /// </summary>
         /// <param name="filename">Required. The path of the file to add an annotation to. For example, assets/css/main.css</param>
         /// <param name="blobHref">Required. The file's full blob URL. You can find the blob_href in the response of the Get a single commit endpoint, by reading the blob_url from an element of the files array. You can also construct the blob URL from the head_sha, the repository, and the filename: https://github.com/:owner/:repo/blob/:head_sha/:filename </param>
         /// <param name="startLine">Required. The start line of the annotation</param>
         /// <param name="endLine">Required. The end line of the annotation</param>
         /// <param name="warningLevel">Required. The warning level of the annotation. Can be one of notice, warning, or failure</param>
         /// <param name="message">Required. A short description of the feedback for these lines of code. The maximum size is 64 KB</param>
+        [Obsolete("This ctor taking Filename, BlobHref and WarningLevel is deprecated but may still be required on GitHub Enterprise 2.14")]
         public NewCheckRunAnnotation(string filename, string blobHref, int startLine, int endLine, CheckWarningLevel warningLevel, string message)
         {
             Filename = filename;
@@ -23,16 +49,27 @@ namespace Octokit
             EndLine = endLine;
             WarningLevel = warningLevel;
             Message = message;
+
+            // Ensure new properties are explicitly null
+            Path = null;
+            AnnotationLevel = null;
         }
 
         /// <summary>
         /// Required. The path of the file to add an annotation to. For example, assets/css/main.css
         /// </summary>
+        [Obsolete("This property is replaced with Path but may still be required on GitHub Enterprise 2.14")]
         public string Filename { get; protected set; }
+
+        /// <summary>
+        /// Required. The path of the file to add an annotation to. For example, assets/css/main.css
+        /// </summary>
+        public string Path { get; protected set; }
 
         /// <summary>
         /// Required. The file's full blob URL. You can find the blob_href in the response of the Get a single commit endpoint, by reading the blob_url from an element of the files array. You can also construct the blob URL from the head_sha, the repository, and the filename: https://github.com/:owner/:repo/blob/:head_sha/:filename
         /// </summary>
+        [Obsolete("This property is deprecated but may still be required on GitHub Enterprise 2.14")]
         public string BlobHref { get; protected set; }
 
         /// <summary>
@@ -48,7 +85,13 @@ namespace Octokit
         /// <summary>
         /// Required. The warning level of the annotation. Can be one of notice, warning, or failure
         /// </summary>
-        public StringEnum<CheckWarningLevel> WarningLevel { get; protected set; }
+        [Obsolete("This property is replaced with AnnotationLevel but may still be required on GitHub Enterprise 2.14")]
+        public StringEnum<CheckWarningLevel>? WarningLevel { get; protected set; }
+
+        /// <summary>
+        /// Required. The level of the annotation. Can be one of notice, warning, or failure
+        /// </summary>
+        public StringEnum<CheckAnnotationLevel>? AnnotationLevel { get; protected set; }
 
         /// <summary>
         /// Required. A short description of the feedback for these lines of code. The maximum size is 64 KB
@@ -65,6 +108,8 @@ namespace Octokit
         /// </summary>
         public string RawDetails { get; set; }
 
-        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Filename: {0}, StartLine: {1}, WarningLevel: {2}", Filename, StartLine, WarningLevel.DebuggerDisplay);
+#pragma warning disable CS0618 // Type or member is obsolete
+        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Path: {0}, StartLine: {1}, AnnotationLevel: {2}", Path ?? Filename, StartLine, AnnotationLevel?.DebuggerDisplay ?? WarningLevel?.DebuggerDisplay);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit/Models/Response/CheckRunAnnotation.cs
+++ b/Octokit/Models/Response/CheckRunAnnotation.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Octokit
@@ -10,13 +11,34 @@ namespace Octokit
         {
         }
 
-        public CheckRunAnnotation(string filename, string blobHref, int startLine, int endLine, CheckWarningLevel warningLevel, string message, string title, string rawDetails)
+        public CheckRunAnnotation(string path, string blobHref, int startLine, int endLine, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
+        {
+            Path = path;
+            BlobHref = blobHref;
+            StartLine = startLine;
+            EndLine = endLine;
+            AnnotationLevel = annotationLevel;
+            Message = message;
+            Title = title;
+            RawDetails = rawDetails;
+
+            // Ensure legacy properties are explicitly null
+#pragma warning disable CS0618 // Type or member is obsolete
+            Filename = null;
+            WarningLevel = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Obsolete("This ctor taking Filename, BlobHref and WarningLevel is deprecated but may still be required on GitHub Enterprise 2.14")]
+        public CheckRunAnnotation(string filename, string path, string blobHref, int startLine, int endLine, CheckWarningLevel? warningLevel, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
         {
             Filename = filename;
+            Path = path;
             BlobHref = blobHref;
             StartLine = startLine;
             EndLine = endLine;
             WarningLevel = warningLevel;
+            AnnotationLevel = annotationLevel;
             Message = message;
             Title = title;
             RawDetails = rawDetails;
@@ -25,7 +47,13 @@ namespace Octokit
         /// <summary>
         /// The path of the file the annotation refers to
         /// </summary>
+        [Obsolete("This property is replaced with Path but may still be required on GitHub Enterprise 2.14")]
         public string Filename { get; protected set; }
+
+        /// <summary>
+        /// The path of the file the annotation refers to
+        /// </summary>
+        public string Path { get; protected set; }
 
         /// <summary>
         /// The file's full blob URL
@@ -45,7 +73,13 @@ namespace Octokit
         /// <summary>
         /// The warning level of the annotation. Can be one of notice, warning, or failure
         /// </summary>
-        public StringEnum<CheckWarningLevel> WarningLevel { get; protected set; }
+        [Obsolete("This property is replaced with AnnotationLevel but may still be required on GitHub Enterprise 2.14")]
+        public StringEnum<CheckWarningLevel>? WarningLevel { get; protected set; }
+
+        /// <summary>
+        /// The level of the annotation. Can be one of notice, warning, or failure
+        /// </summary>
+        public StringEnum<CheckAnnotationLevel>? AnnotationLevel { get; protected set; }
 
         /// <summary>
         /// A short description of the feedback for these lines of code
@@ -62,6 +96,8 @@ namespace Octokit
         /// </summary>
         public string RawDetails { get; protected set; }
 
-        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Filename: {0}, StartLine: {1}, WarningLevel: {2}", Filename, StartLine, WarningLevel.DebuggerDisplay);
+#pragma warning disable CS0618 // Type or member is obsolete
+        internal string DebuggerDisplay => string.Format(CultureInfo.InvariantCulture, "Path: {0}, StartLine: {1}, WarningLevel: {2}", Path ?? Filename, StartLine, AnnotationLevel?.DebuggerDisplay ?? WarningLevel?.DebuggerDisplay);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/Octokit/Models/Response/CheckRunAnnotation.cs
+++ b/Octokit/Models/Response/CheckRunAnnotation.cs
@@ -11,12 +11,14 @@ namespace Octokit
         {
         }
 
-        public CheckRunAnnotation(string path, string blobHref, int startLine, int endLine, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
+        public CheckRunAnnotation(string path, string blobHref, int startLine, int endLine, int? startColumn, int? endColumn, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
         {
             Path = path;
             BlobHref = blobHref;
             StartLine = startLine;
             EndLine = endLine;
+            StartColumn = startColumn;
+            EndColumn = endColumn;
             AnnotationLevel = annotationLevel;
             Message = message;
             Title = title;
@@ -30,13 +32,15 @@ namespace Octokit
         }
 
         [Obsolete("This ctor taking Filename, BlobHref and WarningLevel is deprecated but may still be required on GitHub Enterprise 2.14")]
-        public CheckRunAnnotation(string filename, string path, string blobHref, int startLine, int endLine, CheckWarningLevel? warningLevel, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
+        public CheckRunAnnotation(string filename, string path, string blobHref, int startLine, int endLine, int? startColumn, int? endColumn, CheckWarningLevel? warningLevel, CheckAnnotationLevel? annotationLevel, string message, string title, string rawDetails)
         {
             Filename = filename;
             Path = path;
             BlobHref = blobHref;
             StartLine = startLine;
             EndLine = endLine;
+            StartColumn = startColumn;
+            EndColumn = endColumn;
             WarningLevel = warningLevel;
             AnnotationLevel = annotationLevel;
             Message = message;
@@ -69,6 +73,16 @@ namespace Octokit
         /// The end line of the annotation
         /// </summary>
         public int EndLine { get; protected set; }
+
+        /// <summary>
+        /// The start line of the annotation
+        /// </summary>
+        public int? StartColumn { get; protected set; }
+
+        /// <summary>
+        /// The end line of the annotation
+        /// </summary>
+        public int? EndColumn { get; protected set; }
 
         /// <summary>
         /// The warning level of the annotation. Can be one of notice, warning, or failure


### PR DESCRIPTION
Fixes #1856 

Attempt to handle both old and new annotations models so we can support github.com and GHE 2.14

- [x] add `Path` and `AnnotationLevel` fields to `CheckRunAnnotation` response and `NewCheckRunAnnotation` request
- [x] flag `Filename` and `WarningLevel` as deprecated/obsolete but keep them around so we can use them for GHE 2.14
- [x] also flag `BlobHref` as deprecated on `NewCheckRunAnnotation`
- [x] Adjust ctors so we have a way to create the "old" and "new" model formats, ensuring the relevant fields are `null` so they don't get sent
- [x] Add new re-request endpoint
- [x] Flag old request endpoint for deprecation