### PR TITLE
GitHubClient: HttpClient: RequestTimeout property added

### DIFF
--- a/Octokit.Reactive/IObservableGitHubClient.cs
+++ b/Octokit.Reactive/IObservableGitHubClient.cs
@@ -7,14 +7,13 @@ namespace Octokit.Reactive
         IConnection Connection { get; }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
         /// </summary>
         /// <remarks>
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
-        /// <param name="timeout">The Timeout value</param>
-        void SetRequestTimeout(TimeSpan timeout);
+        TimeSpan RequestTimeout { get; set; }
 
         IObservableAuthorizationsClient Authorization { get; }
         IObservableActivitiesClient Activity { get; }

--- a/Octokit.Reactive/ObservableGitHubClient.cs
+++ b/Octokit.Reactive/ObservableGitHubClient.cs
@@ -57,16 +57,22 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
         /// </summary>
         /// <remarks>
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
-        /// <param name="timeout">The Timeout value</param>
-        public void SetRequestTimeout(TimeSpan timeout)
+        public TimeSpan RequestTimeout
         {
-            _gitHubClient.SetRequestTimeout(timeout);
+            get
+            {
+                return _gitHubClient.RequestTimeout;
+            }
+            set
+            {
+                _gitHubClient.RequestTimeout = value;
+            }
         }
 
         public IObservableAuthorizationsClient Authorization { get; private set; }

--- a/Octokit.Tests/GitHubClientTests.cs
+++ b/Octokit.Tests/GitHubClientTests.cs
@@ -205,10 +205,10 @@ namespace Octokit.Tests
                 var httpClient = Substitute.For<IHttpClient>();
                 var client = new GitHubClient(new Connection(new ProductHeaderValue("OctokitTests"), httpClient));
 
-                client.SetRequestTimeout(TimeSpan.FromSeconds(15));
+                client.RequestTimeout = TimeSpan.FromSeconds(15);
 
 
-                httpClient.Received(1).SetRequestTimeout(TimeSpan.FromSeconds(15));
+                httpClient.Received(1).RequestTimeout = TimeSpan.FromSeconds(15);
             }
         }
     }

--- a/Octokit.Tests/Http/ConnectionTests.cs
+++ b/Octokit.Tests/Http/ConnectionTests.cs
@@ -373,6 +373,33 @@ namespace Octokit.Tests.Http
 
                 Assert.Equal("Request Forbidden - Abuse Detection", exception.Message);
             }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response();
+                var valueNotPropagatedResponse = new Response();
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)).Result;
+                Assert.Equal(valuePropagatedResponse, response.HttpResponse);
+                Assert.NotEqual(valueNotPropagatedResponse, response.HttpResponse);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.GetResponse<string>(new Uri("endpoint", UriKind.Relative)).Result;
+                Assert.NotEqual(valuePropagatedResponse, response.HttpResponse);
+                Assert.Equal(valueNotPropagatedResponse, response.HttpResponse);
+            }
         }
 
         public class TheGetHtmlMethod
@@ -398,6 +425,33 @@ namespace Octokit.Tests.Http
                     req.Method == HttpMethod.Get &&
                     req.Headers["Accept"] == "application/vnd.github.html" &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response();
+                var valueNotPropagatedResponse = new Response();
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.GetHtml(new Uri("endpoint", UriKind.Relative)).Result;
+                Assert.Equal(valuePropagatedResponse, response.HttpResponse);
+                Assert.NotEqual(valueNotPropagatedResponse, response.HttpResponse);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.GetHtml(new Uri("endpoint", UriKind.Relative)).Result;
+                Assert.NotEqual(valuePropagatedResponse, response.HttpResponse);
+                Assert.Equal(valueNotPropagatedResponse, response.HttpResponse);
             }
         }
 
@@ -450,6 +504,33 @@ namespace Octokit.Tests.Http
                 await connection.Patch<string>(new Uri("endpoint", UriKind.Relative), new object(), "custom/accepts");
 
                 httpClient.Received(1).Send(Arg.Is<IRequest>(req => req.Headers["Accept"] == "custom/accepts"), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response();
+                var valueNotPropagatedResponse = new Response();
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.Patch<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.Equal(valuePropagatedResponse, response.HttpResponse);
+                Assert.NotEqual(valueNotPropagatedResponse, response.HttpResponse);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.Patch<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.NotEqual(valuePropagatedResponse, response.HttpResponse);
+                Assert.Equal(valueNotPropagatedResponse, response.HttpResponse);
             }
         }
 
@@ -575,6 +656,33 @@ namespace Octokit.Tests.Http
                     req.Headers["X-GitHub-OTP"] == "two-factor" &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
             }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response();
+                var valueNotPropagatedResponse = new Response();
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.Put<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.Equal(valuePropagatedResponse, response.HttpResponse);
+                Assert.NotEqual(valueNotPropagatedResponse, response.HttpResponse);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.Put<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.NotEqual(valuePropagatedResponse, response.HttpResponse);
+                Assert.Equal(valueNotPropagatedResponse, response.HttpResponse);
+            }
         }
 
         public class ThePostMethod
@@ -660,6 +768,33 @@ namespace Octokit.Tests.Http
                     req.Headers["Accept"] == "application/json" &&
                     req.ContentType == "application/x-www-form-urlencoded"), Args.CancellationToken);
             }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response();
+                var valueNotPropagatedResponse = new Response();
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.Post<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty, null).Result;
+                Assert.Equal(valuePropagatedResponse, response.HttpResponse);
+                Assert.NotEqual(valueNotPropagatedResponse, response.HttpResponse);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.Post<string>(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty, null).Result;
+                Assert.NotEqual(valuePropagatedResponse, response.HttpResponse);
+                Assert.Equal(valueNotPropagatedResponse, response.HttpResponse);
+            }
         }
 
         public class TheDeleteMethod
@@ -684,6 +819,33 @@ namespace Octokit.Tests.Http
                     req.ContentType == null &&
                     req.Method == HttpMethod.Delete &&
                     req.Endpoint == new Uri("endpoint", UriKind.Relative)), Args.CancellationToken);
+            }
+
+            [Fact]
+            public async Task RequestTimeoutValuePropagatedToRequestClass()
+            {
+                var timeout = TimeSpan.FromSeconds(DateTime.Now.Second + 3);
+                var valuePropagatedResponse = new Response(HttpStatusCode.OK, null, new Dictionary<string, string>(), null);
+                var valueNotPropagatedResponse = new Response(HttpStatusCode.Redirect, null, new Dictionary<string, string>(), null);
+                var httpClient = Substitute.For<IHttpClient>();
+                httpClient.Send(Arg.Any<IRequest>(), Args.CancellationToken).Returns(valueNotPropagatedResponse);
+                httpClient.Send(Arg.Is<IRequest>(x => x.Timeout == timeout), Args.CancellationToken).Returns(valuePropagatedResponse);
+
+                var connection = new Connection(new ProductHeaderValue("OctokitTests"),
+                    _exampleUri,
+                    Substitute.For<ICredentialStore>(),
+                    httpClient,
+                    Substitute.For<IJsonSerializer>());
+
+                connection.RequestTimeout = timeout;
+                var response = connection.Delete(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.Equal(valuePropagatedResponse.StatusCode, response);
+                Assert.NotEqual(valueNotPropagatedResponse.StatusCode, response);
+
+                connection.RequestTimeout = timeout.Add(TimeSpan.FromSeconds(7));
+                response = connection.Delete(new Uri("endpoint", UriKind.Relative), string.Empty, string.Empty).Result;
+                Assert.NotEqual(valuePropagatedResponse.StatusCode, response);
+                Assert.Equal(valueNotPropagatedResponse.StatusCode, response);
             }
         }
 

--- a/Octokit/GitHubClient.cs
+++ b/Octokit/GitHubClient.cs
@@ -114,16 +114,22 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
         /// </summary>
         /// <remarks>
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
-        /// <param name="timeout">The Timeout value</param>
-        public void SetRequestTimeout(TimeSpan timeout)
+        public TimeSpan RequestTimeout
         {
-            Connection.SetRequestTimeout(timeout);
+            get
+            {
+                return Connection.RequestTimeout;
+            }
+            set
+            {
+                Connection.RequestTimeout = value;
+            }
         }
 
         /// <summary>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -207,7 +207,8 @@ namespace Octokit
             {
                 Method = HttpMethod.Get,
                 BaseAddress = BaseAddress,
-                Endpoint = uri.ApplyParameters(parameters)
+                Endpoint = uri.ApplyParameters(parameters),
+                Timeout = RequestTimeout,
             });
         }
 
@@ -376,7 +377,8 @@ namespace Octokit
             {
                 Method = method,
                 BaseAddress = baseAddress ?? BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                Timeout = RequestTimeout,
             };
 
             return SendDataInternal<T>(body, accepts, contentType, cancellationToken, twoFactorAuthenticationCode, request);
@@ -417,7 +419,8 @@ namespace Octokit
             {
                 Method = HttpVerb.Patch,
                 BaseAddress = BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                Timeout = RequestTimeout,
             };
             var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
@@ -451,7 +454,8 @@ namespace Octokit
             {
                 Method = HttpMethod.Put,
                 BaseAddress = BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                Timeout = RequestTimeout,
             };
             var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
@@ -485,7 +489,8 @@ namespace Octokit
             {
                 Method = HttpMethod.Delete,
                 BaseAddress = BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                Timeout = RequestTimeout,
             };
             var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
@@ -521,7 +526,8 @@ namespace Octokit
                 Method = HttpMethod.Delete,
                 Body = data,
                 BaseAddress = BaseAddress,
-                Endpoint = uri
+                Endpoint = uri,
+                Timeout = RequestTimeout,
             };
             var response = await Run<object>(request, CancellationToken.None).ConfigureAwait(false);
             return response.HttpResponse.StatusCode;
@@ -780,12 +786,18 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">The Timeout value</param>
-        public void SetRequestTimeout(TimeSpan timeout)
+        public TimeSpan RequestTimeout
         {
-            _httpClient.SetRequestTimeout(timeout);
+            get
+            {
+                return _httpClient.RequestTimeout;
+            }
+            set
+            {
+                _httpClient.RequestTimeout = value;
+            }
         }
     }
 }

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -291,12 +291,19 @@ namespace Octokit.Internal
         }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">The Timeout value</param>
-        public void SetRequestTimeout(TimeSpan timeout)
+        public TimeSpan RequestTimeout
         {
-            _http.Timeout = timeout;
+            get
+            {
+                return _http.Timeout;
+            }
+
+            set
+            {
+                _http.Timeout = value;
+            }
         }
     }
 

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -295,9 +295,8 @@ namespace Octokit
         Credentials Credentials { get; set; }
 
         /// <summary>
-        /// Set the GitHub Api request timeout.
+        /// GitHub Api request timeout.
         /// </summary>
-        /// <param name="timeout">The Timeout value</param>
-        void SetRequestTimeout(TimeSpan timeout);
+        TimeSpan RequestTimeout { get; set; }
     }
 }

--- a/Octokit/Http/IHttpClient.cs
+++ b/Octokit/Http/IHttpClient.cs
@@ -20,11 +20,9 @@ namespace Octokit.Internal
         /// <returns>A <see cref="Task" /> of <see cref="IResponse"/></returns>
         Task<IResponse> Send(IRequest request, CancellationToken cancellationToken);
 
-
         /// <summary>
-        /// Set the GitHub API request timeout.
+        /// GitHub API request timeout.
         /// </summary>
-        /// <param name="timeout">The Timeout value</param>
-        void SetRequestTimeout(TimeSpan timeout);
+        TimeSpan RequestTimeout { get; set; }
     }
 }

--- a/Octokit/IGitHubClient.cs
+++ b/Octokit/IGitHubClient.cs
@@ -8,14 +8,13 @@ namespace Octokit
     public interface IGitHubClient : IApiInfoProvider
     {
         /// <summary>
-        /// Set the GitHub API request timeout.
+        /// GitHub API request timeout.
         /// Useful to set a specific timeout for lengthy operations, such as uploading release assets
         /// </summary>
         /// <remarks>
         /// See more information here: https://technet.microsoft.com/library/system.net.http.httpclient.timeout(v=vs.110).aspx
         /// </remarks>
-        /// <param name="timeout">The Timeout value</param>
-        void SetRequestTimeout(TimeSpan timeout);
+        TimeSpan RequestTimeout { get; set; }
 
         /// <summary>
         /// Provides a client connection to make rest requests to HTTP endpoints.


### PR DESCRIPTION
The problem: 
1. The request timeout is hard-coded inside Request class constructor (TimeSpan.FromSeconds(100))
2. GitHubClient.SetRequestTimeout() method does not change the request timeout as expected: hard-coded Request.Timeout is applied instead.
3. GitHubClient does not provide an ability to get/read an effective request timeout

The solution:
- The method "SetRequestTimeout()" replaced by "RequestTimeout" property: addresses the problem 3
- Request.Timeout property is initialized with "RequestTimeout" property value: addresses the problem 1 and 2




