### PR TITLE
add metadata to each client action

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
         "**/obj": true,
         "**/packaging": true,
         "**/coverage-results": true
-    }
+    },
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true
 }

--- a/Octokit.Tests.Conventions/ClientRouteTests.cs
+++ b/Octokit.Tests.Conventions/ClientRouteTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Octokit.Tests.Conventions
+{
+    public class ClientRouteTests
+    {
+        [Theory]
+        [MemberData(nameof(GetClientClasses))]
+        public void ClassMethodsAreMarkedAsGeneratedManualOrDotNetSpecific(Type clientClass)
+        {
+            var methodFailures = new List<MethodInfo>();
+
+            foreach (var method in clientClass.GetMethodsOrdered().Where(IsNotBoilerplateMethod))
+            {
+                var success = MethodIsMarkedGeneratedManualOrDotNetSpecific(method);
+                if (!success)
+                {
+                    methodFailures.Add(method);
+                }
+            }
+
+            if (methodFailures.Count > 0)
+            {
+                var methodNames = string.Join(", ", methodFailures.Select(m => m.Name));
+                throw new Xunit.Sdk.XunitException($"These methods on {clientClass.Name} are not marked with one of ManualRouteAttribute, GeneratedRouteAttribute or DotNetSpecificRouteAttribute: '{methodNames}'");
+            }
+        }
+
+        static bool MethodIsMarkedGeneratedManualOrDotNetSpecific(MethodInfo method)
+        {
+            var manualRoute = method.GetCustomAttribute<ManualRouteAttribute>();
+            if (manualRoute != null)
+            {
+                return true;
+            }
+
+            var generatedRoute = method.GetCustomAttribute<GeneratedRouteAttribute>();
+            if (generatedRoute != null)
+            {
+                return true;
+            }
+
+            var dotnetSpecificRoute = method.GetCustomAttribute<DotNetSpecificRouteAttribute>();
+            if (dotnetSpecificRoute != null)
+            {
+                return true;
+            }
+
+            var obsolete = method.GetCustomAttribute<ObsoleteAttribute>();
+            if (obsolete != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        static bool IsNotBoilerplateMethod(MethodInfo method)
+        {
+            if (method.IsSpecialName)
+            {
+                return false;
+            }
+
+            if (method.Name == "GetType" || method.Name == "ToString" || method.Name == "GetHashCode" || method.Name == "Equals")
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static IEnumerable<object[]> GetClientClasses()
+        {
+            return typeof(IGitHubClient)
+                .GetTypeInfo()
+                .Assembly
+                .ExportedTypes
+                .Where(TypeExtensions.IsClientClass)
+                .Where(t => t != typeof(StatisticsClient)) // This convention doesn't apply to this one type.
+                .Where(t => t != typeof(GitHubClient))
+                .Select(type => new[] { type });
+        }
+    }
+}

--- a/Octokit.Tests.Conventions/TypeExtensions.cs
+++ b/Octokit.Tests.Conventions/TypeExtensions.cs
@@ -74,6 +74,11 @@ namespace Octokit.Tests.Conventions
             return type.GetTypeInfo().IsInterface && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(IGitHubClient).Namespace;
         }
 
+        public static bool IsClientClass(this Type type)
+        {
+            return type.GetTypeInfo().IsClass && type.Name.EndsWith(ClientSuffix) && type.Namespace == typeof(IGitHubClient).Namespace;
+        }
+
         public static Type GetObservableClientInterface(this Type type)
         {
             var observableClient = typeof(IObservableEventsClient);

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -36,6 +37,7 @@ namespace Octokit
         /// Gets all the available assignees (owner + collaborators) to which issues may be assigned.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -47,6 +49,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">The options to change API's response.</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,6 +66,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">The options to change API's response.</param>
+        [ManualRoute("GET", "/repositories/{id}/assignees")]
         public Task<IReadOnlyList<User>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -78,6 +82,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/assignees/{username}")]
         public async Task<bool> CheckAssignee(string owner, string name, string assignee)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -103,6 +108,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/assignees")]
         public Task<Issue> AddAssignees(string owner, string name, int number, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -120,6 +126,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/assignees")]
         public Task<Issue> RemoveAssignees(string owner, string name, int number, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -134,6 +141,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assignee">Username of the prospective assignee</param>
+        [ManualRoute("GET", "/repositories/{id}/assignees/{username}")]
         public async Task<bool> CheckAssignee(long repositoryId, string assignee)
         {
             Ensure.ArgumentNotNullOrEmptyString(assignee, nameof(assignee));

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -32,6 +32,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
+        [ManualRoute("GET", "/authorizations")]
         public Task<IReadOnlyList<Authorization>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -50,6 +51,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Authorization"/>s for the authenticated user.</returns>
+        [ManualRoute("GET", "/authorizations")]
         public Task<IReadOnlyList<Authorization>> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -70,6 +72,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The specified <see cref="Authorization"/>.</returns>
+        [ManualRoute("GET", "/authorizations/{id}")]
         public Task<Authorization> Get(int id)
         {
             return ApiConnection.Get<Authorization>(ApiUrls.Authorizations(id), null);
@@ -92,6 +95,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("POST", "/authorizations")]
         public Task<ApplicationAuthorization> Create(NewAuthorization newAuthorization)
         {
             Ensure.ArgumentNotNull(newAuthorization, nameof(newAuthorization));
@@ -126,6 +130,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("POST", "/authorizations")]
         public Task<ApplicationAuthorization> Create(
             NewAuthorization newAuthorization,
             string twoFactorAuthenticationCode)
@@ -164,6 +169,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("POST", "/authorizations")]
         public Task<ApplicationAuthorization> Create(
             string clientId,
             string clientSecret,
@@ -208,6 +214,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("POST", "/authorizations")]
         public Task<ApplicationAuthorization> Create(
             string clientId,
             string clientSecret,
@@ -234,7 +241,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
+        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.
         /// </summary>
         /// <remarks>
@@ -252,6 +259,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("PUT", "/authorizations/clients/{id}")]
         public Task<ApplicationAuthorization> GetOrCreateApplicationAuthentication(
             string clientId,
             string clientSecret,
@@ -275,7 +283,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already 
+        /// Creates a new authorization for the specified OAuth application if an authorization for that application doesn’t already
         /// exist for the user; otherwise, returns the user’s existing authorization for that application.
         /// </summary>
         /// <remarks>
@@ -294,6 +302,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The created <see cref="Authorization"/>.</returns>
+        [ManualRoute("PUT", "/authorizations/clients/{id}")]
         public async Task<ApplicationAuthorization> GetOrCreateApplicationAuthentication(
             string clientId,
             string clientSecret,
@@ -336,6 +345,7 @@ namespace Octokit
         /// <param name="clientId">Client Id of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to check</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/>.</returns>
+        [ManualRoute("POST", "/applications/{id}/token")]
         public Task<ApplicationAuthorization> CheckApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
@@ -360,6 +370,7 @@ namespace Octokit
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to reset</param>
         /// <returns>The valid <see cref="ApplicationAuthorization"/> with a new OAuth token</returns>
+        [ManualRoute("PATCH", "/applications/{id}/token")]
         public Task<ApplicationAuthorization> ResetApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
@@ -384,6 +395,7 @@ namespace Octokit
         /// <param name="clientId">ClientID of the OAuth application for the token</param>
         /// <param name="accessToken">The OAuth token to revoke</param>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
+        [ManualRoute("DELETE", "/applications/{id}/token")]
         public Task RevokeApplicationAuthentication(string clientId, string accessToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(clientId, nameof(clientId));
@@ -403,7 +415,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#update-an-existing-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#update-an-existing-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">Id of the <see cref="Authorization"/> to update</param>
@@ -413,6 +425,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The updated <see cref="Authorization"/>.</returns>
+        [ManualRoute("PATCH", "/authorizations/{id}")]
         public Task<Authorization> Update(int id, AuthorizationUpdate authorizationUpdate)
         {
             Ensure.ArgumentNotNull(authorizationUpdate, nameof(authorizationUpdate));
@@ -427,7 +440,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -436,6 +449,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
+        [ManualRoute("DELETE", "/authorizations/{id}")]
         public Task Delete(int id)
         {
             return ApiConnection.Delete(ApiUrls.Authorizations(id));
@@ -446,7 +460,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// This method requires authentication.
-        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API 
+        /// See the <a href="http://developer.github.com/v3/oauth/#delete-an-authorization">API
         /// documentation</a> for more details.
         /// </remarks>
         /// <param name="id">The system-wide Id of the authorization to delete</param>
@@ -456,6 +470,7 @@ namespace Octokit
         /// </exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Task"/> for the request's execution.</returns>
+        [ManualRoute("DELETE", "/authorizations/{id}")]
         public Task Delete(int id, string twoFactorAuthenticationCode)
         {
             return ApiConnection.Delete(ApiUrls.Authorizations(id), twoFactorAuthenticationCode);

--- a/Octokit/Clients/BlobsClient.cs
+++ b/Octokit/Clients/BlobsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/blobs/{file_sha}")]
         public Task<Blob> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -45,6 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA of the blob</param>
+        [ManualRoute("GET", "/repositories/{id}/git/blobs/{file_sha}")]
         public Task<Blob> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -61,6 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newBlob">The new Blob</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/git/blobs")]
         public Task<BlobReference> Create(string owner, string name, NewBlob newBlob)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -78,6 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newBlob">The new Blob</param>
+        [ManualRoute("POST", "/repositories/{id}/git/blobs")]
         public Task<BlobReference> Create(long repositoryId, NewBlob newBlob)
         {
             Ensure.ArgumentNotNull(newBlob, nameof(newBlob));

--- a/Octokit/Clients/CheckRunsClient.cs
+++ b/Octokit/Clients/CheckRunsClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckRun">Details of the Check Run to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/check-runs")]
         public Task<CheckRun> Create(string owner, string name, NewCheckRun newCheckRun)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,6 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newCheckRun">Details of the Check Run to create</param>
+        [ManualRoute("POST", "/repositories/{id}/check-runs")]
         public Task<CheckRun> Create(long repositoryId, NewCheckRun newCheckRun)
         {
             Ensure.ArgumentNotNull(newCheckRun, nameof(newCheckRun));
@@ -64,6 +66,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="checkRunUpdate">The updates to the check run</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
         public Task<CheckRun> Update(string owner, string name, long checkRunId, CheckRunUpdate checkRunUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,6 +85,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="checkRunUpdate">The updates to the check run</param>
+        [ManualRoute("PATCH", "/repositories/{id}/check-runs/{check_run_id}")]
         public Task<CheckRun> Update(long repositoryId, long checkRunId, CheckRunUpdate checkRunUpdate)
         {
             Ensure.ArgumentNotNull(checkRunUpdate, nameof(checkRunUpdate));
@@ -98,6 +102,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
+        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -115,6 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -132,6 +138,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
+        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -151,6 +158,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
         public Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -170,6 +178,7 @@ namespace Octokit
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -195,6 +204,7 @@ namespace Octokit
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -217,6 +227,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -233,6 +244,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(long repositoryId, long checkSuiteId)
         {
             return GetAllForCheckSuite(repositoryId, checkSuiteId, new CheckRunRequest(), ApiOptions.None);
@@ -248,6 +260,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -266,6 +279,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}/check-runs")]
         public Task<CheckRunsResponse> GetAllForCheckSuite(long repositoryId, long checkSuiteId, CheckRunRequest checkRunRequest)
         {
             Ensure.ArgumentNotNull(checkRunRequest, nameof(checkRunRequest));
@@ -284,6 +298,7 @@ namespace Octokit
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -308,6 +323,7 @@ namespace Octokit
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForCheckSuite(long repositoryId, long checkSuiteId, CheckRunRequest checkRunRequest, ApiOptions options)
         {
             Ensure.ArgumentNotNull(checkRunRequest, nameof(checkRunRequest));
@@ -329,6 +345,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
         public Task<CheckRun> Get(string owner, string name, long checkRunId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -345,6 +362,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
+        [ManualRoute("GET", "/repositories/{id}/check-runs/{check_run_id}")]
         public Task<CheckRun> Get(long repositoryId, long checkRunId)
         {
             return ApiConnection.Get<CheckRun>(ApiUrls.CheckRun(repositoryId, checkRunId), null, AcceptHeaders.ChecksApiPreview);
@@ -359,6 +377,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(string owner, string name, long checkRunId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -376,6 +395,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(long repositoryId, long checkRunId)
         {
             return GetAllAnnotations(repositoryId, checkRunId, ApiOptions.None);
@@ -391,6 +411,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(string owner, string name, long checkRunId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -409,6 +430,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(long repositoryId, long checkRunId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{id}")]
         public Task<CheckSuite> Get(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -46,6 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}")]
         public Task<CheckSuite> Get(long repositoryId, long checkSuiteId)
         {
             return ApiConnection.Get<CheckSuite>(ApiUrls.CheckSuite(repositoryId, checkSuiteId), null, AcceptHeaders.ChecksApiPreview);
@@ -60,6 +62,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -77,6 +80,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -94,6 +98,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference, CheckSuiteRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -113,6 +118,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/check-suites")]
         public Task<CheckSuitesResponse> GetAllForReference(long repositoryId, string reference, CheckSuiteRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -132,6 +138,7 @@ namespace Octokit
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
         public async Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference, CheckSuiteRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -157,6 +164,7 @@ namespace Octokit
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
         /// <param name="options">Options to change the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{ref}/check-suites")]
         public async Task<CheckSuitesResponse> GetAllForReference(long repositoryId, string reference, CheckSuiteRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -179,6 +187,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="preferences">The check suite preferences</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/check-suites/preferences")]
         public Task<CheckSuitePreferencesResponse> UpdatePreferences(string owner, string name, CheckSuitePreferences preferences)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -196,6 +205,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="preferences">The check suite preferences</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/preferences")]
         public Task<CheckSuitePreferencesResponse> UpdatePreferences(long repositoryId, CheckSuitePreferences preferences)
         {
             Ensure.ArgumentNotNull(preferences, nameof(preferences));
@@ -212,6 +222,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckSuite">Details of the Check Suite to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/check-suites")]
         public Task<CheckSuite> Create(string owner, string name, NewCheckSuite newCheckSuite)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -229,6 +240,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newCheckSuite">Details of the Check Suite to create</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites")]
         public Task<CheckSuite> Create(long repositoryId, NewCheckSuite newCheckSuite)
         {
             Ensure.ArgumentNotNull(newCheckSuite, nameof(newCheckSuite));
@@ -294,6 +306,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{2}/rerequest")]
         public async Task<bool> Rerequest(string owner, string name, long checkSuiteId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -317,6 +330,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [ManualRoute("GET", "/repositories/{id}/check-suites/{2}/rerequest")]
         public async Task<bool> Rerequest(long repositoryId, long checkSuiteId)
         {
             var httpStatusCode = await Connection.Post(ApiUrls.CheckSuiteRerequest(repositoryId, checkSuiteId), null, AcceptHeaders.ChecksApiPreview).ConfigureAwait(false);

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -25,6 +25,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -42,6 +43,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
@@ -57,6 +59,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -71,6 +74,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -87,6 +91,7 @@ namespace Octokit
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="number">The comment id</param>        
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -100,6 +105,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Clients/CommitStatusClient.cs
+++ b/Octokit/Clients/CommitStatusClient.cs
@@ -29,6 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,6 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -65,6 +67,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>        
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(string owner, string name, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -85,6 +88,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/statuses")]
         public Task<IReadOnlyList<CommitStatus>> GetAll(long repositoryId, string reference, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -103,6 +107,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/status")]
         public Task<CombinedCommitStatus> GetCombined(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -121,6 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/status")]
         public Task<CombinedCommitStatus> GetCombined(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -138,6 +144,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/statuses/{sha}")]
         public Task<CommitStatus> Create(string owner, string name, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -157,6 +164,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference (SHA, branch name, or tag name) to list commits for</param>
         /// <param name="newCommitStatus">The commit status to create</param>
+        [ManualRoute("POST", "/repositories/{id}/statuses/{sha}")]
         public Task<CommitStatus> Create(long repositoryId, string reference, NewCommitStatus newCommitStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));

--- a/Octokit/Clients/CommitsClient.cs
+++ b/Octokit/Clients/CommitsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/commits/{commit_sha}")]
         public Task<Commit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -45,6 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the commit</param>
+        [ManualRoute("GET", "/repositories/{id}/git/commits/{commit_sha}")]
         public Task<Commit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -61,6 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="commit">The commit to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/git/commits")]
         public Task<Commit> Create(string owner, string name, NewCommit commit)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -78,6 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="commit">The commit to create</param>
+        [ManualRoute("POST", "/repositories/{id}/git/commits")]
         public Task<Commit> Create(long repositoryId, NewCommit commit)
         {
             Ensure.ArgumentNotNull(commit, nameof(commit));

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -44,6 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
+        [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId)
         {
             return GetAll(repositoryId, deploymentId, ApiOptions.None);
@@ -60,6 +62,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,6 +85,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -103,6 +107,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -124,6 +129,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        [ManualRoute("POST", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
             Ensure.ArgumentNotNull(newDeploymentStatus, nameof(newDeploymentStatus));

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -31,6 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,6 +48,7 @@ namespace Octokit
         /// http://developer.github.com/v3/repos/deployments/#list-deployments
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -62,6 +64,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -83,6 +86,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -100,6 +104,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/deployments")]
         public Task<Deployment> Create(string owner, string name, NewDeployment newDeployment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -120,6 +125,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
+        [ManualRoute("POST", "/repositories/{id}/deployments")]
         public Task<Deployment> Create(long repositoryId, NewDeployment newDeployment)
         {
             Ensure.ArgumentNotNull(newDeployment, nameof(newDeployment));

--- a/Octokit/Clients/Enterprise/EnterpriseAdminStatsClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseAdminStatsClient.cs
@@ -21,6 +21,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsIssues"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/issues")]
         public Task<AdminStatsIssues> GetStatisticsIssues()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsIssues();
@@ -35,6 +36,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsHooks"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/hooks")]
         public Task<AdminStatsHooks> GetStatisticsHooks()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsHooks();
@@ -49,6 +51,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsMilestones"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/milestones")]
         public Task<AdminStatsMilestones> GetStatisticsMilestones()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsMilestones();
@@ -63,6 +66,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsOrgs"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/orgs")]
         public Task<AdminStatsOrgs> GetStatisticsOrgs()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsOrgs();
@@ -77,6 +81,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsComments"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/comments")]
         public Task<AdminStatsComments> GetStatisticsComments()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsComments();
@@ -91,6 +96,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsPages"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/pages")]
         public Task<AdminStatsPages> GetStatisticsPages()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsPages();
@@ -105,6 +111,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsUsers"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/users")]
         public Task<AdminStatsUsers> GetStatisticsUsers()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsUsers();
@@ -119,6 +126,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsGists"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/comments")]
         public Task<AdminStatsGists> GetStatisticsGists()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsGists();
@@ -133,6 +141,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsPulls"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/pulls")]
         public Task<AdminStatsPulls> GetStatisticsPulls()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsPulls();
@@ -147,6 +156,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStatsRepos"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/repos")]
         public Task<AdminStatsRepos> GetStatisticsRepos()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsRepos();
@@ -161,6 +171,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/admin_stats/#get-statistics
         /// </remarks>
         /// <returns>The <see cref="AdminStats"/> collection of statistics.</returns>
+        [ManualRoute("GET", "/enterprise/stats/all")]
         public Task<AdminStats> GetStatisticsAll()
         {
             var endpoint = ApiUrls.EnterpriseAdminStatsAll();

--- a/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLdapClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="userName">The username to update LDAP mapping</param>
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="User"/> object.</returns>
+        [ManualRoute("PATCH", "/admin/ldap/users/{username}/mapping")]
         public Task<User> UpdateUserMapping(string userName, NewLdapMapping newLdapMapping)
         {
             Ensure.ArgumentNotNull(userName, nameof(userName));
@@ -42,6 +43,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="userName">The userName to sync LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
+        [ManualRoute("POST", "/admin/ldap/users/{username}/sync")]
         public async Task<LdapSyncResponse> QueueSyncUserMapping(string userName)
         {
             Ensure.ArgumentNotNull(userName, nameof(userName));
@@ -66,6 +68,7 @@ namespace Octokit
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <param name="newLdapMapping">The <see cref="NewLdapMapping"/></param>
         /// <returns>The <see cref="Team"/> object.</returns>
+        [ManualRoute("PATCH", "/admin/ldap/teams/{team_id}/mapping")]
         public Task<Team> UpdateTeamMapping(int teamId, NewLdapMapping newLdapMapping)
         {
             Ensure.ArgumentNotNull(teamId, nameof(teamId));
@@ -84,6 +87,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="teamId">The teamId to update LDAP mapping</param>
         /// <returns>The <see cref="LdapSyncResponse"/> of the queue request.</returns>
+        [ManualRoute("POST", "/admin/ldap/teams/{team_id}/sync")]
         public async Task<LdapSyncResponse> QueueSyncTeamMapping(int teamId)
         {
             Ensure.ArgumentNotNull(teamId, nameof(teamId));

--- a/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseLicenseClient.cs
@@ -21,6 +21,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/license/#get-license-information
         /// </remarks>
         /// <returns>The <see cref="LicenseInfo"/> statistics.</returns>
+        [ManualRoute("GET", "/enterprise/settings/license")]
         public Task<LicenseInfo> Get()
         {
             var endpoint = ApiUrls.EnterpriseLicense();

--- a/Octokit/Clients/Enterprise/EnterpriseManagementConsoleClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseManagementConsoleClient.cs
@@ -21,6 +21,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/management_console/#check-maintenance-status
         /// </remarks>
         /// <returns>The <see cref="MaintenanceModeResponse"/>.</returns>
+        [ManualRoute("GET", "/setup/api/maintenance")]
         public Task<MaintenanceModeResponse> GetMaintenanceMode(string managementConsolePassword)
         {
             Ensure.ArgumentNotNullOrEmptyString(managementConsolePassword, "managementConsolePassword");
@@ -37,6 +38,7 @@ namespace Octokit
         /// https://developer.github.com/v3/enterprise/management_console/#check-maintenance-status
         /// </remarks>
         /// <returns>The <see cref="MaintenanceModeResponse"/>.</returns>
+        [ManualRoute("POST", "/setup/api/maintenance")]
         public Task<MaintenanceModeResponse> EditMaintenanceMode(UpdateMaintenanceRequest maintenance, string managementConsolePassword)
         {
             Ensure.ArgumentNotNull(maintenance, "maintenance");

--- a/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseOrganizationClient.cs
@@ -22,6 +22,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="newOrganization">A <see cref="NewOrganization"/> instance describing the organization to be created</param>
         /// <returns>The <see cref="Organization"/> created.</returns>
+        [ManualRoute("POST", "/admin/organizations")]
         public Task<Organization> Create(NewOrganization newOrganization)
         {
             Ensure.ArgumentNotNull(newOrganization, nameof(newOrganization));

--- a/Octokit/Clients/Enterprise/EnterprisePreReceiveEnvironmentsClient.cs
+++ b/Octokit/Clients/Enterprise/EnterprisePreReceiveEnvironmentsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/enterprise-admin/pre_receive_environments/#list-pre-receive-environments">API documentation</a> for more information.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/admin/pre-receive-environments")]
         public Task<IReadOnlyList<PreReceiveEnvironment>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -39,6 +40,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/admin/pre-receive-environments")]
         public Task<IReadOnlyList<PreReceiveEnvironment>> GetAll(ApiOptions options)
         {
             var endpoint = ApiUrls.AdminPreReceiveEnvironments();
@@ -54,6 +56,7 @@ namespace Octokit
         /// <param name="environmentId">The id of the pre-receive environment</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="environmentId"/> does not exist.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/admin/pre-receive-environments/{pre_receive_environment_id}")]
         public Task<PreReceiveEnvironment> Get(long environmentId)
         {
             var endpoint = ApiUrls.AdminPreReceiveEnvironments(environmentId);
@@ -68,6 +71,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="newPreReceiveEnvironment">A description of the pre-receive environment to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("POST", "/admin/pre-receive-environments")]
         public Task<PreReceiveEnvironment> Create(NewPreReceiveEnvironment newPreReceiveEnvironment)
         {
             Ensure.ArgumentNotNull(newPreReceiveEnvironment, nameof(newPreReceiveEnvironment));
@@ -86,6 +90,7 @@ namespace Octokit
         /// <param name="updatePreReceiveEnvironment">A description of the pre-receive environment to edit</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="environmentId"/> does not exist.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PATCH", "/admin/pre-receive-environments/{pre_receive_environment_id}")]
         public Task<PreReceiveEnvironment> Edit(long environmentId, UpdatePreReceiveEnvironment updatePreReceiveEnvironment)
         {
             Ensure.ArgumentNotNull(updatePreReceiveEnvironment, nameof(updatePreReceiveEnvironment));
@@ -103,6 +108,7 @@ namespace Octokit
         /// <param name="environmentId">The id of the pre-receive environment</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="environmentId"/> does not exist.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/admin/pre-receive-environments/{pre_receive_environment_id}")]
         public Task Delete(long environmentId)
         {
             var endpoint = ApiUrls.AdminPreReceiveEnvironments(environmentId);
@@ -118,6 +124,7 @@ namespace Octokit
         /// <param name="environmentId">The id of the pre-receive environment</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="environmentId"/> does not exist.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/admin/pre-receive-environments/{pre_receive_environment_id}/downloads/latest")]
         public Task<PreReceiveEnvironmentDownload> DownloadStatus(long environmentId)
         {
             var endpoint = ApiUrls.AdminPreReceiveEnvironmentDownloadStatus(environmentId);
@@ -134,6 +141,7 @@ namespace Octokit
         /// <param name="environmentId">The id of the pre-receive environment</param>
         /// <exception cref="NotFoundException">Thrown when the specified <paramref name="environmentId"/> does not exist.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("POST", "/admin/pre-receive-environments/{pre_receive_environment_id}/downloads")]
         public Task<PreReceiveEnvironmentDownload> TriggerDownload(long environmentId)
         {
             var endpoint = ApiUrls.AdminPreReceiveEnvironmentDownload(environmentId);

--- a/Octokit/Clients/Enterprise/EnterpriseSearchIndexingClient.cs
+++ b/Octokit/Clients/Enterprise/EnterpriseSearchIndexingClient.cs
@@ -23,6 +23,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> Queue(string owner)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -42,6 +43,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> Queue(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -61,6 +63,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> QueueAll(string owner)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -80,6 +83,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> QueueAllIssues(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -99,6 +103,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> QueueAllIssues(string owner)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -118,6 +123,7 @@ namespace Octokit
         /// <param name="owner">A user or organization account</param>
         /// <param name="repository">A repository</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> QueueAllCode(string owner, string repository)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));
@@ -137,6 +143,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">A user or organization account</param>
         /// <returns>The <see cref="SearchIndexingResponse"/> message.</returns>
+        [ManualRoute("POST", "/staff/indexing_jobs")]
         public Task<SearchIndexingResponse> QueueAllCode(string owner)
         {
             Ensure.ArgumentNotNull(owner, nameof(owner));

--- a/Octokit/Clients/EventsClient.cs
+++ b/Octokit/Clients/EventsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
+        [ManualRoute("GET", "/events")]
         public Task<IReadOnlyList<Activity>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -38,7 +39,8 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
-        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>        
+        /// <returns>All the public <see cref="Activity"/>s for the particular user.</returns>
+        [ManualRoute("GET", "/events")]
         public Task<IReadOnlyList<Activity>> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -54,6 +56,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -69,6 +72,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -83,6 +87,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -100,6 +105,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -115,6 +121,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -130,6 +137,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-issue-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId)
         {
             return GetAllIssuesForRepository(repositoryId, ApiOptions.None);
@@ -144,6 +152,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -161,6 +170,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllIssuesForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -176,6 +186,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/networks/{owner}/{name}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -193,6 +204,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/networks/{owner}/{name}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForRepositoryNetwork(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -209,6 +221,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-for-an-organization
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
+        [ManualRoute("GET", "/orgs/{org}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -224,6 +237,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/events")]
         public Task<IReadOnlyList<Activity>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -239,6 +253,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
+        [ManualRoute("GET", "/users/{username}/received_events")]
         public Task<IReadOnlyList<Activity>> GetAllUserReceived(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -254,6 +269,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/received_events")]
         public Task<IReadOnlyList<Activity>> GetAllUserReceived(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -269,6 +285,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received
         /// </remarks>
         /// <param name="user">The login of the user</param>
+        [ManualRoute("GET", "/users/{username}/received_events/public")]
         public Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -284,6 +301,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/received_events/public")]
         public Task<IReadOnlyList<Activity>> GetAllUserReceivedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -299,6 +317,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
+        [ManualRoute("GET", "/users/{username}/events")]
         public Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -314,6 +333,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/events")]
         public Task<IReadOnlyList<Activity>> GetAllUserPerformed(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -329,6 +349,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/events/#list-public-events-performed-by-a-user
         /// </remarks>
         /// <param name="user">The login of the user</param>
+        [ManualRoute("GET", "/users/{username}/events/public")]
         public Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -344,6 +365,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/events/public")]
         public Task<IReadOnlyList<Activity>> GetAllUserPerformedPublic(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -360,6 +382,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
+        [ManualRoute("GET", "/users/{username}/events/orgs/{org}")]
         public Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -377,6 +400,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{username}/events/orgs/{org}")]
         public Task<IReadOnlyList<Activity>> GetAllForAnOrganization(string user, string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));

--- a/Octokit/Clients/FeedsClient.cs
+++ b/Octokit/Clients/FeedsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// http://developer.github.com/v3/activity/feeds/#list-feeds
         /// </remarks>
         /// <returns>All the public <see cref="Feed"/>s for the particular user.</returns>
+        [ManualRoute("GET", "/feeds")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         public Task<Feed> GetFeeds()
         {

--- a/Octokit/Clients/FollowersClient.cs
+++ b/Octokit/Clients/FollowersClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        [ManualRoute("GET", "/user/followers")]
         public Task<IReadOnlyList<User>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -40,6 +41,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the authenticated user.</returns>
+        [ManualRoute("GET", "/user/followers")]
         public Task<IReadOnlyList<User>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -55,6 +57,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        [ManualRoute("GET", "/user/{username}/followers")]
         public Task<IReadOnlyList<User>> GetAll(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -71,6 +74,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-followers-of-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that follow the passed user.</returns>
+        [ManualRoute("GET", "/user/{username}/followers")]
         public Task<IReadOnlyList<User>> GetAll(string login, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -86,6 +90,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        [ManualRoute("GET", "/user/following")]
         public Task<IReadOnlyList<User>> GetAllFollowingForCurrent()
         {
             return GetAllFollowingForCurrent(ApiOptions.None);
@@ -99,6 +104,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the authenticated user follows.</returns>
+        [ManualRoute("GET", "/user/following")]
         public Task<IReadOnlyList<User>> GetAllFollowingForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -114,6 +120,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        [ManualRoute("GET", "/users/{username}/following")]
         public Task<IReadOnlyList<User>> GetAllFollowing(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -130,6 +137,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{User}"/> of <see cref="User"/>s that the passed user follows.</returns>
+        [ManualRoute("GET", "/users/{username}/following")]
         public Task<IReadOnlyList<User>> GetAllFollowing(string login, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -146,6 +154,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#check-if-you-are-following-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <c>bool</c> representing the success of the operation.</returns>
+        [ManualRoute("GET", "/user/following/{username}")]
         public async Task<bool> IsFollowingForCurrent(string following)
         {
             Ensure.ArgumentNotNullOrEmptyString(following, nameof(following));
@@ -170,6 +179,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#check-if-one-user-follows-another">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <c>bool</c> representing the success of the operation.</returns>
+        [ManualRoute("GET", "/users/{login}/following/{username}")]
         public async Task<bool> IsFollowing(string login, string following)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -194,6 +204,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#follow-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <c>bool</c> representing the success of the operation.</returns>
+        [ManualRoute("PUT", "/user/following/{username}")]
         public async Task<bool> Follow(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -222,6 +233,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/users/followers/#unfollow-a-user">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/user/following/{username}")]
         public Task Unfollow(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));

--- a/Octokit/Clients/GistCommentsClient.cs
+++ b/Octokit/Clients/GistCommentsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task{GistComment}.</returns>
+        [ManualRoute("GET", "/gists/{gist_id}/comments/{comment_id}")]
         public Task<GistComment> Get(string gistId, int commentId)
         {
             return ApiConnection.Get<GistComment>(ApiUrls.GistComment(gistId, commentId));
@@ -37,6 +38,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/gists/comments/#list-comments-on-a-gist</remarks>
         /// <param name="gistId">The id of the gist</param>
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
+        [ManualRoute("GET", "/gists/{gist_id}/comments")]
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId)
         {
             Ensure.ArgumentNotNullOrEmptyString(gistId, nameof(gistId));
@@ -51,6 +53,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>Task{IReadOnlyList{GistComment}}.</returns>
+        [ManualRoute("GET", "/gists/{gist_id}/comments")]
         public Task<IReadOnlyList<GistComment>> GetAllForGist(string gistId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(gistId, nameof(gistId));
@@ -66,6 +69,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="comment">The body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
+        [ManualRoute("POST", "/gists/{gist_id}/comments")]
         public Task<GistComment> Create(string gistId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, nameof(comment));
@@ -81,6 +85,7 @@ namespace Octokit
         /// <param name="commentId">The id of the comment</param>
         /// <param name="comment">The updated body of the comment</param>
         /// <returns>Task{GistComment}.</returns>
+        [ManualRoute("PATCH", "/gists/{gist_id}/comments/{comment_id}")]
         public Task<GistComment> Update(string gistId, int commentId, string comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(comment, nameof(comment));
@@ -95,6 +100,7 @@ namespace Octokit
         /// <param name="gistId">The id of the gist</param>
         /// <param name="commentId">The id of the comment</param>
         /// <returns>Task.</returns>
+        [ManualRoute("DELETE", "/gists/{gist_id}/comments/{comment_id}")]
         public Task Delete(string gistId, int commentId)
         {
             return ApiConnection.Delete(ApiUrls.GistComment(gistId, commentId));

--- a/Octokit/Clients/GistsClient.cs
+++ b/Octokit/Clients/GistsClient.cs
@@ -31,6 +31,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#get-a-single-gist
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("GET", "/gists/{gist_id}")]
         public Task<Gist> Get(string id)
         {
             return ApiConnection.Get<Gist>(ApiUrls.Gist(id));
@@ -43,6 +44,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#create-a-gist
         /// </remarks>
         /// <param name="newGist">The new gist to create</param>
+        [ManualRoute("GET", "/gists")]
         public Task<Gist> Create(NewGist newGist)
         {
             Ensure.ArgumentNotNull(newGist, nameof(newGist));
@@ -73,6 +75,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#fork-a-gist
         /// </remarks>
         /// <param name="id">The id of the gist to fork</param>
+        [ManualRoute("POST", "/gists/{gist_id}/forks")]
         public Task<Gist> Fork(string id)
         {
             return ApiConnection.Post<Gist>(ApiUrls.ForkGist(id), new object());
@@ -85,6 +88,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#delete-a-gist
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("DELETE", "/gists/{gist_id}")]
         public Task Delete(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -99,6 +103,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        [ManualRoute("GET", "/gists")]
         public Task<IReadOnlyList<Gist>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -112,6 +117,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists")]
         public Task<IReadOnlyList<Gist>> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -127,6 +133,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
+        [ManualRoute("GET", "/gists")]
         public Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since)
         {
             return GetAll(since, ApiOptions.None);
@@ -141,6 +148,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists")]
         public Task<IReadOnlyList<Gist>> GetAll(DateTimeOffset since, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -155,6 +163,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        [ManualRoute("GET", "/gists/public")]
         public Task<IReadOnlyList<Gist>> GetAllPublic()
         {
             return GetAllPublic(ApiOptions.None);
@@ -167,6 +176,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/public")]
         public Task<IReadOnlyList<Gist>> GetAllPublic(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -181,6 +191,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
+        [ManualRoute("GET", "/gists/public")]
         public Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since)
         {
             return GetAllPublic(since, ApiOptions.None);
@@ -194,6 +205,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/public")]
         public Task<IReadOnlyList<Gist>> GetAllPublic(DateTimeOffset since, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -208,6 +220,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
+        [ManualRoute("GET", "/gists/starred")]
         public Task<IReadOnlyList<Gist>> GetAllStarred()
         {
             return GetAllStarred(ApiOptions.None);
@@ -220,6 +233,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/starred")]
         public Task<IReadOnlyList<Gist>> GetAllStarred(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -234,6 +248,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
+        [ManualRoute("GET", "/gists/starred")]
         public Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since)
         {
             return GetAllStarred(since, ApiOptions.None);
@@ -247,6 +262,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/starred")]
         public Task<IReadOnlyList<Gist>> GetAllStarred(DateTimeOffset since, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -262,6 +278,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists
         /// </remarks>
         /// <param name="user">The user</param>
+        [ManualRoute("GET", "/users/{user}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -277,6 +294,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The user</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{user}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -293,6 +311,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
+        [ManualRoute("GET", "/users/{user}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -309,6 +328,7 @@ namespace Octokit
         /// <param name="user">The user</param>
         /// <param name="since">Only gists updated at or after this time are returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/users/{user}/gists")]
         public Task<IReadOnlyList<Gist>> GetAllForUser(string user, DateTimeOffset since, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -325,6 +345,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists-commits
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("GET", "/gists/{gist_id}/commits")]
         public Task<IReadOnlyList<GistHistory>> GetAllCommits(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -340,6 +361,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the gist</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/{gist_id}/commits")]
         public Task<IReadOnlyList<GistHistory>> GetAllCommits(string id, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -355,6 +377,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#list-gists-forks
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("GET", "/gists/{gist_id}/forks")]
         public Task<IReadOnlyList<GistFork>> GetAllForks(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -370,6 +393,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the gist</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/gists/{gist_id}/forks")]
         public Task<IReadOnlyList<GistFork>> GetAllForks(string id, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -386,6 +410,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the gist</param>
         /// <param name="gistUpdate">The update to the gist</param>
+        [ManualRoute("PATCH", "/gists/{gist_id}")]
         public Task<Gist> Edit(string id, GistUpdate gistUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -413,6 +438,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#star-a-gist
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("PUT", "/gists/{gist_id}/star")]
         public Task Star(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -427,6 +453,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#unstar-a-gist
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("DELETE", "/gists/{gist_id}/star")]
         public Task Unstar(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));
@@ -441,6 +468,7 @@ namespace Octokit
         /// http://developer.github.com/v3/gists/#check-if-a-gist-is-starred
         /// </remarks>
         /// <param name="id">The id of the gist</param>
+        [ManualRoute("GET", "/gists/{gist_id}/star")]
         public async Task<bool> IsStarred(string id)
         {
             Ensure.ArgumentNotNullOrEmptyString(id, nameof(id));

--- a/Octokit/Clients/GitHubAppsClient.cs
+++ b/Octokit/Clients/GitHubAppsClient.cs
@@ -34,6 +34,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-a-single-github-app</remarks>
         /// <param name="slug">The URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App.</param>
+        [ManualRoute("GET", "/apps/{slug}")]
         public Task<GitHubApp> Get(string slug)
         {
             Ensure.ArgumentNotNullOrEmptyString(slug, nameof(slug));
@@ -45,6 +46,7 @@ namespace Octokit
         /// Returns the GitHub App associated with the authentication credentials used (requires GitHubApp auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-the-authenticated-github-app</remarks>
+        [ManualRoute("GET", "/app")]
         public Task<GitHubApp> GetCurrent()
         {
             return ApiConnection.Get<GitHubApp>(ApiUrls.App(), null, AcceptHeaders.GitHubAppsPreview);
@@ -54,6 +56,7 @@ namespace Octokit
         /// List installations of the authenticated GitHub App (requires GitHubApp auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-installations</remarks>
+        [ManualRoute("GET", "/app/installations")]
         public Task<IReadOnlyList<Installation>> GetAllInstallationsForCurrent()
         {
             return GetAllInstallationsForCurrent(ApiOptions.None);
@@ -64,6 +67,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/#find-installations</remarks>
+        [ManualRoute("GET", "/app/installations")]
         public Task<IReadOnlyList<Installation>> GetAllInstallationsForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -87,6 +91,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-a-single-installation</remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [ManualRoute("GET", "/app/installations/{id}")]
         public Task<Installation> GetInstallationForCurrent(long installationId)
         {
             return ApiConnection.Get<Installation>(ApiUrls.Installation(installationId), null, AcceptHeaders.GitHubAppsPreview);
@@ -96,6 +101,7 @@ namespace Octokit
         /// List installations for the currently authenticated user (requires GitHubApp User-To-Server Auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#list-installations-for-user</remarks>
+        [ManualRoute("GET", "/user/installations")]
         public async Task<InstallationsResponse> GetAllInstallationsForCurrentUser()
         {
             var results = await ApiConnection.GetAll<InstallationsResponse>(ApiUrls.UserInstallations(), null, AcceptHeaders.GitHubAppsPreview).ConfigureAwait(false);
@@ -109,6 +115,7 @@ namespace Octokit
         /// List installations for the currently authenticated user (requires GitHubApp User-To-Server Auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#list-installations-for-user</remarks>
+        [ManualRoute("GET", "/user/installations")]
         public async Task<InstallationsResponse> GetAllInstallationsForCurrentUser(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -129,6 +136,7 @@ namespace Octokit
         /// https://developer.github.com/v3/apps/available-endpoints/
         /// </remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [ManualRoute("GET", "/app/installations/{id}/access_tokens")]
         public Task<AccessToken> CreateInstallationToken(long installationId)
         {
             return ApiConnection.Post<AccessToken>(ApiUrls.AccessTokens(installationId), string.Empty, AcceptHeaders.GitHubAppsPreview);
@@ -139,6 +147,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-organization-installation</remarks>
         /// <param name="organization">The name of the organization</param>
+        [ManualRoute("GET", "/orgs/{org}/installation")]
         public Task<Installation> GetOrganizationInstallationForCurrent(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -152,6 +161,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/apps/#find-repository-installation</remarks>
         /// <param name="owner">The owner of the repo</param>
         /// <param name="repo">The name of the repo</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/installation")]
         public Task<Installation> GetRepositoryInstallationForCurrent(string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -165,6 +175,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-repository-installation</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/installation")]
         public Task<Installation> GetRepositoryInstallationForCurrent(long repositoryId)
         {
             return ApiConnection.Get<Installation>(ApiUrls.RepoInstallation(repositoryId), null, AcceptHeaders.GitHubAppsPreview);
@@ -175,6 +186,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-user-installation</remarks>
         /// <param name="user">The name of the user</param>
+        [ManualRoute("GET", "/users/{user}/installation")]
         public Task<Installation> GetUserInstallationForCurrent(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repositories/{0}/issues/comments/{number}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
@@ -53,7 +55,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -66,7 +69,8 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -81,7 +85,8 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
+        [ManualRoute("GET", "/repositories/{0}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -93,7 +98,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{0}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The issue comment id</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments/{comment_id}")]
         public Task<IssueComment> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The issue comment id</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/comments/{comment_id}")]
         public Task<IssueComment> Get(long repositoryId, int id)
         {
             return ApiConnection.Get<IssueComment>(ApiUrls.IssueComment(repositoryId, id), null, AcceptHeaders.ReactionsPreview);
@@ -51,6 +53,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -64,6 +67,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new IssueCommentRequest(), ApiOptions.None);
@@ -76,6 +80,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -91,6 +96,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -105,6 +111,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -120,6 +127,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repositories/{id}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -135,6 +143,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -152,6 +161,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -167,6 +177,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -181,6 +192,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -194,6 +206,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -210,6 +223,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -225,6 +239,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -241,6 +256,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -257,6 +273,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -275,6 +292,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -291,6 +309,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IssueComment> Create(string owner, string name, int number, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -307,6 +326,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
+        [ManualRoute("POST", "/repositories/{id}/issues/{number}/comments")]
         public Task<IssueComment> Create(long repositoryId, int number, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
@@ -322,6 +342,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/issues/comments/{id}")]
         public Task<IssueComment> Update(string owner, string name, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -338,6 +359,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
         /// <param name="commentUpdate">The modified comment</param>
+        [ManualRoute("PATCH", "/repositories/{id}/issues/comments/{number}")]
         public Task<IssueComment> Update(long repositoryId, int id, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, nameof(commentUpdate));
@@ -352,6 +374,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The comment id</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/comments/{id}")]
         public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -366,6 +389,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The comment id</param>
+        [ManualRoute("DELETE", "/repositories/{id}/issues/comments/{number}")]
         public Task Delete(long repositoryId, int id)
         {
             return ApiConnection.Delete(ApiUrls.IssueComment(repositoryId, id));

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -22,7 +22,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -35,7 +36,8 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -50,7 +52,8 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The issue id</param>        
+        /// <param name="number">The issue id</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -62,7 +65,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -78,6 +82,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -94,6 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repositories/{id}/issues/{number}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -42,6 +43,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -62,6 +64,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -76,6 +79,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -31,8 +31,8 @@ namespace Octokit
         public IAssigneesClient Assignee { get; private set; }
 
         /// <summary>
-        /// Client for reading various event information associated with issues/pull requests.  
-        /// This is useful both for display on issue/pull request information pages and also to 
+        /// Client for reading various event information associated with issues/pull requests.
+        /// This is useful both for display on issue/pull request information pages and also to
         /// determine who should be notified of comments.
         /// </summary>
         public IIssuesEventsClient Events { get; private set; }
@@ -66,6 +66,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}")]
         public Task<Issue> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,6 +83,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}")]
         public Task<Issue> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -95,6 +97,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
+        [ManualRoute("GET", "/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -109,6 +112,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
+        [ManualRoute("GET", "/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -117,13 +121,14 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
+        [ManualRoute("GET", "/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -132,7 +137,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories, 
+        /// Gets all issues across all the authenticated user’s visible repositories including owned repositories,
         /// member repositories, and organization repositories.
         /// </summary>
         /// <remarks>
@@ -140,6 +145,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -156,6 +162,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
+        [ManualRoute("GET", "/user/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories()
         {
             return GetAllForOwnedAndMemberRepositories(ApiOptions.None);
@@ -170,6 +177,7 @@ namespace Octokit
         /// Issues are sorted by the create date descending.
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
+        [ManualRoute("GET", "/user/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -184,6 +192,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
+        [ManualRoute("GET", "/user/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -199,6 +208,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/user/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -214,6 +224,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
+        [ManualRoute("GET", "/orgs/{org}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -229,6 +240,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -245,6 +257,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
+        [ManualRoute("GET", "/orgs/{org}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -262,6 +275,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -279,6 +293,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -294,6 +309,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/#list-issues-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new RepositoryIssueRequest());
@@ -308,6 +324,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -325,6 +342,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -341,6 +359,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -358,6 +377,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
+        [ManualRoute("GET", "/repositories/{id}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -375,6 +395,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -394,6 +415,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -410,6 +432,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues")]
         public Task<Issue> Create(string owner, string name, NewIssue newIssue)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -426,6 +449,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/#create-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newIssue">A <see cref="NewIssue"/> instance describing the new issue to create</param>
+        [ManualRoute("POST", "/repositories/{id}/issues")]
         public Task<Issue> Create(long repositoryId, NewIssue newIssue)
         {
             Ensure.ArgumentNotNull(newIssue, nameof(newIssue));
@@ -442,6 +466,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/issues/{number}")]
         public Task<Issue> Update(string owner, string name, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -460,6 +485,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
+        [ManualRoute("PATCH", "/repositories/{id}/issues/{number}")]
         public Task<Issue> Update(long repositoryId, int number, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
@@ -474,6 +500,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/issues/{number}/lock")]
         public Task Lock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -488,6 +515,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#lock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("PUT", "/repositories/{id}/issues/{number}/lock")]
         public Task Lock(long repositoryId, int number)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, number), new object(), null, AcceptHeaders.IssueLockingUnlockingApiPreview);
@@ -500,6 +528,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/lock")]
         public Task Unlock(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -514,6 +543,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/lock")]
         public Task Unlock(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, number), new object(), AcceptHeaders.IssueLockingUnlockingApiPreview);

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -55,6 +57,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -76,6 +79,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -94,6 +98,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -109,6 +114,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/events/#list-events-for-a-repository
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -123,6 +129,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -143,6 +150,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -162,6 +170,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="eventId">The event id</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/events/{event_id}")]
         public Task<IssueEvent> Get(string owner, string name, long eventId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -180,6 +189,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="eventId">The event id</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/events/{event_id}")]
         public Task<IssueEvent> Get(long repositoryId, long eventId)
         {
             return ApiConnection.Get<IssueEvent>(ApiUrls.IssuesEvent(repositoryId, eventId),

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -25,6 +25,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -41,6 +42,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number)
         {
             return GetAllForIssue(repositoryId, number, ApiOptions.None);
@@ -56,6 +58,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -74,6 +77,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -89,6 +93,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -104,6 +109,7 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -118,6 +124,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -135,6 +142,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -151,6 +159,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -167,6 +176,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
+        [ManualRoute("GET", "/repositories/{id}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number)
         {
             return GetAllForMilestone(repositoryId, number, ApiOptions.None);
@@ -182,6 +192,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -200,6 +211,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the milestone</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/milestones/{number}/labels")]
         public Task<IReadOnlyList<Label>> GetAllForMilestone(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -216,6 +228,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/labels/{name}")]
         public Task<Label> Get(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -233,6 +246,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
+        [ManualRoute("GET", "/repositories/{id}/labels/{name}")]
         public Task<Label> Get(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
@@ -249,6 +263,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/labels/{name}")]
         public Task Delete(string owner, string name, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -266,6 +281,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
+        [ManualRoute("DELETE", "/repositories/{id}/labels/{name}")]
         public Task Delete(long repositoryId, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
@@ -282,6 +298,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/labels")]
         public Task<Label> Create(string owner, string name, NewLabel newLabel)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -299,6 +316,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newLabel">The data for the label to be created</param>
+        [ManualRoute("POST", "/repositories/{id}/labels/{name}")]
         public Task<Label> Create(long repositoryId, NewLabel newLabel)
         {
             Ensure.ArgumentNotNull(newLabel, nameof(newLabel));
@@ -316,12 +334,15 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/labels/{name}")]
         public Task<Label> Update(string owner, string name, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
             Ensure.ArgumentNotNull(labelUpdate, nameof(labelUpdate));
+
+            // BUG: this should be a PATCH instead of POST
 
             return ApiConnection.Post<Label>(ApiUrls.Label(owner, name, labelName), labelUpdate, AcceptHeaders.LabelsApiPreview);
         }
@@ -335,10 +356,13 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="labelName">The name of the label</param>
         /// <param name="labelUpdate">The data for the label to be updated</param>
+        [ManualRoute("PATCH", "/repositories/{id}/labels/{name}")]
         public Task<Label> Update(long repositoryId, string labelName, LabelUpdate labelUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
             Ensure.ArgumentNotNull(labelUpdate, nameof(labelUpdate));
+
+            // BUG: this should be a PATCH instead of POST
 
             return ApiConnection.Post<Label>(ApiUrls.Label(repositoryId, labelName), labelUpdate, AcceptHeaders.LabelsApiPreview);
         }
@@ -353,6 +377,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -371,6 +396,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
+        [ManualRoute("POST", "/repositories/{id}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
@@ -388,6 +414,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -406,6 +433,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
+        [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int number, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
@@ -423,6 +451,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int number, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -441,6 +470,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
+        [ManualRoute("PUT", "/repositories/{id}/issues/{number}/labels")]
         public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int number, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
@@ -457,6 +487,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The number of the issue</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/issues/{number}/labels")]
         public Task RemoveAllFromIssue(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -473,6 +504,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The number of the issue</param>
+        [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
         public Task RemoveAllFromIssue(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, number));

--- a/Octokit/Clients/MergingClient.cs
+++ b/Octokit/Clients/MergingClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "repos/{owner}/{name}/merges")]
         public Task<Merge> Create(string owner, string name, NewMerge merge)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -46,6 +47,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="merge">The merge to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "repositories/{id}/merges")]
         public Task<Merge> Create(long repositoryId, NewMerge merge)
         {
             Ensure.ArgumentNotNull(merge, nameof(merge));

--- a/Octokit/Clients/MigrationsClient.cs
+++ b/Octokit/Clients/MigrationsClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="migration">Sprcifies parameters for the migration in a 
         /// <see cref="StartMigrationRequest"/> object.</param>
         /// <returns>The started migration.</returns>
+        [ManualRoute("POST", "/orgs/{org}/migrations")]
         public async Task<Migration> Start(string org, StartMigrationRequest migration)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -48,6 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The organization of which to list migrations.</param>
         /// <returns>List of most recent <see cref="Migration"/>s.</returns>
+        [ManualRoute("GET", "/orgs/{org}/migrations")]
         public async Task<IReadOnlyList<Migration>> GetAll(string org)
         {
             return await GetAll(org, ApiOptions.None);
@@ -62,6 +64,7 @@ namespace Octokit
         /// <param name="org">The organization of which to list migrations.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>List of most recent <see cref="Migration"/>s.</returns>
+        [ManualRoute("GET", "/orgs/{org}/migrations")]
         public async Task<IReadOnlyList<Migration>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -81,6 +84,7 @@ namespace Octokit
         /// <param name="org">The organization which is migrating.</param>
         /// <param name="id">Migration Id of the organization.</param>
         /// <returns>A <see cref="Migration"/> object representing the state of migration.</returns>
+        [ManualRoute("GET", "/orgs/{org}/migrations/{id}")]
         public async Task<Migration> Get(string org, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -99,6 +103,7 @@ namespace Octokit
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns>The binary contents of the archive as a byte array.</returns>
+        [ManualRoute("GET", "/orgs/{org}/migrations/{id}/archive")]
         public async Task<byte[]> GetArchive(string org, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -118,6 +123,7 @@ namespace Octokit
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/orgs/{org}/migrations/{id}/archive")]
         public Task DeleteArchive(string org, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -137,6 +143,7 @@ namespace Octokit
         /// <param name="id">The Id of the migration.</param>
         /// <param name="repo">The repo to unlock.</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/orgs/{org}/migrations/{id}/repos/{name}/lock")]
         public Task UnlockRepository(string org, int id, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));

--- a/Octokit/Clients/MilestonesClient.cs
+++ b/Octokit/Clients/MilestonesClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones/{number}")]
         public Task<Milestone> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -41,6 +42,7 @@ namespace Octokit
         /// http://developer.github.com/v3/issues/milestones/#get-a-single-milestone
         /// </remarks>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/milestones/{number}")]
         public Task<Milestone> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<Milestone>(ApiUrls.Milestone(repositoryId, number));
@@ -55,6 +57,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -71,6 +74,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new MilestoneRequest());
@@ -86,6 +90,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -104,6 +109,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -121,6 +127,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -139,6 +146,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -157,6 +165,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(string owner, string name, MilestoneRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -178,6 +187,7 @@ namespace Octokit
         /// <param name="request">Used to filter and sort the list of Milestones returned</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/milestones")]
         public Task<IReadOnlyList<Milestone>> GetAllForRepository(long repositoryId, MilestoneRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -196,6 +206,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repos/{owner}/{name}/milestones")]
         public Task<Milestone> Create(string owner, string name, NewMilestone newMilestone)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -213,6 +224,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newMilestone">A <see cref="NewMilestone"/> instance describing the new Milestone to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repositories/{id}/milestones")]
         public Task<Milestone> Create(long repositoryId, NewMilestone newMilestone)
         {
             Ensure.ArgumentNotNull(newMilestone, nameof(newMilestone));
@@ -231,6 +243,7 @@ namespace Octokit
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/milestones/{number}")]
         public Task<Milestone> Update(string owner, string name, int number, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -250,6 +263,7 @@ namespace Octokit
         /// <param name="milestoneUpdate">An <see cref="MilestoneUpdate"/> instance describing the changes to make to the Milestone
         /// </param>
         /// <returns></returns>
+        [ManualRoute("PATCH", "/repositories/{id}/milestones/{number}")]
         public Task<Milestone> Update(long repositoryId, int number, MilestoneUpdate milestoneUpdate)
         {
             Ensure.ArgumentNotNull(milestoneUpdate, nameof(milestoneUpdate));
@@ -266,6 +280,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/milestones/{number}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -282,6 +297,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The milestone number</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/repositories/{id}/milestones/{number}")]
         public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.Milestone(repositoryId, number));

--- a/Octokit/Clients/MiscellaneousClient.cs
+++ b/Octokit/Clients/MiscellaneousClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="IReadOnlyDictionary{TKey,TValue}"/> of emoji and their URI.</returns>
+        [ManualRoute("GET", "/emojis")]
         public Task<IReadOnlyList<Emoji>> GetAllEmojis()
         {
             return ApiConnection.GetAll<Emoji>(ApiUrls.Emojis());
@@ -38,6 +39,7 @@ namespace Octokit
         /// <param name="markdown">A plain-text Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [ManualRoute("POST", "/markdown/raw")]
         public Task<string> RenderRawMarkdown(string markdown)
         {
             return ApiConnection.Post<string>(ApiUrls.RawMarkdown(), markdown, "text/html", "text/plain");
@@ -49,6 +51,7 @@ namespace Octokit
         /// <param name="markdown">An arbitrary Markdown document</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The rendered Markdown.</returns>
+        [ManualRoute("POST", "/markdown")]
         public Task<string> RenderArbitraryMarkdown(NewArbitraryMarkdown markdown)
         {
             return ApiConnection.Post<string>(ApiUrls.Markdown(), markdown, "text/html", "text/plain");
@@ -58,6 +61,7 @@ namespace Octokit
         /// List all templates available to pass as an option when creating a repository.
         /// </summary>
         /// <returns>A list of template names</returns>
+        [ManualRoute("GET", "/gitignore/templates")]
         public Task<IReadOnlyList<string>> GetAllGitIgnoreTemplates()
         {
             return ApiConnection.GetAll<string>(ApiUrls.GitIgnoreTemplates());
@@ -68,6 +72,7 @@ namespace Octokit
         /// </summary>
         /// <param name="templateName"></param>
         /// <returns>A template and its source</returns>
+        [ManualRoute("GET", "/gitignore/templates/{template_name}")]
         public Task<GitIgnoreTemplate> GetGitIgnoreTemplate(string templateName)
         {
             Ensure.ArgumentNotNullOrEmptyString(templateName, nameof(templateName));
@@ -80,6 +85,7 @@ namespace Octokit
         /// list of all possible OSS licenses.
         /// </summary>
         /// <returns>A list of licenses available on the site</returns>
+        [ManualRoute("GET", "/licenses")]
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses()
         {
             return GetAllLicenses(ApiOptions.None);
@@ -91,6 +97,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>A list of licenses available on the site</returns>
+        [ManualRoute("GET", "/licenses")]
         public Task<IReadOnlyList<LicenseMetadata>> GetAllLicenses(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, "options");
@@ -103,6 +110,7 @@ namespace Octokit
         /// </summary>
         /// <param name="key"></param>
         /// <returns>A <see cref="License" /> that includes the license key, text, and attributes of the license.</returns>
+        [ManualRoute("GET", "/licenses/{key}")]
         public Task<License> GetLicense(string key)
         {
             return ApiConnection.Get<License>(ApiUrls.Licenses(key), null, AcceptHeaders.LicensesApiPreview);
@@ -114,6 +122,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="MiscellaneousRateLimit"/> of Rate Limits.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ManualRoute("GET", "/rate_limit")]
         public Task<MiscellaneousRateLimit> GetRateLimits()
         {
             return ApiConnection.Get<MiscellaneousRateLimit>(ApiUrls.RateLimit());
@@ -125,6 +134,7 @@ namespace Octokit
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>An <see cref="Meta"/> containing metadata about the GitHub instance.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        [ManualRoute("GET", "/meta")]
         public Task<Meta> GetMetadata()
         {
             return ApiConnection.Get<Meta>(ApiUrls.Meta());

--- a/Octokit/Clients/NotificationsClient.cs
+++ b/Octokit/Clients/NotificationsClient.cs
@@ -23,6 +23,7 @@ namespace Octokit
         /// Retrieves all of the <see cref="Notification"/>s for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -33,6 +34,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -45,6 +47,7 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -58,6 +61,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForCurrent(NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -72,6 +76,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -85,6 +90,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -97,6 +103,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -112,6 +119,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -126,6 +134,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -141,6 +150,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -156,6 +166,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(string owner, string name, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -173,6 +184,7 @@ namespace Octokit
         /// <param name="request">Specifies the parameters to filter notifications by</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/notifications")]
         public Task<IReadOnlyList<Notification>> GetAllForRepository(long repositoryId, NotificationsRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -185,6 +197,7 @@ namespace Octokit
         /// Marks all notifications as read.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
+        [ManualRoute("PUT", "/notifications")]
         public Task MarkAsRead()
         {
             return ApiConnection.Put<object>(ApiUrls.Notifications(), new object());
@@ -195,6 +208,7 @@ namespace Octokit
         /// </summary>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-as-read</remarks>
+        [ManualRoute("PUT", "/notifications")]
         public Task MarkAsRead(MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, nameof(markAsReadRequest));
@@ -208,6 +222,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/notifications")]
         public Task MarkAsReadForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -221,6 +236,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        [ManualRoute("PUT", "/repositories/{id}/notifications")]
         public Task MarkAsReadForRepository(long repositoryId)
         {
             return ApiConnection.Put<object>(ApiUrls.Notifications(repositoryId), new object());
@@ -233,6 +249,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        [ManualRoute("PUT", "/repos/{owner}/{repo}/notifications")]
         public Task MarkAsReadForRepository(string owner, string name, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -248,6 +265,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="markAsReadRequest">The <see cref="MarkAsReadRequest"/> parameter which specifies which notifications to mark.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository</remarks>
+        [ManualRoute("PUT", "/repositories/{id}/notifications")]
         public Task MarkAsReadForRepository(long repositoryId, MarkAsReadRequest markAsReadRequest)
         {
             Ensure.ArgumentNotNull(markAsReadRequest, nameof(markAsReadRequest));
@@ -260,6 +278,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the notification to retrieve.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#view-a-single-thread</remarks>
+        [ManualRoute("GET", "/notifications/threads/{thread_id}")]
         public Task<Notification> Get(int id)
         {
             return ApiConnection.Get<Notification>(ApiUrls.Notification(id));
@@ -270,6 +289,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The id of the notification.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read</remarks>
+        [ManualRoute("PATCH", "/notifications/threads/{thread_id}")]
         public Task MarkAsRead(int id)
         {
             return ApiConnection.Patch(ApiUrls.Notification(id));
@@ -280,6 +300,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to retrieve subscription status.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#get-a-thread-subscription</remarks>
+        [ManualRoute("GET", "/notifications/threads/{thread_id}/subscription")]
         public Task<ThreadSubscription> GetThreadSubscription(int id)
         {
             return ApiConnection.Get<ThreadSubscription>(ApiUrls.NotificationSubscription(id));
@@ -291,6 +312,7 @@ namespace Octokit
         /// <param name="id">The Id of the thread to update.</param>
         /// <param name="threadSubscription">The subscription parameters to set.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#set-a-thread-subscription</remarks>
+        [ManualRoute("PUT", "/notifications/threads/{thread_id}/subscription")]
         public Task<ThreadSubscription> SetThreadSubscription(int id, NewThreadSubscription threadSubscription)
         {
             Ensure.ArgumentNotNull(threadSubscription, nameof(threadSubscription));
@@ -303,6 +325,7 @@ namespace Octokit
         /// </summary>
         /// <param name="id">The Id of the thread to delete subscription from.</param>
         /// <remarks>http://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription</remarks>
+        [ManualRoute("DELETE", "/notifications/threads/{thread_id}/subscription")]
         public Task DeleteThreadSubscription(int id)
         {
             return ApiConnection.Delete(ApiUrls.NotificationSubscription(id));

--- a/Octokit/Clients/OAuthClient.cs
+++ b/Octokit/Clients/OAuthClient.cs
@@ -36,6 +36,7 @@ namespace Octokit
         /// </summary>
         /// <param name="request">Parameters to the Oauth web flow login url</param>
         /// <returns></returns>
+        [DotNetSpecificRoute]
         public Uri GetGitHubLoginUrl(OauthLoginRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -56,6 +57,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request"></param>
         /// <returns></returns>
+        [ManualRoute("POST", "/login/oauth/access_token")]
         public async Task<OauthToken> CreateAccessToken(OauthTokenRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));

--- a/Octokit/Clients/OrganizationMembersClient.cs
+++ b/Octokit/Clients/OrganizationMembersClient.cs
@@ -81,6 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -109,6 +110,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -138,6 +140,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -167,6 +170,7 @@ namespace Octokit
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -196,6 +200,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members?role={1}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -225,6 +230,7 @@ namespace Octokit
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members?role={1}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersRole role, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -255,6 +261,7 @@ namespace Octokit
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members?filter={1}&role={2}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -285,6 +292,7 @@ namespace Octokit
         /// <param name="role">The role filter to use when getting the users, <see cref="OrganizationMembersRole"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "orgs/{org}/members?filter={1}&role={2}")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, OrganizationMembersRole role, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -299,6 +307,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/orgs/members/#public-members-list</remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/public_members")]
         public Task<IReadOnlyList<User>> GetAllPublic(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -313,6 +322,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/public_members")]
         public Task<IReadOnlyList<User>> GetAllPublic(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -331,6 +341,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/members/{username}")]
         public async Task<bool> CheckMember(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -364,6 +375,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/public_members/{username}")]
         public async Task<bool> CheckMemberPublic(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -392,6 +404,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "orgs/{org}/members/{username}")]
         public Task Delete(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -411,6 +424,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("PUT", "orgs/{org}/public_members/{username}")]
         public async Task<bool> Publicize(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -443,6 +457,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "orgs/{org}/public_members/{username}")]
         public Task Conceal(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -463,6 +478,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/memberships/{username}")]
         public Task<OrganizationMembership> GetOrganizationMembership(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -485,6 +501,7 @@ namespace Octokit
         /// <param name="addOrUpdateRequest">An <see cref="OrganizationMembershipUpdate"/> instance describing the
         /// changes to make to the user's organization membership</param>
         /// <returns></returns>
+        [ManualRoute("PUT", "orgs/{org}/memberships/{username}")]
         public Task<OrganizationMembership> AddOrUpdateOrganizationMembership(string org, string user, OrganizationMembershipUpdate addOrUpdateRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -506,6 +523,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "orgs/{org}/memberships/{username}")]
         public Task RemoveOrganizationMembership(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -523,6 +541,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -540,6 +559,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
+        [ManualRoute("GET", "orgs/{org}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));

--- a/Octokit/Clients/OrganizationOutsideCollaboratorsClient.cs
+++ b/Octokit/Clients/OrganizationOutsideCollaboratorsClient.cs
@@ -32,6 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="org">The login for the organization</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "/orgs/{org}/outside_collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -50,6 +51,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "/orgs/{org}/outside_collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -69,6 +71,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "/orgs/{org}/outside_collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -88,6 +91,7 @@ namespace Octokit
         /// <param name="filter">The filter to use when getting the users, <see cref="OrganizationMembersFilter"/></param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>The users</returns>
+        [ManualRoute("GET", "/orgs/{org}/outside_collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string org, OrganizationMembersFilter filter, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -107,6 +111,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login of the user</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/orgs/{org}/outside_collaborators/{username}")]
         public async Task<bool> Delete(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -147,6 +152,7 @@ namespace Octokit
         /// <param name="org">The login for the organization</param>
         /// <param name="user">The login for the user</param>
         /// <returns></returns>
+        [ManualRoute("PUT", "/orgs/{org}/outside_collaborators/{username}")]
         public async Task<bool> ConvertFromMember(string org, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));

--- a/Octokit/Clients/OrganizationsClient.cs
+++ b/Octokit/Clients/OrganizationsClient.cs
@@ -44,6 +44,7 @@ namespace Octokit
         /// <param name="org">login of the organization to get</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The specified <see cref="Organization"/>.</returns>
+        [ManualRoute("GET", "/orgs/{org}")]
         public Task<Organization> Get(string org)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -56,6 +57,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the current user's <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/user/orgs")]
         public Task<IReadOnlyList<Organization>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -67,6 +69,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the current user's <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/user/orgs")]
         public Task<IReadOnlyList<Organization>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -80,6 +83,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/users/{username}/orgs")]
         public Task<IReadOnlyList<Organization>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -94,6 +98,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the specified user's <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/users/{username}/orgs")]
         public Task<IReadOnlyList<Organization>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -108,6 +113,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/organizations")]
         public Task<IReadOnlyList<Organization>> GetAll()
         {
             return ApiConnection.GetAll<Organization>(ApiUrls.AllOrganizations());
@@ -119,6 +125,7 @@ namespace Octokit
         /// <param name="request">Search parameters of the last organization seen</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of <see cref="Organization"/>s.</returns>
+        [ManualRoute("GET", "/organizations")]
         public Task<IReadOnlyList<Organization>> GetAll(OrganizationRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -135,6 +142,7 @@ namespace Octokit
         /// <param name="updateRequest"></param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="Organization"/></returns>
+        [ManualRoute("PATCH", "/orgs/{org}")]
         public Task<Organization> Update(string organizationName, OrganizationUpdate updateRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(organizationName, nameof(organizationName));

--- a/Octokit/Clients/ProjectCardsClient.cs
+++ b/Octokit/Clients/ProjectCardsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#list-projects-cards">API documentation</a> for more information.
         /// </remarks>
         /// <param name="columnId">The id of the column</param>
+        [ManualRoute("GET", "/projects/columns/{column_id}/cards")]
         public Task<IReadOnlyList<ProjectCard>> GetAll(int columnId)
         {
             return GetAll(columnId, ApiOptions.None);
@@ -37,6 +38,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="columnId">The id of the column</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/projects/columns/{column_id}/cards")]
         public Task<IReadOnlyList<ProjectCard>> GetAll(int columnId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -52,6 +54,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="columnId">The id of the column</param>
         /// <param name="request">Used to filter the list of project cards returned</param>
+        [ManualRoute("GET", "/projects/columns/{column_id}/cards")]
         public Task<IReadOnlyList<ProjectCard>> GetAll(int columnId, ProjectCardRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -68,6 +71,7 @@ namespace Octokit
         /// <param name="columnId">The id of the column</param>
         /// <param name="request">Used to filter the list of project cards returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/projects/columns/{column_id}/cards")]
         public Task<IReadOnlyList<ProjectCard>> GetAll(int columnId, ProjectCardRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -83,6 +87,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
+        [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
         public Task<ProjectCard> Get(int id)
         {
             return ApiConnection.Get<ProjectCard>(ApiUrls.ProjectCard(id), null, AcceptHeaders.ProjectsApiPreview);
@@ -96,6 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="columnId">The id of the column</param>
         /// <param name="newProjectCard">The card to create</param>
+        [ManualRoute("POST", "/projects/columns/{column_id}/cards")]
         public Task<ProjectCard> Create(int columnId, NewProjectCard newProjectCard)
         {
             Ensure.ArgumentNotNull(newProjectCard, nameof(newProjectCard));
@@ -111,6 +117,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
+        [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
         public Task<ProjectCard> Update(int id, ProjectCardUpdate projectCardUpdate)
         {
             Ensure.ArgumentNotNull(projectCardUpdate, nameof(projectCardUpdate));
@@ -125,6 +132,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
+        [ManualRoute("DELETE", "/projects/columns/cards/{card_id}")]
         public async Task<bool> Delete(int id)
         {
             var endpoint = ApiUrls.ProjectCard(id);
@@ -148,6 +156,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="position">The position to move the card</param>
+        [ManualRoute("POST", "/projects/columns/cards/{card_id}/moves")]
         public async Task<bool> Move(int id, ProjectCardMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));

--- a/Octokit/Clients/ProjectColumnsClient.cs
+++ b/Octokit/Clients/ProjectColumnsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#list-project-columns">API documentation</a> for more information.
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
+        [ManualRoute("GET", "projects/{project_id}/columns")]
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId)
         {
             return GetAll(projectId, ApiOptions.None);
@@ -37,6 +38,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "projects/{project_id}/columns")]
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -51,6 +53,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#get-a-project-column">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the column</param>
+        [ManualRoute("GET", "projects/columns/{column_id}")]
         public Task<ProjectColumn> Get(int id)
         {
             return ApiConnection.Get<ProjectColumn>(ApiUrls.ProjectColumn(id), null, AcceptHeaders.ProjectsApiPreview);
@@ -64,6 +67,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
         /// <param name="newProjectColumn">The column to create</param>
+        [ManualRoute("POST", "projects/{project_id}/columns")]
         public Task<ProjectColumn> Create(int projectId, NewProjectColumn newProjectColumn)
         {
             Ensure.ArgumentNotNull(newProjectColumn, nameof(newProjectColumn));
@@ -79,6 +83,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
+        [ManualRoute("PATCH", "projects/columns/{column_id}")]
         public Task<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate)
         {
             Ensure.ArgumentNotNull(projectColumnUpdate, nameof(projectColumnUpdate));
@@ -93,6 +98,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#delete-a-project-column">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the column</param>
+        [ManualRoute("DELETE", "projects/columns/{column_id}")]
         public async Task<bool> Delete(int id)
         {
             var endpoint = ApiUrls.ProjectColumn(id);
@@ -115,6 +121,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         /// <param name="position">The position to move the column</param>
+        [ManualRoute("POST", "projects/columns/{column_id}/moves")]
         public async Task<bool> Move(int id, ProjectColumnMove position)
         {
             Ensure.ArgumentNotNull(position, nameof(position));

--- a/Octokit/Clients/ProjectsClient.cs
+++ b/Octokit/Clients/ProjectsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name)
         {
             return GetAllForRepository(owner, name, ApiOptions.None);
@@ -42,6 +43,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -60,6 +62,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request)
         {
             return GetAllForRepository(owner, name, request, ApiOptions.None);
@@ -75,6 +78,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -92,6 +96,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-repository-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -105,6 +110,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -120,6 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
+        [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId, ProjectRequest request)
         {
             return GetAllForRepository(repositoryId, request, ApiOptions.None);
@@ -134,6 +141,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId, ProjectRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -149,6 +157,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/#list-organization-projects">API documentation</a> for more information.
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
+        [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization)
         {
             return GetAllForOrganization(organization, ApiOptions.None);
@@ -162,6 +171,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -179,6 +189,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter the list of projects returned</param>
+        [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization, ProjectRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -196,6 +207,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization, ProjectRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -212,10 +224,14 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The Id of the project</param>
+        [ManualRoute("GET", "/projects/{project_id}")]
         public Task<Project> Get(int id)
         {
             return ApiConnection.Get<Project>(ApiUrls.Project(id), null, AcceptHeaders.ProjectsApiPreview);
         }
+
+        // NOTE: I think we're missing a Task<Project> CreateForRepository(owner, name, newProject)
+        // Can we identify this programatically?
 
         /// <summary>
         /// Creates a project for this repository.
@@ -225,6 +241,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newProject">The new project to create for this repository</param>
+        [ManualRoute("POST", "/repositories/{id}/projects")]
         public Task<Project> CreateForRepository(long repositoryId, NewProject newProject)
         {
             Ensure.ArgumentNotNull(newProject, nameof(newProject));
@@ -240,6 +257,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="newProject">The new project to create for this repository</param>
+        [ManualRoute("POST", "/orgs/{org}/projects")]
         public Task<Project> CreateForOrganization(string organization, NewProject newProject)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -256,6 +274,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The Id of the project</param>
         /// <param name="projectUpdate">The modified project</param>
+        [ManualRoute("PATCH", "/project/{project_id}")]
         public Task<Project> Update(int id, ProjectUpdate projectUpdate)
         {
             Ensure.ArgumentNotNull(projectUpdate, nameof(projectUpdate));
@@ -270,6 +289,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The Id of the project</param>
+        [ManualRoute("DELETE", "/project/{project_id}")]
         public async Task<bool> Delete(int id)
         {
             var endpoint = ApiUrls.Project(id);

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -22,7 +22,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
         {
             return GetAll(owner, name, number, ApiOptions.None);
@@ -35,7 +36,8 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -50,7 +52,8 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -62,7 +65,8 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
-        /// <param name="options">Options for changing the API response</param>        
+        /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -78,6 +82,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -94,6 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -38,6 +39,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -51,6 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -67,6 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -80,6 +84,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -93,6 +98,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestReviewCommentRequest(), ApiOptions.None);
@@ -105,6 +111,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -120,6 +127,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -134,6 +142,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -149,6 +158,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -164,6 +174,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -181,6 +192,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -196,6 +208,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{number}")]
         public Task<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -210,6 +223,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/comments/{number}")]
         public Task<PullRequestReviewComment> GetComment(long repositoryId, int number)
         {
             return ApiConnection.Get<PullRequestReviewComment>(ApiUrls.PullRequestReviewComment(repositoryId, number));
@@ -223,6 +237,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/comments")]
         public async Task<PullRequestReviewComment> Create(string owner, string name, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -247,6 +262,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="comment">The comment</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/comments")]
         public async Task<PullRequestReviewComment> Create(long repositoryId, int number, PullRequestReviewCommentCreate comment)
         {
             Ensure.ArgumentNotNull(comment, nameof(comment));
@@ -270,6 +286,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/comment")]
         public async Task<PullRequestReviewComment> CreateReply(string owner, string name, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -294,6 +311,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="comment">The comment</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/comments")]
         public async Task<PullRequestReviewComment> CreateReply(long repositoryId, int number, PullRequestReviewCommentReplyCreate comment)
         {
             Ensure.ArgumentNotNull(comment, nameof(comment));
@@ -317,6 +335,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/pulls/comment/{number}")]
         public Task<PullRequestReviewComment> Edit(string owner, string name, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -333,6 +352,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="comment">The edited comment</param>
+        [ManualRoute("PATCH", "/repositories/{id}/pulls/comments/{number}")]
         public Task<PullRequestReviewComment> Edit(long repositoryId, int number, PullRequestReviewCommentEdit comment)
         {
             Ensure.ArgumentNotNull(comment, nameof(comment));
@@ -347,6 +367,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/comment/{number}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -361,6 +382,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/comments/#delete-a-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
+        [ManualRoute("DELETE", "/repositories/{id}/pulls/comments/{number}")]
         public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.PullRequestReviewComment(repositoryId, number));

--- a/Octokit/Clients/PullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/PullRequestReviewRequestsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -55,6 +57,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/requested_reviewers")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId, int number)
         {
             return ApiConnection.GetAll<User>(ApiUrls.PullRequestReviewRequests(repositoryId, number), null, AcceptHeaders.PullRequestReviewsApiPreview);
@@ -67,6 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/requested_reviewers")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -82,6 +86,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
         public async Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -106,6 +111,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/requested_reviewers")]
         public async Task<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
@@ -129,6 +135,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
         public Task Delete(string owner, string name, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -145,6 +152,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request review comment number</param>
         /// <param name="users">List of logins of users that will be not longer requested for review</param>
+        [ManualRoute("DELETE", "/repositories/{id}/pulls/{number}/requested_reviewers")]
         public Task Delete(long repositoryId, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));

--- a/Octokit/Clients/PullRequestReviewsClient.cs
+++ b/Octokit/Clients/PullRequestReviewsClient.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -25,6 +23,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -39,6 +38,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int number)
         {
             return GetAll(repositoryId, number, ApiOptions.None);
@@ -52,6 +52,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -69,6 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/reviews")]
         public Task<IReadOnlyList<PullRequestReview>> GetAll(long repositoryId, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -85,6 +87,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}")]
         public Task<PullRequestReview> Get(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -101,6 +104,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/reviews/{review_id}")]
         public Task<PullRequestReview> Get(long repositoryId, int number, long reviewId)
         {
             var endpoint = ApiUrls.PullRequestReview(repositoryId, number, reviewId);
@@ -115,6 +119,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="review">The review</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/reviews")]
         public Task<PullRequestReview> Create(string owner, string name, int number, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -132,6 +137,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The Pull Request number</param>
         /// <param name="review">The review</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/reviews")]
         public Task<PullRequestReview> Create(long repositoryId, int number, PullRequestReviewCreate review)
         {
             Ensure.ArgumentNotNull(review, nameof(review));
@@ -148,6 +154,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}")]
         public Task Delete(string owner, string name, int number, long reviewId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -164,6 +171,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("DELETE", "/repositories/{id}/pulls/{number}/reviews/{review_id}")]
         public Task Delete(long repositoryId, int number, long reviewId)
         {
             var endpoint = ApiUrls.PullRequestReview(repositoryId, number, reviewId);
@@ -179,6 +187,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/dismissals")]
         public Task<PullRequestReview> Dismiss(string owner, string name, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -197,6 +206,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="dismissMessage">The message indicating why the review was dismissed</param>
+        [ManualRoute("PUT", "/repositories/{id}/pulls/{number}/reviews/{review_id}/dismissals")]
         public Task<PullRequestReview> Dismiss(long repositoryId, int number, long reviewId, PullRequestReviewDismiss dismissMessage)
         {
             Ensure.ArgumentNotNull(dismissMessage, nameof(dismissMessage));
@@ -214,6 +224,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/events")]
         public Task<PullRequestReview> Submit(string owner, string name, int number, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -232,6 +243,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="submitMessage">The message and event being submitted for the review</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/reviews/{review_id}/events")]
         public Task<PullRequestReview> Submit(long repositoryId, int number, long reviewId, PullRequestReviewSubmit submitMessage)
         {
             Ensure.ArgumentNotNull(submitMessage, nameof(submitMessage));
@@ -248,6 +260,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId)
         {
             return GetAllComments(owner, name, number, reviewId, ApiOptions.None);
@@ -260,6 +273,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int number, long reviewId)
         {
             return GetAllComments(repositoryId, number, reviewId, ApiOptions.None);
@@ -274,6 +288,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(string owner, string name, int number, long reviewId, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -291,6 +306,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="reviewId">The pull request review number</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls/{number}/reviews/{review_id}/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllComments(long repositoryId, int number, long reviewId, ApiOptions options)
         {
             var endpoint = ApiUrls.PullRequestReviewComments(repositoryId, number, reviewId);

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -41,6 +41,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}")]
         public Task<PullRequest> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -55,6 +56,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}")]
         public Task<PullRequest> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<PullRequest>(ApiUrls.PullRequest(repositoryId, number), null, AcceptHeaders.DraftPullRequestApiPreview);
@@ -68,6 +70,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -83,6 +86,7 @@ namespace Octokit
         /// http://developer.github.com/v3/pulls/#list-pull-requests
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, new PullRequestRequest(), ApiOptions.None);
@@ -97,6 +101,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -114,6 +119,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -130,6 +136,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -147,6 +154,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -164,6 +172,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -184,6 +193,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -200,6 +210,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pulls")]
         public Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -215,6 +226,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        [ManualRoute("POST", "/repositories/{id}/pulls")]
         public Task<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest)
         {
             Ensure.ArgumentNotNull(newPullRequest, nameof(newPullRequest));
@@ -223,7 +235,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Create a pull request for the specified repository. 
+        /// Create a pull request for the specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="owner">The owner of the repository</param>
@@ -231,6 +243,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/pulls/{number}")]
         public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -241,13 +254,14 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Create a pull request for the specified repository. 
+        /// Create a pull request for the specified repository.
         /// </summary>
         /// <remarks>http://developer.github.com/v3/pulls/#update-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
+        [ManualRoute("PATCH", "/repositories/{id}/pulls/{number}")]
         public Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {
             Ensure.ArgumentNotNull(pullRequestUpdate, nameof(pullRequestUpdate));
@@ -263,6 +277,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/pulls/{number}/merge")]
         public async Task<PullRequestMerge> Merge(string owner, string name, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -297,6 +312,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         /// <param name="mergePullRequest">A <see cref="MergePullRequest"/> instance describing a pull request merge</param>
+        [ManualRoute("PUT", "/repositories/{id}/pulls/{number}/merge")]
         public async Task<PullRequestMerge> Merge(long repositoryId, int number, MergePullRequest mergePullRequest)
         {
             Ensure.ArgumentNotNull(mergePullRequest, nameof(mergePullRequest));
@@ -329,6 +345,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/merge")]
         public async Task<bool> Merged(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -352,6 +369,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/merge")]
         public async Task<bool> Merged(long repositoryId, int number)
         {
             try
@@ -373,6 +391,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/commits")]
         public Task<IReadOnlyList<PullRequestCommit>> Commits(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -387,6 +406,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#list-commits-on-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/commits")]
         public Task<IReadOnlyList<PullRequestCommit>> Commits(long repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestCommit>(ApiUrls.PullRequestCommits(repositoryId, number));
@@ -399,6 +419,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -413,6 +434,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/#list-pull-requests-files</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
+        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/files")]
         public Task<IReadOnlyList<PullRequestFile>> Files(long repositoryId, int number)
         {
             return ApiConnection.GetAll<PullRequestFile>(ApiUrls.PullRequestFiles(repositoryId, number));

--- a/Octokit/Clients/ReactionsClient.cs
+++ b/Octokit/Clients/ReactionsClient.cs
@@ -56,6 +56,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>        
         /// <param name="number">The reaction id</param>        
         /// <returns></returns>
+        [ManualRoute("DELETE", "/reactions/{number}")]
         public Task Delete(int number)
         {
             return ApiConnection.Delete(ApiUrls.Reactions(number), new object(), AcceptHeaders.ReactionsPreview);

--- a/Octokit/Clients/ReferencesClient.cs
+++ b/Octokit/Clients/ReferencesClient.cs
@@ -35,6 +35,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
         public Task<Reference> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -63,6 +64,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/git/refs/{ref}")]
         public Task<Reference> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -84,6 +86,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name)
         {
             return GetAll(owner, name, ApiOptions.None);
@@ -99,6 +102,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -116,6 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -130,6 +135,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/git/refs")]
         public Task<IReadOnlyList<Reference>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -147,6 +153,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace)
         {
             return GetAllForSubNamespace(owner, name, subNamespace, ApiOptions.None);
@@ -168,6 +175,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(string owner, string name, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -192,6 +200,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="subNamespace">The sub-namespace to get references for</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/repositories/{id}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace)
         {
             return GetAllForSubNamespace(repositoryId, subNamespace, ApiOptions.None);
@@ -212,6 +221,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/git/refs/{ref}")]
         public Task<IReadOnlyList<Reference>> GetAllForSubNamespace(long repositoryId, string subNamespace, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(subNamespace, nameof(subNamespace));
@@ -235,6 +245,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repos/{owner}/{name}/git/refs")]
         public Task<Reference> Create(string owner, string name, NewReference reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -253,6 +264,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference to create</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/repositories/{id}/git/refs")]
         public Task<Reference> Create(long repositoryId, NewReference reference)
         {
             Ensure.ArgumentNotNull(reference, nameof(reference));
@@ -276,6 +288,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/git/refs/{ref}")]
         public Task<Reference> Update(string owner, string name, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -306,6 +319,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("PATCH", "/repositories/{id}/git/refs/{ref}")]
         public Task<Reference> Update(long repositoryId, string reference, ReferenceUpdate referenceUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -334,6 +348,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/git/refs/{ref}")]
         public Task Delete(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -362,6 +377,7 @@ namespace Octokit
         /// "refs/tags/release-1") or the shortened form (omitting "refs/", e.g.
         /// "heads/master" or "tags/release-1")
         /// </remarks>
+        [ManualRoute("DELETE", "/repositories/{id}/git/refs/{ref}")]
         public Task Delete(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));

--- a/Octokit/Clients/ReleasesClient.cs
+++ b/Octokit/Clients/ReleasesClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -44,6 +45,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -59,6 +61,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -78,6 +81,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases")]
         public Task<IReadOnlyList<Release>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -96,6 +100,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}")]
         public Task<Release> Get(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -115,6 +120,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="tag">The tag of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/tags/{tag}")]
         public Task<Release> Get(string owner, string name, string tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -134,6 +140,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases/{id}")]
         public Task<Release> Get(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Releases(repositoryId, id);
@@ -149,6 +156,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag of the release</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases/tags/{tag}")]
         public Task<Release> Get(long repositoryId, string tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(tag, nameof(tag));
@@ -166,6 +174,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/latest")]
         public Task<Release> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -183,6 +192,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases/latest")]
         public Task<Release> GetLatest(long repositoryId)
         {
             var endpoint = ApiUrls.LatestRelease(repositoryId);
@@ -199,6 +209,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("POST", "/repos/{owner}/{name}/releases")]
         public Task<Release> Create(string owner, string name, NewRelease data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -218,6 +229,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="data">A description of the release to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("POST", "/repositories/{id}/releases")]
         public Task<Release> Create(long repositoryId, NewRelease data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
@@ -237,6 +249,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/releases/{id}")]
         public Task<Release> Edit(string owner, string name, int id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -257,6 +270,7 @@ namespace Octokit
         /// <param name="id">The id of the release</param>
         /// <param name="data">A description of the release to edit</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PATCH", "/repositories/{id}/releases/{id}")]
         public Task<Release> Edit(long repositoryId, int id, ReleaseUpdate data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
@@ -275,6 +289,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/releases/{id}")]
         public Task Delete(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -293,6 +308,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the release to delete</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repositories/{id}/releases/{id}")]
         public Task Delete(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Releases(repositoryId, id);
@@ -309,6 +325,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -326,6 +343,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases/{id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id)
         {
             return GetAllAssets(repositoryId, id, ApiOptions.None);
@@ -342,6 +360,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/{id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(string owner, string name, int id, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -362,6 +381,7 @@ namespace Octokit
         /// <param name="id">The id of the <see cref="Release"/>.</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/releases/{id}/assets")]
         public Task<IReadOnlyList<ReleaseAsset>> GetAllAssets(long repositoryId, int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -379,6 +399,7 @@ namespace Octokit
         /// <param name="release">The <see cref="Release"/> to attach the uploaded asset to</param>
         /// <param name="data">Description of the asset with its data</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("POST", "{server}/repos/{owner}/{repo}/releases/{release_id}/assets")]
         public Task<ReleaseAsset> UploadAsset(Release release, ReleaseAssetUpload data)
         {
             Ensure.ArgumentNotNull(release, nameof(release));
@@ -412,6 +433,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> GetAsset(string owner, string name, int assetId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -429,6 +451,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
+        [ManualRoute("GET", "/repositories/{id}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> GetAsset(long repositoryId, int assetId)
         {
             var endpoint = ApiUrls.Asset(repositoryId, assetId);
@@ -445,6 +468,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> EditAsset(string owner, string name, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -464,6 +488,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="assetId">The id of the <see cref="ReleaseAsset"/></param>
         /// <param name="data">Description of the asset with its amended data</param>
+        [ManualRoute("PATCH", "/repositories/{id}/releases/assets/{asset_id}")]
         public Task<ReleaseAsset> EditAsset(long repositoryId, int assetId, ReleaseAssetUpdate data)
         {
             Ensure.ArgumentNotNull(data, nameof(data));
@@ -481,6 +506,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/releases/assets/{asset_id}")]
         public Task DeleteAsset(string owner, string name, int id)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -498,6 +524,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The id of the <see cref="ReleaseAsset"/>.</param>
+        [ManualRoute("DELETE", "/repositories/{id}/releases/assets/{asset_id}")]
         public Task DeleteAsset(long repositoryId, int id)
         {
             var endpoint = ApiUrls.Asset(repositoryId, id);

--- a/Octokit/Clients/RepoCollaboratorsClient.cs
+++ b/Octokit/Clients/RepoCollaboratorsClient.cs
@@ -29,6 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -45,6 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -60,6 +62,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -78,6 +81,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -95,6 +99,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, RepositoryCollaboratorListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -113,6 +118,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId, RepositoryCollaboratorListRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -131,6 +137,7 @@ namespace Octokit
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(string owner, string name, RepositoryCollaboratorListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -152,6 +159,7 @@ namespace Octokit
         /// <param name="request">Used to request and filter a list of repository collaborators</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators")]
         public Task<IReadOnlyList<User>> GetAll(long repositoryId, RepositoryCollaboratorListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -170,6 +178,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators/{username}")]
         public async Task<bool> IsCollaborator(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -196,6 +205,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the prospective collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators/{username}")]
         public async Task<bool> IsCollaborator(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -221,6 +231,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the collaborator to check permission for</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/collaborators/{username}/permission")]
         public Task<CollaboratorPermission> ReviewPermission(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -240,6 +251,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the collaborator to check permission for</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repository/{id}/collaborators/{username}/permission")]
         public Task<CollaboratorPermission> ReviewPermission(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -258,6 +270,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
         public Task Add(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -278,6 +291,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
         public async Task<bool> Add(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -304,6 +318,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the new collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repository/{id}/collaborators/{username}")]
         public Task Add(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -321,6 +336,7 @@ namespace Octokit
         /// <param name="user">Username of the new collaborator</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repository/{id}/collaborators/{username}")]
         public async Task<bool> Add(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -344,13 +360,15 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
-        /// <param name="user">The name of the user to invite.</param>        
+        /// <param name="user">The name of the user to invite.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
+
 
             return ApiConnection.Put<RepositoryInvitation>(ApiUrls.RepoCollaborator(owner, name, user), new object(), null, AcceptHeaders.InvitationsApiPreview);
         }
@@ -366,6 +384,7 @@ namespace Octokit
         /// <param name="user">The name of the user to invite.</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(string owner, string name, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -383,8 +402,9 @@ namespace Octokit
         /// See the <a href="http://developer.github.com/v3/repos/collaborators/#add-collaborator">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The id of the repository.</param>
-        /// <param name="user">The name of the user to invite.</param>        
+        /// <param name="user">The name of the user to invite.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repository/{id}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -401,7 +421,8 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository.</param>
         /// <param name="user">The name of the user to invite.</param>
         /// <param name="permission">The permission to set. Only valid on organization-owned repositories.</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>        
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PUT", "/repository/{id}/collaborators/{username}")]
         public Task<RepositoryInvitation> Invite(long repositoryId, string user, CollaboratorRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -420,6 +441,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/collaborators/{username}")]
         public Task Delete(string owner, string name, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -438,6 +460,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="user">Username of the deleted collaborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repository/{id}/collaborators/{username}")]
         public Task Delete(long repositoryId, string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));

--- a/Octokit/Clients/RepositoriesClient.cs
+++ b/Octokit/Clients/RepositoriesClient.cs
@@ -50,6 +50,7 @@ namespace Octokit
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository.</returns>
+        [ManualRoute("POST", "/user/repos")]
         public Task<Repository> Create(NewRepository newRepository)
         {
             Ensure.ArgumentNotNull(newRepository, nameof(newRepository));
@@ -67,6 +68,7 @@ namespace Octokit
         /// <param name="newRepository">A <see cref="NewRepository"/> instance describing the new repository to create</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/> instance for the created repository</returns>
+        [ManualRoute("POST", "/orgs/{org}/repos")]
         public Task<Repository> Create(string organizationLogin, NewRepository newRepository)
         {
             Ensure.ArgumentNotNull(organizationLogin, nameof(organizationLogin));
@@ -141,6 +143,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}")]
         public Task Delete(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -158,6 +161,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repositories/{id}")]
         public Task Delete(long repositoryId)
         {
             return ApiConnection.Delete(ApiUrls.Repository(repositoryId));
@@ -173,6 +177,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
+        [ManualRoute("POST", "/repos/{owner}/{name}/transfer")]
         public Task<Repository> Transfer(string owner, string name, RepositoryTransfer repositoryTransfer)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -191,6 +196,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="repositoryTransfer">Repository transfer information</param>
         /// <returns>A <see cref="Repository"/></returns>
+        [ManualRoute("POST", "/repositories/{id}/transfer")]
         public Task<Repository> Transfer(long repositoryId, RepositoryTransfer repositoryTransfer)
         {
             Ensure.ArgumentNotNull(repositoryTransfer, nameof(repositoryTransfer));
@@ -205,6 +211,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}")]
         public Task<Repository> Edit(string owner, string name, RepositoryUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -221,6 +228,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="update">New values to update the repository with</param>
         /// <returns>The updated <see cref="T:Octokit.Repository"/></returns>
+        [ManualRoute("PATCH", "/repositories/{id}")]
         public Task<Repository> Edit(long repositoryId, RepositoryUpdate update)
         {
             Ensure.ArgumentNotNull(update, nameof(update));
@@ -238,6 +246,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}")]
         public Task<Repository> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -255,6 +264,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A <see cref="Repository"/></returns>
+        [ManualRoute("GET", "/repositories/{id}")]
         public Task<Repository> Get(long repositoryId)
         {
             return ApiConnection.Get<Repository>(ApiUrls.Repository(repositoryId), null, AcceptHeaders.Concat(AcceptHeaders.SquashCommitPreview, AcceptHeaders.LicensesApiPreview));
@@ -269,7 +279,8 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/repositories")]
         public Task<IReadOnlyList<Repository>> GetAllPublic()
         {
             return ApiConnection.GetAll<Repository>(ApiUrls.AllPublicRepositories(), null, AcceptHeaders.LicensesApiPreview);
@@ -285,7 +296,8 @@ namespace Octokit
         /// <param name="request">Search parameters of the last repository seen</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/repositories")]
         public Task<IReadOnlyList<Repository>> GetAllPublic(PublicRepositoryRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -304,7 +316,8 @@ namespace Octokit
         /// </remarks>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -319,7 +332,8 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -337,7 +351,8 @@ namespace Octokit
         /// <param name="request">Search parameters to filter results on</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(RepositoryRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -345,6 +360,19 @@ namespace Octokit
             return GetAllForCurrent(request, ApiOptions.None);
         }
 
+        /// <summary>
+        /// Gets all repositories owned by the current user.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="http://developer.github.com/v3/repos/#list-your-repositories">API documentation</a> for more information.
+        /// The default page size on GitHub.com is 30.
+        /// </remarks>
+        /// <param name="request">Search parameters to filter results on</param>
+        /// <param name="options">Options for changing the API response</param>
+        /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(RepositoryRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -362,7 +390,8 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The account name to search for</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/{username}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -379,7 +408,8 @@ namespace Octokit
         /// <param name="login">The account name to search for</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/user/{username}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string login, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -396,7 +426,8 @@ namespace Octokit
         /// The default page size on GitHub.com is 30.
         /// </remarks>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/orgs/{org}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForOrg(string organization)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -413,7 +444,8 @@ namespace Octokit
         /// <param name="organization">The organization name to search for</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-        /// <returns>A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>.</returns>
+        /// <returns>A <see cref="IReadOnlyList{Repository}"/> of <see cref="Repository"/>.</returns>
+        [ManualRoute("GET", "/orgs/{org}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllForOrg(string organization, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
@@ -436,7 +468,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>
         /// See the <a href="http://developer.github.com/v3/repos/statuses/">Commit Status API documentation</a> for more
-        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a> 
+        /// details. Also check out the <a href="https://github.com/blog/1227-commit-status-api">blog post</a>
         /// that announced this feature.
         /// </remarks>
         public ICommitStatusClient Status { get; private set; }
@@ -450,7 +482,7 @@ namespace Octokit
         /// <summary>
         /// A client for GitHub's Repository Forks API.
         /// </summary>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>        
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/forks/">Forks API documentation</a> for more information.</remarks>
         public IRepositoryForksClient Forks { get; private set; }
 
         /// <summary>
@@ -544,6 +576,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -560,6 +593,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repositories/{id}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId)
         {
             return GetAllContributors(repositoryId, false);
@@ -575,6 +609,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -593,6 +628,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repositories/{id}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -610,6 +646,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, bool includeAnonymous)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -627,6 +664,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repositories/{id}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous)
         {
             return GetAllContributors(repositoryId, includeAnonymous, ApiOptions.None);
@@ -643,6 +681,7 @@ namespace Octokit
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(string owner, string name, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -666,6 +705,7 @@ namespace Octokit
         /// <param name="includeAnonymous">True if anonymous contributors should be included in result; Otherwise false</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All contributors of the repository.</returns>
+        [ManualRoute("GET", "/repositories/{id}/contributors")]
         public Task<IReadOnlyList<RepositoryContributor>> GetAllContributors(long repositoryId, bool includeAnonymous, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -686,6 +726,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/languages")]
         public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -707,6 +748,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All languages used in the repository and the number of bytes of each language.</returns>
+        [ManualRoute("GET", "/repositories/{id}/languages")]
         public async Task<IReadOnlyList<RepositoryLanguage>> GetAllLanguages(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryLanguages(repositoryId);
@@ -726,6 +768,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -742,6 +785,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        [ManualRoute("GET", "/repositories/{id}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId)
         {
             return GetAllTeams(repositoryId, ApiOptions.None);
@@ -757,6 +801,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -775,6 +820,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All <see cref="T:Octokit.Team"/>s associated with the repository</returns>
+        [ManualRoute("GET", "/repositories/{id}/teams")]
         public Task<IReadOnlyList<Team>> GetAllTeams(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -791,6 +837,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>All of the repositories tags.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -807,6 +854,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>All of the repositories tags.</returns>
+        [ManualRoute("GET", "/repositories/{id}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId)
         {
             return GetAllTags(repositoryId, ApiOptions.None);
@@ -822,6 +870,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -840,6 +889,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns>All of the repositories tags.</returns>
+        [ManualRoute("GET", "/repositories/{id}/tags")]
         public Task<IReadOnlyList<RepositoryTag>> GetAllTags(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -856,6 +906,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <returns>Returns the contents of the repository's license file, if one is detected.</returns>
+        [ManualRoute("GET", "/repos/{owner}/{name}/license")]
         public Task<RepositoryContentLicense> GetLicenseContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -872,6 +923,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <returns>Returns the contents of the repository's license file, if one is detected.</returns>
+        [ManualRoute("GET", "/repositories/{id}/license")]
         public Task<RepositoryContentLicense> GetLicenseContents(long repositoryId)
         {
             return ApiConnection.Get<RepositoryContentLicense>(ApiUrls.RepositoryLicense(repositoryId), null, AcceptHeaders.LicensesApiPreview);

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -32,6 +32,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,6 +48,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/branches/#list-branches">API documentation</a> for more details
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -62,6 +64,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -79,6 +82,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -95,6 +99,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}")]
         public Task<Branch> Get(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -112,6 +117,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}")]
         public Task<Branch> Get(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -128,6 +134,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> GetBranchProtection(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -145,6 +152,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -162,6 +170,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> UpdateBranchProtection(string owner, string name, string branch, BranchProtectionSettingsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -181,6 +190,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
+        [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -198,6 +208,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public async Task<bool> DeleteBranchProtection(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -224,6 +235,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection")]
         public async Task<bool> DeleteBranchProtection(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -249,6 +261,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -266,6 +279,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -283,6 +297,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Required status checks</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> UpdateRequiredStatusChecks(string owner, string name, string branch, BranchProtectionRequiredStatusChecksUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -302,6 +317,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Required status checks</param>
+        [ManualRoute("PATCH", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> UpdateRequiredStatusChecks(long repositoryId, string branch, BranchProtectionRequiredStatusChecksUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -319,6 +335,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public async Task<bool> DeleteRequiredStatusChecks(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -346,6 +363,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public async Task<bool> DeleteRequiredStatusChecks(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -372,6 +390,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -389,6 +408,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -406,6 +426,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to replace</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> UpdateRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -425,6 +446,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to replace</param>
+        [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> UpdateRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -443,6 +465,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to add</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> AddRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -462,6 +485,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to add</param>
+        [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> AddRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -480,6 +504,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to remove</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -499,6 +524,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to remove</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -516,6 +542,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> GetReviewEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -533,6 +560,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> GetReviewEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -550,6 +578,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">The required pull request review settings</param>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -569,6 +598,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">The required pull request review settings</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -586,6 +616,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public async Task<bool> RemoveReviewEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -613,6 +644,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public async Task<bool> RemoveReviewEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -639,6 +671,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -656,6 +689,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -672,6 +706,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -689,6 +724,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -705,6 +741,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -732,6 +769,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public async Task<bool> RemoveAdminEnforcement(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -758,6 +796,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
         public Task<BranchProtectionPushRestrictions> GetProtectedBranchRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -775,6 +814,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions")]
         public Task<BranchProtectionPushRestrictions> GetProtectedBranchRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -791,6 +831,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
         public async Task<bool> DeleteProtectedBranchRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -818,6 +859,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions")]
         public async Task<bool> DeleteProtectedBranchRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -844,6 +886,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -861,6 +904,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -878,6 +922,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> UpdateProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -897,6 +942,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access</param>
+        [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> UpdateProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -915,6 +961,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access to add</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> AddProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -934,6 +981,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access to add</param>
+        [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> AddProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -952,6 +1000,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams to remove</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> DeleteProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -971,6 +1020,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams to remove</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> DeleteProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -988,6 +1038,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1005,6 +1056,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -1022,6 +1074,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access</param>
+        [ManualRoute("UPDATE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> UpdateProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1041,6 +1094,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access</param>
+        [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> UpdateProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -1059,6 +1113,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to add</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> AddProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1078,6 +1133,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to add</param>
+        [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> AddProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));
@@ -1096,6 +1152,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to remove</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> DeleteProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -1115,6 +1172,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to remove</param>
+        [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> DeleteProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {
             Ensure.ArgumentNotNullOrEmptyString(branch, nameof(branch));

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/comments/{number}")]
         public Task<CommitComment> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -41,6 +42,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
+        [ManualRoute("GET", "/repositories/{id}/comments/{number}")]
         public Task<CommitComment> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<CommitComment>(ApiUrls.CommitComment(repositoryId, number), null, AcceptHeaders.ReactionsPreview);
@@ -52,6 +54,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -65,6 +68,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [ManualRoute("GET", "/repositories/{id}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -77,6 +81,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -92,6 +97,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [ManualRoute("GET", "/repositories/{id}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -106,6 +112,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -121,6 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="sha">The sha of the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -136,6 +144,7 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -153,6 +162,7 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -169,6 +179,7 @@ namespace Octokit
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
+        [ManualRoute("POST", "/repos/{owner}/{name}/commits/{sha}/comments")]
         public Task<CommitComment> Create(string owner, string name, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -186,6 +197,7 @@ namespace Octokit
         /// <param name="sha">The sha reference of commit</param>
         /// <param name="newCommitComment">The new comment to add to the commit</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#create-a-commit-comment</remarks>
+        [ManualRoute("POST", "/repositories/{id}/commits/{sha}/comments")]
         public Task<CommitComment> Create(long repositoryId, string sha, NewCommitComment newCommitComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(sha, nameof(sha));
@@ -202,6 +214,7 @@ namespace Octokit
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#update-a-commit-comment</remarks>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/comments/{number}")]
         public Task<CommitComment> Update(string owner, string name, int number, string commentUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -218,6 +231,7 @@ namespace Octokit
         /// <param name="number">The comment number</param>
         /// <param name="commentUpdate">The modified comment</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#update-a-commit-comment</remarks>
+        [ManualRoute("PATCH", "/repositories/{id}/comments/{number}")]
         public Task<CommitComment> Update(long repositoryId, int number, string commentUpdate)
         {
             Ensure.ArgumentNotNull(commentUpdate, nameof(commentUpdate));
@@ -232,6 +246,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/comments/{number}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -246,6 +261,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#delete-a-commit-comment</remarks>
+        [ManualRoute("DELETE", "/repositories/{id}/comments/{number}")]
         public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.CommitComment(repositoryId, number));

--- a/Octokit/Clients/RepositoryCommitsClient.cs
+++ b/Octokit/Clients/RepositoryCommitsClient.cs
@@ -23,6 +23,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/compare/{base}...{head}")]
         public Task<CompareResult> Compare(string owner, string name, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -39,6 +40,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="base">The reference to use as the base commit</param>
         /// <param name="head">The reference to use as the head commit</param>
+        [ManualRoute("GET", "/repositories/{id}/compare/{base}...{head}")]
         public Task<CompareResult> Compare(long repositoryId, string @base, string head)
         {
             Ensure.ArgumentNotNullOrEmptyString(@base, nameof(@base));
@@ -53,6 +55,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}")]
         public Task<GitHubCommit> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -67,6 +70,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The reference for the commit (SHA)</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}")]
         public Task<GitHubCommit> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -79,6 +83,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -91,6 +96,7 @@ namespace Octokit
         /// Gets all commits for a given repository
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, new CommitRequest(), ApiOptions.None);
@@ -102,6 +108,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -115,6 +122,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, ApiOptions options)
         {
             return GetAll(repositoryId, new CommitRequest(), options);
@@ -126,6 +134,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -140,6 +149,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
+        [ManualRoute("GET", "/repositories/{id}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -154,6 +164,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(string owner, string name, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -170,6 +181,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter list of commits returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/commits")]
         public Task<IReadOnlyList<GitHubCommit>> GetAll(long repositoryId, CommitRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -184,6 +196,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The repository reference</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}")]
         public Task<string> GetSha1(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -198,6 +211,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The repository reference</param>
+        [ManualRoute("GET", "/repositories/{id}/commits/{sha}")]
         public Task<string> GetSha1(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -29,6 +29,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -48,6 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
+        [ManualRoute("GET", "repoitories/{id}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId, string path)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -65,6 +67,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "repos/{owner}/{name}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -82,6 +85,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "repositories/{id}/contents/{path}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContents(long repositoryId)
         {
             var url = ApiUrls.RepositoryContent(repositoryId, string.Empty);
@@ -100,6 +104,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -123,6 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ManualRoute("GET", "repositories/{id}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string path, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -142,6 +148,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository�s default branch (usually master)</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -162,6 +169,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
+        [ManualRoute("GET", "repositories/{id}/contents/{path}?ref={ref}")]
         public Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -180,6 +188,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "repos/{owner}/{name}/readme")]
         public async Task<Readme> GetReadme(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -199,6 +208,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "repositories/{id}/readme")]
         public async Task<Readme> GetReadme(long repositoryId)
         {
             var endpoint = ApiUrls.RepositoryReadme(repositoryId);
@@ -216,6 +226,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [DotNetSpecificRouteAttribute]
         public Task<string> GetReadmeHtml(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -232,6 +243,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [DotNetSpecificRouteAttribute]
         public Task<string> GetReadmeHtml(long repositoryId)
         {
             return ApiConnection.GetHtml(ApiUrls.RepositoryReadme(repositoryId), null);
@@ -243,6 +255,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -256,6 +269,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(long repositoryId)
         {
             return GetArchive(repositoryId, ArchiveFormat.Tarball, string.Empty);
@@ -268,6 +282,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -282,6 +297,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/contents/#get-archive-link</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
+        [ManualRoute("GET", "/repositories/{id}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat)
         {
             return GetArchive(repositoryId, archiveFormat, string.Empty);
@@ -295,6 +311,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -311,6 +328,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
+        [ManualRoute("GET", "/repositories/{id}/{archive_format}/{ref}")]
         public Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference)
         {
             Ensure.ArgumentNotNull(reference, nameof(reference));
@@ -327,6 +345,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/{archive_format}/{ref}")]
         public async Task<byte[]> GetArchive(string owner, string name, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -349,6 +368,7 @@ namespace Octokit
         /// <param name="archiveFormat">The format of the archive. Can be either tarball or zipball</param>
         /// <param name="reference">A valid Git reference.</param>
         /// <param name="timeout"> Time span until timeout </param>
+        [ManualRoute("GET", "/repositories/{id}/{archive_format}/{ref}")]
         public async Task<byte[]> GetArchive(long repositoryId, ArchiveFormat archiveFormat, string reference, TimeSpan timeout)
         {
             Ensure.ArgumentNotNull(reference, nameof(reference));
@@ -368,6 +388,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/contents/{path}")]
         public Task<RepositoryContentChangeSet> CreateFile(string owner, string name, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -385,6 +406,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to create</param>
+        [ManualRoute("PUT", "/repositories/{id}/contents/{path}")]
         public Task<RepositoryContentChangeSet> CreateFile(long repositoryId, string path, CreateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -401,6 +423,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/contents/{path}")]
         public Task<RepositoryContentChangeSet> UpdateFile(string owner, string name, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -418,6 +441,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to update</param>
+        [ManualRoute("PUT", "/repositories/{id}/contents/{path}")]
         public Task<RepositoryContentChangeSet> UpdateFile(long repositoryId, string path, UpdateFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
@@ -434,6 +458,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/contents/{path}")]
         public Task DeleteFile(string owner, string name, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -451,6 +476,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="path">The path to the file</param>
         /// <param name="request">Information about the file to delete</param>
+        [ManualRoute("DELETE", "/repositorioes/{id}/contents/{path}")]
         public Task DeleteFile(long repositoryId, string path, DeleteFileRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));

--- a/Octokit/Clients/RepositoryDeployKeysClient.cs
+++ b/Octokit/Clients/RepositoryDeployKeysClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/keys/{number}")]
         public Task<DeployKey> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -46,6 +47,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key.</param>
+        [ManualRoute("GET", "/repositories/{id}/keys/{number}")]
         public Task<DeployKey> Get(long repositoryId, int number)
         {
             return ApiConnection.Get<DeployKey>(ApiUrls.RepositoryDeployKey(repositoryId, number));
@@ -59,6 +61,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -74,6 +77,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/keys/#list"> API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
+        [ManualRoute("GET", "/repositories/{id}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -88,6 +92,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -105,6 +110,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/keys")]
         public Task<IReadOnlyList<DeployKey>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -121,6 +127,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/keys")]
         public Task<DeployKey> Create(string owner, string name, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -144,6 +151,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="newDeployKey">The deploy key to create for the repository.</param>
+        [ManualRoute("POST", "/repositories/{id}/keys")]
         public Task<DeployKey> Create(long repositoryId, NewDeployKey newDeployKey)
         {
             Ensure.ArgumentNotNull(newDeployKey, nameof(newDeployKey));
@@ -166,6 +174,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository.</param>
         /// <param name="name">The name of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
+        [ManualRoute("DELETE", "/repositories/{id}/keys/{number}")]
         public Task Delete(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -182,6 +191,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="number">The id of the deploy key to delete.</param>
+        [ManualRoute("DELETE", "/repositories/{id}/keys/{number}")]
         public Task Delete(long repositoryId, int number)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryDeployKey(repositoryId, number));

--- a/Octokit/Clients/RepositoryForksClient.cs
+++ b/Octokit/Clients/RepositoryForksClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -43,6 +44,7 @@ namespace Octokit
         /// See <a href="http://developer.github.com/v3/repos/forks/#list-forks">API documentation</a> for more information.
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -57,6 +59,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -74,6 +77,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -90,6 +94,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -107,6 +112,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
+        [ManualRoute("GET", "/repositories/{id}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -124,6 +130,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repos/{owner}/{repo}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(string owner, string name, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -143,6 +150,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to request and filter a list of repository forks</param>
         /// <param name="options">Options for changing the API response</param>
+        [ManualRoute("GET", "/repositories/{id}/forks")]
         public Task<IReadOnlyList<Repository>> GetAll(long repositoryId, RepositoryForksListRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -160,6 +168,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
+        [ManualRoute("POST", "/repos/{owner}/{repo}/forks")]
         public Task<Repository> Create(string owner, string name, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -177,6 +186,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="fork">Used to fork a repository</param>
+        [ManualRoute("POST", "/repositories/{id}/forks")]
         public Task<Repository> Create(long repositoryId, NewRepositoryFork fork)
         {
             Ensure.ArgumentNotNull(fork, nameof(fork));

--- a/Octokit/Clients/RepositoryHooksClient.cs
+++ b/Octokit/Clients/RepositoryHooksClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -39,6 +40,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repositories/{id}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -51,6 +53,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -66,6 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#list">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repositories/{id}/hooks")]
         public Task<IReadOnlyList<RepositoryHook>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -80,6 +84,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/hooks/{id}")]
         public Task<RepositoryHook> Get(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -94,6 +99,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#get-single-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("GET", "/repositories/{id}/hooks/{id}")]
         public Task<RepositoryHook> Get(long repositoryId, int hookId)
         {
             return ApiConnection.Get<RepositoryHook>(ApiUrls.RepositoryHookById(repositoryId, hookId));
@@ -106,6 +112,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("POST", "/repos/{owner}/{name}/hooks")]
         public Task<RepositoryHook> Create(string owner, string name, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -121,6 +128,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hook">The hook's parameters</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#create-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("POST", "/repositories/{id}/hooks")]
         public Task<RepositoryHook> Create(long repositoryId, NewRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, nameof(hook));
@@ -136,6 +144,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("PATCH", "/repos/{owner}/{name}/hooks/{id}")]
         public Task<RepositoryHook> Edit(string owner, string name, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -152,6 +161,7 @@ namespace Octokit
         /// <param name="hookId">The repository's hook id</param>
         /// <param name="hook">The requested changes to an edit repository hook</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("POST", "/repositories/{id}/hooks/{hook_id}")]
         public Task<RepositoryHook> Edit(long repositoryId, int hookId, EditRepositoryHook hook)
         {
             Ensure.ArgumentNotNull(hook, nameof(hook));
@@ -165,9 +175,10 @@ namespace Octokit
         /// <param name="owner">The repository's owner</param>
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
-        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information.
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        [ManualRoute("POST", "/repos/{owner}/{name}/hooks/{id}/tests")]
         public Task Test(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -181,9 +192,10 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
-        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information. 
-        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook 
+        /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#test-a-hook">API documentation</a> for more information.
+        /// This will trigger the hook with the latest push to the current repository if the hook is subscribed to push events. If the hook
         /// is not subscribed to push events, the server will respond with 204 but no test POST will be generated.</remarks>
+        [ManualRoute("POST", "/repositories/{id}/hooks/{hook_id}/tests")]
         public Task Test(long repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookTest(repositoryId, hookId));
@@ -196,6 +208,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("POST", "/repos/{owner}/{name}/hooks/{id}/pings")]
         public Task Ping(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -210,6 +223,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#edit-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("POST", "/repositories/{id}/hooks/{hook_id}/pings")]
         public Task Ping(long repositoryId, int hookId)
         {
             return ApiConnection.Post(ApiUrls.RepositoryHookPing(repositoryId, hookId));
@@ -222,6 +236,7 @@ namespace Octokit
         /// <param name="name">The repository's name</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/hooks/{id}")]
         public Task Delete(string owner, string name, int hookId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -236,6 +251,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="hookId">The repository's hook id</param>
         /// <remarks>See <a href="http://developer.github.com/v3/repos/hooks/#delete-a-hook">API documentation</a> for more information.</remarks>
+        [ManualRoute("DELETE", "/repositories/{id}/hooks/{hook_id}")]
         public Task Delete(long repositoryId, int hookId)
         {
             return ApiConnection.Delete(ApiUrls.RepositoryHookById(repositoryId, hookId));

--- a/Octokit/Clients/RepositoryInvitationsClient.cs
+++ b/Octokit/Clients/RepositoryInvitationsClient.cs
@@ -19,7 +19,8 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation">API documentation</a> for more information.
         /// </remarks>        
         /// <param name="invitationId">The id of the invitation</param>
-        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>        
+        /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PATCH", "/user/repository_invitations/{invitation_id}")]
         public async Task<bool> Accept(int invitationId)
         {
             var endpoint = ApiUrls.UserInvitations(invitationId);
@@ -43,6 +44,7 @@ namespace Octokit
         /// </remarks>        
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/user/repository_invitations/{invitation_id}")]
         public async Task<bool> Decline(int invitationId)
         {
             var endpoint = ApiUrls.UserInvitations(invitationId);
@@ -67,6 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="invitationId">The id of the invitation</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("DELETE", "/repos/:owner/:repo/invitations/{invitation_id}")]
         public async Task<bool> Delete(long repositoryId, int invitationId)
         {
             var endpoint = ApiUrls.RepositoryInvitations(repositoryId, invitationId);
@@ -89,6 +92,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/invitations/#list-a-users-repository-invitations">API documentation</a> for more information.
         /// </remarks>        
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/user/repository_invitations")]
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -102,6 +106,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/user/repository_invitations")]
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -116,6 +121,7 @@ namespace Octokit
         /// </remarks>        
         /// <param name="repositoryId">The id of the repository</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/invitations")]
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId)
         {
             return GetAllForRepository(repositoryId, ApiOptions.None);
@@ -130,6 +136,7 @@ namespace Octokit
         /// <param name="repositoryId">The id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("GET", "/repositories/{id}/invitations")]
         public Task<IReadOnlyList<RepositoryInvitation>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -146,6 +153,7 @@ namespace Octokit
         /// <param name="invitationId">The id of the invitation</param>
         /// <param name="permissions">The permission for the collsborator</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [ManualRoute("PATCH", "/repositories/{id}/invitations/{invitation_id}")]
         public Task<RepositoryInvitation> Edit(long repositoryId, int invitationId, InvitationUpdate permissions)
         {
             Ensure.ArgumentNotNull(permissions, nameof(permissions));

--- a/Octokit/Clients/RepositoryPagesClient.cs
+++ b/Octokit/Clients/RepositoryPagesClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pages")]
         public Task<Page> Get(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -42,6 +43,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/pages")]
         public Task<Page> Get(long repositoryId)
         {
             return ApiConnection.Get<Page>(ApiUrls.RepositoryPage(repositoryId));
@@ -55,6 +57,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -70,6 +73,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId)
         {
             return GetAll(repositoryId, ApiOptions.None);
@@ -84,6 +88,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -102,6 +107,7 @@ namespace Octokit
         /// <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-pages-builds">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/pages/builds")]
         public Task<IReadOnlyList<PagesBuild>> GetAll(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -118,6 +124,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repos/{owner}/{name}/pages/builds/latest")]
         public Task<PagesBuild> GetLatest(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -133,6 +140,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#list-latest-pages-build">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("GET", "/repositories/{id}/pages/builds/latest")]
         public Task<PagesBuild> GetLatest(long repositoryId)
         {
             return ApiConnection.Get<PagesBuild>(ApiUrls.RepositoryPageBuildsLatest(repositoryId));
@@ -146,6 +154,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("POST", "/repos/{owner}/{name}/pages/builds")]
         public Task<PagesBuild> RequestPageBuild(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -161,6 +170,7 @@ namespace Octokit
         ///  <remarks>
         /// See the <a href="https://developer.github.com/v3/repos/pages/#request-a-page-build">API documentation</a> for more information.
         /// </remarks>
+        [ManualRoute("POST", "/repositories/{id}/pages/builds")]
         public Task<PagesBuild> RequestPageBuild(long repositoryId)
         {
             return ApiConnection.Post<PagesBuild>(ApiUrls.RepositoryPageBuilds(repositoryId), AcceptHeaders.PagesApiPreview);

--- a/Octokit/Clients/RepositoryTrafficClient.cs
+++ b/Octokit/Clients/RepositoryTrafficClient.cs
@@ -15,6 +15,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/traffic/popular/paths")]
         public Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(long repositoryId)
         {
             return ApiConnection.GetAll<RepositoryTrafficPath>(ApiUrls.RepositoryTrafficPaths(repositoryId), AcceptHeaders.RepositoryTrafficApiPreview);
@@ -26,6 +27,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-paths</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/popular/paths")]
         public Task<IReadOnlyList<RepositoryTrafficPath>> GetAllPaths(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -39,6 +41,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
+        [ManualRoute("GET", "/repositories/{id}/traffic/popular/referrers")]
         public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(long repositoryId)
         {
             return ApiConnection.GetAll<RepositoryTrafficReferrer>(ApiUrls.RepositoryTrafficReferrers(repositoryId), AcceptHeaders.RepositoryTrafficApiPreview);
@@ -50,6 +53,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#list-referrers</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
+        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/popular/referrers")]
         public Task<IReadOnlyList<RepositoryTrafficReferrer>> GetAllReferrers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -64,6 +68,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#clones</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
+        [ManualRoute("GET", "/repositories/{id}/traffic/clones")]
         public Task<RepositoryTrafficCloneSummary> GetClones(long repositoryId, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNull(per, nameof(per));
@@ -78,6 +83,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
+        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/clones")]
         public Task<RepositoryTrafficCloneSummary> GetClones(string owner, string name, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -93,6 +99,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/repos/traffic/#views</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
+        [ManualRoute("GET", "/repositories/{id}/traffic/views")]
         public Task<RepositoryTrafficViewSummary> GetViews(long repositoryId, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNull(per, nameof(per));
@@ -107,6 +114,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="per">Breakdown per day or week</param>
+        [ManualRoute("GET", "/repositories/{owner}/{name}/traffic/views")]
         public Task<RepositoryTrafficViewSummary> GetViews(string owner, string name, RepositoryTrafficRequest per)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/SearchClient.cs
+++ b/Octokit/Clients/SearchClient.cs
@@ -25,6 +25,7 @@ namespace Octokit
         /// </summary>
         /// <param name="search"></param>
         /// <returns>List of repos</returns>
+        [ManualRoute("GET", "/search/repositories")]
         public Task<SearchRepositoryResult> SearchRepo(SearchRepositoriesRequest search)
         {
             Ensure.ArgumentNotNull(search, nameof(search));
@@ -37,6 +38,7 @@ namespace Octokit
         /// </summary>
         /// <param name="search"></param>
         /// <returns>List of users</returns>
+        [ManualRoute("GET", "/search/users")]
         public Task<SearchUsersResult> SearchUsers(SearchUsersRequest search)
         {
             Ensure.ArgumentNotNull(search, nameof(search));
@@ -49,6 +51,7 @@ namespace Octokit
         /// </summary>
         /// <param name="search"></param>
         /// <returns>List of issues</returns>
+        [ManualRoute("GET", "/search/issues")]
         public Task<SearchIssuesResult> SearchIssues(SearchIssuesRequest search)
         {
             Ensure.ArgumentNotNull(search, nameof(search));
@@ -61,6 +64,7 @@ namespace Octokit
         /// </summary>
         /// <param name="search"></param>
         /// <returns>List of files</returns>
+        [ManualRoute("GET", "/search/code")]
         public Task<SearchCodeResult> SearchCode(SearchCodeRequest search)
         {
             Ensure.ArgumentNotNull(search, nameof(search));
@@ -73,6 +77,7 @@ namespace Octokit
         /// </summary>
         /// <param name="search"></param>
         /// <returns>List of labels</returns>
+        [ManualRoute("GET", "/search/labels")]
         public Task<SearchLabelsResult> SearchLabels(SearchLabelsRequest search)
         {
             Ensure.ArgumentNotNull(search, nameof(search));

--- a/Octokit/Clients/StarredClient.cs
+++ b/Octokit/Clients/StarredClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -39,6 +40,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId)
         {
             return GetAllStargazers(repositoryId, ApiOptions.None);
@@ -51,6 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -66,6 +69,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/stargazers")]
         public Task<IReadOnlyList<User>> GetAllStargazers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -79,6 +83,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -92,6 +97,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId)
         {
             return GetAllStargazersWithTimestamps(repositoryId, ApiOptions.None);
@@ -104,6 +110,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -119,6 +126,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/stargazers")]
         public Task<IReadOnlyList<UserStar>> GetAllStargazersWithTimestamps(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -130,6 +138,7 @@ namespace Octokit
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -140,6 +149,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -151,6 +161,7 @@ namespace Octokit
         /// Retrieves all of the starred <see cref="Repository"/>(ies) for the current user with star creation timestamps.
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps()
         {
             return GetAllForCurrentWithTimestamps(ApiOptions.None);
@@ -161,6 +172,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -175,6 +187,7 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
             Justification = "But i think i do need star-specific request parameters")]
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -188,6 +201,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -203,6 +217,7 @@ namespace Octokit
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters",
             Justification = "But i think i do need star-specific request parameters")]
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -216,6 +231,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForCurrentWithTimestamps(StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -229,6 +245,7 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -242,6 +259,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -255,6 +273,7 @@ namespace Octokit
         /// </summary>
         /// <param name="user">The login of the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -268,6 +287,7 @@ namespace Octokit
         /// <param name="user">The login of the user</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -283,6 +303,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -298,6 +319,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -314,6 +336,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -329,6 +352,7 @@ namespace Octokit
         /// <param name="request">Star-specific request parameters that sort the results</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/users/{user}/starred")]
         public Task<IReadOnlyList<RepositoryStar>> GetAllForUserWithTimestamps(string user, StarredRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -344,6 +368,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/user/starred/{owner}/{name}")]
         public async Task<bool> CheckStarred(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -365,6 +390,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
+        [ManualRoute("PUT", "/user/starred/{owner}/{name}")]
         public async Task<bool> StarRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -386,6 +412,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
+        [ManualRoute("DELETE", "/user/starred/{owner}/{name}")]
         public async Task<bool> RemoveStarFromRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));

--- a/Octokit/Clients/TagsClient.cs
+++ b/Octokit/Clients/TagsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
+        [ManualRoute("GET", "/repos/{owner}/{name}/git/tags/{sha}")]
         public Task<GitTag> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -45,6 +46,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">Tha sha reference of the tag</param>
+        [ManualRoute("GET", "/repositories/{id}/git/tags/{sha}")]
         public Task<GitTag> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -61,6 +63,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="tag">The tag to create</param>
+        [ManualRoute("POST", "/repos/{owner}/{name}/git/tags")]
         public Task<GitTag> Create(string owner, string name, NewTag tag)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -78,6 +81,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="tag">The tag to create</param>
+        [ManualRoute("POST", "/repositories/{id}/git/tags")]
         public Task<GitTag> Create(long repositoryId, NewTag tag)
         {
             Ensure.ArgumentNotNull(tag, nameof(tag));

--- a/Octokit/Clients/TeamsClient.cs
+++ b/Octokit/Clients/TeamsClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier.</param>
         /// <returns>The <see cref="Team"/> with the given identifier.</returns>
+        [ManualRoute("GET", "/teams/{id}")]
         public Task<Team> Get(int id)
         {
             var endpoint = ApiUrls.Teams(id);
@@ -43,6 +44,7 @@ namespace Octokit
         /// <param name="org">Organization to list teams of.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        [ManualRoute("GET", "/orgs/{org}/teams")]
         public Task<IReadOnlyList<Team>> GetAll(string org)
         {
             return GetAll(org, ApiOptions.None);
@@ -55,6 +57,7 @@ namespace Octokit
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the orgs's teams <see cref="Team"/>s.</returns>
+        [ManualRoute("GET", "/orgs/{org}/teams")]
         public Task<IReadOnlyList<Team>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -69,6 +72,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [ManualRoute("GET", "/user/teams")]
         public Task<IReadOnlyList<Team>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -80,6 +84,7 @@ namespace Octokit
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>A list of the user's <see cref="Team"/>s.</returns>
+        [ManualRoute("GET", "/user/teams")]
         public Task<IReadOnlyList<Team>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -96,6 +101,7 @@ namespace Octokit
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-child-teams
         /// </remarks>
+        [ManualRoute("GET", "/teams{id}/teams")]
         public Task<IReadOnlyList<Team>> GetAllChildTeams(int id)
         {
             return GetAllChildTeams(id, ApiOptions.None);
@@ -109,6 +115,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
+        [ManualRoute("GET", "/teams{id}/teams")]
         public Task<IReadOnlyList<Team>> GetAllChildTeams(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -119,25 +126,27 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
+        [ManualRoute("GET", "/teams{id}/members")]
         public Task<IReadOnlyList<User>> GetAllMembers(int id)
         {
             return GetAllMembers(id, ApiOptions.None);
         }
 
         /// <summary>
-        /// Returns all members of the given team. 
+        /// Returns all members of the given team.
         /// </summary>
         /// <remarks>
         /// https://developer.github.com/v3/orgs/teams/#list-team-members
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour.</param>
+        [ManualRoute("GET", "/teams{id}/members")]
         public Task<IReadOnlyList<User>> GetAllMembers(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -155,6 +164,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
+        [ManualRoute("GET", "/teams{id}/members")]
         public Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -171,6 +181,7 @@ namespace Octokit
         /// <param name="id">The team identifier</param>
         /// <param name="request">The request filter</param>
         /// <param name="options">Options to change API behaviour.</param>
+        [ManualRoute("GET", "/teams{id}/members")]
         public Task<IReadOnlyList<User>> GetAllMembers(int id, TeamMembersRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
@@ -182,7 +193,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Gets whether the user with the given <paramref name="login"/> 
+        /// Gets whether the user with the given <paramref name="login"/>
         /// is a member of the team with the given <paramref name="id"/>.
         /// A <see cref="NotFoundException"/> is thrown if the user is not a member.
         /// </summary>
@@ -191,6 +202,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team to check.</param>
         /// <param name="login">The user to check.</param>
+        [ManualRoute("GET", "/teams/{id}/memberships/{username}")]
         public Task<TeamMembershipDetails> GetMembershipDetails(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -205,6 +217,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Newly created <see cref="Team"/></returns>
+        [ManualRoute("POST", "/orgs/{org}/teams")]
         public Task<Team> Create(string org, NewTeam team)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -219,6 +232,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>Updated <see cref="Team"/></returns>
+        [ManualRoute("PATCH", "/teams/{id}")]
         public Task<Team> Update(int id, UpdateTeam team)
         {
             Ensure.ArgumentNotNull(team, nameof(team));
@@ -232,6 +246,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/teams/{id}")]
         public Task Delete(int id)
         {
             var endpoint = ApiUrls.Teams(id);
@@ -248,6 +263,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to add to the team.</param>
         /// <param name="request">Additional parameters for the request</param>
+        [ManualRoute("PUT", "/teams/{id}/memberships/{username}")]
         public Task<TeamMembershipDetails> AddOrEditMembership(int id, string login, UpdateTeamMembership request)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -267,6 +283,7 @@ namespace Octokit
         /// <param name="id">The team identifier.</param>
         /// <param name="login">The user to remove from the team.</param>
         /// <returns><see langword="true"/> if the user was removed from the team; <see langword="false"/> otherwise.</returns>
+        [ManualRoute("DELETE", "/teams/{id}/memberships/{username}")]
         public async Task<bool> RemoveMembership(int id, string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -291,6 +308,7 @@ namespace Octokit
         /// <param name="id">Team Id.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
+        [ManualRoute("GET", "/teams/{id}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllRepositories(int id)
         {
             return GetAllRepositories(id, ApiOptions.None);
@@ -303,6 +321,7 @@ namespace Octokit
         /// <param name="options">Options to change API behaviour.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns>The team's repositories</returns>
+        [ManualRoute("GET", "/teams/{id}/repos")]
         public Task<IReadOnlyList<Repository>> GetAllRepositories(int id, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -317,10 +336,23 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
+        [ManualRoute("PUT", "/orgs/{org}/team/{team_slug}/repos/{owner}/{repo}")]
         public async Task<bool> AddRepository(int id, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
+
+            // TODO: I am very suspicious of this due to the documentation
+            // https://developer.github.com/v3/teams/#add-or-update-team-repository
+            //
+            // Recommended:
+            // PUT /orgs/:org/teams/:team_slug/repos/:owner/:repo
+            //
+            // or
+            //
+            // PUT /organizations/:org_id/team/:team_id/repos/:owner/:repo
+            //
+            // Likely will require a breaking change
 
             var endpoint = ApiUrls.TeamRepository(id, organization, repoName);
 
@@ -344,10 +376,23 @@ namespace Octokit
         /// <param name="permission">The permission to grant the team on this repository.</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
+        [ManualRoute("PUT", "/orgs/{org}/team/{team_slug}/repos/{owner}/{repo}")]
         public async Task<bool> AddRepository(int id, string organization, string repoName, RepositoryPermissionRequest permission)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
+
+            // TODO: I am very suspicious of this due to the documentation
+            // https://developer.github.com/v3/teams/#add-or-update-team-repository
+            //
+            // Recommended:
+            // PUT /orgs/:org/teams/:team_slug/repos/:owner/:repo
+            //
+            // or
+            //
+            // PUT /organizations/:org_id/team/:team_id/repos/:owner/:repo
+            //
+            // Likely will require a breaking change
 
             var endpoint = ApiUrls.TeamRepository(id, organization, repoName);
 
@@ -367,10 +412,23 @@ namespace Octokit
         /// </summary>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/orgs/:org/teams/:team_slug/repos/:owner/:repo")]
         public async Task<bool> RemoveRepository(int id, string organization, string repoName)
         {
             Ensure.ArgumentNotNullOrEmptyString(organization, nameof(organization));
             Ensure.ArgumentNotNullOrEmptyString(repoName, nameof(repoName));
+
+            // TODO: I am very suspicious of this due to the documentation
+            // https://developer.github.com/v3/teams/#remove-team-repository
+            //
+            // Recommended:
+            // DELETE /orgs/:org/teams/:team_slug/repos/:owner/:repo
+            //
+            // or
+            //
+            // DELETE /organizations/:org_id/team/:team_id/repos/:owner/:repo
+            //
+            // Likely will require a breaking change
 
             var endpoint = ApiUrls.TeamRepository(id, organization, repoName);
 
@@ -396,6 +454,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/orgs/teams/#get-team-repo">API documentation</a> for more information.
         /// </remarks>
         /// <returns><see langword="true"/> if the repository is managed by the given team; <see langword="false"/> otherwise.</returns>
+        [ManualRoute("GET", "/teams/{id}/repos/{owner}/{name}")]
         public async Task<bool> IsRepositoryManagedByTeam(int id, string owner, string repo)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -423,6 +482,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The team identifier</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/teams/{id}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id)
         {
             Ensure.ArgumentNotNull(id, nameof(id));
@@ -440,6 +500,7 @@ namespace Octokit
         /// <param name="id">The team identifier</param>
         /// <param name="options">Options to change API behaviour</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/teams/{id}/invitations")]
         public Task<IReadOnlyList<OrganizationMembershipInvitation>> GetAllPendingInvitations(int id, ApiOptions options)
         {
             return ApiConnection.GetAll<OrganizationMembershipInvitation>(ApiUrls.TeamPendingInvitations(id), null, AcceptHeaders.OrganizationMembershipPreview, options);

--- a/Octokit/Clients/TreesClient.cs
+++ b/Octokit/Clients/TreesClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/git/trees/{tree_sha}")]
         public Task<TreeResponse> Get(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -47,6 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
+        [ManualRoute("GET", "/repositories/{id}/git/trees/{tree_sha}")]
         public Task<TreeResponse> Get(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -63,6 +65,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1")]
         public Task<TreeResponse> GetRecursive(string owner, string name, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -80,6 +83,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="reference">The SHA that references the tree</param>
+        [ManualRoute("GET", "/repositories/{id}/git/trees/{tree_sha}?recursive=1")]
         public Task<TreeResponse> GetRecursive(long repositoryId, string reference)
         {
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
@@ -96,6 +100,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
+        [ManualRoute("POST", "/repos/{owner}/{repo}/git/trees")]
         public Task<TreeResponse> Create(string owner, string name, NewTree newTree)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -118,6 +123,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newTree">The value of the new tree</param>
+        [ManualRoute("POST", "/repos/{id}/git/trees")]
         public Task<TreeResponse> Create(long repositoryId, NewTree newTree)
         {
             Ensure.ArgumentNotNull(newTree, nameof(newTree));

--- a/Octokit/Clients/UserAdministrationClient.cs
+++ b/Octokit/Clients/UserAdministrationClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="newUser">The <see cref="NewUser"/> object describing the user to create</param>
         /// <returns>The created <see cref="User"/> object</returns>
+        [ManualRoute("POST", "/admin/users")]
         public Task<User> Create(NewUser newUser)
         {
             Ensure.ArgumentNotNull(newUser, nameof(newUser));
@@ -50,6 +51,7 @@ namespace Octokit
         /// <param name="login">The username to rename</param>
         /// <param name="userRename">The <see cref="UserRename"/> request, specifying the new login</param>
         /// <returns>A <see cref="UserRenameResponse"/> object indicating the queued task message and Url to the user</returns>
+        [ManualRoute("POST", "/admin/users/{username}")]
         public Task<UserRenameResponse> Rename(string login, UserRename userRename)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -70,6 +72,7 @@ namespace Octokit
         /// <param name="login">The user to impersonate</param>
         /// <param name="newImpersonationToken">The <see cref="NewImpersonationToken"/> request specifying the required scopes</param>
         /// <returns>An <see cref="Authorization"/> object containing the impersonation token</returns>
+        [ManualRoute("POST", "/admin/users/{username}/authorizations")]
         public Task<Authorization> CreateImpersonationToken(string login, NewImpersonationToken newImpersonationToken)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -89,6 +92,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to remove impersonation token from</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/admin/users/{username}/authorizations")]
         public async Task DeleteImpersonationToken(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -111,6 +115,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to promote to administrator.</param>
         /// <returns></returns>
+        [ManualRoute("PUT", "/users/{username}/site_admin")]
         public Task Promote(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -127,6 +132,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to demote from administrator.</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/users/{username}/site_admin")]
         public Task Demote(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -143,6 +149,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to suspend.</param>
         /// <returns></returns>
+        [ManualRoute("PUT", "/users/{username}/suspended")]
         public Task Suspend(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -159,6 +166,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to unsuspend.</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/users/{username}/suspended")]
         public Task Unsuspend(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -174,6 +182,7 @@ namespace Octokit
         /// for more information.
         /// </remarks>
         /// <returns></returns>
+        [ManualRoute("PUT", "/admin/keys")]
         public Task<IReadOnlyList<PublicKey>> ListAllPublicKeys()
         {
             var endpoint = ApiUrls.UserAdministrationPublicKeys();
@@ -189,6 +198,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="login">The user to delete</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/admin/users/{username}")]
         public async Task Delete(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -210,6 +220,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="keyId">The key to delete</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/admin/keys/{key_id}")]
         public async Task DeletePublicKey(int keyId)
         {
             Ensure.ArgumentNotNull(keyId, nameof(keyId));

--- a/Octokit/Clients/UserEmailsClient.cs
+++ b/Octokit/Clients/UserEmailsClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
         /// </remarks>
         /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        [ManualRoute("GET", "/user/emails")]
         public Task<IReadOnlyList<EmailAddress>> GetAll()
         {
             return GetAll(ApiOptions.None);
@@ -40,6 +41,7 @@ namespace Octokit
         /// http://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user
         /// </remarks>
         /// <returns>The <see cref="EmailAddress"/>es for the authenticated user.</returns>
+        [ManualRoute("GET", "/user/emails")]
         public Task<IReadOnlyList<EmailAddress>> GetAll(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -55,6 +57,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="emailAddresses">The email addresses to add.</param>
         /// <returns>Returns the added <see cref="EmailAddress"/>es.</returns>
+        [ManualRoute("POST", "/user/emails")]
         public Task<IReadOnlyList<EmailAddress>> Add(params string[] emailAddresses)
         {
             Ensure.ArgumentNotNull(emailAddresses, nameof(emailAddresses));
@@ -72,6 +75,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="emailAddresses">The email addresses to delete.</param>
         /// <returns>Returns the added <see cref="EmailAddress"/>es.</returns>
+        [ManualRoute("DELETE", "/user/emails")]
         public Task Delete(params string[] emailAddresses)
         {
             Ensure.ArgumentNotNull(emailAddresses, nameof(emailAddresses));

--- a/Octokit/Clients/UserGpgKeysClient.cs
+++ b/Octokit/Clients/UserGpgKeysClient.cs
@@ -28,6 +28,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{GpgKey}"/> of <see cref="GpgKey"/>s for the current user.</returns>
+        [ManualRoute("GET", "/user/gpg_keys")]
         public Task<IReadOnlyList<GpgKey>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -41,6 +42,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys">API documentation</a> for more information.
         /// </remarks>
         /// <returns>A <see cref="IReadOnlyList{GpgKey}"/> of <see cref="GpgKey"/>s for the current user.</returns>
+        [ManualRoute("GET", "/user/gpg_keys")]
         public Task<IReadOnlyList<GpgKey>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -56,6 +58,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns>The <see cref="GpgKey"/> for the specified Id.</returns>
+        [ManualRoute("GET", "/user/gpg_keys/{id}")]
         public Task<GpgKey> Get(int id)
         {
             return ApiConnection.Get<GpgKey>(ApiUrls.GpgKeys(id), null, AcceptHeaders.GpgKeysPreview);
@@ -69,6 +72,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns>The newly created <see cref="GpgKey"/>.</returns>
+        [ManualRoute("POST", "/user/gpg_keys")]
         public Task<GpgKey> Create(NewGpgKey newGpgKey)
         {
             Ensure.ArgumentNotNull(newGpgKey, nameof(newGpgKey));
@@ -84,6 +88,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key">API documentation</a> for more information.
         /// </remarks>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/user/gpg_keys/{id}")]
         public Task Delete(int id)
         {
             return ApiConnection.Delete(ApiUrls.GpgKeys(id), new object(), AcceptHeaders.GpgKeysPreview);

--- a/Octokit/Clients/UserKeysClient.cs
+++ b/Octokit/Clients/UserKeysClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="userName">The @ handle of the user.</param>
         /// <returns>Lists the verified public keys for a user.</returns>
+        [ManualRoute("GET", "/users/{username}/keys")]
         public Task<IReadOnlyList<PublicKey>> GetAll(string userName)
         {
             Ensure.ArgumentNotNullOrEmptyString(userName, nameof(userName));
@@ -40,6 +41,7 @@ namespace Octokit
         /// <param name="userName">The @ handle of the user.</param>
         /// <param name="options">Options to change API's behavior.</param>
         /// <returns>Lists the verified public keys for a user.</returns>
+        [ManualRoute("GET", "/users/{username}/keys")]
         public Task<IReadOnlyList<PublicKey>> GetAll(string userName, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(userName, nameof(userName));
@@ -55,6 +57,7 @@ namespace Octokit
         /// https://developer.github.com/v3/users/keys/#list-your-public-keys
         /// </remarks>
         /// <returns>Lists the current user's keys.</returns>
+        [ManualRoute("GET", "/user/keys")]
         public Task<IReadOnlyList<PublicKey>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -68,6 +71,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="options">Options to chagne API's behavior.</param>
         /// <returns>Lists the current user's keys.</returns>
+        [ManualRoute("GET", "/user/keys")]
         public Task<IReadOnlyList<PublicKey>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -83,6 +87,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The Id of the SSH key</param>
         /// <returns></returns>
+        [ManualRoute("GET", "/user/keys/{public_key_id}")]
         public Task<PublicKey> Get(int id)
         {
             return ApiConnection.Get<PublicKey>(ApiUrls.Keys(id));
@@ -96,6 +101,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="newKey">The SSH Key contents</param>
         /// <returns></returns>
+        [ManualRoute("POST", "/user/keys")]
         public Task<PublicKey> Create(NewPublicKey newKey)
         {
             Ensure.ArgumentNotNull(newKey, nameof(newKey));
@@ -111,6 +117,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the key to delete</param>
         /// <returns></returns>
+        [ManualRoute("DELETE", "/user/keys/{public_key_id}")]
         public Task Delete(int id)
         {
             return ApiConnection.Delete(ApiUrls.Keys(id));

--- a/Octokit/Clients/UsersClient.cs
+++ b/Octokit/Clients/UsersClient.cs
@@ -55,6 +55,7 @@ namespace Octokit
         /// Returns the user specified by the login.
         /// </summary>
         /// <param name="login">The login name for the user</param>
+        [ManualRoute("GET", "/users/{username}")]
         public Task<User> Get(string login)
         {
             Ensure.ArgumentNotNullOrEmptyString(login, nameof(login));
@@ -67,6 +68,7 @@ namespace Octokit
         /// </summary>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="User"/></returns>
+        [ManualRoute("GET", "/user")]
         public Task<User> Current()
         {
             return ApiConnection.Get<User>(_userEndpoint);
@@ -78,6 +80,7 @@ namespace Octokit
         /// <param name="user">The login for the user</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
         /// <returns>A <see cref="User"/></returns>
+        [ManualRoute("PATCH", "/user")]
         public Task<User> Update(UserUpdate user)
         {
             Ensure.ArgumentNotNull(user, nameof(user));

--- a/Octokit/Clients/WatchedClient.cs
+++ b/Octokit/Clients/WatchedClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -40,6 +41,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId)
         {
             return GetAllWatchers(repositoryId, ApiOptions.None);
@@ -52,6 +54,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(string owner, string name, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -67,6 +70,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing API's response.</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/subscribers")]
         public Task<IReadOnlyList<User>> GetAllWatchers(long repositoryId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -81,6 +85,7 @@ namespace Octokit
         /// <returns>
         /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) watched by the current authenticated user.
         /// </returns>
+        [ManualRoute("GET", "/user/subscribers")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent()
         {
             return GetAllForCurrent(ApiOptions.None);
@@ -94,6 +99,7 @@ namespace Octokit
         /// <returns>
         /// A <see cref="IReadOnlyPagedCollection{Repository}"/> of <see cref="Repository"/>(ies) watched by the current authenticated user.
         /// </returns>
+        [ManualRoute("GET", "/user/subscribers")]
         public Task<IReadOnlyList<Repository>> GetAllForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -109,6 +115,7 @@ namespace Octokit
         /// <returns>
         /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) watched by the specified user.
         /// </returns>
+        [ManualRoute("GET", "/users/{username}/subscriptions")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -125,6 +132,7 @@ namespace Octokit
         /// <returns>
         /// A <see cref="IReadOnlyPagedCollection{Repository}"/>(ies) watched by the specified user.
         /// </returns>
+        [ManualRoute("GET", "/users/{username}/subscriptions")]
         public Task<IReadOnlyList<Repository>> GetAllForUser(string user, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(user, nameof(user));
@@ -139,6 +147,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repos/{owner}/{name}/subscription")]
         public async Task<bool> CheckWatched(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -162,6 +171,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <exception cref="AuthorizationException">Thrown if the client is not authenticated.</exception>
+        [ManualRoute("GET", "/repositories/{id}/subscription")]
         public async Task<bool> CheckWatched(long repositoryId)
         {
             try
@@ -183,6 +193,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository to star</param>
         /// <param name="name">The name of the repository to star</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        [ManualRoute("PUT", "/repos/{owner}/{name}/subscription")]
         public Task<Subscription> WatchRepo(string owner, string name, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -197,6 +208,7 @@ namespace Octokit
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newSubscription">A <see cref="NewSubscription"/> instance describing the new subscription to create</param>
+        [ManualRoute("PUT", "/repositories/{id}/subscription")]
         public Task<Subscription> WatchRepo(long repositoryId, NewSubscription newSubscription)
         {
             Ensure.ArgumentNotNull(newSubscription, nameof(newSubscription));
@@ -209,6 +221,7 @@ namespace Octokit
         /// </summary>
         /// <param name="owner">The owner of the repository to unstar</param>
         /// <param name="name">The name of the repository to unstar</param>
+        [ManualRoute("DELETE", "/repos/{owner}/{name}/subscription")]
         public async Task<bool> UnwatchRepo(string owner, string name)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -231,6 +244,7 @@ namespace Octokit
         /// Unwatches a repository for the authenticated user.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
+        [ManualRoute("DELETE", "/repositories/{id}/subscription")]
         public async Task<bool> UnwatchRepo(long repositoryId)
         {
             try

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -634,7 +634,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> to add and remove assignees for an issue.        
+        /// Returns the <see cref="Uri"/> to add and remove assignees for an issue.
         /// </summary>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
@@ -726,7 +726,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> that returns a 204 if the user is a public member of the 
+        /// Returns the <see cref="Uri"/> that returns a 204 if the user is a public member of the
         /// organization.
         /// Otherwise returns a 404.
         /// </summary>
@@ -1661,7 +1661,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// returns the <see cref="Uri"/> for org teams 
+        /// returns the <see cref="Uri"/> for org teams
         /// use for both Get and Create methods
         /// </summary>
         /// <param name="organization"></param>
@@ -1672,7 +1672,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Returns the <see cref="Uri"/> to discover teams 
+        /// Returns the <see cref="Uri"/> to discover teams
         /// for the current user
         /// </summary>
         /// <returns></returns>
@@ -2217,7 +2217,7 @@ namespace Octokit
         }
 
         /// <summary>
-        /// Creates the relative <see cref="Uri"/> for retrieving the 
+        /// Creates the relative <see cref="Uri"/> for retrieving the
         /// current users followers
         /// </summary>
         /// <returns>The <see cref="Uri"/> for retrieving the current users followers</returns>

--- a/Octokit/Helpers/ManualRouteAttribute.cs
+++ b/Octokit/Helpers/ManualRouteAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Octokit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class ManualRouteAttribute : Attribute
+    {
+        public string Verb { get; private set; }
+        public string Path { get; private set; }
+
+        public ManualRouteAttribute(string verb, string path)
+        {
+            this.Verb = verb;
+            this.Path = path;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class GeneratedRouteAttribute : Attribute
+    {
+        public string Verb { get; private set; }
+        public string Path { get; private set; }
+
+        public GeneratedRouteAttribute(string verb, string path)
+        {
+            this.Verb = verb;
+            this.Path = path;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class DotNetSpecificRouteAttribute : Attribute
+    {
+    }
+}

--- a/Octokit/Models/Response/PullRequest.cs
+++ b/Octokit/Models/Response/PullRequest.cs
@@ -243,7 +243,7 @@ namespace Octokit
         /// Users requested for review
         /// </summary>
         public IReadOnlyList<User> RequestedReviewers { get; protected set; }
-        
+
         /// <summary>
         /// Teams requested for review
         /// </summary>


### PR DESCRIPTION
This PR adds attributes to each client action to provide context about where each client method is sourced from. 

This comes with two main benefits:

 - by including the verb and path for each route, this will help me audit what parts of the API are not implemented currently
 - using `ManualRouteAttribute` will help me to track which code was hand-crafted, and hopefully which ones are generated by tooling in the future

I also noticed some places where things are likely broken, and some long-obsolete APIs, and I might need to make changes to this metadata down the track, but I can follow-up with other PRs later once I've given this another look.

  - [x] review diff
  - [x] extract issues for follow-up - #2125 #2126 