### PR TITLE
Allow fully qualified or short references to be used to generate "reference" Uri

### DIFF
--- a/Octokit.Reactive/Clients/ObservableReferencesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableReferencesClient.cs
@@ -146,13 +146,23 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public IObservable<Reference> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
             Ensure.ArgumentNotNull(options, nameof(options));
+
+            if (subNamespace.StartsWith("refs/"))
+            {
+                subNamespace = subNamespace.Replace("refs/", string.Empty);
+            }
 
             return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
@@ -180,11 +190,21 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public IObservable<Reference> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
             Ensure.ArgumentNotNull(options, nameof(options));
+
+            if (subNamespace.StartsWith("refs/"))
+            {
+                subNamespace = subNamespace.Replace("refs/", string.Empty);
+            }
 
             return _connection.GetAndFlattenAllPages<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }

--- a/Octokit.Tests/Clients/ReferencesClientTests.cs
+++ b/Octokit.Tests/Clients/ReferencesClientTests.cs
@@ -48,12 +48,34 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRef()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Get("owner", "repo", "refs/heads/develop");
+
+                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReferencesClient(connection);
 
                 await client.Get(1, "heads/develop");
+
+                connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdAndRefs()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Get(1, "refs/heads/develop");
 
                 connection.Received().Get<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
             }
@@ -151,12 +173,34 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRef()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.GetAllForSubNamespace("owner", "repo", "refs/heads");
+
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads"), Args.ApiOptions);
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReferencesClient(connection);
 
                 await client.GetAllForSubNamespace(1, "heads");
+
+                connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"), Args.ApiOptions);
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdAndRefs()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.GetAllForSubNamespace(1, "refs/heads");
 
                 connection.Received().GetAll<Reference>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads"), Args.ApiOptions);
             }
@@ -283,12 +327,34 @@ namespace Octokit.Tests.Clients
             }
 
             [Fact]
+            public async Task RequestsCorrectUrlWithRefs()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Delete("owner", "repo", "refs/heads/develop");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repos/owner/repo/git/refs/heads/develop"));
+            }
+
+            [Fact]
             public async Task RequestsCorrectUrlWithRepositoryId()
             {
                 var connection = Substitute.For<IApiConnection>();
                 var client = new ReferencesClient(connection);
 
                 await client.Delete(1, "heads/develop");
+
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
+            }
+
+            [Fact]
+            public async Task RequestsCorrectUrlWithRepositoryIdAndRefs()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new ReferencesClient(connection);
+
+                await client.Delete(1, "refs/heads/develop");
 
                 connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "repositories/1/git/refs/heads/develop"));
             }

--- a/Octokit/Clients/IReferencesClient.cs
+++ b/Octokit/Clients/IReferencesClient.cs
@@ -20,8 +20,13 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Reference> Get(string owner, string name, string reference);
@@ -33,8 +38,13 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#get-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
         Task<Reference> Get(long repositoryId, string reference);
@@ -92,7 +102,12 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace);
 
         /// <summary>
@@ -105,7 +120,12 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options);
 
         /// <summary>
@@ -116,7 +136,12 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace);
 
         /// <summary>
@@ -128,7 +153,12 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options);
 
         /// <summary>
@@ -140,7 +170,12 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference to create</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<Reference> Create(string owner, string name, NewReference reference);
 
         /// <summary>
@@ -162,9 +197,14 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
+        /// <param name="reference">The reference name</param>
         /// <param name="referenceUpdate">The updated reference data</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
@@ -174,9 +214,14 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#update-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
+        /// <param name="reference">The reference name</param>
         /// <param name="referenceUpdate">The updated reference data</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate);
 
         /// <summary>
@@ -187,8 +232,13 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task Delete(string owner, string name, string reference);
 
         /// <summary>
@@ -198,8 +248,13 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#delete-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         Task Delete(long repositoryId, string reference);
     }
 }

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -175,8 +175,6 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
             Ensure.ArgumentNotNull(options, nameof(options));
 
-            // TODO: Handle 404 when subNamespace cannot be found
-
             if (subNamespace.StartsWith("refs/"))
             {
                 subNamespace = subNamespace.Replace("refs/", string.Empty);
@@ -218,8 +216,6 @@ namespace Octokit
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
             Ensure.ArgumentNotNull(options, nameof(options));
-
-            // TODO: Handle 404 when subNamespace cannot be found
 
             if (subNamespace.StartsWith("refs/"))
             {

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -28,13 +28,23 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<Reference> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Get<Reference>(ApiUrls.Reference(owner, name, reference));
         }
@@ -46,11 +56,21 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#get-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<Reference> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Get<Reference>(ApiUrls.Reference(repositoryId, reference));
         }
@@ -142,7 +162,12 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -151,6 +176,11 @@ namespace Octokit
             Ensure.ArgumentNotNull(options, nameof(options));
 
             // TODO: Handle 404 when subNamespace cannot be found
+
+            if (subNamespace.StartsWith("refs/"))
+            {
+                subNamespace = subNamespace.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.GetAll<Reference>(ApiUrls.Reference(owner, name, subNamespace), options);
         }
@@ -178,13 +208,23 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The subNamespace parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
             Ensure.ArgumentNotNull(options, nameof(options));
 
             // TODO: Handle 404 when subNamespace cannot be found
+
+            if (subNamespace.StartsWith("refs/"))
+            {
+                subNamespace = subNamespace.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.GetAll<Reference>(ApiUrls.Reference(repositoryId, subNamespace), options);
         }
@@ -232,15 +272,25 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
+        /// <param name="reference">The reference name</param>
         /// <param name="referenceUpdate">The updated reference data</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
             Ensure.ArgumentNotNull(referenceUpdate, nameof(referenceUpdate));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Patch<Reference>(ApiUrls.Reference(owner, name, reference), referenceUpdate);
         }
@@ -252,13 +302,23 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#update-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
+        /// <param name="reference">The reference name</param>
         /// <param name="referenceUpdate">The updated reference data</param>
-        /// <returns></returns>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
             Ensure.ArgumentNotNull(referenceUpdate, nameof(referenceUpdate));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Patch<Reference>(ApiUrls.Reference(repositoryId, reference), referenceUpdate);
         }
@@ -271,13 +331,23 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task Delete(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Delete(ApiUrls.Reference(owner, name, reference));
         }
@@ -289,11 +359,21 @@ namespace Octokit
         /// http://developer.github.com/v3/git/refs/#delete-a-reference
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="reference">The canonical name of the reference without the 'refs/' prefix. e.g. "heads/master" or "tags/release-1"</param>
-        /// <returns></returns>
+        /// <param name="reference">The reference name</param>
+        /// <remarks>
+        /// The reference parameter supports either the fully-qualified ref
+        /// (prefixed with  "refs/", e.g. "refs/heads/master" or
+        /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
+        /// "heads/master" or "tags/release-1")
+        /// </remarks>
         public Task Delete(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+
+            if (reference.StartsWith("refs/"))
+            {
+                reference = reference.Replace("refs/", string.Empty);
+            }
 
             return ApiConnection.Delete(ApiUrls.Reference(repositoryId, reference));
         }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -3185,7 +3185,8 @@ namespace Octokit
         /// <returns>The <see cref="Uri"/> for the specified reference.</returns>
         public static Uri Reference(long repositoryId, string referenceName)
         {
-            return "repositories/{0}/git/refs/{1}".FormatUri(repositoryId, referenceName);
+            return "repositories/{0}/git/refs/{1}".FormatUri(repositoryId,
+                referenceName.Replace("refs/", string.Empty));
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -3185,8 +3185,7 @@ namespace Octokit
         /// <returns>The <see cref="Uri"/> for the specified reference.</returns>
         public static Uri Reference(long repositoryId, string referenceName)
         {
-            return "repositories/{0}/git/refs/{1}".FormatUri(repositoryId,
-                referenceName.Replace("refs/", string.Empty));
+            return "repositories/{0}/git/refs/{1}".FormatUri(repositoryId, referenceName);
         }
 
         /// <summary>


### PR DESCRIPTION
Supersedes #1934
Fixes #1933

 - [x] review outstanding feedback from previous PR
 - [x] add new unit tests for omitting `refs`
 - [x] update xml-docs
 - [x] add integration tests for including or omitting `refs`
