### PR TITLE
Correctly support language filter in repo search

### DIFF
--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -463,7 +463,7 @@ namespace Octokit.Tests.Clients
                 request.Language = Language.Ruby;
                 client.SearchRepo(request);
                 connection.Received().Get<SearchRepositoryResult>(Arg.Is<Uri>(u => u.ToString() == "search/repositories"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "github+language:Ruby"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "github+language:ruby"));
             }
 
             [Fact]

--- a/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
+++ b/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
@@ -25,5 +25,13 @@ public class SearchRepositoryRequestTests
             Assert.True(string.IsNullOrWhiteSpace(request.Sort));
             Assert.False(request.Parameters.ContainsKey("sort"));
         }
+
+        [Fact]
+        public void LanguageUsesParameterTranslation()
+        {
+            var request = new SearchRepositoriesRequest() { Language = Language.CPlusPlus };
+            var result = request.MergedQualifiers();
+            Assert.Contains(result, x => string.Equals(x, "language:C++"));
+        }
     }
 }

--- a/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
+++ b/Octokit.Tests/Models/SearchRepositoryRequestTests.cs
@@ -31,7 +31,7 @@ public class SearchRepositoryRequestTests
         {
             var request = new SearchRepositoriesRequest() { Language = Language.CPlusPlus };
             var result = request.MergedQualifiers();
-            Assert.Contains(result, x => string.Equals(x, "language:C++"));
+            Assert.Contains(result, x => string.Equals(x, "language:cpp"));
         }
     }
 }

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -460,7 +460,7 @@ namespace Octokit
         ColdFusion,
         CommonLisp,
         Coq,
-        [Parameter(Value = "C++")]
+        [Parameter(Value = "cpp")]
         CPlusPlus,
         [Parameter(Value = "CSharp")]
         CSharp,

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -148,7 +148,7 @@ namespace Octokit
 
             if (Language != null)
             {
-                parameters.Add(string.Format(CultureInfo.InvariantCulture, "language:{0}", Language));
+                parameters.Add(string.Format(CultureInfo.InvariantCulture, "language:{0}", Language.ToParameter()));
             }
 
             if (User.IsNotBlank())


### PR DESCRIPTION
The language was being directly converted to a string through `ToString()` instead of using the value in the `ParameterAttribute`.