### PR TITLE
Add a warning to the statistics client about caching

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -203,17 +203,13 @@ namespace Octokit.Reactive
         /// <summary>
         /// Client for GitHub's Repository Statistics API
         /// </summary>
+        /// <summary>
+        /// Note that the GitHub API uses caching on these endpoints,
+        /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+        /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
-        /// <remarks>
-        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-        /// Give the job a few moments to complete, and then submit the request again.
-        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
-        /// </remarks>
         IObservableStatisticsClient Statistics { get; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -206,6 +206,14 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
+        /// <remarks>
+        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+        /// Give the job a few moments to complete, and then submit the request again.
+        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+        /// </remarks>
         IObservableStatisticsClient Statistics { get; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoriesClient.cs
@@ -201,9 +201,7 @@ namespace Octokit.Reactive
         IObservableDeploymentsClient Deployment { get; }
 
         /// <summary>
-        /// Client for GitHub's Repository Statistics API
-        /// </summary>
-        /// <summary>
+        /// Client for GitHub's Repository Statistics API.
         /// Note that the GitHub API uses caching on these endpoints,
         /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
         /// </summary>

--- a/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
@@ -6,16 +6,12 @@ namespace Octokit.Reactive
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
     /// </summary>
+    /// <summary>
+    /// Note that the GitHub API uses caching on these endpoints,
+    /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+    /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
-    /// </remarks>
-    /// <remarks>
-    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-    /// Give the job a few moments to complete, and then submit the request again.
-    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
     /// </remarks>
     public interface IObservableStatisticsClient
     {

--- a/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
@@ -9,6 +9,14 @@ namespace Octokit.Reactive
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
     /// </remarks>
+    /// <remarks>
+    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+    /// Give the job a few moments to complete, and then submit the request again.
+    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+    /// </remarks>
     public interface IObservableStatisticsClient
     {
         /// <summary>

--- a/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableStatisticsClient.cs
@@ -5,8 +5,6 @@ namespace Octokit.Reactive
 {
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
-    /// </summary>
-    /// <summary>
     /// Note that the GitHub API uses caching on these endpoints,
     /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
     /// </summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -315,8 +315,6 @@ namespace Octokit.Reactive
 
         /// <summary>
         /// Client for GitHub's Repository Statistics API
-        /// </summary>
-        /// <summary>
         /// Note that the GitHub API uses caching on these endpoints,
         /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
         /// </summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -316,17 +316,13 @@ namespace Octokit.Reactive
         /// <summary>
         /// Client for GitHub's Repository Statistics API
         /// </summary>
+        /// <summary>
+        /// Note that the GitHub API uses caching on these endpoints,
+        /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+        /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
-        /// <remarks>
-        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-        /// Give the job a few moments to complete, and then submit the request again.
-        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
-        /// </remarks>
         public IObservableStatisticsClient Statistics { get; private set; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoriesClient.cs
@@ -319,6 +319,14 @@ namespace Octokit.Reactive
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
+        /// <remarks>
+        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+        /// Give the job a few moments to complete, and then submit the request again.
+        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+        /// </remarks>
         public IObservableStatisticsClient Statistics { get; private set; }
 
         /// <summary>

--- a/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
@@ -7,16 +7,12 @@ namespace Octokit.Reactive
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
     /// </summary>
+    /// <summary>
+    /// Note that the GitHub API uses caching on these endpoints,
+    /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+    /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
-    /// </remarks>
-    /// <remarks>
-    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-    /// Give the job a few moments to complete, and then submit the request again.
-    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
     /// </remarks>
     public class ObservableStatisticsClient : IObservableStatisticsClient
     {

--- a/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
@@ -10,6 +10,14 @@ namespace Octokit.Reactive
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
     /// </remarks>
+    /// <remarks>
+    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+    /// Give the job a few moments to complete, and then submit the request again.
+    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+    /// </remarks>
     public class ObservableStatisticsClient : IObservableStatisticsClient
     {
         readonly IGitHubClient _client;

--- a/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableStatisticsClient.cs
@@ -6,8 +6,6 @@ namespace Octokit.Reactive
 {
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
-    /// </summary>
-    /// <summary>
     /// Note that the GitHub API uses caching on these endpoints,
     /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
     /// </summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -316,9 +316,7 @@ namespace Octokit
         IDeploymentsClient Deployment { get; }
 
         /// <summary>
-        /// Client for GitHub's Repository Statistics API
-        /// </summary>
-        /// <summary>
+        /// Client for GitHub's Repository Statistics API.
         /// Note that the GitHub API uses caching on these endpoints,
         /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
         /// </summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -321,6 +321,14 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
+        /// <remarks>
+        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+        /// Give the job a few moments to complete, and then submit the request again.
+        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+        /// </remarks>
         IStatisticsClient Statistics { get; }
 
         /// <summary>

--- a/Octokit/Clients/IRepositoriesClient.cs
+++ b/Octokit/Clients/IRepositoriesClient.cs
@@ -318,17 +318,13 @@ namespace Octokit
         /// <summary>
         /// Client for GitHub's Repository Statistics API
         /// </summary>
+        /// <summary>
+        /// Note that the GitHub API uses caching on these endpoints,
+        /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+        /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
-        /// <remarks>
-        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-        /// Give the job a few moments to complete, and then submit the request again.
-        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
-        /// </remarks>
         IStatisticsClient Statistics { get; }
 
         /// <summary>

--- a/Octokit/Clients/IStatisticsClient.cs
+++ b/Octokit/Clients/IStatisticsClient.cs
@@ -7,16 +7,12 @@ namespace Octokit
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
     /// </summary>
+    /// <summary>
+    /// Note that the GitHub API uses caching on these endpoints,
+    /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+    /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
-    /// </remarks>
-    /// <remarks>
-    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-    /// Give the job a few moments to complete, and then submit the request again.
-    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
     /// </remarks>
     public interface IStatisticsClient
     {

--- a/Octokit/Clients/IStatisticsClient.cs
+++ b/Octokit/Clients/IStatisticsClient.cs
@@ -10,6 +10,14 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
     /// </remarks>
+    /// <remarks>
+    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+    /// Give the job a few moments to complete, and then submit the request again.
+    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+    /// </remarks>
     public interface IStatisticsClient
     {
         /// <summary>

--- a/Octokit/Clients/IStatisticsClient.cs
+++ b/Octokit/Clients/IStatisticsClient.cs
@@ -6,8 +6,6 @@ namespace Octokit
 {
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
-    /// </summary>
-    /// <summary>
     /// Note that the GitHub API uses caching on these endpoints,
     /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
     /// </summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -471,8 +471,6 @@ namespace Octokit
 
         /// <summary>
         /// Client for GitHub's Repository Statistics API
-        /// </summary>
-        /// <summary>
         /// Note that the GitHub API uses caching on these endpoints,
         /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
         /// </summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -475,6 +475,14 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
+        /// <remarks>
+        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+        /// Give the job a few moments to complete, and then submit the request again.
+        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+        /// </remarks>
         public IStatisticsClient Statistics { get; private set; }
 
         /// <summary>

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -472,17 +472,13 @@ namespace Octokit
         /// <summary>
         /// Client for GitHub's Repository Statistics API
         /// </summary>
+        /// <summary>
+        /// Note that the GitHub API uses caching on these endpoints,
+        /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+        /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statistics/">Statistics API documentation</a> for more details
         ///</remarks>
-        /// <remarks>
-        /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-        /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-        /// Give the job a few moments to complete, and then submit the request again.
-        /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-        /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-        /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
-        /// </remarks>
         public IStatisticsClient Statistics { get; private set; }
 
         /// <summary>

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -8,16 +8,12 @@ namespace Octokit
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
     /// </summary>
+    /// <summary>
+    /// Note that the GitHub API uses caching on these endpoints,
+    /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
+    /// </summary>
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
-    /// </remarks>
-    /// <remarks>
-    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
-    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
-    /// Give the job a few moments to complete, and then submit the request again.
-    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
-    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
-    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
     /// </remarks>
     public class StatisticsClient : ApiClient, IStatisticsClient
     {

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -7,8 +7,6 @@ namespace Octokit
 {
     /// <summary>
     /// A client for GitHub's Repository Statistics API.
-    /// </summary>
-    /// <summary>
     /// Note that the GitHub API uses caching on these endpoints,
     /// see <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more details.
     /// </summary>

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -11,6 +11,14 @@ namespace Octokit
     /// <remarks>
     /// See the <a href="https://developer.github.com/v3/repos/statistics/">Repository Statistics API documentation</a> for more information.
     /// </remarks>
+    /// <remarks>
+    /// Computing repository statistics is an expensive operation, so we try to return cached data whenever possible.
+    /// If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response; a background job is also fired to start compiling these statistics.
+    /// Give the job a few moments to complete, and then submit the request again.
+    /// If the job has completed, that request will receive a 200 response with the statistics in the response body.
+    /// Repository statistics are cached by the SHA of the repository's default branch, which is usually master; pushing to the default branch resets the statistics cache.
+    /// See <a href="https://developer.github.com/v3/repos/statistics/#a-word-about-caching">a word about caching</a> for more information.
+    /// </remarks>
     public class StatisticsClient : ApiClient, IStatisticsClient
     {
         /// <summary>


### PR DESCRIPTION
I had to add the warning to the `Statistics` property as well on the `*RepositoriesClient` otherwise the warning won't show up in intellisense when you do `github.Repositories.Statistics`

Fixes #1814 