### PR TITLE
Add ProjectCard attribute to events model

### DIFF
--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<EventInfo> GetAllForIssue(string owner, string name, int number);
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number);
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number)
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number)
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -63,13 +63,13 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<EventInfo> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<EventInfo>(ApiUrls.IssuesEvents(owner, name, number), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(owner, name, number), options);
         }
 
         /// <summary>
@@ -81,11 +81,11 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<EventInfo> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return _connection.GetAndFlattenAllPages<EventInfo>(ApiUrls.IssuesEvents(repositoryId, number), options);
+            return _connection.GetAndFlattenAllPages<IssueEvent>(ApiUrls.IssuesEvents(repositoryId, number), options);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests/Clients/IssueTimelineClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview",
+                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
                     Arg.Any<ApiOptions>());
             }
 
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview",
+                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview",
+                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
                     Arg.Any<ApiOptions>());
             }
 
@@ -76,7 +76,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview",
+                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -26,8 +26,7 @@ namespace Octokit.Tests.Clients
                 var client = new IssuesEventsClient(connection);
 
                 await client.GetAllForIssue("fake", "repo", 42);
-
-                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
             }
 
             [Fact]
@@ -38,7 +37,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42);
 
-                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
             }
 
             [Fact]
@@ -56,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue("fake", "repo", 42, options);
 
-                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, Args.AnyAcceptHeaders, options);
             }
 
             [Fact]
@@ -74,7 +73,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42, options);
 
-                connection.Received().GetAll<EventInfo>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, Args.AnyAcceptHeaders, options);
             }
 
             [Fact]
@@ -107,7 +106,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
             }
 
             [Fact]
@@ -118,7 +117,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
             }
 
             [Fact]
@@ -136,7 +135,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo", options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, Args.AnyAcceptHeaders, options);
             }
 
             [Fact]
@@ -154,7 +153,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, Args.AnyAcceptHeaders, options);
             }
 
             [Fact]
@@ -187,7 +186,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"));
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"), null, Args.AnyAcceptHeaders);
             }
 
             [Fact]
@@ -198,7 +197,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get(1, 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"));
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"), null, Args.AnyAcceptHeaders);
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
                 var client = new IssuesEventsClient(connection);
 
                 await client.GetAllForIssue("fake", "repo", 42);
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
             }
 
             [Fact]
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
             }
 
             [Fact]
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue("fake", "repo", 42, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, Args.AnyAcceptHeaders, options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview", options);
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, Args.AnyAcceptHeaders, options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview", options);
             }
 
             [Fact]
@@ -106,7 +106,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
             }
 
             [Fact]
@@ -117,7 +117,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, Args.AnyAcceptHeaders, Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
             }
 
             [Fact]
@@ -135,7 +135,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo", options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, Args.AnyAcceptHeaders, options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview", options);
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, Args.AnyAcceptHeaders, options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview", options);
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"), null, Args.AnyAcceptHeaders);
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"), null, "application/vnd.github.starfox-preview");
             }
 
             [Fact]
@@ -197,7 +197,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get(1, 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"), null, Args.AnyAcceptHeaders);
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"), null, "application/vnd.github.starfox-preview");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesEventsClientTests.cs
@@ -26,53 +26,53 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task RequestsCorrectUrl()
             {
-                var result = new List<EventInfo> { new EventInfo() };
+                var result = new List<IssueEvent> { new IssueEvent() };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableIssuesEventsClient(gitHubClient);
 
-                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
                     new Response
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Args.EmptyDictionary, null)
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Args.EmptyDictionary, null)
                     .Returns(Task.FromResult(response));
 
                 var eventInfos = await client.GetAllForIssue("fake", "repo", 42).ToList();
 
-                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), Args.EmptyDictionary, null);
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), Args.EmptyDictionary, null);
                 Assert.Equal(1, eventInfos.Count);
             }
 
             [Fact]
             public async Task RequestsCorrectUrlWithRepositoryId()
             {
-                var result = new List<EventInfo> { new EventInfo() };
+                var result = new List<IssueEvent> { new IssueEvent() };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
                 var client = new ObservableIssuesEventsClient(gitHubClient);
 
-                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
                     new Response
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Args.EmptyDictionary, null)
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Args.EmptyDictionary, null)
                     .Returns(Task.FromResult(response));
 
                 var eventInfos = await client.GetAllForIssue(1, 42).ToList();
 
-                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Args.EmptyDictionary, null);
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Args.EmptyDictionary, null);
                 Assert.Equal(1, eventInfos.Count);
             }
 
             [Fact]
             public async Task RequestsCorrectUrlWithApiOptions()
             {
-                var result = new List<EventInfo> { new EventInfo() };
+                var result = new List<IssueEvent> { new IssueEvent() };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
@@ -85,24 +85,24 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
                     new Response
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
                     .Returns(Task.FromResult(response));
 
                 var eventInfos = await client.GetAllForIssue("fake", "repo", 42, options).ToList();
 
-                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
                 Assert.Equal(1, eventInfos.Count);
             }
 
             [Fact]
             public async Task RequestsCorrectUrlWithRepositoryIdWithApiOptions()
             {
-                var result = new List<EventInfo> { new EventInfo() };
+                var result = new List<IssueEvent> { new IssueEvent() };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
@@ -115,17 +115,17 @@ namespace Octokit.Tests.Reactive
                     PageSize = 1
                 };
 
-                IApiResponse<List<EventInfo>> response = new ApiResponse<List<EventInfo>>(
+                IApiResponse<List<IssueEvent>> response = new ApiResponse<List<IssueEvent>>(
                     new Response
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<EventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
+                gitHubClient.Connection.Get<List<IssueEvent>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null)
                     .Returns(Task.FromResult(response));
 
                 var eventInfos = await client.GetAllForIssue(1, 42, options).ToList();
 
-                connection.Received().Get<List<EventInfo>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
+                connection.Received().Get<List<IssueEvent>>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), Arg.Is<Dictionary<string, string>>(d => d.Count == 2), null);
                 Assert.Equal(1, eventInfos.Count);
             }
 

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -48,7 +48,10 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, number), null, AcceptHeaders.IssueTimelineApiPreview, options);
+            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(owner, repo, number),
+                                                            null,
+                                                            AcceptHeaders.Concat(AcceptHeaders.IssueTimelineApiPreview, AcceptHeaders.IssueEventsApiPreview),
+                                                            options);
         }
 
         /// <summary>
@@ -77,7 +80,10 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, number), null, AcceptHeaders.IssueTimelineApiPreview, options);
+            return ApiConnection.GetAll<TimelineEventInfo>(ApiUrls.IssueTimeline(repositoryId, number),
+                                                            null,
+                                                            AcceptHeaders.Concat(AcceptHeaders.IssueTimelineApiPreview, AcceptHeaders.IssueEventsApiPreview),
+                                                            options);
         }
     }
 }

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -40,7 +40,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
         }
@@ -55,13 +55,16 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<EventInfo>(ApiUrls.IssuesEvents(owner, name, number), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name, number),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview,
+                                                    options);
         }
 
         /// <summary>
@@ -73,11 +76,14 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public Task<IReadOnlyList<EventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<EventInfo>(ApiUrls.IssuesEvents(repositoryId, number), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(repositoryId, number),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview,
+                                                    options);
         }
 
         /// <summary>
@@ -123,7 +129,10 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(owner, name),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview,
+                                                    options);
         }
 
         /// <summary>
@@ -138,7 +147,10 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(repositoryId), options);
+            return ApiConnection.GetAll<IssueEvent>(ApiUrls.IssuesEvents(repositoryId),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview,
+                                                    options);
         }
 
         /// <summary>
@@ -155,7 +167,9 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(owner, name, eventId));
+            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(owner, name, eventId),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview);
         }
 
         /// <summary>
@@ -168,7 +182,9 @@ namespace Octokit
         /// <param name="eventId">The event id</param>
         public Task<IssueEvent> Get(long repositoryId, long eventId)
         {
-            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, eventId));
+            return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, eventId),
+                                                    null,
+                                                    AcceptHeaders.IssueEventsApiPreview);
         }
     }
 }

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -69,6 +69,8 @@ namespace Octokit
 
         public const string ProtectedBranchesRequiredApprovingApiPreview = "application/vnd.github.luke-cage-preview+json";
 
+        public const string IssueEventsApiPreview = "application/vnd.github.starfox-preview";
+
         /// <summary>
         /// Combines multiple preview headers. GitHub API supports Accept header with multiple
         /// values separated by comma.

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public IssueEvent() { }
 
-        public IssueEvent(long id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl)
+        public IssueEvent(long id, string nodeId, string url, User actor, User assignee, Label label, EventInfoState @event, string commitId, DateTimeOffset createdAt, Issue issue, string commitUrl, RenameInfo rename, IssueEventProjectCard projectCard)
         {
             Id = id;
             NodeId = nodeId;
@@ -22,6 +22,8 @@ namespace Octokit
             CreatedAt = createdAt;
             Issue = issue;
             CommitUrl = commitUrl;
+            Rename = rename;
+            ProjectCard = projectCard;
         }
 
         /// <summary>

--- a/Octokit/Models/Response/IssueEvent.cs
+++ b/Octokit/Models/Response/IssueEvent.cs
@@ -79,6 +79,18 @@ namespace Octokit
         /// </summary>
         public Issue Issue { get; protected set; }
 
+        /// <summary>
+        /// An object containing rename details
+        /// Only provided for renamed events
+        /// </summary>
+        public RenameInfo Rename { get; protected set; }
+
+        /// <summary>
+        /// Information about the project card that triggered the event.
+        /// The project_card attribute is not returned if someone deletes the project board, or if you do not have permission to view it.
+        /// </summary>
+        public IssueEventProjectCard ProjectCard { get; protected set; }
+
         internal string DebuggerDisplay
         {
             get { return string.Format(CultureInfo.InvariantCulture, "Id: {0} CreatedAt: {1}", Id, CreatedAt); }

--- a/Octokit/Models/Response/IssueEventProjectCard.cs
+++ b/Octokit/Models/Response/IssueEventProjectCard.cs
@@ -1,0 +1,58 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+
+namespace Octokit
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class IssueEventProjectCard
+    {
+        public IssueEventProjectCard() { }
+
+        public IssueEventProjectCard(long id, string url, long projectId, string projectUrl, string columnName, string previousColumnName)
+        {
+            Id = id;
+            Url = url;
+            ProjectId = projectId;
+            ProjectUrl = projectUrl;
+            ColumnName = columnName;
+            PreviousColumnName = previousColumnName;
+        }
+
+        /// <summary>
+        /// The identification number of the project card.
+        /// </summary>
+        public long Id { get; protected set; }
+
+        /// <summary>
+        /// The API URL of the project card, if the card still exists.
+        /// Not included for removed_from_project events.
+        /// </summary>
+        public string Url { get; protected set; }
+
+        /// <summary>
+        /// The identification number of the project.
+        /// </summary>
+        public long ProjectId { get; protected set; }
+
+        /// <summary>
+        /// The API URL of the project.
+        /// </summary>
+        public string ProjectUrl { get; protected set; }
+
+        /// <summary>
+        /// The name of the column that the card is listed in.
+        /// </summary>
+        public string ColumnName { get; protected set; }
+
+        /// <summary>
+        /// The name of the column that the card was listed in prior to column_name
+        /// Only returned for moved_columns_in_project events.
+        /// </summary>
+        public string PreviousColumnName { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get { return string.Format(CultureInfo.InvariantCulture, "Id: {0}", Id); }
+        }
+    }
+}

--- a/Octokit/Models/Response/TimelineEventInfo.cs
+++ b/Octokit/Models/Response/TimelineEventInfo.cs
@@ -9,7 +9,7 @@ namespace Octokit
     {
         public TimelineEventInfo() { }
 
-        public TimelineEventInfo(long id, string nodeId, string url, User actor, string commitId, EventInfoState @event, DateTimeOffset createdAt, Label label, User assignee, Milestone milestone, SourceInfo source, RenameInfo rename)
+        public TimelineEventInfo(long id, string nodeId, string url, User actor, string commitId, EventInfoState @event, DateTimeOffset createdAt, Label label, User assignee, Milestone milestone, SourceInfo source, RenameInfo rename, IssueEventProjectCard projectCard)
         {
             Id = id;
             NodeId = nodeId;
@@ -23,6 +23,7 @@ namespace Octokit
             Milestone = milestone;
             Source = source;
             Rename = rename;
+            ProjectCard = projectCard;
         }
 
         public long Id { get; protected set; }

--- a/Octokit/Models/Response/TimelineEventInfo.cs
+++ b/Octokit/Models/Response/TimelineEventInfo.cs
@@ -40,8 +40,24 @@ namespace Octokit
         public Label Label { get; protected set; }
         public User Assignee { get; protected set; }
         public Milestone Milestone { get; protected set; }
+
+        /// <summary>
+        /// The source of reference from another issue
+        /// Only provided for cross-referenced events
+        /// </summary>
         public SourceInfo Source { get; protected set; }
+
+        /// <summary>
+        /// An object containing rename details
+        /// Only provided for renamed events
+        /// </summary>
         public RenameInfo Rename { get; protected set; }
+
+        /// <summary>
+        /// The name of the column that the card was listed in prior to column_name.
+        /// Only returned for moved_columns_in_project events
+        /// </summary>
+        public IssueEventProjectCard ProjectCard { get; protected set; }
 
         internal string DebuggerDisplay
         {

--- a/Octokit/Octokit.csproj
+++ b/Octokit/Octokit.csproj
@@ -40,11 +40,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="images\octokit.png" Pack="true" PackagePath="\"/>
+    <None Include="images\octokit.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hello!
I have faced with issue that Event model doesn't contain `project_card` property that is important for all events that are related to GitHub boards (Projects).
For example, for event `added_to_project`, it contains the name of column where issue is added.
For event `moved_columns_in_project`, it contains the previous and new column names.
This PR includes the following changes:
1) Change `EventInfo` model to `IssueEvent` (please see note below for details)
2) Add model `IssueEventProjectCard` accordingly to [GitHub API description](https://developer.github.com/v3/issues/events/#attributes)
3) Add header `IssueEventsApiPreview = "application/vnd.github.starfox-preview"` that is needed to get `project_card` value
4) Update tests
5) Update `Octokit.Reactive` with the same changes

**Note:** Why `EventInfo` model was replaced by `IssueEvent` in `IssueClient`:
These models are pretty similar but `IssueEvent` contains additional fields like `Issue` and `ProjectCard`.
I am not sure why some methods in `IssueClient` used `IssueEvent` but some methods used `EventInfo`. Based on API, all methods in `IssueClient` should use `IssueEvent`.