### PR TITLE
Double quote issue labels in search API

### DIFF
--- a/Octokit.Tests/Clients/SearchClientTests.cs
+++ b/Octokit.Tests/Clients/SearchClientTests.cs
@@ -962,7 +962,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+label:bug"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+label:\"bug\""));
             }
 
             [Fact]
@@ -977,7 +977,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
-                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+label:bug+label:feature"));
+                    Arg.Is<Dictionary<string, string>>(d => d["q"] == "something+label:\"bug\"+label:\"feature\""));
             }
 
             [Fact]
@@ -1560,7 +1560,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<SearchIssuesResult>(
                     Arg.Is<Uri>(u => u.ToString() == "search/issues"),
                     Arg.Is<Dictionary<string, string>>(d => d["q"] ==
-                        "something+label:bug+user:alfhenrik+repo:octokit/octokit.net"));
+                        "something+label:\"bug\"+user:alfhenrik+repo:octokit/octokit.net"));
             }
         }
 

--- a/Octokit.Tests/Models/SearchIssuesRequestTests.cs
+++ b/Octokit.Tests/Models/SearchIssuesRequestTests.cs
@@ -114,9 +114,9 @@ public class SearchIssuesRequestTests
             var request = new SearchIssuesRequest("test");
             Assert.DoesNotContain(request.MergedQualifiers(), x => x.Contains("label:"));
 
-            request.Labels = new[] { "label1", "label2" };
-            Assert.Contains("label:label1", request.MergedQualifiers());
-            Assert.Contains("label:label2", request.MergedQualifiers());
+            request.Labels = new[] { "label1", "label 2" };
+            Assert.Contains("label:\"label1\"", request.MergedQualifiers());
+            Assert.Contains("label:\"label 2\"", request.MergedQualifiers());
         }
 
         [Fact]

--- a/Octokit/Models/Request/SearchIssuesRequest.cs
+++ b/Octokit/Models/Request/SearchIssuesRequest.cs
@@ -328,7 +328,7 @@ namespace Octokit
 
             if (Labels != null)
             {
-                parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "label:{0}", label)));
+                parameters.AddRange(Labels.Select(label => string.Format(CultureInfo.InvariantCulture, "label:\"{0}\"", label)));
             }
 
             if (No.HasValue)


### PR DESCRIPTION
Fixes #2044 

Hello,

I went with the easy way, double quote all labels. It will save us the check (whether the label has spaces or not) since having quotes on normal labels doesn't change anything.

I changed the test to include a test case `label 2` and tested it separately on this repository.