### PR TITLE
Don't apply Tls1.2 workaround when .NET 4.7 SystemDefault is set

### DIFF
--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -32,7 +32,7 @@ namespace Octokit.Internal
             // 
             // .NET Frameworks less than 4.6 did not enable TLS1.2 by default
             //
-            // Eventhough this is an AppDomain wide setting, the decision was made for Octokit to
+            // Even though this is an AppDomain wide setting, the decision was made for Octokit to
             // ensure that TLS1.2 is enabled so that existing applications using Octokit did not need to
             // make changes outside Octokit to continue to work with GitHub Api
             //

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -34,7 +34,7 @@ namespace Octokit.Internal
             //
             // Even though this is an AppDomain wide setting, the decision was made for Octokit to
             // ensure that TLS1.2 is enabled so that existing applications using Octokit did not need to
-            // make changes outside Octokit to continue to work with GitHub Api
+            // make changes outside Octokit to continue to work with GitHub API
             //
             // *Update*
             // .NET Framework 4.7 introduced a new value (SecurityProtocolType.SystemDefault = 0)

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -28,7 +28,7 @@ namespace Octokit.Internal
             Ensure.ArgumentNotNull(getHandler, nameof(getHandler));
 
 #if HAS_SERVICEPOINTMANAGER
-            // GitHub Api requires TLS1.2 as of Febryary 2018
+            // GitHub API requires TLS1.2 as of February 2018
             // 
             // .NET Frameworks less than 4.6 did not enable TLS1.2 by default
             //

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -28,7 +28,28 @@ namespace Octokit.Internal
             Ensure.ArgumentNotNull(getHandler, nameof(getHandler));
 
 #if HAS_SERVICEPOINTMANAGER
-            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+            // GitHub Api requires TLS1.2 as of Febryary 2018
+            // 
+            // .NET Frameworks less than 4.6 did not enable TLS1.2 by default
+            //
+            // Eventhough this is an AppDomain wide setting, the decision was made for Octokit to
+            // ensure that TLS1.2 is enabled so that existing applications using Octokit did not need to
+            // make changes outside Octokit to continue to work with GitHub Api
+            //
+            // *Update*
+            // .NET Framework 4.7 introduced a new value (SecurityProtocolType.SystemDefault = 0)
+            // which defers enabled protocols to operating system defaults
+            // If this is the current value we shouldn't do anything, as that would cause TLS1.2 to be the ONLY enabled protocol!
+            //
+            // See https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.7
+            // See https://github.com/octokit/octokit.net/issues/1914
+
+            // Only apply when current setting is not SystemDefault (0) added in .NET 4.7
+            if ((int)ServicePointManager.SecurityProtocol != 0)
+            {
+                // Add Tls1.2 to the existing enabled protocols
+                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+            }
 #endif
 
             _http = new HttpClient(new RedirectHandler { InnerHandler = getHandler() });

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -30,7 +30,7 @@ namespace Octokit.Internal
 #if HAS_SERVICEPOINTMANAGER
             // GitHub API requires TLS1.2 as of February 2018
             // 
-            // .NET Frameworks less than 4.6 did not enable TLS1.2 by default
+            // .NET Framework before 4.6 did not enable TLS1.2 by default
             //
             // Even though this is an AppDomain wide setting, the decision was made for Octokit to
             // ensure that TLS1.2 is enabled so that existing applications using Octokit did not need to


### PR DESCRIPTION
Fixes #1914

Don't touch SecurityProtocol when current value is the new SystemDefault added in .NET 4.7

Added comment to explain what we are doing

