### PR TITLE
Revert "upgrade sourcelink tools (#2065)"

### DIFF
--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -46,9 +46,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="3.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
   </ItemGroup>
-
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or  '$(TargetFramework)' == 'net46'  ">
     <Reference Include="System" />

--- a/Octokit.Reactive/Octokit.Reactive.csproj
+++ b/Octokit.Reactive/Octokit.Reactive.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reactive" Version="3.1.0" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
   </ItemGroup>

--- a/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
+++ b/Octokit.Tests.Integration/Octokit.Tests.Integration.csproj
@@ -45,8 +45,10 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="GitHubJwt" Version="0.0.4" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="GitHubJwt">
+      <Version>0.0.4</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -52,9 +52,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.3" />
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
   </ItemGroup>
 
 </Project>

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.2" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.2" />
   </ItemGroup>

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -21,6 +21,7 @@ public class Context : FrostingContext
     public bool IsTagged { get; set; }
     public bool IsMasterBranch { get; set; }
     public bool ForcePublish { get; set; }
+    public bool ShouldFormatCode { get; set; }
 
     public bool AppVeyor { get; set; }
     public bool GitHubActions { get; set; }

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -51,7 +51,7 @@ public class Lifetime : FrostingLifetime<Context>
         };
 
         context.DotNetFormatToolPath = ToolInstaller.DotNetCoreToolInstall(context, "dotnet-format", "3.1.37601", "dotnet-format");
-        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.1.3", "dotnet-gitversion");
+        context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.0.0", "dotnet-gitversion");
 
         // Calculate semantic version.
         context.Version = BuildVersion.Calculate(context);

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -52,7 +52,7 @@ public class Lifetime : FrostingLifetime<Context>
             new Project { Name = "Octokit.Tests.Integration", Path = "./Octokit.Tests.Integration/Octokit.Tests.Integration.csproj", IntegrationTests = true }
         };
 
-        context.DotNetFormatToolPath = ToolInstaller.DotNetCoreToolInstall(context, "dotnet-format", "3.1.37601", "dotnet-format");
+        context.DotNetFormatToolPath = ToolInstaller.DotNetCoreToolInstall(context, "dotnet-format", "3.2.107702", "dotnet-format");
         context.GitVersionToolPath = ToolInstaller.DotNetCoreToolInstall(context, "GitVersion.Tool", "5.0.0", "dotnet-gitversion");
 
         // Calculate semantic version.

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -20,6 +20,8 @@ public class Lifetime : FrostingLifetime<Context>
         var buildSystem = context.BuildSystem();
         context.IsLocalBuild = buildSystem.IsLocalBuild;
 
+        // TODO: tidy this up
+        context.ShouldFormatCode = true;
         context.GitHubActions = buildSystem.GitHubActions.IsRunningOnGitHubActions;
         context.AppVeyor = buildSystem.AppVeyor.IsRunningOnAppVeyor;
         context.IsTagged = IsBuildTagged(buildSystem);

--- a/build/Tasks/FormatCode.cs
+++ b/build/Tasks/FormatCode.cs
@@ -15,6 +15,6 @@ public sealed class FormatCode : FrostingTask<Context>
 
     public override bool ShouldRun(Context context)
     {
-        return context.IsLocalBuild;
+        return context.ShouldFormatCode;
     }
 }


### PR DESCRIPTION
While CI has been fine for a while, I've not been able to `sourcelink test` locally for a while, and it prevented me from publishing packages from my local machine. After trying a bunch of things that might have explained why my development environment was different to Appveyor (where this works fine) I've decided to try and back out the commit that I think is to blame.

I want to get to a point where I can release from GitHub - push tag, CI passes, packages published to NuGet - but for now I'd like to just be able to publish to NuGet without dirty workaround.

- [ ] verify AppVeyor passes
- [ ] verify local Windows build passes
- [ ] verify GitHub Actions passes (or pause for now)
- [ ] ???