### PR TITLE
Add support to get raw file content as byte[]

### DIFF
--- a/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableRepositoryContentsClient.cs
@@ -138,6 +138,17 @@ namespace Octokit.Reactive
         IObservable<RepositoryContent> GetAllContents(string owner, string name);
 
         /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        IObservable<byte[]> GetRawContent(string owner, string name, string path);
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
@@ -155,6 +166,18 @@ namespace Octokit.Reactive
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         /// <param name="path">The content path</param>
         IObservable<RepositoryContent> GetAllContentsByRef(string owner, string name, string reference, string path);
+
+        /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag.</param>
+        IObservable<byte[]> GetRawContentByRef(string owner, string name, string path, string reference);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.

--- a/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableRepositoryContentsClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using Octokit.Reactive.Internal;
 
@@ -239,6 +240,28 @@ namespace Octokit.Reactive
         }
 
         /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        public IObservable<byte[]> GetRawContent(string owner, string name, string path)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
+
+            return _client
+                .Connection
+                .GetRaw(ApiUrls.RepositoryContent(owner, name, path), null)
+                .ToObservable()
+                .Select(e => e.Body);
+        }
+
+        /// <summary>
         /// Returns the contents of the root directory in a repository.
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>
@@ -268,6 +291,30 @@ namespace Octokit.Reactive
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
 
             return _client.Connection.GetAndFlattenAllPages<RepositoryContent>(ApiUrls.RepositoryContent(owner, name, path, reference));
+        }
+
+        /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag.</param>
+        public IObservable<byte[]> GetRawContentByRef(string owner, string name, string path, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
+
+            return _client
+                .Connection
+                .GetRaw(ApiUrls.RepositoryContent(owner, name, path, reference), null)
+                .ToObservable()
+                .Select(e => e.Body);
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -222,7 +222,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ReturnsRawContent()
             {
-                var result = new byte[] {1, 2, 3};
+                var result = new byte[] { 1, 2, 3 };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetRaw(Args.Uri, default).Returns(result);
@@ -349,7 +349,7 @@ namespace Octokit.Tests.Clients
             [Fact]
             public async Task ReturnsRawContent()
             {
-                var result = new byte[] {1, 2, 3};
+                var result = new byte[] { 1, 2, 3 };
 
                 var connection = Substitute.For<IApiConnection>();
                 connection.GetRaw(Args.Uri, default).Returns(result);

--- a/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Clients/RepositoryContentsClientTests.cs
@@ -217,6 +217,39 @@ namespace Octokit.Tests.Clients
             }
         }
 
+        public class TheGetRawContentMethod
+        {
+            [Fact]
+            public async Task ReturnsRawContent()
+            {
+                var result = new byte[] {1, 2, 3};
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetRaw(Args.Uri, default).Returns(result);
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var rawContent = await contentsClient.GetRawContent("fake", "repo", "path/to/file.txt");
+
+                connection.Received().GetRaw(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/path/to/file.txt"), null);
+                Assert.Same(result, rawContent);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContent(null, "name", "path"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContent("owner", null, "path"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContent("owner", "name", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContent("", "name", "path"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContent("owner", "", "path"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContent("owner", "name", ""));
+            }
+        }
+
         public class TheGetContentsByRefMethod
         {
             [Fact]
@@ -308,6 +341,41 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, "", "reference"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, "path", ""));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetAllContentsByRef(1, ""));
+            }
+        }
+
+        public class TheGetRawContentByRefMethod
+        {
+            [Fact]
+            public async Task ReturnsRawContent()
+            {
+                var result = new byte[] {1, 2, 3};
+
+                var connection = Substitute.For<IApiConnection>();
+                connection.GetRaw(Args.Uri, default).Returns(result);
+                var contentsClient = new RepositoryContentsClient(connection);
+
+                var rawContent = await contentsClient.GetRawContentByRef("fake", "repo", "path/to/file.txt", "reference");
+
+                connection.Received().GetRaw(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/path/to/file.txt?ref=reference"), null);
+                Assert.Same(result, rawContent);
+            }
+
+            [Fact]
+            public async Task EnsuresNonNullArguments()
+            {
+                var connection = Substitute.For<IApiConnection>();
+                var client = new RepositoryContentsClient(connection);
+
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContentByRef(null, "name", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContentByRef("owner", null, "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContentByRef("owner", "name", null, "reference"));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetRawContentByRef("owner", "name", "path", null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContentByRef("", "name", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContentByRef("owner", "", "path", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContentByRef("owner", "name", "", "reference"));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.GetRawContentByRef("owner", "name", "path", ""));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -274,6 +274,45 @@ namespace Octokit.Tests.Reactive
             }
         }
 
+        public class TheGetRawContentMethod
+        {
+            [Fact]
+            public async Task ReturnsRawContent()
+            {
+                var result = new byte[] {1, 2, 3};
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<byte[]> response = new ApiResponse<byte[]>
+                (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                );
+                connection.GetRaw(Args.Uri, default).Returns(response);
+
+                var rawContent = await contentsClient.GetRawContent("fake", "repo", "path/to/file.txt");
+
+                connection.Received().GetRaw(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/path/to/file.txt"), null);
+                Assert.Same(result, rawContent);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContent(null, "name", "path"));
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContent("owner", null, "path"));
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContent("owner", "name", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetRawContent("", "name", "path"));
+                Assert.Throws<ArgumentException>(() => client.GetRawContent("owner", "", "path"));
+                Assert.Throws<ArgumentException>(() => client.GetRawContent("owner", "name", ""));
+            }
+        }
+
         public class TheGetContentsByRefMethod
         {
             [Fact]
@@ -393,6 +432,47 @@ namespace Octokit.Tests.Reactive
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, "", "reference"));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, "path", ""));
                 Assert.Throws<ArgumentException>(() => client.GetAllContentsByRef(1, ""));
+            }
+        }
+
+        public class TheGetRawContentByRefMethod
+        {
+            [Fact]
+            public async Task ReturnsRawContent()
+            {
+                var result = new byte[] {1, 2, 3};
+
+                var connection = Substitute.For<IConnection>();
+                var gitHubClient = new GitHubClient(connection);
+                var contentsClient = new ObservableRepositoryContentsClient(gitHubClient);
+                IApiResponse<byte[]> response = new ApiResponse<byte[]>
+                (
+                    new Response { ApiInfo = new ApiInfo(new Dictionary<string, Uri>(), new List<string>(), new List<string>(), "etag", new RateLimit()) },
+                    result
+                );
+                connection.GetRaw(Args.Uri, default).Returns(response);
+
+                var rawContent = await contentsClient.GetRawContentByRef("fake", "repo", "path/to/file.txt", "reference");
+
+                connection.Received().GetRaw(Arg.Is<Uri>(u => u.ToString() == "repos/fake/repo/contents/path/to/file.txt?ref=reference"), null);
+                Assert.Same(result, rawContent);
+            }
+
+            [Fact]
+            public void EnsuresNonNullArguments()
+            {
+                var gitHubClient = Substitute.For<IGitHubClient>();
+                var client = new ObservableRepositoryContentsClient(gitHubClient);
+
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContentByRef(null, "name", "path", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContentByRef("owner", null, "path", "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContentByRef("owner", "name", null, "reference"));
+                Assert.Throws<ArgumentNullException>(() => client.GetRawContentByRef("owner", "name", "path", null));
+
+                Assert.Throws<ArgumentException>(() => client.GetRawContentByRef("", "name", "path", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetRawContentByRef("owner", "", "path", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetRawContentByRef("owner", "name", "", "reference"));
+                Assert.Throws<ArgumentException>(() => client.GetRawContentByRef("owner", "name", "path", ""));
             }
         }
 

--- a/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableRepositoryContentsClientTests.cs
@@ -279,7 +279,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task ReturnsRawContent()
             {
-                var result = new byte[] {1, 2, 3};
+                var result = new byte[] { 1, 2, 3 };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);
@@ -440,7 +440,7 @@ namespace Octokit.Tests.Reactive
             [Fact]
             public async Task ReturnsRawContent()
             {
-                var result = new byte[] {1, 2, 3};
+                var result = new byte[] { 1, 2, 3 };
 
                 var connection = Substitute.For<IConnection>();
                 var gitHubClient = new GitHubClient(connection);

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -26,6 +26,18 @@ namespace Octokit
         Task<IReadOnlyList<RepositoryContent>> GetAllContents(string owner, string name, string path);
 
         /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<byte[]> GetRawContent(string owner, string name, string path);
+
+        /// <summary>
         /// Returns the contents of a file or directory in a repository.
         /// </summary>
         /// <remarks>
@@ -69,6 +81,19 @@ namespace Octokit
         /// <param name="reference">The name of the commit/branch/tag. Default: the repository’s default branch (usually master)</param>
         [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<IReadOnlyList<RepositoryContent>> GetAllContentsByRef(string owner, string name, string path, string reference);
+
+        /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag.</param>
+        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
+        Task<byte[]> GetRawContentByRef(string owner, string name, string path, string reference);
 
         /// <summary>
         /// Returns the contents of a file or directory in a repository.

--- a/Octokit/Clients/IRepositoryContentsClient.cs
+++ b/Octokit/Clients/IRepositoryContentsClient.cs
@@ -34,7 +34,6 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<byte[]> GetRawContent(string owner, string name, string path);
 
         /// <summary>
@@ -92,7 +91,6 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="path">The content path</param>
         /// <param name="reference">The name of the commit/branch/tag.</param>
-        [ExcludeFromPaginationApiOptionsConventionTest("Pagination not supported by GitHub API (tested 29/08/2017)")]
         Task<byte[]> GetRawContentByRef(string owner, string name, string path, string reference);
 
         /// <summary>

--- a/Octokit/Clients/RepositoryContentsClient.cs
+++ b/Octokit/Clients/RepositoryContentsClient.cs
@@ -42,6 +42,27 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}")]
+        public Task<byte[]> GetRawContent(string owner, string name, string path)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
+
+            var url = ApiUrls.RepositoryContent(owner, name, path);
+
+            return ApiConnection.GetRaw(url, null);
+        }
+
+        /// <summary>
         /// Returns the contents of a file or directory in a repository.
         /// </summary>
         /// <remarks>
@@ -112,11 +133,30 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
             Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
 
-            var url = (path == "/")
-                ? ApiUrls.RepositoryContent(owner, name, "", reference)
-                : ApiUrls.RepositoryContent(owner, name, path, reference);
-
+            var url = ApiUrls.RepositoryContent(owner, name, path, reference);
             return ApiConnection.GetAll<RepositoryContent>(url);
+        }
+
+        /// <summary>
+        /// Returns the raw content of the file at the given <paramref name="path"/> or <c>null</c> if the path is a directory.
+        /// </summary>
+        /// <remarks>
+        /// See the <a href="https://developer.github.com/v3/repos/contents/#get-contents">API documentation</a> for more information.
+        /// </remarks>
+        /// <param name="owner">The owner of the repository</param>
+        /// <param name="name">The name of the repository</param>
+        /// <param name="path">The content path</param>
+        /// <param name="reference">The name of the commit/branch/tag.</param>
+        [ManualRoute("GET", "repos/{owner}/{repo}/contents/{path}?ref={ref}")]
+        public Task<byte[]> GetRawContentByRef(string owner, string name, string path, string reference)
+        {
+            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
+            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
+            Ensure.ArgumentNotNullOrEmptyString(path, nameof(path));
+            Ensure.ArgumentNotNullOrEmptyString(reference, nameof(reference));
+
+            var url = ApiUrls.RepositoryContent(owner, name, path, reference);
+            return ApiConnection.GetRaw(url, null);
         }
 
         /// <summary>

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -13,6 +13,12 @@ namespace Octokit
 
         public const string CommitReferenceSha1MediaType = "application/vnd.github.v3.sha";
 
+        /// <summary>
+        /// Support for retrieving raw file content with the <see cref="IConnection.GetRaw"/> method.
+        /// </summary>
+        /// <remarks>https://developer.github.com/v3/repos/contents/#custom-media-types</remarks>
+        public const string RawContentMediaType = "application/vnd.github.v3.raw";
+
         public const string StarCreationTimestamps = "application/vnd.github.v3.star+json";
 
         public const string MigrationsApiPreview = "application/vnd.github.wyandotte-preview+json";

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -2363,7 +2363,7 @@ namespace Octokit
         /// <returns>The <see cref="Uri"/> for getting the contents of the specified repository and path</returns>
         public static Uri RepositoryContent(string owner, string name, string path, string reference)
         {
-            return "repos/{0}/{1}/contents/{2}?ref={3}".FormatUri(owner, name, path, reference);
+            return "repos/{0}/{1}/contents/{2}?ref={3}".FormatUri(owner, name, path == "/" ? "" : path, reference);
         }
 
         /// <summary>

--- a/Octokit/Http/ApiConnection.cs
+++ b/Octokit/Http/ApiConnection.cs
@@ -107,6 +107,21 @@ namespace Octokit
         }
 
         /// <summary>
+        /// Gets the raw content of the API resource at the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        public async Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            var response = await Connection.GetRaw(uri, parameters).ConfigureAwait(false);
+            return response.Body;
+        }
+
+        /// <summary>
         /// Gets all API resources in the list at the specified URI.
         /// </summary>
         /// <typeparam name="T">Type of the API resource in the list.</typeparam>

--- a/Octokit/Http/Connection.cs
+++ b/Octokit/Http/Connection.cs
@@ -211,6 +211,25 @@ namespace Octokit
             });
         }
 
+        /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        public Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters)
+        {
+            Ensure.ArgumentNotNull(uri, nameof(uri));
+
+            return GetRaw(new Request
+            {
+                Method = HttpMethod.Get,
+                BaseAddress = BaseAddress,
+                Endpoint = uri.ApplyParameters(parameters)
+            });
+        }
+
         public Task<IApiResponse<T>> Patch<T>(Uri uri, object body)
         {
             Ensure.ArgumentNotNull(uri, nameof(uri));
@@ -618,6 +637,13 @@ namespace Octokit
             request.Headers.Add("Accept", AcceptHeaders.StableVersionHtml);
             var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
             return new ApiResponse<string>(response, response.Body as string);
+        }
+
+        async Task<IApiResponse<byte[]>> GetRaw(IRequest request)
+        {
+            request.Headers.Add("Accept", AcceptHeaders.RawContentMediaType);
+            var response = await RunRequest(request, CancellationToken.None).ConfigureAwait(false);
+            return new ApiResponse<byte[]>(response, response.Body as byte[]);
         }
 
         async Task<IApiResponse<T>> Run<T>(IRequest request, CancellationToken cancellationToken)

--- a/Octokit/Http/HttpClientAdapter.cs
+++ b/Octokit/Http/HttpClientAdapter.cs
@@ -100,6 +100,7 @@ namespace Octokit.Internal
             // We added support for downloading images,zip-files and application/octet-stream. 
             // Let's constrain this appropriately.
             var binaryContentTypes = new[] {
+                AcceptHeaders.RawContentMediaType,
                 "application/zip" ,
                 "application/x-gzip" ,
                 "application/octet-stream"};

--- a/Octokit/Http/IApiConnection.cs
+++ b/Octokit/Http/IApiConnection.cs
@@ -63,6 +63,15 @@ namespace Octokit
         Task<string> GetHtml(Uri uri, IDictionary<string, string> parameters);
 
         /// <summary>
+        /// Gets the raw content of the API resource at the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the API resource to get</param>
+        /// <param name="parameters">Parameters to add to the API request</param>
+        /// <returns>The API resource's raw content or <c>null</c> if the <paramref name="uri"/> points to a directory.</returns>
+        /// <exception cref="ApiException">Thrown when an API error occurs.</exception>
+        Task<byte[]> GetRaw(Uri uri, IDictionary<string, string> parameters);
+
+        /// <summary>
         /// Gets all API resources in the list at the specified URI.
         /// </summary>
         /// <typeparam name="T">Type of the API resource in the list.</typeparam>

--- a/Octokit/Http/IConnection.cs
+++ b/Octokit/Http/IConnection.cs
@@ -21,6 +21,15 @@ namespace Octokit
         Task<IApiResponse<string>> GetHtml(Uri uri, IDictionary<string, string> parameters);
 
         /// <summary>
+        /// Performs an asynchronous HTTP GET request that expects a <seealso cref="IResponse"/> containing raw data.
+        /// </summary>
+        /// <param name="uri">URI endpoint to send request to</param>
+        /// <param name="parameters">Querystring parameters for the request</param>
+        /// <returns><seealso cref="IResponse"/> representing the received HTTP response</returns>
+        /// <remarks>The <see cref="IResponse.Body"/> property will be <c>null</c> if the <paramref name="uri"/> points to a directory instead of a file</remarks>
+        Task<IApiResponse<byte[]>> GetRaw(Uri uri, IDictionary<string, string> parameters);
+
+        /// <summary>
         /// Performs an asynchronous HTTP GET request.
         /// Attempts to map the response to an object of type <typeparamref name="T"/>
         /// </summary>


### PR DESCRIPTION
This allows to spare a little over 100ms in my tests on small files vs using the `GetAllContentsByRef` API.

Fixes #1651