### PR TITLE
switch to Microsoft.SourceLink.GitHub package to perform linking

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -46,10 +46,9 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="3.1.0" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
+
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or  '$(TargetFramework)' == 'net46'  ">
     <Reference Include="System" />

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
   </ItemGroup>


### PR DESCRIPTION
I want to do away with the use of `DotNetCliToolReference` inside here (there's a kludge that I'll explain when we get to it) and for now it looks like `Microsoft.SourceLink.*` are the current ways to achieve this (with some options that I might look into later).

For now, I just want to confirm this works and passes `sourcelink test` for each build.