### PR TITLE
Fix for ThrowInt32OverflowException in Issue.Events.GetAllForRepository

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(string owner, string name, int number);
+        IObservable<Issue> Get(string owner, string name, long number);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(long repositoryId, int number);
+        IObservable<Issue> Get(long repositoryId, long number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -304,7 +304,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(string owner, string name, long number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -315,7 +315,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(long repositoryId, long number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -324,7 +324,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Lock(string owner, string name, int number);
+        IObservable<Unit> Lock(string owner, string name, long number);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -332,7 +332,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Lock(long repositoryId, int number);
+        IObservable<Unit> Lock(long repositoryId, long number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -341,7 +341,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(string owner, string name, int number);
+        IObservable<Unit> Unlock(string owner, string name, long number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -349,6 +349,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<Unit> Unlock(long repositoryId, int number);
+        IObservable<Unit> Unlock(long repositoryId, long number);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
+        IObservable<EventInfo> GetAllForIssue(string owner, string name, long number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number);
+        IObservable<EventInfo> GetAllForIssue(long repositoryId, long number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        IObservable<EventInfo> GetAllForIssue(string owner, string name, long number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<EventInfo> GetAllForIssue(long repositoryId, long number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -106,7 +106,7 @@ namespace Octokit.Reactive
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<IssueEvent> Get(string owner, string name, int number);
+        IObservable<IssueEvent> Get(string owner, string name, long number);
 
         /// <summary>
         /// Gets a single event
@@ -118,6 +118,6 @@ namespace Octokit.Reactive
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<IssueEvent> Get(long repositoryId, int number);
+        IObservable<IssueEvent> Get(long repositoryId, long number);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -71,7 +71,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Issue> Get(string owner, string name, int number)
+        public IObservable<Issue> Get(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -87,7 +87,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Issue> Get(long repositoryId, int number)
+        public IObservable<Issue> Get(long repositoryId, long number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }
@@ -448,7 +448,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(string owner, string name, long number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -466,7 +466,7 @@ namespace Octokit.Reactive
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(long repositoryId, long number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
@@ -480,7 +480,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Lock(string owner, string name, int number)
+        public IObservable<Unit> Lock(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -494,7 +494,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Lock(long repositoryId, int number)
+        public IObservable<Unit> Lock(long repositoryId, long number)
         {
             return _client.Lock(repositoryId, number).ToObservable();
         }
@@ -506,7 +506,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(string owner, string name, int number)
+        public IObservable<Unit> Unlock(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -520,7 +520,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<Unit> Unlock(long repositoryId, int number)
+        public IObservable<Unit> Unlock(long repositoryId, long number)
         {
             return _client.Unlock(repositoryId, number).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number)
+        public IObservable<EventInfo> GetAllForIssue(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number)
+        public IObservable<EventInfo> GetAllForIssue(long repositoryId, long number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public IObservable<EventInfo> GetAllForIssue(string owner, string name, long number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<EventInfo> GetAllForIssue(long repositoryId, long number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -158,7 +158,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        public IObservable<IssueEvent> Get(string owner, string name, int number)
+        public IObservable<IssueEvent> Get(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -174,7 +174,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The event id</param>
-        public IObservable<IssueEvent> Get(long repositoryId, int number)
+        public IObservable<IssueEvent> Get(long repositoryId, long number)
         {
             return _client.Get(repositoryId, number).ToObservable();
         }

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -402,7 +402,7 @@ public class IssuesEventsClientTests : IDisposable
         var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
-        int issueEventId = issueEvents[0].Id;
+        long issueEventId = issueEvents[0].Id;
 
         var issueEventLookupById = await _issuesEventsClient.Get(_context.RepositoryOwner, _context.RepositoryName, issueEventId);
 
@@ -418,7 +418,7 @@ public class IssuesEventsClientTests : IDisposable
         var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.Repository.Id);
-        int issueEventId = issueEvents[0].Id;
+        long issueEventId = issueEvents[0].Id;
 
         var issueEventLookupById = await _issuesEventsClient.Get(_context.Repository.Id, issueEventId);
 

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -52,7 +52,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(string owner, string name, int number);
+        Task<Issue> Get(string owner, string name, long number);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(long repositoryId, int number);
+        Task<Issue> Get(long repositoryId, long number);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -301,7 +301,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate);
+        Task<Issue> Update(string owner, string name, long number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
@@ -312,7 +312,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate);
+        Task<Issue> Update(long repositoryId, long number, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -321,7 +321,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Lock(string owner, string name, int number);
+        Task Lock(string owner, string name, long number);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -329,7 +329,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Lock(long repositoryId, int number);
+        Task Lock(long repositoryId, long number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -338,7 +338,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Unlock(string owner, string name, int number);
+        Task Unlock(string owner, string name, long number);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -346,6 +346,6 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task Unlock(long repositoryId, int number);
+        Task Unlock(long repositoryId, long number);
     }
 }

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, long number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, long number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, long number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, long number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.
@@ -107,7 +107,7 @@ namespace Octokit
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueEvent> Get(string owner, string name, int number);
+        Task<IssueEvent> Get(string owner, string name, long number);
 
         /// <summary>
         /// Gets a single event
@@ -119,6 +119,6 @@ namespace Octokit
         /// <param name="number">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueEvent> Get(long repositoryId, int number);
+        Task<IssueEvent> Get(long repositoryId, long number);
     }
 }

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<Issue> Get(string owner, string name, int number)
+        public Task<Issue> Get(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -82,7 +82,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<Issue> Get(long repositoryId, int number)
+        public Task<Issue> Get(long repositoryId, long number)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
         }
@@ -442,7 +442,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
+        public Task<Issue> Update(string owner, string name, long number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -460,7 +460,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
+        public Task<Issue> Update(long repositoryId, long number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 
@@ -474,7 +474,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Lock(string owner, string name, int number)
+        public Task Lock(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -488,7 +488,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Lock(long repositoryId, int number)
+        public Task Lock(long repositoryId, long number)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
         }
@@ -500,7 +500,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Unlock(string owner, string name, int number)
+        public Task Unlock(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -514,7 +514,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task Unlock(long repositoryId, int number)
+        public Task Unlock(long repositoryId, long number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);
         }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -40,7 +40,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, long number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, long number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -73,7 +73,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, long number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -150,7 +150,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The event id</param>
-        public Task<IssueEvent> Get(string owner, string name, int number)
+        public Task<IssueEvent> Get(string owner, string name, long number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -166,7 +166,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The event id</param>
-        public Task<IssueEvent> Get(long repositoryId, int number)
+        public Task<IssueEvent> Get(long repositoryId, long number)
         {
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));
         }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -430,7 +430,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri Issue(string owner, string name, int number)
+        public static Uri Issue(string owner, string name, long number)
         {
             return "repos/{0}/{1}/issues/{2}".FormatUri(owner, name, number);
         }
@@ -442,7 +442,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLock(string owner, string name, int number)
+        public static Uri IssueLock(string owner, string name, long number)
         {
             return "repos/{0}/{1}/issues/{2}/lock".FormatUri(owner, name, number);
         }
@@ -815,7 +815,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns></returns>
-        public static Uri IssuesEvents(string owner, string name, int number)
+        public static Uri IssuesEvents(string owner, string name, long number)
         {
             return "repos/{0}/{1}/issues/{2}/events".FormatUri(owner, name, number);
         }
@@ -838,7 +838,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The event id</param>
         /// <returns></returns>
-        public static Uri IssuesEvent(string owner, string name, int id)
+        public static Uri IssuesEvent(string owner, string name, long id)
         {
             return "repos/{0}/{1}/issues/events/{2}".FormatUri(owner, name, id);
         }
@@ -850,7 +850,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
-        public static Uri Milestone(string owner, string name, int number)
+        public static Uri Milestone(string owner, string name, long number)
         {
             return "repos/{0}/{1}/milestones/{2}".FormatUri(owner, name, number);
         }
@@ -2884,7 +2884,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue.</returns>
-        public static Uri Issue(long repositoryId, int number)
+        public static Uri Issue(long repositoryId, long number)
         {
             return "repositories/{0}/issues/{1}".FormatUri(repositoryId, number);
         }
@@ -2950,7 +2950,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue to be locked/unlocked.</returns>
-        public static Uri IssueLock(long repositoryId, int number)
+        public static Uri IssueLock(long repositoryId, long number)
         {
             return "repositories/{0}/issues/{1}/lock".FormatUri(repositoryId, number);
         }
@@ -2971,7 +2971,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The event id</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified event.</returns>
-        public static Uri IssuesEvent(long repositoryId, int id)
+        public static Uri IssuesEvent(long repositoryId, long id)
         {
             return "repositories/{0}/issues/events/{1}".FormatUri(repositoryId, id);
         }
@@ -2982,7 +2982,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.</returns>
-        public static Uri IssuesEvents(long repositoryId, int number)
+        public static Uri IssuesEvents(long repositoryId, long number)
         {
             return "repositories/{0}/issues/{1}/events".FormatUri(repositoryId, number);
         }

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(int id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
+        public IssueEvent(long id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
         {
             Id = id;
             NodeId = nodeId;
@@ -27,7 +27,7 @@ namespace Octokit
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// GraphQL Node Id


### PR DESCRIPTION
Fixes #2031

 - Updated Model with long Id
 - Fixed tests
 - Updated IssuesClient and interface
 - Updated IssuesEventsClient and interface

- Double checked that the same tests still failing for the same reasons.