### PR TITLE
Update IssueEvent ID field from int to long

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -103,10 +103,10 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The event id</param>
+        /// <param name="eventId">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<IssueEvent> Get(string owner, string name, int number);
+        IObservable<IssueEvent> Get(string owner, string name, long eventId);
 
         /// <summary>
         /// Gets a single event
@@ -115,9 +115,9 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#get-a-single-event
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The event id</param>
+        /// <param name="eventId">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
         Justification = "Method makes a network request")]
-        IObservable<IssueEvent> Get(long repositoryId, int number);
+        IObservable<IssueEvent> Get(long repositoryId, long eventId);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -157,13 +157,13 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The event id</param>
-        public IObservable<IssueEvent> Get(string owner, string name, int number)
+        /// <param name="eventId">The event id</param>
+        public IObservable<IssueEvent> Get(string owner, string name, long eventId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _client.Get(owner, name, number).ToObservable();
+            return _client.Get(owner, name, eventId).ToObservable();
         }
 
         /// <summary>
@@ -173,10 +173,10 @@ namespace Octokit.Reactive
         /// http://developer.github.com/v3/issues/events/#get-a-single-event
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The event id</param>
-        public IObservable<IssueEvent> Get(long repositoryId, int number)
+        /// <param name="eventId">The event id</param>
+        public IObservable<IssueEvent> Get(long repositoryId, long eventId)
         {
-            return _client.Get(repositoryId, number).ToObservable();
+            return _client.Get(repositoryId, eventId).ToObservable();
         }
     }
 }

--- a/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesEventsClientTests.cs
@@ -402,7 +402,7 @@ public class IssuesEventsClientTests : IDisposable
         var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
-        int issueEventId = issueEvents[0].Id;
+        var issueEventId = issueEvents[0].Id;
 
         var issueEventLookupById = await _issuesEventsClient.Get(_context.RepositoryOwner, _context.RepositoryName, issueEventId);
 
@@ -418,7 +418,7 @@ public class IssuesEventsClientTests : IDisposable
         var closed = await _issuesClient.Update(_context.RepositoryOwner, _context.RepositoryName, issue.Number, new IssueUpdate { State = ItemState.Closed });
         Assert.NotNull(closed);
         var issueEvents = await _issuesEventsClient.GetAllForRepository(_context.Repository.Id);
-        int issueEventId = issueEvents[0].Id;
+        var issueEventId = issueEvents[0].Id;
 
         var issueEventLookupById = await _issuesEventsClient.Get(_context.Repository.Id, issueEventId);
 

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -104,10 +104,10 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The event id</param>
+        /// <param name="eventId">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueEvent> Get(string owner, string name, int number);
+        Task<IssueEvent> Get(string owner, string name, long eventId);
 
         /// <summary>
         /// Gets a single event
@@ -116,9 +116,9 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#get-a-single-event
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The event id</param>
+        /// <param name="eventId">The event id</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<IssueEvent> Get(long repositoryId, int number);
+        Task<IssueEvent> Get(long repositoryId, long eventId);
     }
 }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -149,13 +149,13 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The event id</param>
-        public Task<IssueEvent> Get(string owner, string name, int number)
+        /// <param name="eventId">The event id</param>
+        public Task<IssueEvent> Get(string owner, string name, long eventId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(owner, name, number));
+            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(owner, name, eventId));
         }
 
         /// <summary>
@@ -165,10 +165,10 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#get-a-single-event
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The event id</param>
-        public Task<IssueEvent> Get(long repositoryId, int number)
+        /// <param name="eventId">The event id</param>
+        public Task<IssueEvent> Get(long repositoryId, long eventId)
         {
-            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, number));
+            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, eventId));
         }
     }
 }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -838,7 +838,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The event id</param>
         /// <returns></returns>
-        public static Uri IssuesEvent(string owner, string name, int id)
+        public static Uri IssuesEvent(string owner, string name, long id)
         {
             return "repos/{0}/{1}/issues/events/{2}".FormatUri(owner, name, id);
         }
@@ -2971,7 +2971,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The event id</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event and issue info for the specified event.</returns>
-        public static Uri IssuesEvent(long repositoryId, int id)
+        public static Uri IssuesEvent(long repositoryId, long id)
         {
             return "repositories/{0}/issues/events/{1}".FormatUri(repositoryId, id);
         }

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(int id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
+        public IssueEvent(long id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
         {
             Id = id;
             NodeId = nodeId;
@@ -27,7 +27,7 @@ namespace Octokit
         /// <summary>
         /// The id of the issue/pull request event.
         /// </summary>
-        public int Id { get; protected set; }
+        public long Id { get; protected set; }
 
         /// <summary>
         /// GraphQL Node Id


### PR DESCRIPTION
This PR fixes issues #1979 and #2031 (stack overflow when attempting to retrieve events on issues due to large ID numbers) and replaces the seemingly-abandoned PR #2037.

In addition to changing the types of the relevant field and parameters, the names of the parameters have also been updated (from `number` to `eventId`) to better reflect what's expected to be passed.