### PR TITLE
Fix `IIssueLabelsClient.RemoveFromIssue()`

### DIFF
--- a/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesLabelsClientTests.cs
@@ -367,7 +367,7 @@ namespace Octokit.Tests.Reactive
 
                 client.RemoveFromIssue("fake", "repo", 42, "label");
 
-                connection.Received().Delete<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels/label"), "application/vnd.github.symmetra-preview+json");
+                connection.Received().Delete<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/labels/label"), Arg.Any<object>(), "application/vnd.github.symmetra-preview+json");
             }
 
             [Fact]
@@ -379,7 +379,7 @@ namespace Octokit.Tests.Reactive
 
                 client.RemoveFromIssue(1, 42, "label");
 
-                connection.Received().Delete<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels/label"), "application/vnd.github.symmetra-preview+json");
+                connection.Received().Delete<IReadOnlyList<Label>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/labels/label"), Arg.Any<object>(), "application/vnd.github.symmetra-preview+json");
             }
 
             [Fact]

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -514,6 +514,24 @@ namespace Octokit
         /// Performs an asynchronous HTTP DELETE request.
         /// Attempts to map the response body to an object of type <typeparamref name="T"/>
         /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="accepts">Specifies accept response media type</param>
+        /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>
+        public async Task<T> Delete<T>(Uri uri, string accepts)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+            Ensure.ArgumentNotNull(accepts, nameof(accepts));
+
+            var response = await Connection.Delete<T>(uri, null, accepts).ConfigureAwait(false);
+
+            return response.Body;
+        }
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
+        /// Attempts to map the response body to an object of type <typeparamref name="T"/>
+        /// </summary>
         /// <typeparam name="T">The type to map the response to</typeparam>
         /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="data">The object to serialize as the body of the request</param>

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -334,6 +334,16 @@ namespace Octokit
         /// </summary>
         /// <typeparam name="T">The API resource's type.</typeparam>
         /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="accepts">Specifies accept response media type</param>
+        /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>
+        Task<T> Delete<T>(Uri uri, string accepts);
+
+        /// <summary>
+        /// Performs an asynchronous HTTP DELETE request.
+        /// Attempts to map the response body to an object of type <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">The API resource's type.</typeparam>
+        /// <param name="uri">URI endpoint to send request to</param>
         /// <param name="data">The object to serialize as the body of the request</param>
         /// <param name="accepts">Specifies accept response media type</param>
         /// <returns>The returned <seealso cref="HttpStatusCode"/></returns>


### PR DESCRIPTION
Fixes #1865 

`IIssueLabelsClient.RemoveFromIssue()` was incorrectly passing an accept header to the body parameter of the delete call.  Recent upstream api changes seem to have occured where this previously ignored situation is now being rejected as the body can't be parsed as valid json.  Also the preview functionality for label emojis/descriptions wouldnt have been working on this call due to the accept header not being passed correctly.

This PR fixes the issue by adding an overload for `ApiConnection.Delete<T>(Uri uri, string accepts)` that takes a Uri and accept header, but no body, which the existing code in `RemoveFromIssue()` will now use instead of `ApiConnection.Delete<T>(Uri uri, object data)`