### PR TITLE
Add `stale` check conclusion

### DIFF
--- a/Octokit/Models/Common/CheckStatus.cs
+++ b/Octokit/Models/Common/CheckStatus.cs
@@ -37,6 +37,9 @@ namespace Octokit
 
         [Parameter(Value = "skipped")]
         Skipped,
+        
+        [Parameter(Value = "stale")]
+        Stale,
     }
 
     public enum CheckAnnotationLevel


### PR DESCRIPTION
Hey Dotnet SDK team 👋 

I work on the team which maintains checks at GitHub and I wanted to add this conclusion ahead of release. This check conclusion will be fully documented on release.

I would also like to note that we could add new check/status states at any time, since adding states would be an additive change. The client-side logic should reflect this in some way so that new states don't break integrators systems.