### PR TITLE
add support for multiple extension filters

### DIFF
--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1801,14 +1801,16 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something");
-                request.Extensions.Add("cs");
+                var request = new SearchCodeRequest("something")
+                {
+                    Extensions = new[] { "txt" }
+                };
 
                 client.SearchCode(request);
 
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+extension:cs"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+extension:txt"));
             }
 
             [Fact]
@@ -1816,9 +1818,10 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something");
-                request.Extensions.Add("cs");
-                request.Extensions.Add("lol");
+                var request = new SearchCodeRequest("something")
+                {
+                    Extensions = new[] { "cs", "lol" }
+                };
 
                 client.SearchCode(request);
 
@@ -1891,10 +1894,11 @@ namespace Octokit.Tests.Clients
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
-                var request = new SearchCodeRequest("something", "octokit", "octokit.net");
+                var request = new SearchCodeRequest("something", "octokit", "octokit.net")
+                {
+                    Extensions = new[] { "fs", "cs" }
+                };
                 request.Path = "tools/FAKE.core";
-                request.Extensions.Add("fs");
-                request.Extensions.Add("cs");
 
                 client.SearchCode(request);
 

--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -1802,13 +1802,29 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new SearchClient(connection);
                 var request = new SearchCodeRequest("something");
-                request.Extension = "cs";
+                request.Extensions.Add("cs");
 
                 client.SearchCode(request);
 
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+extension:cs"));
+            }
+
+            [Fact]
+            public void TestingTheExtensionQualifier_Multiple()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new SearchClient(connection);
+                var request = new SearchCodeRequest("something");
+                request.Extensions.Add("cs");
+                request.Extensions.Add("lol");
+
+                client.SearchCode(request);
+
+                connection.Received().Get<SearchCodeResult>(
+                    Arg.Is<Uri>(u => u.ToString() == "search/code"),
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+extension:cs+extension:lol"));
             }
 
             [Fact]
@@ -1877,14 +1893,15 @@ namespace Octokit.Tests.Clients
                 var client = new SearchClient(connection);
                 var request = new SearchCodeRequest("something", "octokit", "octokit.net");
                 request.Path = "tools/FAKE.core";
-                request.Extension = "fs";
+                request.Extensions.Add("fs");
+                request.Extensions.Add("cs");
 
                 client.SearchCode(request);
 
                 connection.Received().Get<SearchCodeResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/code"),
                     Arg.Is<Dictionary<string, string>>(d =>
-                        d["q"] == "something+path:tools/FAKE.core+extension:fs+repo:octokit/octokit.net"));
+                        d["q"] == "something+path:tools/FAKE.core+extension:fs+extension:cs+repo:octokit/octokit.net"));
             }
 
             [Fact]

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -121,7 +121,7 @@ namespace Octokit
         /// <remarks>
         /// https://help.github.com/articles/searching-code#extension
         /// </remarks>
-        public IList<string> Extensions { get; set; } = new List<string>();
+        public IEnumerable<string> Extensions { get; set; } = new List<string>();
 
         /// <summary>
         /// Matches specific file names

--- a/Octokit/Models/Request/SearchCodeRequest.cs
+++ b/Octokit/Models/Request/SearchCodeRequest.cs
@@ -116,12 +116,12 @@ namespace Octokit
         public string Path { get; set; }
 
         /// <summary>
-        /// Matches files with a certain extension.
+        /// Matches files with a certain extensions.
         /// </summary>
         /// <remarks>
         /// https://help.github.com/articles/searching-code#extension
         /// </remarks>
-        public string Extension { get; set; }
+        public IList<string> Extensions { get; set; } = new List<string>();
 
         /// <summary>
         /// Matches specific file names
@@ -189,9 +189,12 @@ namespace Octokit
                 parameters.Add(string.Format(CultureInfo.InvariantCulture, "path:{0}", Path));
             }
 
-            if (Extension.IsNotBlank())
+            if (Extensions.Any())
             {
-                parameters.Add(string.Format(CultureInfo.InvariantCulture, "extension:{0}", Extension));
+                foreach (var extension in Extensions)
+                {
+                    parameters.Add(string.Format(CultureInfo.InvariantCulture, "extension:{0}", extension));
+                }
             }
 
             if (FileName.IsNotBlank())

--- a/docs/search.md
+++ b/docs/search.md
@@ -212,7 +212,7 @@ var request = new SearchCodeRequest("auth")
     Path = "app/assets",
     
     // we may want to restrict the file based on file extension
-    Extension = "json",
+    Extensions = new[] { "json", "sql" },
     
     // restrict search to a specific file name
     FileName = "app.json",


### PR DESCRIPTION
Modifies `SearchCodeRequest.Extension` to be a list for filtering by `x` number of extensions. Helps reduce the number of required API calls.

Question: Is there an open issue to support the negation of qualifiers (`-extension:{0}`)? I couldn't find one.