### PR TITLE
move formatting code to optional flag

### DIFF
--- a/Octokit/Models/Common/CheckStatus.cs
+++ b/Octokit/Models/Common/CheckStatus.cs
@@ -37,7 +37,7 @@ namespace Octokit
 
         [Parameter(Value = "skipped")]
         Skipped,
-        
+
         [Parameter(Value = "stale")]
         Stale,
     }

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -10,6 +10,7 @@ public class Context : FrostingContext
     public string Target { get; set; }
     public new string Configuration { get; set; }
     public bool LinkSources { get; set; }
+    public bool FormatCode { get; set; }
     public BuildVersion Version { get; set; }
 
     public DirectoryPath Artifacts { get; set; }

--- a/build/Lifetime.cs
+++ b/build/Lifetime.cs
@@ -12,6 +12,7 @@ public class Lifetime : FrostingLifetime<Context>
         context.Target = context.Argument("target", "Default");
         context.Configuration = context.Argument("configuration", "Release");
         context.LinkSources = context.Argument("linkSources", false);
+        context.FormatCode = context.Argument("formatCode", false);
 
         context.Artifacts = "./packaging/";
         context.CodeCoverage = "./coverage-results/";

--- a/build/Tasks/FormatCode.cs
+++ b/build/Tasks/FormatCode.cs
@@ -15,6 +15,6 @@ public sealed class FormatCode : FrostingTask<Context>
 
     public override bool ShouldRun(Context context)
     {
-        return context.IsLocalBuild;
+        return context.FormatCode;
     }
 }


### PR DESCRIPTION
I'm still digging into why `FormatCode` decides to insert some stray CR characters on Windows, but for now I'm making this optional rather than always running for local builds.