### PR TITLE
we can ignore that this clashes with something it inherits

### DIFF
--- a/build/Context.cs
+++ b/build/Context.cs
@@ -8,7 +8,7 @@ using Cake.Frosting;
 public class Context : FrostingContext
 {
     public string Target { get; set; }
-    public string Configuration { get; set; }
+    public new string Configuration { get; set; }
     public bool LinkSources { get; set; }
     public BuildVersion Version { get; set; }
 


### PR DESCRIPTION
```
Context.cs(11,19): warning CS0108: 'Context.Configuration' hides inherited member 'CakeContextAdapter.Configuration'. Use the new keyword if hiding was intended. [/Users/shiftkey/src/octokit.net/build/Build.csproj]
```