### PR TITLE
update travis to use a recent .NET Core version when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: csharp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
-      dotnet: 2.1.300
+      dotnet: 2.2
     - os: osx
       osx_image: xcode8.3
-      dotnet: 2.1.300
+      dotnet: 2.2.402
 
 branches:
   only:


### PR DESCRIPTION
This might help with #1991 which is currently failing on macOS only due to something that looks like https://github.com/dotnet/corefx/issues/13309 (definitely fixed in 3.0)