### PR TITLE
Add Author Association for comments related models

### DIFF
--- a/Octokit/Models/Common/AuthorAssociation.cs
+++ b/Octokit/Models/Common/AuthorAssociation.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Octokit.Internal;
+
+namespace Octokit
+{
+    /// <summary>
+    /// States of a Team/Organization Membership
+    /// </summary>
+    public enum AuthorAssociation
+    {
+
+        /// <summary>
+        /// Author has been invited to collaborate on the repository.
+        /// </summary>
+        [Parameter(Value = "COLLABORATOR")]
+        Collaborator,
+
+        /// <summary>
+        /// Author has previously committed to the repository.
+        /// </summary>
+        [Parameter(Value = "CONTRIBUTOR")]
+        Contributor,
+
+        /// <summary>
+        /// Author has not previously committed to GitHub.
+        /// </summary>
+        [Parameter(Value = "FIRST_TIMER")]
+        FirstTimer,
+
+        /// <summary>
+        /// Author has not previously committed to the repository.
+        /// </summary>
+        [Parameter(Value = "FIRST_TIME_CONTRIBUTOR")]
+        FirstTimeContributor,
+
+        /// <summary>
+        /// Author is a member of the organization that owns the repository.
+        /// </summary>
+        [Parameter(Value = "MEMBER")]
+        Member,
+
+        /// <summary>
+        /// Author is the owner of the repository. 
+        /// </summary>
+        [Parameter(Value = "OWNER")]
+        Owner,
+
+        /// <summary>
+        /// Author has no association with the repository.
+        /// </summary>
+        [Parameter(Value = "NONE")]
+        None
+    }
+}

--- a/Octokit/Models/Common/AuthorAssociation.cs
+++ b/Octokit/Models/Common/AuthorAssociation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Octokit.Internal;
+﻿using Octokit.Internal;
 
 namespace Octokit
 {
@@ -8,7 +7,6 @@ namespace Octokit
     /// </summary>
     public enum AuthorAssociation
     {
-
         /// <summary>
         /// Author has been invited to collaborate on the repository.
         /// </summary>

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public IssueComment() { }
 
-        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions)
+        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions,AuthorAssociation? authorAssociation=null)
         {
             Id = id;
             NodeId = nodeId;
@@ -21,6 +21,7 @@ namespace Octokit
             UpdatedAt = updatedAt;
             User = user;
             Reactions = reactions;
+            AuthorAssociation = authorAssociation;
         }
 
         /// <summary>
@@ -62,6 +63,11 @@ namespace Octokit
         /// The user that created the issue comment.
         /// </summary>
         public User User { get; protected set; }
+
+        /// <summary>
+        /// The comment author association with repository.
+        /// </summary>
+        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
 
         /// <summary>
         /// The reaction summary for this comment.

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public IssueComment() { }
 
-        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions,AuthorAssociation authorAssociation)
+        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions, AuthorAssociation authorAssociation)
         {
             Id = id;
             NodeId = nodeId;

--- a/Octokit/Models/Response/IssueComment.cs
+++ b/Octokit/Models/Response/IssueComment.cs
@@ -10,7 +10,7 @@ namespace Octokit
     {
         public IssueComment() { }
 
-        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions,AuthorAssociation? authorAssociation=null)
+        public IssueComment(int id, string nodeId, string url, string htmlUrl, string body, DateTimeOffset createdAt, DateTimeOffset? updatedAt, User user, ReactionSummary reactions,AuthorAssociation authorAssociation)
         {
             Id = id;
             NodeId = nodeId;
@@ -67,7 +67,7 @@ namespace Octokit
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
 
         /// <summary>
         /// The reaction summary for this comment.

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReview(long id, string nodeId, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state, AuthorAssociation? authorAssociation=null)
+        public PullRequestReview(long id, string nodeId, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state, AuthorAssociation authorAssociation)
         {
             Id = id;
             NodeId = nodeId;
@@ -72,7 +72,7 @@ namespace Octokit
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReview(long id, string nodeId, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state)
+        public PullRequestReview(long id, string nodeId, string commitId, User user, string body, string htmlUrl, string pullRequestUrl, PullRequestReviewState state, AuthorAssociation? authorAssociation=null)
         {
             Id = id;
             NodeId = nodeId;
@@ -25,6 +25,8 @@ namespace Octokit
             HtmlUrl = htmlUrl;
             PullRequestUrl = pullRequestUrl;
             State = state;
+            AuthorAssociation = authorAssociation;
+
         }
 
         /// <summary>
@@ -66,6 +68,11 @@ namespace Octokit
         /// The URL for the pull request via the API.
         /// </summary>
         public string PullRequestUrl { get; protected set; }
+
+        /// <summary>
+        /// The comment author association with repository.
+        /// </summary>
+        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReview.cs
+++ b/Octokit/Models/Response/PullRequestReview.cs
@@ -26,7 +26,6 @@ namespace Octokit
             PullRequestUrl = pullRequestUrl;
             State = state;
             AuthorAssociation = authorAssociation;
-
         }
 
         /// <summary>

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId)
+        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId,AuthorAssociation? authorAssociation=null)
         {
             PullRequestReviewId = pullRequestReviewId;
             Url = url;
@@ -35,6 +35,7 @@ namespace Octokit
             PullRequestUrl = pullRequestUrl;
             Reactions = reactions;
             InReplyToId = inReplyToId;
+            AuthorAssociation = authorAssociation;
         }
 
         /// <summary>
@@ -126,6 +127,11 @@ namespace Octokit
         /// The Id of the pull request this comment belongs to.
         /// </summary>
         public int? PullRequestReviewId { get; protected set; }
+
+        /// <summary>
+        /// The comment author association with repository.
+        /// </summary>
+        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId,AuthorAssociation? authorAssociation=null)
+        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId,AuthorAssociation authorAssociation)
         {
             PullRequestReviewId = pullRequestReviewId;
             Url = url;
@@ -131,7 +131,7 @@ namespace Octokit
         /// <summary>
         /// The comment author association with repository.
         /// </summary>
-        public StringEnum<AuthorAssociation>? AuthorAssociation { get; protected set; }
+        public StringEnum<AuthorAssociation> AuthorAssociation { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Models/Response/PullRequestReviewComment.cs
+++ b/Octokit/Models/Response/PullRequestReviewComment.cs
@@ -15,7 +15,7 @@ namespace Octokit
             Id = id;
         }
 
-        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId,AuthorAssociation authorAssociation)
+        public PullRequestReviewComment(string url, int id, string nodeId, string diffHunk, string path, int? position, int? originalPosition, string commitId, string originalCommitId, User user, string body, DateTimeOffset createdAt, DateTimeOffset updatedAt, string htmlUrl, string pullRequestUrl, ReactionSummary reactions, int? inReplyToId, int? pullRequestReviewId, AuthorAssociation authorAssociation)
         {
             PullRequestReviewId = pullRequestReviewId;
             Url = url;


### PR DESCRIPTION
It seems that GitHub has recently added a new field called _[author_association](https://developer.github.com/v4/enum/commentauthorassociation/)_ to comment related response models such as[ Issue Comments](https://api.github.com/repos/dotnet/coreclr/issues/17920/comments), [Pull Request Review Comments](https://api.github.com/repos/dotnet/corefx/pulls/154/comments), and[ Pull Request Reviewers](https://api.github.com/repos/dotnet/corefx/pulls/11694/reviews
). This field shows how an author is related to a repo.


The proposed change adds a new enum named AuthorAssociate, changes constructors in affected models, and lastly adds a new attribute called AuthorAssociate to related models.