### PR TITLE
move GitHubAppInstallationsClient into root namespace

### DIFF
--- a/Octokit.Tests/Clients/GitHubAppInstallationsClientTests.cs
+++ b/Octokit.Tests/Clients/GitHubAppInstallationsClientTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NSubstitute;
-using Octokit.Clients;
+using Octokit;
 using Xunit;
 
 namespace Octokit.Tests.Clients

--- a/Octokit.Tests/Reactive/ObservableGitHubAppInstallationsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableGitHubAppInstallationsClientTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NSubstitute;
-using Octokit.Clients;
+using Octokit;
 using Octokit.Reactive;
 using Xunit;
 

--- a/Octokit/Clients/GitHubAppInstallationsClient.cs
+++ b/Octokit/Clients/GitHubAppInstallationsClient.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 
-namespace Octokit.Clients
+namespace Octokit
 {
     /// <summary>
     /// A client for GitHub Applications Installations API.
@@ -19,6 +19,7 @@ namespace Octokit.Clients
         /// List repositories of the authenticated GitHub App Installation (requires GitHubApp Installation-Token auth).
         /// </summary>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories</remarks>
+        [ManualRoute("GET", "/installation/repositories")]
         public Task<RepositoriesResponse> GetAllRepositoriesForCurrent()
         {
             return GetAllRepositoriesForCurrent(ApiOptions.None);
@@ -29,6 +30,7 @@ namespace Octokit.Clients
         /// </summary>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories</remarks>
+        [ManualRoute("GET", "/installation/repositories")]
         public async Task<RepositoriesResponse> GetAllRepositoriesForCurrent(ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -45,6 +47,7 @@ namespace Octokit.Clients
         /// </summary>
         /// <param name="installationId">The Id of the installation</param>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation</remarks>
+        [ManualRoute("GET", "/user/installation/{id}/repositories")]
         public Task<RepositoriesResponse> GetAllRepositoriesForCurrentUser(long installationId)
         {
             return GetAllRepositoriesForCurrentUser(installationId, ApiOptions.None);
@@ -56,6 +59,7 @@ namespace Octokit.Clients
         /// <param name="installationId">The Id of the installation</param>
         /// <param name="options">Options for changing the API response</param>
         /// <remarks>https://developer.github.com/v3/apps/installations/#list-repositories-accessible-to-the-user-for-an-installation</remarks>
+        [ManualRoute("GET", "/user/installation/{id}/repositories")]
         public async Task<RepositoriesResponse> GetAllRepositoriesForCurrentUser(long installationId, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));

--- a/Octokit/Clients/GitHubAppsClient.cs
+++ b/Octokit/Clients/GitHubAppsClient.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Octokit.Clients;
 
 namespace Octokit
 {


### PR DESCRIPTION
A follow-up from #2128 for a case that wasn't caught by our conventions, because it was created in the `Octokit.Clients` namespace rather than the root `Octokit` namespace.

This updates the namespace and adds the necessary route attributes to get the build passing again.