### PR TITLE
get CI running on Actions, redux

### DIFF
--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -1,0 +1,27 @@
+name: Build and test with .NET Core
+
+on:
+  pull_request:
+    branches:
+      - "master"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1.4.0
+      with:
+        dotnet-version: 2.1.803
+    - name: Build with dotnet
+      run: ./build.sh --linksources=true --verbosity=verbose


### PR DESCRIPTION
This PR revives #2015 now I have a better grasp on why it was failing locally:

 - [x] get build working for Linux
 - [x] get build working for macOS
 - [x] get build working for Windows
 - [x] tweak config to only run builds for PRs and `master`