### PR TITLE
WIP: Get team by org and name

### DIFF
--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -32,21 +32,6 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(null, "valid teamName"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get("validOrgName", null));
             }
-
-            [Fact]
-            public void UsesTheGetAllMethod()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new TeamsClient(connection);
-
-                client.Get("theOrg", "theTeam");
-
-                connection.Received().GetAll<Team>(
-                    Arg.Is<Uri>(u => u.ToString() == "orgs/theOrg/teams"),
-                    null,
-                    "application/vnd.github.hellcat-preview+json",
-                    Args.ApiOptions);
-            }
         }
         public class TheGetMethod
         {

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -32,6 +32,21 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(null, "valid teamName"));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get("validOrgName", null));
             }
+
+            [Fact]
+            public void UsesTheGetAllMethod()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new TeamsClient(connection);
+
+                client.Get("theOrg", "theTeam");
+
+                connection.Received().GetAll<Team>(
+                    Arg.Is<Uri>(u => u.ToString() == "orgs/theOrg/teams"),
+                    null,
+                    "application/vnd.github.hellcat-preview+json",
+                    Args.ApiOptions);
+            }
         }
         public class TheGetMethod
         {

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -22,17 +22,6 @@ namespace Octokit.Tests.Clients
             }
         }
 
-        public class TheGetMethodForTeamName
-        {
-            [Fact]
-            public async Task EnsuresNonNullArguments()
-            {
-                var teams = new TeamsClient(Substitute.For<IApiConnection>());
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(null, "valid teamName"));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get("validOrgName", null));
-            }
-        }
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -39,6 +39,45 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetByNameMethod
+        {
+            [Fact]
+            public async Task ThrowsWhenOptionsArentProvided()
+            {
+                var teams = new TeamsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(null, "validString", "validString"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(ApiOptions.None, null, "validString"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(ApiOptions.None, "validString", null));
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData("   ")]
+            public async Task ThrowsWhenStringArgumentsAreIncorrect(string inputString)
+            {
+                var teams = new TeamsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentException>(() => teams.Get(ApiOptions.None, inputString, "validString"));
+                await Assert.ThrowsAsync<ArgumentException>(() => teams.Get(ApiOptions.None, "validString", inputString));
+            }
+
+            [Fact]
+            public void CallsCorrectUrl()
+            {
+                // TODO
+            }
+
+            [Fact]
+            public void SlugifiesTheTeamName()
+            {
+                // TODO
+                //"My Cool Team", "my-cool-team"
+            }
+
+        }
+
+
         public class TheGetAllMethod
         {
             [Fact]

--- a/Octokit.Tests/Clients/TeamsClientTests.cs
+++ b/Octokit.Tests/Clients/TeamsClientTests.cs
@@ -22,6 +22,17 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetMethodForTeamName
+        {
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var teams = new TeamsClient(Substitute.For<IApiConnection>());
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get(null, "valid teamName"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => teams.Get("validOrgName", null));
+            }
+        }
         public class TheGetMethod
         {
             [Fact]

--- a/Octokit.Tests/Helpers/ApiUrlsTests.cs
+++ b/Octokit.Tests/Helpers/ApiUrlsTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Octokit.Tests.Helpers
+{
+    public class ApiUrlsTests
+    {
+        public class TeamByName
+        {
+            [Fact]
+            public void UsesCorrectUrl()
+            {
+                var result = ApiUrls.TeamByName("theOrg", "theRepoTeam");
+
+                Assert.Equal("orgs/theOrg/teams/therepoteam", result.OriginalString);
+            }
+
+            [Fact]
+            public void ConvertsSpacesToDashes()
+            {
+                var result = ApiUrls.TeamByName("theOrg", "the repo team");
+
+                Assert.Equal("orgs/theOrg/teams/the-repo-team", result.OriginalString);
+            }
+
+            [Fact]
+            public void ConvertsToLowercase()
+            {
+                var result = ApiUrls.TeamByName("theOrg", "THETEAM");
+
+                Assert.Equal("orgs/theOrg/teams/theteam", result.OriginalString);
+            }
+        }
+    }
+}

--- a/Octokit.Tests/Helpers/ApiUrlsTests.cs
+++ b/Octokit.Tests/Helpers/ApiUrlsTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 
 namespace Octokit.Tests.Helpers
 {

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -40,15 +40,15 @@ namespace Octokit
 
         /// <summary>
         /// Gets a single <see cref="Team"/> by name.
-        /// Note: this is more expensive than using the
-        /// team ID, as first we perform a lookup to determine
-        /// matching teams.
         /// </summary>
         /// <remarks>
-        /// https://developer.github.com/v3/orgs/teams/#get-team
+        /// this is more expensive than using the team ID, as first we
+        /// perform a lookup to determine matching teams.
         /// </remarks>
         /// <param name="orgName">The organization name.</param>
         /// <param name="teamName">The team name.</param>
+        /// <exception cref="ArgumentNullException">if the list of teams returned from GetAll is null.</exception>
+        /// <exception cref="InvalidOperationException">if no matching team name is found.</exception>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
         public async Task<Team> Get(string orgName, string teamName)
         {

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Octokit
 {
@@ -36,28 +35,6 @@ namespace Octokit
             var endpoint = ApiUrls.Teams(id);
 
             return ApiConnection.Get<Team>(endpoint, null, AcceptHeaders.NestedTeamsPreview);
-        }
-
-        /// <summary>
-        /// Gets a single <see cref="Team"/> by name.
-        /// Note: this is more expensive than using the
-        /// team ID, as first we perform a lookup to determine
-        /// matching teams.
-        /// </summary>
-        /// <remarks>
-        /// https://developer.github.com/v3/orgs/teams/#get-team
-        /// </remarks>
-        /// <param name="orgName">The organization name.</param>
-        /// <param name="teamName">The team name.</param>
-        /// <returns>The <see cref="Team"/> with the given identifier.</returns>
-        public async Task<Team> Get(string orgName, string teamName)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(orgName, nameof(orgName));
-            Ensure.ArgumentNotNullOrEmptyString(teamName, nameof(teamName));
-
-            var allTeams = await this.GetAll(orgName);
-
-            return allTeams.First(x => string.Equals(x.Name, teamName, StringComparison.CurrentCultureIgnoreCase));
         }
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -90,6 +90,25 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the <see cref="Team" /> for the specified org and team name.
+        /// </summary>
+        /// <param name="options">Options to change API behaviour.</param>
+        /// <param name="orgName">The org name.</param>
+        /// <param name="teamName">The team name.</param>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>The <see cref="Team"/> corresponding to the entered name.</returns>
+        public Task<Team> Get(ApiOptions options, string orgName, string teamName)
+        {
+            Ensure.ArgumentNotNull(options, nameof(options));
+            Ensure.ArgumentNotNullOrEmptyString(orgName, nameof(orgName));
+            Ensure.ArgumentNotNullOrEmptyString(teamName, nameof(teamName));
+
+            var endpoint = ApiUrls.TeamByName(orgName, teamName);
+
+            return ApiConnection.Get<Team>(endpoint,null, AcceptHeaders.NestedTeamsPreview);
+        }
+
+        /// <summary>
         /// Returns all child teams of the given team.
         /// </summary>
         /// <param name="id">The team identifier</param>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Octokit
 {
@@ -35,6 +36,28 @@ namespace Octokit
             var endpoint = ApiUrls.Teams(id);
 
             return ApiConnection.Get<Team>(endpoint, null, AcceptHeaders.NestedTeamsPreview);
+        }
+
+        /// <summary>
+        /// Gets a single <see cref="Team"/> by name.
+        /// Note: this is more expensive than using the
+        /// team ID, as first we perform a lookup to determine
+        /// matching teams.
+        /// </summary>
+        /// <remarks>
+        /// https://developer.github.com/v3/orgs/teams/#get-team
+        /// </remarks>
+        /// <param name="orgName">The organization name.</param>
+        /// <param name="teamName">The team name.</param>
+        /// <returns>The <see cref="Team"/> with the given identifier.</returns>
+        public async Task<Team> Get(string orgName, string teamName)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(orgName, nameof(orgName));
+            Ensure.ArgumentNotNullOrEmptyString(teamName, nameof(teamName));
+
+            var allTeams = await this.GetAll(orgName);
+
+            return allTeams.First(x => string.Equals(x.Name, teamName, StringComparison.CurrentCultureIgnoreCase));
         }
 
         /// <summary>

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -40,15 +40,15 @@ namespace Octokit
 
         /// <summary>
         /// Gets a single <see cref="Team"/> by name.
+        /// Note: this is more expensive than using the
+        /// team ID, as first we perform a lookup to determine
+        /// matching teams.
         /// </summary>
         /// <remarks>
-        /// this is more expensive than using the team ID, as first we
-        /// perform a lookup to determine matching teams.
+        /// https://developer.github.com/v3/orgs/teams/#get-team
         /// </remarks>
         /// <param name="orgName">The organization name.</param>
         /// <param name="teamName">The team name.</param>
-        /// <exception cref="ArgumentNullException">if the list of teams returned from GetAll is null.</exception>
-        /// <exception cref="InvalidOperationException">if no matching team name is found.</exception>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
         public async Task<Team> Get(string orgName, string teamName)
         {

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -2544,6 +2544,15 @@ namespace Octokit
             return "orgs/{0}/migrations/{1}".FormatUri(org, id);
         }
 
+        public static Uri TeamByName(string org, string teamName)
+        {
+            var slugifiedTeamName = teamName
+                .Replace(' ', '-')
+                .ToLowerInvariant();
+
+            return "orgs/{0}/teams/{1}".FormatUri(org, slugifiedTeamName);
+        }
+
         public static Uri EnterpriseMigrations(string org)
         {
             return "orgs/{0}/migrations".FormatUri(org);


### PR DESCRIPTION
This allows someone to use `Teams.Get("organizationName", "teamName")` to retrieve a `Team` object in cases where someone may not know the team ID off-hand. 

NOTE: This uses `.First()` on the result of `GetAll()`, which I think is sufficient in this case as we'd want an error to occur if no matching team is found. However, let me know if you'd like this error to be more expressive.