### PR TITLE
Implement renaming and deprecation of GitHub App Installation Access Token route

### DIFF
--- a/Octokit.Reactive/Clients/IObservableGitHubAppsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableGitHubAppsClient.cs
@@ -53,5 +53,17 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
         IObservable<AccessToken> CreateInstallationToken(long installationId);
+
+        /// <summary>
+        /// Create a time bound access token for a GitHubApp Installation that can be used to access other API endpoints (requires GitHubApp JWT token auth).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/apps/#create-a-new-installation-token
+        /// https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+        /// https://developer.github.com/v3/apps/available-endpoints/
+        /// </remarks>
+        /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Obsolete("This method is provided to enable Installation Tokens under the initial GitHub App Preview functionality, which may still be required on GitHub Enterprise 2.14")]
+        IObservable<AccessToken> CreateInstallationTokenPreview(long installationId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableGitHubAppsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableGitHubAppsClient.cs
@@ -81,5 +81,20 @@ namespace Octokit.Reactive
         {
             return _client.CreateInstallationToken(installationId).ToObservable();
         }
+
+        /// <summary>
+        /// Create a time bound access token for a GitHubApp Installation that can be used to access other API endpoints (requires GitHubApp JWT token auth).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/apps/#create-a-new-installation-token
+        /// https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+        /// https://developer.github.com/v3/apps/available-endpoints/
+        /// </remarks>
+        /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Obsolete("This method is provided to enable Installation Tokens under the initial GitHub App Preview functionality, which may still be required on GitHub Enterprise 2.14")]
+        public IObservable<AccessToken> CreateInstallationTokenPreview(long installationId)
+        {
+            return _client.CreateInstallationTokenPreview(installationId).ToObservable();
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
@@ -129,5 +129,29 @@ namespace Octokit.Tests.Integration.Clients
                 Assert.True(DateTimeOffset.Now < result.ExpiresAt);
             }
         }
+
+        public class TheCreateInstallationTokenPreviewMethod
+        {
+            IGitHubClient _github;
+
+            public TheCreateInstallationTokenPreviewMethod()
+            {
+                // Authenticate as a GitHubApp
+                _github = Helper.GetAuthenticatedGitHubAppsClient();
+            }
+
+            [GitHubAppsTest]
+            public async Task CreatesInstallationToken()
+            {
+                // Get the installation Id
+                var installationId = Helper.GetGitHubAppInstallationForOwner(Helper.UserName).Id;
+
+                // Create installation token
+                var result = await _github.GitHubApps.CreateInstallationTokenPreview(installationId);
+
+                Assert.NotNull(result.Token);
+                Assert.True(DateTimeOffset.Now < result.ExpiresAt);
+            }
+        }
     }
 }

--- a/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/GitHubAppsClientTests.cs
@@ -147,7 +147,9 @@ namespace Octokit.Tests.Integration.Clients
                 var installationId = Helper.GetGitHubAppInstallationForOwner(Helper.UserName).Id;
 
                 // Create installation token
+#pragma warning disable CS0618 // Type or member is obsolete
                 var result = await _github.GitHubApps.CreateInstallationTokenPreview(installationId);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 Assert.NotNull(result.Token);
                 Assert.True(DateTimeOffset.Now < result.ExpiresAt);

--- a/Octokit.Tests/Clients/GitHubAppsClientTests.cs
+++ b/Octokit.Tests/Clients/GitHubAppsClientTests.cs
@@ -98,7 +98,7 @@ namespace Octokit.Tests.Clients
 
                 client.CreateInstallationToken(fakeInstallationId);
 
-                connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
+                connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "app/installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
             }
         }
 
@@ -116,7 +116,7 @@ namespace Octokit.Tests.Clients
                 client.CreateInstallationTokenPreview(fakeInstallationId);
 #pragma warning restore CS0618 // Type or member is obsolete
 
-                connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "app/installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
+                connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
             }
         }
     }

--- a/Octokit.Tests/Clients/GitHubAppsClientTests.cs
+++ b/Octokit.Tests/Clients/GitHubAppsClientTests.cs
@@ -101,5 +101,23 @@ namespace Octokit.Tests.Clients
                 connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
             }
         }
+
+        public class TheCreateInstallationTokenPreviewMethod
+        {
+            [Fact]
+            public void PostsToCorrectUrl()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new GitHubAppsClient(connection);
+
+                int fakeInstallationId = 3141;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                client.CreateInstallationTokenPreview(fakeInstallationId);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                connection.Received().Post<AccessToken>(Arg.Is<Uri>(u => u.ToString() == "app/installations/3141/access_tokens"), string.Empty, "application/vnd.github.machine-man-preview+json");
+            }
+        }
     }
 }

--- a/Octokit/Clients/GitHubAppsClient.cs
+++ b/Octokit/Clients/GitHubAppsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -77,6 +78,21 @@ namespace Octokit
         public Task<AccessToken> CreateInstallationToken(long installationId)
         {
             return ApiConnection.Post<AccessToken>(ApiUrls.AccessTokens(installationId), string.Empty, AcceptHeaders.GitHubAppsPreview);
+        }
+
+        /// <summary>
+        /// Create a time bound access token for a GitHubApp Installation that can be used to access other API endpoints (requires GitHubApp JWT token auth).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/apps/#create-a-new-installation-token
+        /// https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+        /// https://developer.github.com/v3/apps/available-endpoints/
+        /// </remarks>
+        /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Obsolete("This method is provided to enable Installation Tokens under the initial GitHub App Preview functionality, which may still be required on GitHub Enterprise 2.14")]
+        public Task<AccessToken> CreateInstallationTokenPreview(long installationId)
+        {
+            return ApiConnection.Post<AccessToken>(ApiUrls.AccessTokensPreview(installationId), string.Empty, AcceptHeaders.GitHubAppsPreview);
         }
     }
 }

--- a/Octokit/Clients/IGitHubAppsClient.cs
+++ b/Octokit/Clients/IGitHubAppsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -54,5 +55,17 @@ namespace Octokit
         /// </remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
         Task<AccessToken> CreateInstallationToken(long installationId);
+
+        /// <summary>
+        /// Create a time bound access token for a GitHubApp Installation that can be used to access other API endpoints (requires GitHubApp JWT token auth).
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/apps/#create-a-new-installation-token
+        /// https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/#authenticating-as-an-installation
+        /// https://developer.github.com/v3/apps/available-endpoints/
+        /// </remarks>
+        /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Obsolete("This method is provided to enable Installation Tokens under the initial GitHub App Preview functionality, which may still be required on GitHub Enterprise 2.14")]
+        Task<AccessToken> CreateInstallationTokenPreview(long installationId);
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -287,6 +287,15 @@ namespace Octokit
         /// <param name="installationId">The Id of the GitHub App installation.</param>
         public static Uri AccessTokens(long installationId)
         {
+            return "app/installations/{0}/access_tokens".FormatUri(installationId);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="Uri"/> for creating a new installation token on GitHub Enterprise 2.14.
+        /// </summary>
+        /// <param name="installationId">The Id of the GitHub App installation.</param>
+        public static Uri AccessTokensPreview(long installationId)
+        {
             return "installations/{0}/access_tokens".FormatUri(installationId);
         }
 


### PR DESCRIPTION
Fixes #1858

- Update `CreateInstallationToken()` method to handle the new `/app/installations/...` route
- Add an `[Obsolete]` flagged `CreateInstallationTokenPreview()` method still using the old `/installations/...` route, for GitHub Enterprise 2.14 compatibility