### PR TITLE
add attribute for tracking preview usage in the codebase

### DIFF
--- a/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableMigrationsClient.cs
@@ -37,7 +37,7 @@ namespace Octokit.Reactive
         /// https://developer.github.com/v3/migration/migrations/#start-a-migration
         /// </remarks>
         /// <param name="org">The organization for which to start a migration.</param>
-        /// <param name="migration">Sprcifies parameters for the migration in a 
+        /// <param name="migration">Specifies parameters for the migration in a
         /// <see cref="StartMigrationRequest"/> object.</param>
         /// <returns>The started migration.</returns>
         public IObservable<Migration> Start(string org, StartMigrationRequest migration)

--- a/Octokit.Tests/Clients/AuthorizationsClientTests.cs
+++ b/Octokit.Tests/Clients/AuthorizationsClientTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Octokit.Tests.Clients
 {
     /// <summary>
-    /// Client tests mostly just need to make sure they call the IApiConnection with the correct 
+    /// Client tests mostly just need to make sure they call the IApiConnection with the correct
     /// relative Uri. No need to fake up the response. All *those* tests are in ApiConnectionTests.cs.
     /// </summary>
     public class AuthorizationsClientTests
@@ -293,7 +293,8 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Post<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    "application/vnd.github.doctor-strange-preview+json");
             }
 
             [Fact]
@@ -321,7 +322,8 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Patch<ApplicationAuthorization>(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    "application/vnd.github.doctor-strange-preview+json");
             }
 
             [Fact]
@@ -349,7 +351,8 @@ namespace Octokit.Tests.Clients
 
                 client.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "applications/clientId/token"),
-                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"));
+                    Arg.Is<Object>(o => o.GetType().GetProperty("access_token").GetValue(o).ToString() == "accessToken"),
+                    "application/vnd.github.doctor-strange-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/CommitCommentReactionsClientTests.cs
@@ -27,7 +27,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -45,7 +45,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -56,7 +56,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -74,7 +74,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -113,7 +113,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -126,7 +126,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/DeploymentsClientTests.cs
+++ b/Octokit.Tests/Clients/DeploymentsClientTests.cs
@@ -133,7 +133,7 @@ public class DeploymentsClientTests
             connection.Received(1)
                 .GetAll<Deployment>(Arg.Is<Uri>(u => u.ToString() == expectedUrl),
                                     Arg.Any<IDictionary<string, string>>(),
-                                    Arg.Is<string>(s => s == AcceptHeaders.DeploymentApiPreview),
+                                    "application/vnd.github.ant-man-preview+json",
                                     Args.ApiOptions);
         }
     }
@@ -212,7 +212,7 @@ public class DeploymentsClientTests
 
             connection.Received(1).Post<Deployment>(Arg.Any<Uri>(),
                                                     Arg.Any<NewDeployment>(),
-                                                    Arg.Is<string>(s => s == AcceptHeaders.DeploymentApiPreview));
+                                                    "application/vnd.github.ant-man-preview+json");
         }
     }
 

--- a/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentReactionsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -112,7 +112,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -125,7 +125,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueCommentsClientTests.cs
@@ -23,7 +23,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments/42"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -36,7 +36,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments/42"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -65,7 +65,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -101,7 +101,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -122,7 +122,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -162,7 +162,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -196,7 +196,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -215,7 +215,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -237,7 +237,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<IssueComment>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -258,7 +258,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<IssueComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/3/comments"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 

--- a/Octokit.Tests/Clients/IssueReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/IssueReactionsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -44,7 +44,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -112,7 +112,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -125,7 +125,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests/Clients/IssueTimelineClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
                     Arg.Any<ApiOptions>());
             }
 
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
                     Arg.Any<ApiOptions>());
             }
 
@@ -76,7 +76,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 

--- a/Octokit.Tests/Clients/IssueTimelineClientTests.cs
+++ b/Octokit.Tests/Clients/IssueTimelineClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview+json",
                     Arg.Any<ApiOptions>());
             }
 
@@ -46,7 +46,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview+json",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 
@@ -61,7 +61,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview+json",
                     Arg.Any<ApiOptions>());
             }
 
@@ -76,7 +76,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<TimelineEventInfo>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview",
+                    "application/vnd.github.mockingbird-preview+json,application/vnd.github.starfox-preview+json",
                     Arg.Is<ApiOptions>(ao => ao.PageSize == 30));
             }
 

--- a/Octokit.Tests/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesClientTests.cs
@@ -22,7 +22,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -35,7 +35,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().Get<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -74,7 +74,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -92,7 +92,7 @@ namespace Octokit.Tests.Clients
                         && d["sort"] == "created"
                         && d["state"] == "open"
                         && d["direction"] == "asc"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
         }
@@ -120,7 +120,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "user/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
         }
@@ -162,7 +162,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "orgs/fake/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -183,7 +183,7 @@ namespace Octokit.Tests.Clients
                         && d["direction"] == "asc"
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
         }
@@ -236,7 +236,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -250,7 +250,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -271,7 +271,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -292,7 +292,7 @@ namespace Octokit.Tests.Clients
 
                 connection.Received().GetAll<Issue>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -313,7 +313,7 @@ namespace Octokit.Tests.Clients
                         && d["direction"] == "asc"
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -334,7 +334,7 @@ namespace Octokit.Tests.Clients
                         && d["direction"] == "asc"
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     Args.ApiOptions);
             }
 
@@ -362,7 +362,7 @@ namespace Octokit.Tests.Clients
                         && d["direction"] == "asc"
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
 
@@ -390,7 +390,7 @@ namespace Octokit.Tests.Clients
                         && d["direction"] == "asc"
                         && d["sort"] == "created"
                         && d["filter"] == "assigned"),
-                    "application/vnd.github.squirrel-girl-preview",
+                    "application/vnd.github.squirrel-girl-preview+json",
                     options);
             }
         }

--- a/Octokit.Tests/Clients/IssuesEventsClientTests.cs
+++ b/Octokit.Tests/Clients/IssuesEventsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
                 var client = new IssuesEventsClient(connection);
 
                 await client.GetAllForIssue("fake", "repo", 42);
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -55,7 +55,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue("fake", "repo", 42, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview", options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/events"), null, "application/vnd.github.starfox-preview+json", options);
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForIssue(1, 42, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview", options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/events"), null, "application/vnd.github.starfox-preview+json", options);
             }
 
             [Fact]
@@ -106,7 +106,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo");
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -117,7 +117,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview", Args.ApiOptions);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -135,7 +135,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository("fake", "repo", options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview", options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events"), null, "application/vnd.github.starfox-preview+json", options);
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAllForRepository(1, options);
 
-                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview", options);
+                connection.Received().GetAll<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events"), null, "application/vnd.github.starfox-preview+json", options);
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get("fake", "repo", 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"), null, "application/vnd.github.starfox-preview");
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/events/42"), null, "application/vnd.github.starfox-preview+json");
             }
 
             [Fact]
@@ -197,7 +197,7 @@ namespace Octokit.Tests.Clients
 
                 client.Get(1, 42);
 
-                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"), null, "application/vnd.github.starfox-preview");
+                connection.Received().Get<IssueEvent>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/events/42"), null, "application/vnd.github.starfox-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/MigrationsClientTests.cs
+++ b/Octokit.Tests/Clients/MigrationsClientTests.cs
@@ -31,7 +31,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Get<Migration>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69"),
                     null,
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
 
             [Fact]
@@ -58,7 +58,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<Migration>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations"),
                     null,
-                    AcceptHeaders.MigrationsApiPreview,
+                    "application/vnd.github.wyandotte-preview+json",
                     Args.ApiOptions);
             }
 
@@ -79,7 +79,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().GetAll<Migration>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations"),
                     null,
-                    AcceptHeaders.MigrationsApiPreview,
+                    "application/vnd.github.wyandotte-preview+json",
                     options);
             }
 
@@ -109,7 +109,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Post<Migration>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations"),
                     Arg.Any<StartMigrationRequest>(),
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
 
             [Fact]
@@ -142,7 +142,7 @@ namespace Octokit.Tests.Clients
                         m.Repositories.Equals(migrationRequest.Repositories) &&
                         m.LockRepositories == migrationRequest.LockRepositories &&
                         m.ExcludeAttachments == migrationRequest.ExcludeAttachments),
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
         }
 
@@ -159,7 +159,7 @@ namespace Octokit.Tests.Clients
                 connection.Connection.Received().Get<byte[]>(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69/archive"),
                     null,
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69/archive"),
                     Arg.Any<object>(),
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
 
             [Fact]
@@ -213,7 +213,7 @@ namespace Octokit.Tests.Clients
                 connection.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "orgs/fake/migrations/69/repos/repo/lock"),
                     Arg.Any<object>(),
-                    AcceptHeaders.MigrationsApiPreview);
+                    "application/vnd.github.wyandotte-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/PullRequestReviewCommentReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentReactionsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -43,7 +43,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll("fake", "repo", 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -54,7 +54,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
             }
 
             [Fact]
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Clients
 
                 await client.GetAll(1, 42, options);
 
-                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview", options);
+                connection.Received().GetAll<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/42/reactions"), null, "application/vnd.github.squirrel-girl-preview+json", options);
             }
 
             [Fact]
@@ -110,7 +110,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create("fake", "repo", 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -123,7 +123,7 @@ namespace Octokit.Tests.Clients
 
                 client.Create(1, 1, newReaction);
 
-                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Post<Reaction>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/pulls/comments/1/reactions"), newReaction, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewCommentsClientTests.cs
@@ -100,7 +100,7 @@ public class PullRequestReviewCommentsClientTests
             connection.Received().GetAll<PullRequestReviewComment>(
                 Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/comments"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ public class PullRequestReviewCommentsClientTests
             connection.Received().GetAll<PullRequestReviewComment>(
                 Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/comments"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview", options);
+                "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
                 Args.ApiOptions);
         }
 
@@ -224,7 +224,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
         }
 
         [Fact]
@@ -254,7 +254,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
                 options);
         }
 
@@ -285,7 +285,7 @@ public class PullRequestReviewCommentsClientTests
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
                         && d["sort"] == "updated"),
-                "application/vnd.github.squirrel-girl-preview", options);
+                "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -300,7 +300,7 @@ public class PullRequestReviewCommentsClientTests
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
                 Args.ApiOptions);
         }
 
@@ -316,7 +316,7 @@ public class PullRequestReviewCommentsClientTests
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+                "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
         }
 
         [Fact]
@@ -338,7 +338,7 @@ public class PullRequestReviewCommentsClientTests
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
                 options);
         }
 
@@ -361,7 +361,7 @@ public class PullRequestReviewCommentsClientTests
                 Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                "application/vnd.github.squirrel-girl-preview", options);
+                "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -421,7 +421,7 @@ public class PullRequestReviewCommentsClientTests
             connection.Received().Get<PullRequestReviewComment>(
                 Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/comments/53"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview");
+                "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]

--- a/Octokit.Tests/Clients/ReactionsClientTests.cs
+++ b/Octokit.Tests/Clients/ReactionsClientTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.Tests.Clients
 
                 await client.Delete(42);
 
-                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "reactions/42"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview");
+                connection.Received().Delete(Arg.Is<Uri>(u => u.ToString() == "reactions/42"), Arg.Any<object>(), "application/vnd.github.squirrel-girl-preview+json");
             }
         }
     }

--- a/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryCommentsClientTests.cs
@@ -20,7 +20,7 @@ public class RepositoryCommentsClientTests
 
             await client.Get("fake", "repo", 42);
 
-            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview");
+            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments/42"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -31,7 +31,7 @@ public class RepositoryCommentsClientTests
 
             await client.Get(1, 42);
 
-            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview");
+            connection.Received().Get<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments/42"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -57,7 +57,7 @@ public class RepositoryCommentsClientTests
 
             await client.GetAllForRepository("fake", "repo");
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ public class RepositoryCommentsClientTests
 
             await client.GetAllForRepository(1);
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview", Args.ApiOptions);
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json", Args.ApiOptions);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ public class RepositoryCommentsClientTests
 
             await client.GetAllForRepository("fake", "repo", options);
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview", options);
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ public class RepositoryCommentsClientTests
 
             await client.GetAllForRepository(1, options);
 
-            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview", options);
+            connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/comments"), Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ public class RepositoryCommentsClientTests
 
             connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
             Args.ApiOptions);
         }
 
@@ -155,7 +155,7 @@ public class RepositoryCommentsClientTests
 
             connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/comments"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview",
+                "application/vnd.github.squirrel-girl-preview+json",
                 Args.ApiOptions);
         }
 
@@ -175,7 +175,7 @@ public class RepositoryCommentsClientTests
             await client.GetAllForCommit("fake", "repo", "sha", options);
 
             connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/commits/sha/comments"), Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview", options);
+                "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ public class RepositoryCommentsClientTests
 
             connection.Received().GetAll<CommitComment>(Arg.Is<Uri>(u => u.ToString() == "repositories/1/commits/sha/comments"),
                 Arg.Any<Dictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview", options);
+                "application/vnd.github.squirrel-girl-preview+json", options);
         }
 
         [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueCommentsClientTests.cs
@@ -59,7 +59,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/comments", UriKind.Relative),
                     Arg.Any<IDictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repositories/1/issues/comments", UriKind.Relative),
                     Arg.Any<IDictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -103,7 +103,7 @@ namespace Octokit.Tests.Reactive
                         && d["direction"] == "desc"
                         && d["since"] == "2016-11-23T11:11:11Z"
                         && d["sort"] == "updated"),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -133,7 +133,7 @@ namespace Octokit.Tests.Reactive
                         && d["direction"] == "desc"
                         && d["since"] == "2016-11-23T11:11:11Z"
                         && d["sort"] == "updated"),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -172,7 +172,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Arg.Any<IDictionary<string, string>>(),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -184,7 +184,7 @@ namespace Octokit.Tests.Reactive
                 client.GetAllForIssue(1, 3);
 
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
-                    new Uri("repositories/1/issues/3/comments", UriKind.Relative), Arg.Any<IDictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview");
+                    new Uri("repositories/1/issues/3/comments", UriKind.Relative), Arg.Any<IDictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -204,7 +204,7 @@ namespace Octokit.Tests.Reactive
                     new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 3
                          && d["since"] == "2016-11-23T11:11:11Z"),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -224,7 +224,7 @@ namespace Octokit.Tests.Reactive
                     new Uri("repositories/1/issues/3/comments", UriKind.Relative),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                                 && d["since"] == "2016-11-23T11:11:11Z"),
-                            "application/vnd.github.squirrel-girl-preview");
+                            "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -245,7 +245,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repos/fake/repo/issues/3/comments", UriKind.Relative),
                     Arg.Is<IDictionary<string, string>>(d => d.Count == 4),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -266,7 +266,7 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Received(1).Get<List<IssueComment>>(
                     new Uri("repositories/1/issues/3/comments", UriKind.Relative),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 4),
-                            "application/vnd.github.squirrel-girl-preview");
+                            "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableIssueTimelineClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssueTimelineClientTests.cs
@@ -37,7 +37,7 @@ namespace Octokit.Tests.Reactive
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Args.EmptyDictionary, "application/vnd.github.mockingbird-preview")
+                gitHubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Args.EmptyDictionary, "application/vnd.github.mockingbird-preview+json")
                     .Returns(Task.FromResult(response));
 
                 var timelineEvents = await client.GetAllForIssue("fake", "repo", 42).ToList();
@@ -45,7 +45,7 @@ namespace Octokit.Tests.Reactive
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview");
+                    "application/vnd.github.mockingbird-preview+json");
                 Assert.Equal(1, timelineEvents.Count);
             }
 
@@ -63,7 +63,7 @@ namespace Octokit.Tests.Reactive
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                gitHubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview")
+                gitHubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview+json")
                     .Returns(Task.FromResult(response));
 
                 var timelineEvents = await client.GetAllForIssue("fake", "repo", 42, new ApiOptions { PageSize = 30 }).ToList();
@@ -71,7 +71,7 @@ namespace Octokit.Tests.Reactive
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues/42/timeline"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 1 && d["per_page"] == "30"),
-                    "application/vnd.github.mockingbird-preview");
+                    "application/vnd.github.mockingbird-preview+json");
                 Assert.Equal(1, timelineEvents.Count);
             }
 
@@ -88,7 +88,7 @@ namespace Octokit.Tests.Reactive
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                githubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Args.EmptyDictionary, "application/vnd.github.mockingbird-preview")
+                githubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Args.EmptyDictionary, "application/vnd.github.mockingbird-preview+json")
                     .Returns(Task.FromResult(response));
 
                 var timelineEvents = await client.GetAllForIssue(1, 42).ToList();
@@ -96,7 +96,7 @@ namespace Octokit.Tests.Reactive
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Any<Dictionary<string, string>>(),
-                    "application/vnd.github.mockingbird-preview");
+                    "application/vnd.github.mockingbird-preview+json");
                 Assert.Equal(1, timelineEvents.Count);
             }
 
@@ -113,7 +113,7 @@ namespace Octokit.Tests.Reactive
                     {
                         ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()),
                     }, result);
-                githubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview")
+                githubClient.Connection.Get<List<TimelineEventInfo>>(Args.Uri, Arg.Is<Dictionary<string, string>>(d => d.Count == 1), "application/vnd.github.mockingbird-preview+json")
                     .Returns(Task.FromResult(response));
 
                 var timelineEvents = await client.GetAllForIssue(1, 42, new ApiOptions { PageSize = 30 }).ToList();
@@ -121,7 +121,7 @@ namespace Octokit.Tests.Reactive
                 connection.Received().Get<List<TimelineEventInfo>>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/1/issues/42/timeline"),
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 1 && d["per_page"] == "30"),
-                    "application/vnd.github.mockingbird-preview");
+                    "application/vnd.github.mockingbird-preview+json");
                 Assert.Equal(1, timelineEvents.Count);
             }
 

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -95,7 +95,7 @@ public class ObservableIssuesClientTests
 
             gitHubClient.Connection.Received().Get<List<Issue>>(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/issues"),
                 Arg.Any<IDictionary<string, string>>(),
-                "application/vnd.github.squirrel-girl-preview");
+                "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -133,7 +133,7 @@ public class ObservableIssuesClientTests
                 && d["direction"] == "desc"
                 && d["page"] == "1"
                 && d["per_page"] == "1"),
-                "application/vnd.github.squirrel-girl-preview");
+                "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -178,7 +178,7 @@ public class ObservableIssuesClientTests
                 && d["state"] == "open"
                 && d["sort"] == "created"
                 && d["direction"] == "asc"),
-                "application/vnd.github.squirrel-girl-preview");
+                "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -226,7 +226,7 @@ public class ObservableIssuesClientTests
                 && d["direction"] == "asc"
                 && d["page"] == "1"
                 && d["per_page"] == "1"),
-                "application/vnd.github.squirrel-girl-preview");
+                "application/vnd.github.squirrel-girl-preview+json");
         }
 
         [Fact]
@@ -302,9 +302,9 @@ public class ObservableIssuesClientTests
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"), Arg.Any<string>())
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 
@@ -377,11 +377,11 @@ public class ObservableIssuesClientTests
                     && d["state"] == "open"
                     && d["sort"] == "created"
                     && d["filter"] == "assigned"),
-                "application/vnd.github.squirrel-girl-preview")
+                "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 
@@ -463,11 +463,11 @@ public class ObservableIssuesClientTests
                     && d["direction"] == "desc"
                     && d["state"] == "open"
                     && d["sort"] == "created"
-                    && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview")
+                    && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
 
             var client = new ObservableIssuesClient(gitHubClient);
@@ -536,11 +536,11 @@ public class ObservableIssuesClientTests
                     && d["direction"] == "desc"
                     && d["state"] == "open"
                     && d["sort"] == "created"
-                    && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview")
+                    && d["filter"] == "assigned"), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => firstPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(secondPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => secondPageResponse));
-            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview")
+            gitHubClient.Connection.Get<List<Issue>>(thirdPageUrl, Arg.Any<Dictionary<string, string>>(), "application/vnd.github.squirrel-girl-preview+json")
                 .Returns(Task.Factory.StartNew<IApiResponse<List<Issue>>>(() => lastPageResponse));
             var client = new ObservableIssuesClient(gitHubClient);
 

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewCommentsClientTests.cs
@@ -125,7 +125,7 @@ namespace Octokit.Tests.Reactive
                 );
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var acceptHeader = "application/vnd.github.squirrel-girl-preview";
+                var acceptHeader = "application/vnd.github.squirrel-girl-preview+json";
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl, Args.EmptyDictionary, acceptHeader)
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Args.EmptyDictionary, acceptHeader)
@@ -344,7 +344,7 @@ namespace Octokit.Tests.Reactive
                 );
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
-                var previewAcceptHeader = "application/vnd.github.squirrel-girl-preview";
+                var previewAcceptHeader = "application/vnd.github.squirrel-girl-preview+json";
 
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl,
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
@@ -433,17 +433,17 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
@@ -462,15 +462,15 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview");
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json");
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview");
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json");
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 3
                         && d["direction"] == "desc"
                         && d["since"] == "2013-11-15T11:43:01Z"
-                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview");
+                        && d["sort"] == "updated"), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -570,7 +570,7 @@ namespace Octokit.Tests.Reactive
 
                 var gitHubClient = Substitute.For<IGitHubClient>();
 
-                var previewAcceptHeader = "application/vnd.github.squirrel-girl-preview";
+                var previewAcceptHeader = "application/vnd.github.squirrel-girl-preview+json";
 
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl,
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 2
@@ -645,15 +645,15 @@ namespace Octokit.Tests.Reactive
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(firstPageUrl,
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
-                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => firstPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
-                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => secondPageResponse));
                 gitHubClient.Connection.Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
-                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview")
+                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json")
                     .Returns(Task.Factory.StartNew<IApiResponse<List<PullRequestReviewComment>>>(() => lastPageResponse));
 
                 var client = new ObservablePullRequestReviewCommentsClient(gitHubClient);
@@ -665,14 +665,14 @@ namespace Octokit.Tests.Reactive
                     Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                    "application/vnd.github.squirrel-girl-preview");
+                    "application/vnd.github.squirrel-girl-preview+json");
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(secondPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
                         && d["sort"] == "created"),
-                        "application/vnd.github.squirrel-girl-preview");
+                        "application/vnd.github.squirrel-girl-preview+json");
                 gitHubClient.Connection.Received(1).Get<List<PullRequestReviewComment>>(thirdPageUrl, Arg.Is<Dictionary<string, string>>(d => d.Count == 2
                         && d["direction"] == "asc"
-                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview");
+                        && d["sort"] == "created"), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryCommentsClientTests.cs
@@ -66,7 +66,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo");
                 githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repos/fake/repo/comments"),
-                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview");
+                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -77,7 +77,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1);
                 githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repositories/1/comments"),
-                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview");
+                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -95,7 +95,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository("fake", "repo", options);
                 githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repos/fake/repo/comments"),
-                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), "application/vnd.github.squirrel-girl-preview");
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -113,7 +113,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForRepository(1, options);
                 githubClient.Connection.Received(1).Get<List<CommitComment>>(Arg.Is<Uri>(uri => uri.ToString() == "repositories/1/comments"),
-                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), "application/vnd.github.squirrel-girl-preview");
+                    Arg.Is<Dictionary<string, string>>(dictionary => dictionary.Count == 2), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -147,7 +147,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCommit("fake", "repo", "sha");
                 githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repos/fake/repo/commits/sha/comments", UriKind.Relative)),
-                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview");
+                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -158,7 +158,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCommit(1, "sha");
                 githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repositories/1/commits/sha/comments", UriKind.Relative)),
-                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview");
+                    Args.EmptyDictionary, "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -176,7 +176,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCommit("fake", "repo", "sha", options);
                 githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repos/fake/repo/commits/sha/comments", UriKind.Relative)),
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview");
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]
@@ -194,7 +194,7 @@ namespace Octokit.Tests.Reactive
 
                 client.GetAllForCommit(1, "sha", options);
                 githubClient.Connection.Received().Get<List<CommitComment>>(Arg.Is(new Uri("repositories/1/commits/sha/comments", UriKind.Relative)),
-                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview");
+                    Arg.Is<IDictionary<string, string>>(d => d.Count == 2), "application/vnd.github.squirrel-girl-preview+json");
             }
 
             [Fact]

--- a/Octokit/Clients/AuthorizationsClient.cs
+++ b/Octokit/Clients/AuthorizationsClient.cs
@@ -357,7 +357,7 @@ namespace Octokit
             };
 
             var endpoint = ApiUrls.ApplicationAuthorization(clientId);
-            return ApiConnection.Post<ApplicationAuthorization>(endpoint, requestData);
+            return ApiConnection.Post<ApplicationAuthorization>(endpoint, requestData, AcceptHeaders.OAuthApplicationsPreview);
         }
 
         /// <summary>
@@ -382,7 +382,7 @@ namespace Octokit
             };
 
             var endpoint = ApiUrls.ApplicationAuthorization(clientId);
-            return ApiConnection.Patch<ApplicationAuthorization>(endpoint, requestData);
+            return ApiConnection.Patch<ApplicationAuthorization>(endpoint, requestData, AcceptHeaders.OAuthApplicationsPreview);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace Octokit
             };
 
             var endpoint = ApiUrls.ApplicationAuthorization(clientId);
-            return ApiConnection.Delete(endpoint, requestData);
+            return ApiConnection.Delete(endpoint, requestData, AcceptHeaders.OAuthApplicationsPreview);
         }
 
         /// <summary>

--- a/Octokit/Clients/CheckRunsClient.cs
+++ b/Octokit/Clients/CheckRunsClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckRun">Details of the Check Run to create</param>
+        [Preview("antiope")]
         [ManualRoute("POST", "/repos/{owner}/{name}/check-runs")]
         public Task<CheckRun> Create(string owner, string name, NewCheckRun newCheckRun)
         {
@@ -48,6 +49,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newCheckRun">Details of the Check Run to create</param>
+        [Preview("antiope")]
         [ManualRoute("POST", "/repositories/{id}/check-runs")]
         public Task<CheckRun> Create(long repositoryId, NewCheckRun newCheckRun)
         {
@@ -66,6 +68,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="checkRunUpdate">The updates to the check run</param>
+        [Preview("antiope")]
         [ManualRoute("PATCH", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
         public Task<CheckRun> Update(string owner, string name, long checkRunId, CheckRunUpdate checkRunUpdate)
         {
@@ -85,6 +88,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="checkRunUpdate">The updates to the check run</param>
+        [Preview("antiope")]
         [ManualRoute("PATCH", "/repositories/{id}/check-runs/{check_run_id}")]
         public Task<CheckRun> Update(long repositoryId, long checkRunId, CheckRunUpdate checkRunUpdate)
         {
@@ -178,6 +182,7 @@ namespace Octokit
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "repos/{owner}/{name}/commits/{sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(string owner, string name, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
@@ -204,6 +209,7 @@ namespace Octokit
         /// <param name="reference">The commit reference (can be a SHA, branch name, or a tag name)</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/commits/{sha}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForReference(long repositoryId, string reference, CheckRunRequest checkRunRequest, ApiOptions options)
         {
@@ -298,6 +304,7 @@ namespace Octokit
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/check-suite/{check_suite_id}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForCheckSuite(string owner, string name, long checkSuiteId, CheckRunRequest checkRunRequest, ApiOptions options)
         {
@@ -323,6 +330,7 @@ namespace Octokit
         /// <param name="checkSuiteId">The Id of the check suite</param>
         /// <param name="checkRunRequest">Details to filter the request, such as by check name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}/check-runs")]
         public async Task<CheckRunsResponse> GetAllForCheckSuite(long repositoryId, long checkSuiteId, CheckRunRequest checkRunRequest, ApiOptions options)
         {
@@ -345,6 +353,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}")]
         public Task<CheckRun> Get(string owner, string name, long checkRunId)
         {
@@ -362,6 +371,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-runs/{check_run_id}")]
         public Task<CheckRun> Get(long repositoryId, long checkRunId)
         {
@@ -411,6 +421,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(string owner, string name, long checkRunId, ApiOptions options)
         {
@@ -430,6 +441,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkRunId">The Id of the check run</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-runs/{check_run_id}/annotations")]
         public Task<IReadOnlyList<CheckRunAnnotation>> GetAllAnnotations(long repositoryId, long checkRunId, ApiOptions options)
         {

--- a/Octokit/Clients/CheckSuitesClient.cs
+++ b/Octokit/Clients/CheckSuitesClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{id}")]
         public Task<CheckSuite> Get(string owner, string name, long checkSuiteId)
         {
@@ -47,6 +48,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-suites/{check_suite_id}")]
         public Task<CheckSuite> Get(long repositoryId, long checkSuiteId)
         {
@@ -138,6 +140,7 @@ namespace Octokit
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/commits/{ref}/check-suites")]
         public async Task<CheckSuitesResponse> GetAllForReference(string owner, string name, string reference, CheckSuiteRequest request, ApiOptions options)
         {
@@ -164,6 +167,7 @@ namespace Octokit
         /// <param name="reference">The reference (SHA, branch name or tag name) to list check suites for</param>
         /// <param name="request">Details to filter the request, such as by App Id or Check Name</param>
         /// <param name="options">Options to change the API response</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/commits/{ref}/check-suites")]
         public async Task<CheckSuitesResponse> GetAllForReference(long repositoryId, string reference, CheckSuiteRequest request, ApiOptions options)
         {
@@ -187,6 +191,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="preferences">The check suite preferences</param>
+        [Preview("antiope")]
         [ManualRoute("PATCH", "/repos/{owner}/{name}/check-suites/preferences")]
         public Task<CheckSuitePreferencesResponse> UpdatePreferences(string owner, string name, CheckSuitePreferences preferences)
         {
@@ -205,6 +210,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="preferences">The check suite preferences</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-suites/preferences")]
         public Task<CheckSuitePreferencesResponse> UpdatePreferences(long repositoryId, CheckSuitePreferences preferences)
         {
@@ -222,6 +228,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newCheckSuite">Details of the Check Suite to create</param>
+        [Preview("antiope")]
         [ManualRoute("POST", "/repos/{owner}/{name}/check-suites")]
         public Task<CheckSuite> Create(string owner, string name, NewCheckSuite newCheckSuite)
         {
@@ -240,6 +247,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newCheckSuite">Details of the Check Suite to create</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-suites")]
         public Task<CheckSuite> Create(long repositoryId, NewCheckSuite newCheckSuite)
         {
@@ -257,6 +265,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repos/{owner}/{name}/check-suites/{2}/rerequest")]
         public async Task<bool> Rerequest(string owner, string name, long checkSuiteId)
         {
@@ -281,6 +290,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="checkSuiteId">The Id of the check suite</param>
+        [Preview("antiope")]
         [ManualRoute("GET", "/repositories/{id}/check-suites/{2}/rerequest")]
         public async Task<bool> Rerequest(long repositoryId, long checkSuiteId)
         {

--- a/Octokit/Clients/CommitCommentReactionsClient.cs
+++ b/Octokit/Clients/CommitCommentReactionsClient.cs
@@ -25,6 +25,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
@@ -43,6 +44,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
         /// <returns></returns>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
@@ -57,7 +59,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number)
@@ -74,6 +76,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -89,7 +92,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment</remarks>
         /// <param name="repositoryId">The owner of the repository</param>
-        /// <param name="number">The comment id</param>        
+        /// <param name="number">The comment id</param>
         /// <returns></returns>
         [ManualRoute("GET", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number)
@@ -105,6 +108,7 @@ namespace Octokit
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
         /// <returns></returns>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -62,6 +62,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("ant-man")]
         [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
@@ -85,6 +86,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("ant-man")]
         [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options)
         {
@@ -107,6 +109,7 @@ namespace Octokit
         /// <param name="name">The name of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        [Preview("ant-man")]
         [ManualRoute("POST", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
@@ -129,6 +132,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository.</param>
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
+        [Preview("ant-man")]
         [ManualRoute("POST", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {

--- a/Octokit/Clients/DeploymentStatusClient.cs
+++ b/Octokit/Clients/DeploymentStatusClient.cs
@@ -63,6 +63,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("ant-man")]
+        [Preview("flash")]
         [ManualRoute("GET", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(string owner, string name, int deploymentId, ApiOptions options)
         {
@@ -87,6 +88,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("ant-man")]
+        [Preview("flash")]
         [ManualRoute("GET", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<IReadOnlyList<DeploymentStatus>> GetAll(long repositoryId, int deploymentId, ApiOptions options)
         {
@@ -110,6 +112,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         [Preview("ant-man")]
+        [Preview("flash")]
         [ManualRoute("POST", "/repos/{owner}/{name}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(string owner, string name, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {
@@ -133,6 +136,7 @@ namespace Octokit
         /// <param name="deploymentId">The id of the deployment.</param>
         /// <param name="newDeploymentStatus">The new deployment status to create.</param>
         [Preview("ant-man")]
+        [Preview("flash")]
         [ManualRoute("POST", "/repositories/{id}/deployments/{deployment_id}/statuses")]
         public Task<DeploymentStatus> Create(long repositoryId, int deploymentId, NewDeploymentStatus newDeploymentStatus)
         {

--- a/Octokit/Clients/DeploymentsClient.cs
+++ b/Octokit/Clients/DeploymentsClient.cs
@@ -64,6 +64,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("ant-man")]
         [ManualRoute("GET", "/repos/{owner}/{name}/deployments")]
         public Task<IReadOnlyList<Deployment>> GetAll(string owner, string name, ApiOptions options)
         {
@@ -104,6 +105,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newDeployment">A <see cref="NewDeployment"/> instance describing the new deployment to create</param>
+        [Preview("ant-man")]
         [ManualRoute("POST", "/repos/{owner}/{name}/deployments")]
         public Task<Deployment> Create(string owner, string name, NewDeployment newDeployment)
         {

--- a/Octokit/Clients/GitHubAppInstallationsClient.cs
+++ b/Octokit/Clients/GitHubAppInstallationsClient.cs
@@ -30,6 +30,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/installation/repositories")]
         public async Task<RepositoriesResponse> GetAllRepositoriesForCurrent(ApiOptions options)
         {
@@ -59,6 +60,7 @@ namespace Octokit
         /// <param name="installationId">The Id of the installation</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/user/installation/{id}/repositories")]
         public async Task<RepositoriesResponse> GetAllRepositoriesForCurrentUser(long installationId, ApiOptions options)
         {

--- a/Octokit/Clients/GitHubAppsClient.cs
+++ b/Octokit/Clients/GitHubAppsClient.cs
@@ -33,6 +33,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-a-single-github-app</remarks>
         /// <param name="slug">The URL-friendly name of your GitHub App. You can find this on the settings page for your GitHub App.</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/apps/{slug}")]
         public Task<GitHubApp> Get(string slug)
         {
@@ -45,6 +46,7 @@ namespace Octokit
         /// Returns the GitHub App associated with the authentication credentials used (requires GitHubApp auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-the-authenticated-github-app</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/app")]
         public Task<GitHubApp> GetCurrent()
         {
@@ -66,6 +68,7 @@ namespace Octokit
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/#find-installations</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/app/installations")]
         public Task<IReadOnlyList<Installation>> GetAllInstallationsForCurrent(ApiOptions options)
         {
@@ -90,6 +93,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#get-a-single-installation</remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/app/installations/{id}")]
         public Task<Installation> GetInstallationForCurrent(long installationId)
         {
@@ -100,6 +104,7 @@ namespace Octokit
         /// List installations for the currently authenticated user (requires GitHubApp User-To-Server Auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#list-installations-for-user</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/user/installations")]
         public async Task<InstallationsResponse> GetAllInstallationsForCurrentUser()
         {
@@ -114,6 +119,7 @@ namespace Octokit
         /// List installations for the currently authenticated user (requires GitHubApp User-To-Server Auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#list-installations-for-user</remarks>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/user/installations")]
         public async Task<InstallationsResponse> GetAllInstallationsForCurrentUser(ApiOptions options)
         {
@@ -135,6 +141,7 @@ namespace Octokit
         /// https://developer.github.com/v3/apps/available-endpoints/
         /// </remarks>
         /// <param name="installationId">The Id of the GitHub App Installation</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/app/installations/{id}/access_tokens")]
         public Task<AccessToken> CreateInstallationToken(long installationId)
         {
@@ -146,6 +153,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-organization-installation</remarks>
         /// <param name="organization">The name of the organization</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/orgs/{org}/installation")]
         public Task<Installation> GetOrganizationInstallationForCurrent(string organization)
         {
@@ -160,6 +168,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/apps/#find-repository-installation</remarks>
         /// <param name="owner">The owner of the repo</param>
         /// <param name="repo">The name of the repo</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/repos/{owner}/{name}/installation")]
         public Task<Installation> GetRepositoryInstallationForCurrent(string owner, string repo)
         {
@@ -174,6 +183,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-repository-installation</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/repositories/{id}/installation")]
         public Task<Installation> GetRepositoryInstallationForCurrent(long repositoryId)
         {
@@ -185,6 +195,7 @@ namespace Octokit
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/#find-user-installation</remarks>
         /// <param name="user">The name of the user</param>
+        [Preview("machine-man")]
         [ManualRoute("GET", "/users/{user}/installation")]
         public Task<Installation> GetUserInstallationForCurrent(string user)
         {

--- a/Octokit/Clients/IssueCommentReactionsClient.cs
+++ b/Octokit/Clients/IssueCommentReactionsClient.cs
@@ -24,6 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
@@ -41,6 +42,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repositories/{0}/issues/comments/{number}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {
@@ -70,6 +72,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repos/{owner}/{name}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -99,6 +102,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{0}/issues/comments/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -26,6 +26,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="id">The issue comment id</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments/{comment_id}")]
         public Task<IssueComment> Get(string owner, string name, int id)
         {
@@ -41,6 +42,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#get-a-single-comment</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="id">The issue comment id</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/issues/comments/{comment_id}")]
         public Task<IssueComment> Get(long repositoryId, int id)
         {
@@ -143,6 +145,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(string owner, string name, IssueCommentRequest request, ApiOptions options)
         {
@@ -161,6 +164,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/issues/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForRepository(long repositoryId, IssueCommentRequest request, ApiOptions options)
         {
@@ -273,6 +277,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number]/comments")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int number, IssueCommentRequest request, ApiOptions options)
         {
@@ -293,6 +298,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
+        [Preview("squirrel-girl")]
         public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int number, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -37,6 +37,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -66,6 +67,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
@@ -82,6 +84,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repos/{owner}/{name}/issues/{number}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
@@ -99,6 +102,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -43,6 +43,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
+        [Preview("mockingbird")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
         {
@@ -79,6 +80,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("mockingbird")]
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -44,6 +44,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
         [Preview("mockingbird")]
+        [Preview("starfox")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int number, ApiOptions options)
         {
@@ -81,6 +82,7 @@ namespace Octokit
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [Preview("mockingbird")]
+        [Preview("starfox")]
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
         public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -66,6 +66,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}")]
         public Task<Issue> Get(string owner, string name, int number)
         {
@@ -83,6 +84,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/issues/{number}")]
         public Task<Issue> Get(long repositoryId, int number)
         {
@@ -145,6 +147,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForCurrent(IssueRequest request, ApiOptions options)
         {
@@ -208,6 +211,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/user/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOwnedAndMemberRepositories(IssueRequest request, ApiOptions options)
         {
@@ -275,6 +279,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/orgs/{org}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForOrganization(string organization, IssueRequest request, ApiOptions options)
         {
@@ -395,6 +400,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(string owner, string name, RepositoryIssueRequest request, ApiOptions options)
         {
@@ -415,6 +421,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of issues returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/issues")]
         public Task<IReadOnlyList<Issue>> GetAllForRepository(long repositoryId, RepositoryIssueRequest request, ApiOptions options)
         {

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -57,6 +57,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int number, ApiOptions options)
         {
@@ -79,6 +80,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int number, ApiOptions options)
         {
@@ -129,6 +131,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
@@ -150,6 +153,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repositories/{id}/issues/events")]
         public Task<IReadOnlyList<IssueEvent>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
@@ -170,6 +174,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="eventId">The event id</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repos/{owner}/{name}/issues/events/{event_id}")]
         public Task<IssueEvent> Get(string owner, string name, long eventId)
         {
@@ -189,6 +194,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="eventId">The event id</param>
+        [Preview("starfox")]
         [ManualRoute("GET", "/repositories/{id}/issues/events/{event_id}")]
         public Task<IssueEvent> Get(long repositoryId, long eventId)
         {

--- a/Octokit/Clients/MigrationsClient.cs
+++ b/Octokit/Clients/MigrationsClient.cs
@@ -27,9 +27,10 @@ namespace Octokit
         /// https://developer.github.com/v3/migration/migrations/#start-a-migration
         /// </remarks>
         /// <param name="org">The organization for which to start a migration.</param>
-        /// <param name="migration">Sprcifies parameters for the migration in a 
+        /// <param name="migration">Specifies parameters for the migration in a
         /// <see cref="StartMigrationRequest"/> object.</param>
         /// <returns>The started migration.</returns>
+        [Preview("wyandotte")]
         [ManualRoute("POST", "/orgs/{org}/migrations")]
         public async Task<Migration> Start(string org, StartMigrationRequest migration)
         {
@@ -65,6 +66,7 @@ namespace Octokit
         /// <param name="options">Options for changing the API response</param>
         /// <returns>List of most recent <see cref="Migration"/>s.</returns>
         [ManualRoute("GET", "/orgs/{org}/migrations")]
+        [Preview("wyandotte")]
         public async Task<IReadOnlyList<Migration>> GetAll(string org, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(org, nameof(org));
@@ -84,6 +86,7 @@ namespace Octokit
         /// <param name="org">The organization which is migrating.</param>
         /// <param name="id">Migration Id of the organization.</param>
         /// <returns>A <see cref="Migration"/> object representing the state of migration.</returns>
+        [Preview("wyandotte")]
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}")]
         public async Task<Migration> Get(string org, int id)
         {
@@ -103,6 +106,7 @@ namespace Octokit
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns>The binary contents of the archive as a byte array.</returns>
+        [Preview("wyandotte")]
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}/archive")]
         public async Task<byte[]> GetArchive(string org, int id)
         {
@@ -123,6 +127,7 @@ namespace Octokit
         /// <param name="org">The organization of which the migration was.</param>
         /// <param name="id">The Id of the migration.</param>
         /// <returns></returns>
+        [Preview("wyandotte")]
         [ManualRoute("DELETE", "/orgs/{org}/migrations/{id}/archive")]
         public Task DeleteArchive(string org, int id)
         {
@@ -143,6 +148,7 @@ namespace Octokit
         /// <param name="id">The Id of the migration.</param>
         /// <param name="repo">The repo to unlock.</param>
         /// <returns></returns>
+        [Preview("wyandotte")]
         [ManualRoute("GET", "/orgs/{org}/migrations/{id}/repos/{name}/lock")]
         public Task UnlockRepository(string org, int id, string repo)
         {

--- a/Octokit/Clients/ProjectCardsClient.cs
+++ b/Octokit/Clients/ProjectCardsClient.cs
@@ -71,6 +71,7 @@ namespace Octokit
         /// <param name="columnId">The id of the column</param>
         /// <param name="request">Used to filter the list of project cards returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/projects/columns/{column_id}/cards")]
         public Task<IReadOnlyList<ProjectCard>> GetAll(int columnId, ProjectCardRequest request, ApiOptions options)
         {
@@ -87,6 +88,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
         public Task<ProjectCard> Get(int id)
         {
@@ -101,6 +103,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="columnId">The id of the column</param>
         /// <param name="newProjectCard">The card to create</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "/projects/columns/{column_id}/cards")]
         public Task<ProjectCard> Create(int columnId, NewProjectCard newProjectCard)
         {
@@ -117,6 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="projectCardUpdate">New values to update the card with</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/projects/columns/cards/{card_id}")]
         public Task<ProjectCard> Update(int id, ProjectCardUpdate projectCardUpdate)
         {
@@ -132,6 +136,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project-card">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the card</param>
+        [Preview("inertia")]
         [ManualRoute("DELETE", "/projects/columns/cards/{card_id}")]
         public async Task<bool> Delete(int id)
         {
@@ -156,6 +161,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the card</param>
         /// <param name="position">The position to move the card</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "/projects/columns/cards/{card_id}/moves")]
         public async Task<bool> Move(int id, ProjectCardMove position)
         {

--- a/Octokit/Clients/ProjectColumnsClient.cs
+++ b/Octokit/Clients/ProjectColumnsClient.cs
@@ -38,6 +38,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "projects/{project_id}/columns")]
         public Task<IReadOnlyList<ProjectColumn>> GetAll(int projectId, ApiOptions options)
         {
@@ -53,6 +54,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#get-a-project-column">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the column</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "projects/columns/{column_id}")]
         public Task<ProjectColumn> Get(int id)
         {
@@ -67,6 +69,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="projectId">The Id of the project</param>
         /// <param name="newProjectColumn">The column to create</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "projects/{project_id}/columns")]
         public Task<ProjectColumn> Create(int projectId, NewProjectColumn newProjectColumn)
         {
@@ -83,6 +86,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         /// <param name="projectColumnUpdate">New values to update the column with</param>
+        [Preview("inertia")]
         [ManualRoute("PATCH", "projects/columns/{column_id}")]
         public Task<ProjectColumn> Update(int id, ProjectColumnUpdate projectColumnUpdate)
         {
@@ -98,6 +102,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/projects/columns/#delete-a-project-column">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The id of the column</param>
+        [Preview("inertia")]
         [ManualRoute("DELETE", "projects/columns/{column_id}")]
         public async Task<bool> Delete(int id)
         {
@@ -121,6 +126,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The id of the column</param>
         /// <param name="position">The position to move the column</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "projects/columns/{column_id}/moves")]
         public async Task<bool> Move(int id, ProjectColumnMove position)
         {

--- a/Octokit/Clients/ProjectsClient.cs
+++ b/Octokit/Clients/ProjectsClient.cs
@@ -43,6 +43,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
@@ -78,6 +79,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/repos/{owner}/{name}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(string owner, string name, ProjectRequest request, ApiOptions options)
         {
@@ -110,6 +112,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
@@ -141,6 +144,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/repositories/{id}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForRepository(long repositoryId, ProjectRequest request, ApiOptions options)
         {
@@ -171,6 +175,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization, ApiOptions options)
         {
@@ -207,6 +212,7 @@ namespace Octokit
         /// <param name="organization">The name of the organization</param>
         /// <param name="request">Used to filter the list of projects returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/orgs/{org}/projects")]
         public Task<IReadOnlyList<Project>> GetAllForOrganization(string organization, ProjectRequest request, ApiOptions options)
         {
@@ -224,6 +230,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#get-a-project">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The Id of the project</param>
+        [Preview("inertia")]
         [ManualRoute("GET", "/projects/{project_id}")]
         public Task<Project> Get(int id)
         {
@@ -241,6 +248,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newProject">The new project to create for this repository</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "/repositories/{id}/projects")]
         public Task<Project> CreateForRepository(long repositoryId, NewProject newProject)
         {
@@ -257,6 +265,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="organization">The name of the organization</param>
         /// <param name="newProject">The new project to create for this repository</param>
+        [Preview("inertia")]
         [ManualRoute("POST", "/orgs/{org}/projects")]
         public Task<Project> CreateForOrganization(string organization, NewProject newProject)
         {
@@ -274,6 +283,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="id">The Id of the project</param>
         /// <param name="projectUpdate">The modified project</param>
+        [Preview("inertia")]
         [ManualRoute("PATCH", "/project/{project_id}")]
         public Task<Project> Update(int id, ProjectUpdate projectUpdate)
         {
@@ -289,6 +299,7 @@ namespace Octokit
         /// See the <a href="https://developer.github.com/v3/repos/projects/#delete-a-project">API documentation</a> for more information.
         /// </remarks>
         /// <param name="id">The Id of the project</param>
+        [Preview("inertia")]
         [ManualRoute("DELETE", "/project/{project_id}")]
         public async Task<bool> Delete(int id)
         {

--- a/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentReactionsClient.cs
@@ -37,6 +37,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int number, ApiOptions options)
         {
@@ -66,6 +67,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/pulls/comments/{comment_id}/reactions")]
         public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int number, ApiOptions options)
         {
@@ -82,6 +84,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repos/{owner}/{name}/pulls/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(string owner, string name, int number, NewReaction reaction)
         {
@@ -99,6 +102,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <param name="reaction">The reaction to create</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("POST", "/repositories/{id}/pulls/comments/{comment_id}/reactions")]
         public Task<Reaction> Create(long repositoryId, int number, NewReaction reaction)
         {

--- a/Octokit/Clients/PullRequestReviewCommentsClient.cs
+++ b/Octokit/Clients/PullRequestReviewCommentsClient.cs
@@ -54,6 +54,7 @@ namespace Octokit
         /// <param name="number">The pull request number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/comments")]
+        [Preview("squirrel-girl")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAll(string owner, string name, int number, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
@@ -174,6 +175,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(string owner, string name, PullRequestReviewCommentRequest request, ApiOptions options)
         {
@@ -192,6 +194,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">The sorting <see cref="PullRequestReviewCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/pulls/comments")]
         public Task<IReadOnlyList<PullRequestReviewComment>> GetAllForRepository(long repositoryId, PullRequestReviewCommentRequest request, ApiOptions options)
         {
@@ -208,6 +211,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request review comment number</param>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/comments/{number}")]
         public Task<PullRequestReviewComment> GetComment(string owner, string name, int number)
         {

--- a/Octokit/Clients/PullRequestsClient.cs
+++ b/Octokit/Clients/PullRequestsClient.cs
@@ -41,6 +41,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
+        [Preview("shadow-cat")]
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}")]
         public Task<PullRequest> Get(string owner, string name, int number)
         {
@@ -56,6 +57,7 @@ namespace Octokit
         /// <remarks>
         /// http://developer.github.com/v3/pulls/#get-a-single-pull-request
         /// </remarks>
+        [Preview("shadow-cat")]
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}")]
         public Task<PullRequest> Get(long repositoryId, int number)
         {
@@ -172,6 +174,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("shadow-cat")]
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(string owner, string name, PullRequestRequest request, ApiOptions options)
         {
@@ -193,6 +196,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="request">Used to filter and sort the list of pull requests returned</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("shadow-cat")]
         [ManualRoute("GET", "/repositories/{id}/pulls")]
         public Task<IReadOnlyList<PullRequest>> GetAllForRepository(long repositoryId, PullRequestRequest request, ApiOptions options)
         {
@@ -210,6 +214,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        [Preview("shadow-cat")]
         [ManualRoute("POST", "/repos/{owner}/{name}/pulls")]
         public Task<PullRequest> Create(string owner, string name, NewPullRequest newPullRequest)
         {
@@ -226,6 +231,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/pulls/#create-a-pull-request</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="newPullRequest">A <see cref="NewPullRequest"/> instance describing the new PullRequest to create</param>
+        [Preview("shadow-cat")]
         [ManualRoute("POST", "/repositories/{id}/pulls")]
         public Task<PullRequest> Create(long repositoryId, NewPullRequest newPullRequest)
         {
@@ -243,6 +249,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
+        [Preview("shadow-cat")]
         [ManualRoute("PATCH", "/repos/{owner}/{name}/pulls/{number}")]
         public Task<PullRequest> Update(string owner, string name, int number, PullRequestUpdate pullRequestUpdate)
         {
@@ -261,6 +268,7 @@ namespace Octokit
         /// <param name="number">The PullRequest number</param>
         /// <param name="pullRequestUpdate">An <see cref="PullRequestUpdate"/> instance describing the changes to make to the PullRequest
         /// </param>
+        [Preview("shadow-cat")]
         [ManualRoute("PATCH", "/repositories/{id}/pulls/{number}")]
         public Task<PullRequest> Update(long repositoryId, int number, PullRequestUpdate pullRequestUpdate)
         {

--- a/Octokit/Clients/ReactionsClient.cs
+++ b/Octokit/Clients/ReactionsClient.cs
@@ -53,9 +53,10 @@ namespace Octokit
         /// <summary>
         /// Delete a reaction.
         /// </summary>
-        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>        
-        /// <param name="number">The reaction id</param>        
+        /// <remarks>https://developer.github.com/v3/reactions/#delete-a-reaction</remarks>
+        /// <param name="number">The reaction id</param>
         /// <returns></returns>
+        [Preview("squirrel-girl")]
         [ManualRoute("DELETE", "/reactions/{number}")]
         public Task Delete(int number)
         {

--- a/Octokit/Clients/RepositoryBranchesClient.cs
+++ b/Octokit/Clients/RepositoryBranchesClient.cs
@@ -64,6 +64,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options for changing the API response</param>
         /// <exception cref="ApiException">Thrown when a general API error occurs.</exception>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(string owner, string name, ApiOptions options)
         {
@@ -82,6 +83,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options for changing the API response</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches")]
         public Task<IReadOnlyList<Branch>> GetAll(long repositoryId, ApiOptions options)
         {
@@ -99,6 +101,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}")]
         public Task<Branch> Get(string owner, string name, string branch)
         {
@@ -117,6 +120,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}")]
         public Task<Branch> Get(long repositoryId, string branch)
         {
@@ -134,6 +138,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> GetBranchProtection(string owner, string name, string branch)
         {
@@ -152,6 +157,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> GetBranchProtection(long repositoryId, string branch)
         {
@@ -170,6 +176,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> UpdateBranchProtection(string owner, string name, string branch, BranchProtectionSettingsUpdate update)
         {
@@ -190,6 +197,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Branch protection settings</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection")]
         public Task<BranchProtectionSettings> UpdateBranchProtection(long repositoryId, string branch, BranchProtectionSettingsUpdate update)
         {
@@ -208,6 +216,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection")]
         public async Task<bool> DeleteBranchProtection(string owner, string name, string branch)
         {
@@ -235,6 +244,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection")]
         public async Task<bool> DeleteBranchProtection(long repositoryId, string branch)
         {
@@ -261,6 +271,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(string owner, string name, string branch)
         {
@@ -279,6 +290,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> GetRequiredStatusChecks(long repositoryId, string branch)
         {
@@ -297,6 +309,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Required status checks</param>
+        [Preview("luke-cage")]
         [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> UpdateRequiredStatusChecks(string owner, string name, string branch, BranchProtectionRequiredStatusChecksUpdate update)
         {
@@ -317,6 +330,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">Required status checks</param>
+        [Preview("luke-cage")]
         [ManualRoute("PATCH", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public Task<BranchProtectionRequiredStatusChecks> UpdateRequiredStatusChecks(long repositoryId, string branch, BranchProtectionRequiredStatusChecksUpdate update)
         {
@@ -335,6 +349,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks")]
         public async Task<bool> DeleteRequiredStatusChecks(string owner, string name, string branch)
         {
@@ -363,6 +378,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_status_checks")]
         public async Task<bool> DeleteRequiredStatusChecks(long repositoryId, string branch)
         {
@@ -390,6 +406,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(string owner, string name, string branch)
         {
@@ -408,6 +425,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> GetAllRequiredStatusChecksContexts(long repositoryId, string branch)
         {
@@ -426,6 +444,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to replace</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> UpdateRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
@@ -446,6 +465,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to replace</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> UpdateRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
@@ -465,6 +485,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> AddRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
@@ -485,6 +506,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> AddRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
@@ -504,6 +526,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(string owner, string name, string branch, IReadOnlyList<string> contexts)
         {
@@ -524,6 +547,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="contexts">The contexts to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_status_checks/contexts")]
         public Task<IReadOnlyList<string>> DeleteRequiredStatusChecksContexts(long repositoryId, string branch, IReadOnlyList<string> contexts)
         {
@@ -542,6 +566,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> GetReviewEnforcement(string owner, string name, string branch)
         {
@@ -560,6 +585,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> GetReviewEnforcement(long repositoryId, string branch)
         {
@@ -578,6 +604,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">The required pull request review settings</param>
+        [Preview("luke-cage")]
         [ManualRoute("PATCH", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(string owner, string name, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
@@ -598,6 +625,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="update">The required pull request review settings</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public Task<BranchProtectionRequiredReviews> UpdateReviewEnforcement(long repositoryId, string branch, BranchProtectionRequiredReviewsUpdate update)
         {
@@ -616,6 +644,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/required_pull_request_reviews")]
         public async Task<bool> RemoveReviewEnforcement(string owner, string name, string branch)
         {
@@ -644,6 +673,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/required_pull_request_reviews")]
         public async Task<bool> RemoveReviewEnforcement(long repositoryId, string branch)
         {
@@ -671,6 +701,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> GetAdminEnforcement(string owner, string name, string branch)
         {
@@ -689,6 +720,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> GetAdminEnforcement(long repositoryId, string branch)
         {
@@ -706,6 +738,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> AddAdminEnforcement(string owner, string name, string branch)
         {
@@ -724,6 +757,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public Task<EnforceAdmins> AddAdminEnforcement(long repositoryId, string branch)
         {
@@ -741,6 +775,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/enforce_admins")]
         public async Task<bool> RemoveAdminEnforcement(string owner, string name, string branch)
         {
@@ -769,6 +804,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/enforce_admins")]
         public async Task<bool> RemoveAdminEnforcement(long repositoryId, string branch)
         {
@@ -796,6 +832,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
         public Task<BranchProtectionPushRestrictions> GetProtectedBranchRestrictions(string owner, string name, string branch)
         {
@@ -814,6 +851,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions")]
         public Task<BranchProtectionPushRestrictions> GetProtectedBranchRestrictions(long repositoryId, string branch)
         {
@@ -831,6 +869,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions")]
         public async Task<bool> DeleteProtectedBranchRestrictions(string owner, string name, string branch)
         {
@@ -859,6 +898,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions")]
         public async Task<bool> DeleteProtectedBranchRestrictions(long repositoryId, string branch)
         {
@@ -886,6 +926,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(string owner, string name, string branch)
         {
@@ -904,6 +945,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> GetAllProtectedBranchTeamRestrictions(long repositoryId, string branch)
         {
@@ -922,6 +964,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> UpdateProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
@@ -942,6 +985,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> UpdateProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
@@ -961,6 +1005,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> AddProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
@@ -981,6 +1026,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams with push access to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> AddProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
@@ -1000,6 +1046,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> DeleteProtectedBranchTeamRestrictions(string owner, string name, string branch, BranchProtectionTeamCollection teams)
         {
@@ -1020,6 +1067,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="teams">List of teams to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions/teams")]
         public Task<IReadOnlyList<Team>> DeleteProtectedBranchTeamRestrictions(long repositoryId, string branch, BranchProtectionTeamCollection teams)
         {
@@ -1038,6 +1086,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(string owner, string name, string branch)
         {
@@ -1056,6 +1105,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
+        [Preview("luke-cage")]
         [ManualRoute("GET", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> GetAllProtectedBranchUserRestrictions(long repositoryId, string branch)
         {
@@ -1074,6 +1124,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access</param>
+        [Preview("luke-cage")]
         [ManualRoute("UPDATE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> UpdateProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
@@ -1094,6 +1145,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access</param>
+        [Preview("luke-cage")]
         [ManualRoute("PUT", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> UpdateProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {
@@ -1113,6 +1165,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> AddProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
@@ -1133,6 +1186,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to add</param>
+        [Preview("luke-cage")]
         [ManualRoute("POST", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> AddProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {
@@ -1152,6 +1206,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repos/{owner}/{name}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> DeleteProtectedBranchUserRestrictions(string owner, string name, string branch, BranchProtectionUserCollection users)
         {
@@ -1172,6 +1227,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="branch">The name of the branch</param>
         /// <param name="users">List of users with push access to remove</param>
+        [Preview("luke-cage")]
         [ManualRoute("DELETE", "/repositories/{id}/branches/{branch}/protection/restrictions/users")]
         public Task<IReadOnlyList<User>> DeleteProtectedBranchUserRestrictions(long repositoryId, string branch, BranchProtectionUserCollection users)
         {

--- a/Octokit/Clients/RepositoryCommentsClient.cs
+++ b/Octokit/Clients/RepositoryCommentsClient.cs
@@ -27,6 +27,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/comments/{number}")]
         public Task<CommitComment> Get(string owner, string name, int number)
         {
@@ -42,6 +43,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The comment id</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#get-a-single-commit-comment</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/comments/{number}")]
         public Task<CommitComment> Get(long repositoryId, int number)
         {
@@ -81,6 +83,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(string owner, string name, ApiOptions options)
         {
@@ -97,6 +100,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForRepository(long repositoryId, ApiOptions options)
         {
@@ -144,6 +148,7 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repos/{owner}/{name}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(string owner, string name, string sha, ApiOptions options)
         {
@@ -162,6 +167,7 @@ namespace Octokit
         /// <param name="sha">The sha of the commit</param>
         /// <param name="options">Options to change the API response</param>
         /// <remarks>http://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit</remarks>
+        [Preview("squirrel-girl")]
         [ManualRoute("GET", "/repositories/{id}/commits/{sha}/comments")]
         public Task<IReadOnlyList<CommitComment>> GetAllForCommit(long repositoryId, string sha, ApiOptions options)
         {

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -30,7 +30,7 @@ namespace Octokit
 
         public const string MigrationsApiPreview = "application/vnd.github.wyandotte-preview+json";
 
-        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview";
+        public const string ReactionsPreview = "application/vnd.github.squirrel-girl-preview+json";
 
         public const string SignatureVerificationPreview = "application/vnd.github.cryptographer-preview+sha";
 

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -69,7 +69,7 @@ namespace Octokit
 
         public const string ProtectedBranchesRequiredApprovingApiPreview = "application/vnd.github.luke-cage-preview+json";
 
-        public const string IssueEventsApiPreview = "application/vnd.github.starfox-preview";
+        public const string IssueEventsApiPreview = "application/vnd.github.starfox-preview+json";
 
         public const string DeploymentStatusesPreview = "application/vnd.github.flash-preview+json";
 

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -73,6 +73,8 @@ namespace Octokit
 
         public const string DeploymentStatusesPreview = "application/vnd.github.flash-preview+json";
 
+        public const string OAuthApplicationsPreview = "application/vnd.github.doctor-strange-preview+json";
+
         /// <summary>
         /// Combines multiple preview headers. GitHub API supports Accept header with multiple
         /// values separated by comma.

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -43,7 +43,7 @@ namespace Octokit
 
         public const string PagesApiPreview = "application/vnd.github.mister-fantastic-preview+json";
 
-        public const string IssueTimelineApiPreview = "application/vnd.github.mockingbird-preview";
+        public const string IssueTimelineApiPreview = "application/vnd.github.mockingbird-preview+json";
 
         public const string RepositoryTrafficApiPreview = "application/vnd.github.spiderman-preview";
 

--- a/Octokit/Helpers/PreviewAttribute.cs
+++ b/Octokit/Helpers/PreviewAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Metadata for tracking which endpoints rely on preview API behaviour
+    /// </summary>
+    /// <remarks>https://developer.github.com/v3/previews/</remarks>
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class PreviewAttribute : Attribute
+    {
+        public string Name { get; private set; }
+
+        public PreviewAttribute(string name)
+        {
+            this.Name = name;
+        }
+    }
+}

--- a/Octokit/Helpers/PreviewAttribute.cs
+++ b/Octokit/Helpers/PreviewAttribute.cs
@@ -7,7 +7,7 @@ namespace Octokit
     /// </summary>
     /// <remarks>https://developer.github.com/v3/previews/</remarks>
 
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class PreviewAttribute : Attribute
     {
         public string Name { get; private set; }


### PR DESCRIPTION
Review the codebase for each of the previews from https://developer.github.com/v3/previews/ :

 - add attribute usage for each place in the codebase
 - review usage matches the documentation
 
OR

 - open an issue to track supporting the preview API

Current preview support:

 - [x] Migrations
 - [x] Enhanced deployments
 - [x] Reactions
 - [x] Timeline
 - [x] Integrations
 - [x] Projects
 - ~[ ] Commit search~ #2132
 - ~[ ] Community profile metrics~ #2133
 - ~[ ] User blocking~ #2134
 - ~[ ] Repository topics~ #1707 #1720
 - ~[ ] Codes of conduct~ #2135
 - ~[ ] Add lock reason~ #2136
 - ~[ ] Require signed commits~ #2137
 - [x] Require multiple approving reviews
 - [x] Check runs and check suites API
 - [x] Project card details
 - ~[ ] GitHub App Manifests~ #2138
 - [x] Deployment statuses
 - ~[ ] Repository creation permissions~ #2139
 - ~[ ] Content attachments~ #2140
 - ~[ ] Interaction restrictions for repositories and organizations~ #2141
 - [x] Draft pull requests
 - ~[ ] Enable and disable Pages~ #2142
 - ~[ ] List branches or pull requests for a commit~ #2143
 - ~[ ] Uninstall a GitHub App~ #2144
 - ~[ ] Enable or disable vulnerability alerts for a repository~ #2145
 - ~[ ] Update a pull request branch~ #2146
 - ~[ ] Enable or disable automated security fixes~ #2147
 - ~[ ] Create and use repository templates~ #2148
 - [x] New OAuth Applications API endpoints
 - ~[ ] New visibility parameter for the Repositories API~ #2149