### PR TITLE
upgrade sourcelink tools and GitVersion

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -48,9 +48,9 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="3.1.0" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or  '$(TargetFramework)' == 'net46'  ">

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -47,10 +47,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="GitHubJwt">
-      <Version>0.0.4</Version>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="GitHubJwt" Version="0.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -54,9 +54,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
   </ItemGroup>
 
 </Project>

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -57,7 +57,7 @@ public class Lifetime : FrostingLifetime<Context>
         };
 
         context.DotNetFormatToolPath = ToolInstaller.DotNetCoreToolInstall(context, "dotnet-format", "3.1.37601", "dotnet-format");
-        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.0.0", "dotnet-gitversion");
+        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.1.3", "dotnet-gitversion");
 
         // Calculate semantic version.
         context.Version = BuildVersion.Calculate(context);


### PR DESCRIPTION
Following on from #2064 

Not sure why some of these dependencies aren't being detected by Dependabot, but for building and linking on Linux without Mono these upgrades are useful.

The change from `SourceLink.Create.GitHub` to `SourceLink.Create.CommandLine` was recommended in https://github.com/ctaggart/SourceLink/issues/321#issuecomment-373508013 due to problems raised previously with this project (the switch didn't happen earlier because it seemed to be an intermittent issue).