### PR TITLE
Minor improvements to authorization tests

### DIFF
--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -126,8 +126,9 @@ namespace Octokit.Tests.Clients
 
                 authEndpoint.GetOrCreateApplicationAuthentication("clientId", "secret", data);
 
-                client.Received().Put<ApplicationAuthorization>(Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId"),
-                    Args.Object);
+                client.Received().Put<ApplicationAuthorization>(
+                    Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId"),
+                    Arg.Is<Object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"));
             }
 
             [Fact]
@@ -141,7 +142,7 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Put<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "authorizations/clients/clientId"),
-                    Args.Object,
+                    Arg.Is<Object>(o => o.GetType().GetProperty("client_secret").GetValue(o).ToString() == "secret"),
                     "two-factor");
             }
 


### PR DESCRIPTION
Minor improvements to a couple of tests in
TheGetOrCreateApplicationAuthenticationMethod to verify the interesting
piece of the request object. This brings these tests into line with
recent changes to tests in TheCheckApplicationAuthenticationMethod
et.al.