### PR TITLE
Add the undocumented (but used) check suite conclusion "skipped"

### DIFF
--- a/Octokit/Models/Common/CheckStatus.cs
+++ b/Octokit/Models/Common/CheckStatus.cs
@@ -34,6 +34,9 @@ namespace Octokit
 
         [Parameter(Value = "action_required")]
         ActionRequired,
+
+        [Parameter(Value = "skipped")]
+        Skipped,
     }
 
     public enum CheckAnnotationLevel


### PR DESCRIPTION
Hello!

There is currently an undocumented check suite conclusion ("skipped") that exists in the wild (see https://github.community/t5/GitHub-API-Development-and/Is-quot-skipped-quot-now-a-valid-check-suite-conclusion/m-p/43980#M3900) that causes this library to throw an exception while attempting to load check suites with that conclusion. Since I can't seem to get an answer as to whether or not this has been added to the Checks API, I'm assuming that it has and that this is a documentation deficiency. I'm therefore submitting this trivial PR to add it. Unfortunately I don't think that I was able to run all of the tests (I'm not on Windows) - hope that's okay.

Additionally, do you have any plans to release another version soon? In addition to this issue, I would love to have access to the organization membership methods that were added two commits after v0.36.0. Thanks!