### PR TITLE
migrate to dotnet-format tool

### DIFF
--- a/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentReactionsClient.cs
@@ -107,7 +107,7 @@ namespace Octokit.Reactive
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
         }
     }

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -73,7 +73,7 @@ namespace Octokit.Reactive
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.IssueReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
         }
 

--- a/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
@@ -61,7 +61,7 @@ namespace Octokit.Reactive
         public IObservable<Migration> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return _connection.GetAndFlattenAllPages<Migration>(ApiUrls.EnterpriseMigrations(org), null, AcceptHeaders.MigrationsApiPreview, options);
         }
 

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewCommentReactionsClient.cs
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         public IObservable<Reaction> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return _connection.GetAndFlattenAllPages<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
         }
 

--- a/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/CommitCommentReactionsClientTests.cs
@@ -93,7 +93,7 @@ public class CommitCommentReactionsClientTests
             var reactions = await _github.Reaction.CommitComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, result.Id, options);
 
             Assert.Equal(1, reactions.Count);
-            
+
             Assert.Equal(reaction.Id, reactions[0].Id);
             Assert.Equal(reaction.Content, reactions[0].Content);
         }
@@ -111,7 +111,7 @@ public class CommitCommentReactionsClientTests
             Assert.NotNull(result);
 
             var reactions = new List<Reaction>();
-            var reactionsContent = new []{ ReactionType.Confused, ReactionType.Hooray };
+            var reactionsContent = new[] { ReactionType.Confused, ReactionType.Hooray };
             for (var i = 0; i < 2; i++)
             {
                 var newReaction = new NewReaction(reactionsContent[i]);
@@ -128,7 +128,7 @@ public class CommitCommentReactionsClientTests
             var reactionsInfo = await _github.Reaction.CommitComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, result.Id, options);
 
             Assert.Equal(1, reactionsInfo.Count);
-            
+
             Assert.Equal(reactions.Last().Id, reactionsInfo[0].Id);
             Assert.Equal(reactions.Last().Content, reactionsInfo[0].Content);
         }
@@ -145,7 +145,7 @@ public class CommitCommentReactionsClientTests
 
             Assert.NotNull(result);
 
-            var reactionsContent = new []{ ReactionType.Confused, ReactionType.Hooray };
+            var reactionsContent = new[] { ReactionType.Confused, ReactionType.Hooray };
             for (var i = 0; i < 2; i++)
             {
                 var newReaction = new NewReaction(reactionsContent[i]);
@@ -159,7 +159,7 @@ public class CommitCommentReactionsClientTests
                 StartPage = 1
             };
             var firstPage = await _github.Reaction.CommitComment.GetAll(_context.RepositoryOwner, _context.RepositoryName, result.Id, startOptions);
-            
+
             var skipStartOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -221,7 +221,7 @@ public class CommitCommentReactionsClientTests
             var reactions = await _github.Reaction.CommitComment.GetAll(_context.Repository.Id, result.Id, options);
 
             Assert.Equal(1, reactions.Count);
-            
+
             Assert.Equal(reaction.Id, reactions[0].Id);
             Assert.Equal(reaction.Content, reactions[0].Content);
         }
@@ -239,7 +239,7 @@ public class CommitCommentReactionsClientTests
             Assert.NotNull(result);
 
             var reactions = new List<Reaction>();
-            var reactionsContent = new []{ ReactionType.Confused, ReactionType.Hooray };
+            var reactionsContent = new[] { ReactionType.Confused, ReactionType.Hooray };
             for (var i = 0; i < 2; i++)
             {
                 var newReaction = new NewReaction(reactionsContent[i]);
@@ -256,7 +256,7 @@ public class CommitCommentReactionsClientTests
             var reactionsInfo = await _github.Reaction.CommitComment.GetAll(_context.Repository.Id, result.Id, options);
 
             Assert.Equal(1, reactionsInfo.Count);
-            
+
             Assert.Equal(reactions.Last().Id, reactionsInfo[0].Id);
             Assert.Equal(reactions.Last().Content, reactionsInfo[0].Content);
         }
@@ -273,7 +273,7 @@ public class CommitCommentReactionsClientTests
 
             Assert.NotNull(result);
 
-            var reactionsContent = new []{ ReactionType.Confused, ReactionType.Hooray };
+            var reactionsContent = new[] { ReactionType.Confused, ReactionType.Hooray };
             for (var i = 0; i < 2; i++)
             {
                 var newReaction = new NewReaction(reactionsContent[i]);
@@ -287,7 +287,7 @@ public class CommitCommentReactionsClientTests
                 StartPage = 1
             };
             var firstPage = await _github.Reaction.CommitComment.GetAll(_context.Repository.Id, result.Id, startOptions);
-            
+
             var skipStartOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -300,7 +300,7 @@ public class CommitCommentReactionsClientTests
             Assert.Equal(1, secondPage.Count);
             Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
             Assert.NotEqual(firstPage[0].Content, secondPage[0].Content);
-        }        
+        }
         [IntegrationTest]
         public async Task CanCreateReaction()
         {

--- a/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueReactionsClientTests.cs
@@ -58,7 +58,7 @@ public class IssueReactionsClientTests
                 PageSize = 1,
                 PageCount = 1
             };
-            
+
             var issueReactions = await _github.Reaction.Issue.GetAll(_context.RepositoryOwner, _context.RepositoryName, issue.Number, options);
 
             Assert.Equal(1, issueReactions.Count);
@@ -89,7 +89,7 @@ public class IssueReactionsClientTests
                 PageCount = 1,
                 StartPage = 2
             };
-            
+
             var issueReactions = await _github.Reaction.Issue.GetAll(_context.RepositoryOwner, _context.RepositoryName, issue.Number, options);
 
             Assert.Equal(1, issueReactions.Count);
@@ -121,7 +121,7 @@ public class IssueReactionsClientTests
                 StartPage = 1
             };
             var firstPage = await _github.Reaction.Issue.GetAll(_context.RepositoryOwner, _context.RepositoryName, issue.Number, startOptions);
-            
+
             var skipStartOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -129,7 +129,7 @@ public class IssueReactionsClientTests
                 StartPage = 2
             };
             var secondPage = await _github.Reaction.Issue.GetAll(_context.RepositoryOwner, _context.RepositoryName, issue.Number, skipStartOptions);
-            
+
             Assert.Equal(1, firstPage.Count);
             Assert.Equal(1, secondPage.Count);
             Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);
@@ -169,7 +169,7 @@ public class IssueReactionsClientTests
                 PageSize = 1,
                 PageCount = 1
             };
-            
+
             var issueReactions = await _github.Reaction.Issue.GetAll(_context.Repository.Id, issue.Number, options);
 
             Assert.Equal(1, issueReactions.Count);
@@ -200,7 +200,7 @@ public class IssueReactionsClientTests
                 PageCount = 1,
                 StartPage = 2
             };
-            
+
             var issueReactions = await _github.Reaction.Issue.GetAll(_context.Repository.Id, issue.Number, options);
 
             Assert.Equal(1, issueReactions.Count);
@@ -232,7 +232,7 @@ public class IssueReactionsClientTests
                 StartPage = 1
             };
             var firstPage = await _github.Reaction.Issue.GetAll(_context.Repository.Id, issue.Number, startOptions);
-            
+
             var skipStartOptions = new ApiOptions
             {
                 PageSize = 1,
@@ -240,7 +240,7 @@ public class IssueReactionsClientTests
                 StartPage = 2
             };
             var secondPage = await _github.Reaction.Issue.GetAll(_context.Repository.Id, issue.Number, skipStartOptions);
-            
+
             Assert.Equal(1, firstPage.Count);
             Assert.Equal(1, secondPage.Count);
             Assert.NotEqual(firstPage[0].Id, secondPage[0].Id);

--- a/Octokit.Tests.Integration/Clients/MigrationsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/MigrationsClientTests.cs
@@ -75,12 +75,12 @@ public class MigrationsClientTests : IDisposable
             PageCount = 1,
             PageSize = 1
         };
-        
+
         var migrations = await _gitHub.Migration.Migrations.GetAll(_orgName, options);
 
         Assert.Equal(1, migrations.Count);
     }
-    
+
     [IntegrationTest]
     public async Task ReturnsCorrectCountOfMigrationsWithStart()
     {
@@ -90,7 +90,7 @@ public class MigrationsClientTests : IDisposable
             PageSize = 1,
             StartPage = 2
         };
-        
+
         var migrations = await _gitHub.Migration.Migrations.GetAll(_orgName, options);
 
         Assert.Equal(1, migrations.Count);
@@ -105,7 +105,7 @@ public class MigrationsClientTests : IDisposable
             PageSize = 1,
             StartPage = 1
         };
-        
+
         var firstPage = await _gitHub.Migration.Migrations.GetAll(_orgName, startOptions);
 
         var skipStartOptions = new ApiOptions

--- a/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/PullRequestsClientTests.cs
@@ -42,7 +42,7 @@ public class PullRequestsClientTests : IDisposable
     public async Task CanCreateDraft()
     {
         await CreateTheWorld();
-        
+
         var newPullRequest = new NewPullRequest("a draft pull request", branchName, "master") { Draft = true };
         var result = await _fixture.Create(Helper.UserName, _context.RepositoryName, newPullRequest);
         Assert.Equal("a draft pull request", result.Title);
@@ -63,13 +63,13 @@ public class PullRequestsClientTests : IDisposable
     public async Task CanCreateDraftWithRepositoryId()
     {
         await CreateTheWorld();
-        
+
         var newPullRequest = new NewPullRequest("a draft pull request", branchName, "master") { Draft = true };
         var result = await _fixture.Create(_context.Repository.Id, newPullRequest);
         Assert.Equal("a draft pull request", result.Title);
         Assert.True(result.Draft);
     }
-    
+
     [IntegrationTest]
     public async Task CanGetForRepository()
     {

--- a/Octokit.Tests.Integration/Helpers/GitHubAppsTestAttribute.cs
+++ b/Octokit.Tests.Integration/Helpers/GitHubAppsTestAttribute.cs
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Integration
                 return Enumerable.Empty<IXunitTestCase>();
             }
 
-            return new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None,  testMethod) };
+            return new[] { new XunitTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod) };
         }
     }
 

--- a/Octokit.Tests.Integration/Helpers/MaintenanceModeContext.cs
+++ b/Octokit.Tests.Integration/Helpers/MaintenanceModeContext.cs
@@ -18,7 +18,7 @@ namespace Octokit.Tests.Integration.Helpers
         }
 
         private IConnection _connection;
-        
+
         public void Dispose()
         {
             // Ensure maintenance mode is OFF

--- a/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1,
                     PageSize = 1
                 };
-                
+
                 await client.GetAll(1, 42, options);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -190,7 +190,7 @@ namespace Octokit.Tests.Clients
                 {
                     Since = new DateTimeOffset(2016, 11, 23, 11, 11, 11, 00, new TimeSpan()),
                 };
-                
+
                 await client.GetAllForIssue("fake", "repo", 3, request);
 
                 connection.Received().GetAll<IssueComment>(

--- a/Octokit.Tests/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueReactionsClientTests.cs
@@ -28,7 +28,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
             }
-            
+
             [Fact]
             public async Task RequestsCorrectUrlApiOptions()
             {
@@ -70,7 +70,7 @@ namespace Octokit.Tests.Clients
                     StartPage = 1,
                     PageSize = 1
                 };
-                
+
                 await client.GetAll(1, 42, options);
 
                 connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -201,7 +201,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3, request);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 3
                          && d["since"] == "2016-11-23T11:11:11Z"),
                     "application/vnd.github.squirrel-girl-preview");
@@ -243,7 +243,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue("fake", "repo", 3, options);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative), 
+                    new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 4),
                     "application/vnd.github.squirrel-girl-preview");
             }

--- a/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueReactionsClientTests.cs
@@ -80,7 +80,7 @@ namespace Octokit.Tests.Reactive
 
                 Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
                 Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));                
+                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
 
                 Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
                 Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -97,7 +97,7 @@ namespace Octokit
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return ApiConnection.GetAll<Reaction>(ApiUrls.IssueCommentReactions(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
         }
     }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -263,7 +263,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(owner, name, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 
@@ -279,7 +279,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return ApiConnection.GetAll<IssueComment>(ApiUrls.IssueComments(repositoryId, number), request.ToParametersDictionary(), AcceptHeaders.ReactionsPreview, options);
         }
 

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -66,7 +66,7 @@ namespace Octokit
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
-            
+
             return ApiConnection.GetAll<Reaction>(ApiUrls.PullRequestReviewCommentReaction(repositoryId, number), null, AcceptHeaders.ReactionsPreview, options);
         }
 

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -46,7 +46,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(owner, name, number), null,AcceptHeaders.DraftPullRequestApiPreview);
+            return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(owner, name, number), null, AcceptHeaders.DraftPullRequestApiPreview);
         }
 
         /// <summary>

--- a/Octokit/Models/Request/NewPullRequest.cs
+++ b/Octokit/Models/Request/NewPullRequest.cs
@@ -50,7 +50,7 @@ namespace Octokit
         /// Body of the pull request (optional)
         /// </summary>
         public string Body { get; set; }
-        
+
         /// <summary>
         /// Whether the pull request is in a draft state or not (optional)
         /// </summary>

--- a/Octokit/Models/Request/SearchRepositoriesRequest.cs
+++ b/Octokit/Models/Request/SearchRepositoriesRequest.cs
@@ -331,7 +331,7 @@ namespace Octokit
         /// Matches repositories with regards to both the <param name="from"/> and <param name="to"/> dates.
         /// </summary>
         [Obsolete("This ctor does not support the time component or timezone and will be removed in a future release. Please use the DateTimeOffset overload instead")]
-        public DateRange(DateTime from, DateTime to) 
+        public DateRange(DateTime from, DateTime to)
         {
             query = $"{from.ToString(DatePattern, CultureInfo.InvariantCulture)}..{to.ToString(DatePattern, CultureInfo.InvariantCulture)}";
         }

--- a/Octokit/Models/Response/Milestone.cs
+++ b/Octokit/Models/Response/Milestone.cs
@@ -42,7 +42,7 @@ namespace Octokit
         /// The Html page for this milestone.
         /// </summary>
         public string HtmlUrl { get; protected set; }
-        
+
         /// <summary>
         /// The ID for this milestone.
         /// </summary>

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -170,7 +170,7 @@ namespace Octokit
         /// Whether or not the pull request is in a draft state, and cannot be merged.
         /// </summary>
         public bool Draft { get; protected set; }
-        
+
         /// <summary>
         /// Whether or not the pull request has been merged.
         /// </summary>

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -29,6 +29,7 @@ public class Context : FrostingContext
 
     public Project[] Projects { get; set; }
 
+    public FilePath DotNetFormatToolPath { get; set; }
     public FilePath GitVersionToolPath { get; set; }
 
     public DotNetCoreTestSettings GetTestSettings()

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -56,18 +56,7 @@ public class Lifetime : FrostingLifetime<Context>
             new Project { Name = "Octokit.Tests.Integration", Path = "./Octokit.Tests.Integration/Octokit.Tests.Integration.csproj", IntegrationTests = true }
         };
 
-        // Install tools
-        if (context.CoreOnly)
-        {
-            context.Information("Skipping tool installation for core-only build");
-        }
-        else
-        {
-            context.Information("Installing tools...");
-            ToolInstaller.Install(context, "Octokit.CodeFormatter", "1.0.0-preview");
-        }
-
-
+        context.DotNetFormatToolPath = ToolInstaller.DotNetCoreToolInstall(context, "dotnet-format", "3.1.37601", "dotnet-format");
         context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.0.0", "dotnet-gitversion");
 
         // Calculate semantic version.

--- a/build/Tasks/Build.cs
+++ b/build/Tasks/Build.cs
@@ -4,6 +4,7 @@ using Cake.Core;
 using Cake.Frosting;
 
 [Dependency(typeof(Restore))]
+[Dependency(typeof(FormatCode))]
 public class Build : FrostingTask<Context>
 {
     public override void Run(Context context)

--- a/build/Tasks/FormatCode.cs
+++ b/build/Tasks/FormatCode.cs
@@ -1,76 +1,15 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using Cake.Common;
-using Cake.Common.Diagnostics;
-using Cake.Core;
-using Cake.Core.IO;
+﻿using Cake.Common.Tools.DotNetCore;
 using Cake.Frosting;
 
 public sealed class FormatCode : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        var codeFormatterExe = context.FileSystem
-            .GetDirectory("tools")
-            .GetFiles("CodeFormatter.exe", SearchScope.Recursive)
-            .First()
-            .Path
-            .MakeAbsolute(context.Environment);
-
-        foreach (var project in context.Projects)
-        {
-            context.Information("Formatting code of {0}", project.Name);
-
-            var tempCsprojFile = CreateTempCsproj(context, project.Name);
-            context.Information("Generated temporary {0} file to run the formatter", new FilePath(tempCsprojFile).GetFilename());
-
-            var exitCode = context.StartProcess(
-                codeFormatterExe,
-                $"{tempCsprojFile} /nocopyright /nounicode");
-
-            if (exitCode != 0)
-            {
-                throw new CakeException($"An error occured while formatting code of {project.Name}");
-            }
-        }
-
-        context.Information("Successfully formatted code of all the projects");
+        context.DotNetCoreTool("format");
     }
 
     public override bool ShouldRun(Context context)
     {
-        // Core only builds do not download the formatter exe
-        // Only windows is guaranteed to be able to run exe files in the first place
-        return context.IsRunningOnWindows() && !context.CoreOnly;
-    }
-
-    private static string CreateTempCsproj(Context context, string projectName)
-    {
-        DirectoryPath tempFolder = System.IO.Path.GetTempPath();
-        var projectCsproj = tempFolder.CombineWithFilePath($"{projectName}.csproj").FullPath;
-
-        var files = context.FileSystem
-            .GetDirectory(projectName)
-            .GetFiles("*.cs", SearchScope.Recursive)
-            .Select(x => x.Path.MakeAbsolute(context.Environment))
-            .ToArray();
-
-        var compileElements = files
-            .Select(x => $"<Compile Include=\"{x}\" />")
-            .ToArray();
-
-        var csprojContent =
-$@"<?xml version=""1.0"" encoding=""utf-8""?>
-<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <ItemGroup>
-    {string.Join(Environment.NewLine, compileElements)}
-  </ItemGroup>
-  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
-</Project>";
-
-        File.WriteAllText(projectCsproj, csprojContent);
-
-        return projectCsproj;
+        return context.IsLocalBuild;
     }
 }


### PR DESCRIPTION
Back in the day I added [`shiftkey/Octokit.CodeFormatter`](https://github.com/shiftkey/Octokit.CodeFormatter) to this project, but that predates the global tools support for .NET Core. I had a look around today before I took a shot at updating it and found [`dotnet-format`](https://github.com/dotnet/format) has shipped, so I'm going to retire that in favour of this.

This PR now adds in the `FormatCode` step as a local build (so devs can run `./build.ps1` or `./build.sh` and have their code tidied up for free) and tidies up what is currently on `master`.