### PR TITLE
Failing tests for GetAllContentsByRef on a branch with a root path

### DIFF
--- a/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/RepositoryContentsClientTests.cs
@@ -223,6 +223,18 @@ namespace Octokit.Tests.Integration.Clients
             }
 
             [IntegrationTest]
+            public async Task GetsContentNonMasterWithRootPath()
+            {
+                var github = Helper.GetAuthenticatedClient();
+
+                var contents = await github
+                    .Repository
+                    .Content
+                    .GetAllContentsByRef("octocat", "Spoon-Knife", "/", reference: "test-branch");
+                Assert.Equal(4, contents.Count);
+            }
+
+            [IntegrationTest]
             public async Task GetsDirectoryContentWithRepositoryId()
             {
                 var github = Helper.GetAuthenticatedClient();


### PR DESCRIPTION
the `"/"` seems to force it back to the master branch. just wondering if this is by design?