### PR TITLE
address new Travis build warning

### DIFF
--- a/Octokit.Tests/Http/ApiConnectionTests.cs
+++ b/Octokit.Tests/Http/ApiConnectionTests.cs
@@ -388,6 +388,7 @@ namespace Octokit.Tests.Http
                 connection.Received(3).GetResponse<IReadOnlyList<object>>(queuedOperationUrl, Args.CancellationToken);
             }
 
+            [Fact(Skip = "Test triggers deadlock when run, needs to be investigated")]
             public async Task CanCancelQueuedOperation()
             {
                 var queuedOperationUrl = new Uri("anything", UriKind.Relative);

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Octokit;
 using Octokit.Tests.Helpers;
 using Xunit;
+// hack because Travis on LInux is somehow upgraded to a version of .NET (Core?) that also has System.Range
+using Range = Octokit.Range;
 
 public class SearchIssuesRequestTests
 {


### PR DESCRIPTION
Recent Travis builds on Linux seem to now have `System.Range` available, which clashes with our `Octokit.Range` type:

```
Models/SearchIssuesRequestTests.cs(187,32): error CS0104: 'Range' is an ambiguous reference between 'Octokit.Range' and 'System.Range' [/home/travis/build/octokit/octokit.net/Octokit.Tests/Octokit.Tests.csproj]
```

This should disambiguate it without impacting the other builds.

Oh, and the second commit is to tidy up the last xUnit warning (by opting in and skipping the test with a warning).