### PR TITLE
strip CoreOnly usages from codebase as they are no longer needed

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -6,9 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CoreOnly Condition="$(CoreOnly) == '' and $([MSBuild]::IsOsPlatform('Windows'))">False</CoreOnly>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(CoreOnly) != '' and !$(CoreOnly)">$(TargetFrameworks);net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net46</TargetFrameworks>
     <AssemblyName>Octokit.Reactive</AssemblyName>
     <PackageId>Octokit.Reactive</PackageId>
     <DebugType>embedded</DebugType>

--- a/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
+++ b/Octokit.Tests.Conventions/Octokit.Tests.Conventions.csproj
@@ -4,9 +4,7 @@
     <Description>Convention-based tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests.Conventions</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <CoreOnly Condition="$(CoreOnly) == '' and $([MSBuild]::IsOsPlatform('Windows'))">False</CoreOnly>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(CoreOnly) != '' and !$(CoreOnly)">$(TargetFrameworks);net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests.Conventions</AssemblyName>
     <PackageId>Octokit.Tests.Conventions</PackageId>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -4,9 +4,7 @@
     <Description>Integration tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests.Integration</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <CoreOnly Condition="$(CoreOnly) == '' and $([MSBuild]::IsOsPlatform('Windows'))">False</CoreOnly>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(CoreOnly) != '' and !$(CoreOnly)">$(TargetFrameworks);net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests.Integration</AssemblyName>
     <PackageId>Octokit.Tests.Integration</PackageId>

--- a/Octokit.Tests/Octokit.Tests.csproj
+++ b/Octokit.Tests/Octokit.Tests.csproj
@@ -4,9 +4,7 @@
     <Description>Tests for Octokit</Description>
     <AssemblyTitle>Octokit.Tests</AssemblyTitle>
     <Authors>GitHub</Authors>
-    <CoreOnly Condition="$(CoreOnly) == '' and $([MSBuild]::IsOsPlatform('Windows'))">False</CoreOnly>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(CoreOnly) != '' and !$(CoreOnly)">$(TargetFrameworks);net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS4014;CS1998</NoWarn>
     <AssemblyName>Octokit.Tests</AssemblyName>
     <PackageId>Octokit.Tests</PackageId>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -6,9 +6,7 @@
     <Authors>GitHub</Authors>
     <Version>0.0.0-dev</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <CoreOnly Condition="$(CoreOnly) == '' and $([MSBuild]::IsOsPlatform('Windows'))">False</CoreOnly>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(CoreOnly) != '' and !$(CoreOnly)">$(TargetFrameworks);net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net46</TargetFrameworks>
     <AssemblyName>Octokit</AssemblyName>
     <PackageId>Octokit</PackageId>
     <DebugType>embedded</DebugType>

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -25,8 +25,6 @@ public class Context : FrostingContext
     public bool AppVeyor { get; set; }
     public bool TravisCI { get; set; }
 
-    public bool CoreOnly { get; set; }
-
     public Project[] Projects { get; set; }
 
     public FilePath DotNetFormatToolPath { get; set; }

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -12,7 +12,6 @@ public class Lifetime : FrostingLifetime<Context>
         context.Target = context.Argument("target", "Default");
         context.Configuration = context.Argument("configuration", "Release");
         context.LinkSources = context.Argument("linkSources", false);
-        context.CoreOnly = context.Argument("CoreOnly", !context.IsRunningOnWindows());
 
         context.Artifacts = "./packaging/";
         context.CodeCoverage = "./coverage-results/";
@@ -20,11 +19,6 @@ public class Lifetime : FrostingLifetime<Context>
         // Build system information.
         var buildSystem = context.BuildSystem();
         context.IsLocalBuild = buildSystem.IsLocalBuild;
-
-        if (context.CoreOnly && !context.IsLocalBuild)
-        {
-            context.Warning("CoreOnly was specified on a non-local build. Artifacts may be versioned incorrectly!");
-        }
 
         context.AppVeyor = buildSystem.AppVeyor.IsRunningOnAppVeyor;
         context.TravisCI = buildSystem.TravisCI.IsRunningOnTravisCI;
@@ -68,7 +62,6 @@ public class Lifetime : FrostingLifetime<Context>
         context.Information("Version suffix: {0}", context.Version.Suffix);
         context.Information("Configuration:  {0}", context.Configuration);
         context.Information("LinkSources:    {0}", context.LinkSources);
-        context.Information("CoreOnly:       {0}", context.CoreOnly);
         context.Information("Target:         {0}", context.Target);
         context.Information("AppVeyor:       {0}", context.AppVeyor);
         context.Information("TravisCI:       {0}", context.TravisCI);

--- a/build/Tasks/Build.cs
+++ b/build/Tasks/Build.cs
@@ -14,8 +14,7 @@ public class Build : FrostingTask<Context>
             Configuration = context.Configuration,
             ArgumentCustomization = args => args
                 .Append("/p:Version={0}", context.Version.GetSemanticVersion())
-                .Append("/p:SourceLinkCreate={0}", context.LinkSources.ToString().ToLower())
-                .Append("/p:CoreOnly={0}", context.CoreOnly),
+                .Append("/p:SourceLinkCreate={0}", context.LinkSources.ToString().ToLower()),
         });
     }
 }

--- a/build/Tasks/Package.cs
+++ b/build/Tasks/Package.cs
@@ -23,8 +23,7 @@ public sealed class Package : FrostingTask<Context>
                     NoBuild = true,
                     OutputDirectory = context.Artifacts,
                     ArgumentCustomization = args => args
-                        .Append("/p:Version={0}", context.Version.GetSemanticVersion())
-                        .Append("/p:CoreOnly={0}", context.CoreOnly),
+                        .Append("/p:Version={0}", context.Version.GetSemanticVersion()),
                 });
             }
         }


### PR DESCRIPTION
This was a vestige of the days when we needed Mono to target the classic NetFX targets, and shouldn't be needed now.