### PR TITLE
Update OAuth Token operations to new APIs

### DIFF
--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -292,7 +292,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Post<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Args.Object);
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
             }
 
             [Fact]
@@ -320,7 +320,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Patch<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Args.Object);
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
             }
 
             [Fact]
@@ -348,7 +348,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Args.Object);
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -290,9 +290,9 @@ namespace Octokit.Tests.Clients
 
                 authEndpoint.CheckApplicationAuthentication("clientId", "accessToken");
 
-                client.Received().Get<ApplicationAuthorization>(
-                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/tokens/accessToken"),
-                    null);
+                client.Received().Post<ApplicationAuthorization>(
+                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
+                    Args.Object);
             }
 
             [Fact]
@@ -318,8 +318,8 @@ namespace Octokit.Tests.Clients
 
                 authEndpoint.ResetApplicationAuthentication("clientId", "accessToken");
 
-                client.Received().Post<ApplicationAuthorization>(
-                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/tokens/accessToken"),
+                client.Received().Patch<ApplicationAuthorization>(
+                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
                     Args.Object);
             }
 
@@ -347,7 +347,8 @@ namespace Octokit.Tests.Clients
                 authEndpoint.RevokeApplicationAuthentication("clientId", "accessToken");
 
                 client.Received().Delete(
-                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/tokens/accessToken"));
+                    Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
+                    Args.Object);
             }
 
             [Fact]

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -341,8 +341,13 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
             Ensure.ArgumentNotNullOrEmptyString(accessToken, nameof(accessToken));
 
-            var endpoint = ApiUrls.ApplicationAuthorization(clientId, accessToken);
-            return ApiConnection.Get<ApplicationAuthorization>(endpoint, null);
+            var requestData = new
+            {
+                access_token = accessToken
+            };
+
+            var endpoint = ApiUrls.ApplicationAuthorization(clientId);
+            return ApiConnection.Post<ApplicationAuthorization>(endpoint, requestData);
         }
 
         /// <summary>
@@ -360,9 +365,13 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
             Ensure.ArgumentNotNullOrEmptyString(accessToken, nameof(accessToken));
 
-            var requestData = new { };
+            var requestData = new
+            {
+                access_token = accessToken
+            };
 
-            return ApiConnection.Post<ApplicationAuthorization>(ApiUrls.ApplicationAuthorization(clientId, accessToken), requestData);
+            var endpoint = ApiUrls.ApplicationAuthorization(clientId);
+            return ApiConnection.Patch<ApplicationAuthorization>(endpoint, requestData);
         }
 
         /// <summary>
@@ -380,8 +389,13 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
             Ensure.ArgumentNotNullOrEmptyString(accessToken, nameof(accessToken));
 
-            return ApiConnection.Delete(
-                ApiUrls.ApplicationAuthorization(clientId, accessToken));
+            var requestData = new
+            {
+                access_token = accessToken
+            };
+
+            var endpoint = ApiUrls.ApplicationAuthorization(clientId);
+            return ApiConnection.Delete(endpoint, requestData);
         }
 
         /// <summary>

--- a/Octokit/Helpers/ApiUrls.Authorizations.cs
+++ b/Octokit/Helpers/ApiUrls.Authorizations.cs
@@ -36,12 +36,7 @@ namespace Octokit
 
         public static Uri ApplicationAuthorization(string clientId)
         {
-            return "applications/{0}/tokens".FormatUri(clientId);
-        }
-
-        public static Uri ApplicationAuthorization(string clientId, string accessToken)
-        {
-            return "applications/{0}/tokens/{1}".FormatUri(clientId, accessToken);
+            return "applications/{0}/token".FormatUri(clientId);
         }
     }
 }


### PR DESCRIPTION
Per ['Deprecating OAuth Application API'](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/)
the HTTP API endpoints called by CheckApplicationAuthentication,
ResetApplicationAuthentication and RevokeApplicationAuthentication are
being deprecated.

This PR updates those APIs to call the new HTTP API endpoints as
documented at the above link.

# Details

Amend CheckApplicationAuthentication, ResetApplicationAuthentication and
RevokeApplicationAuthentication to create an object containing the OAuth
access token and to call the single arg version of
ApiUrls.ApplicationAuthorization. The object is used as the request
body.

Amend CheckApplicationAuthentication to use POST.

Amend ResetApplicationAuthentication to use PATCH.

Remove the two arg version of ApiUrls.ApplicationAuthorization as it is
no longer called. Amend the single arg version to use the new API path.

Amend unit tests to account for the above changes.