### PR TITLE
Add new events to the EventInfoState enum

### DIFF
--- a/Octokit/Models/Response/EventInfo.cs
+++ b/Octokit/Models/Response/EventInfo.cs
@@ -193,6 +193,12 @@ namespace Octokit
         HeadRefForcePushed,
 
         /// <summary>
+        /// The pull request is ready for review
+        /// </summary>
+        [Parameter(Value = "ready_for_review")]
+        ReadyForReview,
+
+        /// <summary>
         /// The actor dismissed a review from the pull request.
         /// </summary>
         [Parameter(Value = "review_dismissed")]
@@ -308,6 +314,24 @@ namespace Octokit
         /// An issue was transferred.
         /// </summary>
         [Parameter(Value = "transferred")]
-        Transferred
+        Transferred,
+
+        /// <summary>
+        /// An issue was connected.
+        /// </summary>
+        [Parameter(Value = "connected")]
+        Connected,
+
+        /// <summary>
+        /// An issue was pinned.
+        /// </summary>
+        [Parameter(Value = "pinned")]
+        Pinned,
+
+        /// <summary>
+        /// An issue was unpinned.
+        /// </summary>
+        [Parameter(Value = "unpinned")]
+        Unpinned,
     }
 }


### PR DESCRIPTION
Hello!
Recently, I have started to use this library and I have faced with issue that loading of events for some issues fail because of unrecognized events.
Unfortunately, I didn't find these events in the list of events in [GitHub API](https://developer.github.com/v3/issues/events/) page (it looks like it is pretty outdated) so I can't guarantee that my list is full. But I just added events that I have found in my repo so if you have the full list, please let me know