### PR TITLE
(build) Update to Cake 0.35.0, update dependencies and improve dotnet-format execution.

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Coverlet" Version="1.3.1" />
-    <PackageReference Include="Cake.Frosting" Version="0.34.1" />
-    <PackageReference Include="Cake.Codecov" Version="0.4.0" />
-    <PackageReference Include="Codecov" Version="1.1.0" />
+    <PackageReference Include="Cake.Coverlet" Version="2.3.4" />
+    <PackageReference Include="Cake.Frosting" Version="0.35.0" />
+    <PackageReference Include="Cake.Codecov" Version="0.7.0" />
+    <PackageReference Include="Codecov" Version="1.7.2" />
   </ItemGroup>
 
 </Project>

--- a/build/Tasks/CodeCoverage.cs
+++ b/build/Tasks/CodeCoverage.cs
@@ -51,7 +51,7 @@ public sealed class CodeCoverage : FrostingTask<Context>
 
                 var userProfilePath = context.EnvironmentVariable("USERPROFILE");
                 var codecovPath = new DirectoryPath(userProfilePath)
-                    .CombineWithFilePath(".nuget\\packages\\codecov\\1.1.0\\tools\\codecov.exe");
+                    .CombineWithFilePath(".nuget\\packages\\codecov\\1.7.2\\tools\\codecov.exe");
 
                 context.Tools.RegisterFile(codecovPath);
 

--- a/build/Tasks/FormatCode.cs
+++ b/build/Tasks/FormatCode.cs
@@ -1,11 +1,16 @@
-﻿using Cake.Common.Tools.DotNetCore;
+﻿using System;
+using Cake.Common;
 using Cake.Frosting;
 
 public sealed class FormatCode : FrostingTask<Context>
 {
     public override void Run(Context context)
     {
-        context.DotNetCoreTool("format");
+        int result  = context.StartProcess(context.DotNetFormatToolPath);
+        if (result != 0)
+        {
+            throw new Exception($"Failed to execute {context.DotNetFormatToolPath} ({result})");
+        }
     }
 
     public override bool ShouldRun(Context context)


### PR DESCRIPTION
* Cake.Frosting 0.35.0
* Cake.Coverlet 2.3.4
* Cake.Codecov 0.7.0
* Codecov 1.7.2
* Make dotnet-format execution more robust (currently can fail if not installed globally)