### PR TITLE
tidy up the mentions of the supported platforms

### DIFF
--- a/.github/workflows/netcore.yml
+++ b/.github/workflows/netcore.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -25,3 +25,4 @@ jobs:
         dotnet-version: 2.1.803
     - name: Build with dotnet
       run: ./build.sh --linksources=true --verbosity=verbose
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 
 ![logo](octokit-dotnet_2.png)
 
-Octokit is a client library targeting .NET 4.5 and above that provides an easy
-way to interact with the [GitHub API](http://developer.github.com/v3/).
+Octokit is a client library targeting .NET Framework 4.5+ and .NET Standard 1+
+and above that provides an easy way to interact with the
+[GitHub API](http://developer.github.com/v3/).
 
 ## Usage examples
 
@@ -24,8 +25,8 @@ Console.WriteLine(user.Followers + " folks love the half ogre!");
 
 ## Supported Platforms
 
-* .NET 4.5 (Desktop / Server)
-* [.NET Standard 1.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)
+* .NET 4.5 (Desktop / Server) or greater
+* [.NET Standard 1.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) or greater
 
 ## Getting Started
 


### PR DESCRIPTION
There's a release or two planned before #2055 which increases the minimum supported platforms, and I realise there's some prominent places on the README that list the versions.

These will need to be refreshed when we drop support for older platforms :soon: .