### PR TITLE
Add ability to specify 'since' request parameter to issue comments

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -138,6 +138,46 @@ namespace Octokit.Reactive
         IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -205,7 +205,7 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForIssue(owner, name, number, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -219,7 +219,74 @@ namespace Octokit.Reactive
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId, number), options);
+            return GetAllForIssue(repositoryId, number, new IssueCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return GetAllForIssue(owner, name, number, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return GetAllForIssue(repositoryId, number, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(owner, name, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+
+            return _connection.GetAndFlattenAllPages<IssueComment>(ApiUrls.IssueComments(repositoryId, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -233,9 +233,11 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null, ApiOptions.None));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -181,6 +181,45 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithIssueCommentRequest()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                var request = new IssueCommentRequest()
+                {
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                };
+                
+                await client.GetAllForIssue("fake", "repo", 3, request);
+
+                connection.Received().GetAll<IssueComment>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    "application/vnd.github.squirrel-girl-preview",
+                    Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdWithIssueCommentRequest()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new IssueCommentsClient(connection);
+
+                var request = new IssueCommentRequest()
+                {
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                };
+
+                await client.GetAllForIssue(1, 3, request);
+
+                connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/3/comments"),
+                    Arg.Any<Dictionary<string, string>>(),
+                    "application/vnd.github.squirrel-girl-preview",
+                    Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
                 var connection = Substitute.For<IApiConnection>();
@@ -234,9 +273,11 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, request: null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, options: null));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, request: null));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null, ApiOptions.None));
 
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllForIssue("", "name", 1));

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -171,7 +171,7 @@ namespace Octokit.Tests.Reactive
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
-                    Args.EmptyDictionary,
+                    Arg.Any<IDictionary<string, string>>(),
                     "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -184,7 +184,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue(1, 3);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/3/comments", UriKind.Relative), Args.EmptyDictionary, null);
+                    new Uri("repositories/1/issues/3/comments", UriKind.Relative), Arg.Any<IDictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -193,6 +193,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
+                var request = new IssueCommentRequest()
+                {
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                };
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -200,10 +204,13 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForIssue("fake", "repo", 3, options);
+                client.GetAllForIssue("fake", "repo", 3, request, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview");
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 5
+                         && d["since"] == "2016-11-23T11:11:11Z"),
+                    "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -212,6 +219,10 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
+                var request = new IssueCommentRequest()
+                {
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                };
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -219,10 +230,13 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForIssue(1, 3, options);
+                client.GetAllForIssue(1, 3, request, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/3/comments", UriKind.Relative), Arg.Is<IDictionary<string, string>>(d => d.Count == 2), null);
+                    new Uri("repositories/1/issues/3/comments", UriKind.Relative),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
+                                && d["since"] == "2016-11-23T11:11:11Z"),
+                            "application/vnd.github.squirrel-girl-preview");
             }
 
             [Fact]
@@ -235,9 +249,11 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, options: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null, ApiOptions.None));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, options: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null, ApiOptions.None));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1));
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("owner", "", 1));

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -188,7 +188,7 @@ namespace Octokit.Tests.Reactive
             }
 
             [Fact]
-            public void RequestsCorrectUrlWithApiOptions()
+            public void RequestsCorrectUrlWithIssueCommentRequest()
             {
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
@@ -197,6 +197,42 @@ namespace Octokit.Tests.Reactive
                 {
                     Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
                 };
+
+                client.GetAllForIssue("fake", "repo", 3, request);
+
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 3
+                         && d["since"] == "2016-11-23T11:11:11Z"),
+                    "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithRepositoryIdWithIssueCommentRequest()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueCommentsClient(gitHubClient);
+
+                var request = new IssueCommentRequest()
+                {
+                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
+                };
+
+                client.GetAllForIssue(1, 3, request);
+
+                gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
+                    new Uri("repositories/1/issues/3/comments", UriKind.Relative),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 3
+                                && d["since"] == "2016-11-23T11:11:11Z"),
+                            "application/vnd.github.squirrel-girl-preview");
+            }
+
+            [Fact]
+            public void RequestsCorrectUrlWithApiOptions()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableIssueCommentsClient(gitHubClient);
+
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -204,12 +240,11 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForIssue("fake", "repo", 3, request, options);
+                client.GetAllForIssue("fake", "repo", 3, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 5
-                         && d["since"] == "2016-11-23T11:11:11Z"),
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 4),
                     "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -219,10 +254,6 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservableIssueCommentsClient(gitHubClient);
 
-                var request = new IssueCommentRequest()
-                {
-                    Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
-                };
                 var options = new ApiOptions
                 {
                     StartPage = 1,
@@ -230,12 +261,11 @@ namespace Octokit.Tests.Reactive
                     PageCount = 1
                 };
 
-                client.GetAllForIssue(1, 3, request, options);
+                client.GetAllForIssue(1, 3, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repositories/1/issues/3/comments", UriKind.Relative),
-                    Arg.Is<Dictionary<string, string>>(d => d.Count == 5
-                                && d["since"] == "2016-11-23T11:11:11Z"),
+                    Arg.Is<Dictionary<string, string>>(d => d.Count == 4),
                             "application/vnd.github.squirrel-girl-preview");
             }
 
@@ -250,9 +280,11 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(null, "name", 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", null, 1, ApiOptions.None));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, options: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, request: null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue("owner", "name", 1, null, ApiOptions.None));
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, options: null));
+                Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, request: null));
                 Assert.Throws<ArgumentNullException>(() => client.GetAllForIssue(1, 1, null, ApiOptions.None));
 
                 Assert.Throws<ArgumentException>(() => client.GetAllForIssue("", "name", 1));

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -138,6 +138,46 @@ namespace Octokit
         Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options);
+
+        /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#create-a-comment</remarks>

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -200,7 +200,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForIssue(owner, name, number, new IssueCommentRequest(), options);
         }
 
         /// <summary>
@@ -214,7 +214,73 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
+            return GetAllForIssue(repositoryId, number, new IssueCommentRequest(), options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return GetAllForIssue(owner, name, number, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+
+            return GetAllForIssue(repositoryId, number, request, ApiOptions.None);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+            
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
+        }
+
+        /// <summary>
+        /// Gets Issue Comments for a specified Issue.
+        /// </summary>
+        /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
+        /// <param name="repositoryId">The Id of the repository</param>
+        /// <param name="number">The issue number</param>
+        /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        /// <param name="options">Options for changing the API response</param>
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
+        {
+            Ensure.ArgumentNotNull(request, nameof(request));
+            Ensure.ArgumentNotNull(options, nameof(options));
+            
+            return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed that `IObservable<IssueComment> GetAllForIssue(long repositoryId, int number, ApiOptions otpions)` didn't specify `AcceptHeaders.ReactionsPreview` so I added this as part of my changes.

- [x] Tests ~? (I checked the `GetAllForRepository` method and noticed that there are no tests that use the `IssueCommentRequest` parameter, but I can add tests for the `GetAllForIssue` if desired)~ `Codecov` clearly wants me to write some tests 😁 

Fixes octokit/octokit.net#1960