### PR TITLE
#2031 Int32 Overflow exception

### DIFF
--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -27,7 +27,7 @@ namespace Octokit
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// GraphQL Node Id


### PR DESCRIPTION
Fixed this issue by changing the model property to be a long.

The Working fix:
<img width="644" alt="long_screenshot" src="https://user-images.githubusercontent.com/20315527/67424101-cac10f80-f5d5-11e9-9022-bd987e29b30f.png">

The int32 overflow exception:
<img width="543" alt="stackoverflow_exception" src="https://user-images.githubusercontent.com/20315527/67424140-e4625700-f5d5-11e9-8d89-b4ad0c28114a.PNG">


This is one of my first pr's, so let me know if I'm missing something. We don't appear to need to change the docs for this one.