### PR TITLE
Update to Cake.Frosting 0.31.0

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="0.30.0" />
+    <PackageReference Include="Cake.Frosting" Version="0.31.0" />
   </ItemGroup>
 
 </Project>

--- a/build/Tasks/Clean.cs
+++ b/build/Tasks/Clean.cs
@@ -1,12 +1,18 @@
 ﻿using Cake.Common.IO;
+using Cake.Core.IO;
 using Cake.Frosting;
 
 public sealed class Clean : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        var directories = context.GetDirectories("./**/bin", x => !x.Path.FullPath.Contains("/build/"))
-            + context.GetDirectories("./**/obj", x => !x.Path.FullPath.Contains("/build/"))
+        var globberSettings = new GlobberSettings
+        {
+            Predicate = x => !x.Path.FullPath.Contains("/build/")
+        };
+
+        var directories = context.GetDirectories("./**/bin", globberSettings)
+            + context.GetDirectories("./**/obj", globberSettings)
             + context.Artifacts;
 
         foreach (var directory in directories)

--- a/build/nuget.config
+++ b/build/nuget.config
@@ -1,6 +1,0 @@
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="myget.org" value="https://www.myget.org/F/cake/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
* Uses Cake.Core & Cake.Common 0.31.0 ( read more about improvements at https://cakebuild.net/blog/2018/12/cake-v0.31.0-released )
* 0.31.0 is on NuGet.org so nuget.config no longer needed
* GetDirectories with predicate  is now obsolete, replaced by GlobberSettings