### PR TITLE
Graduate review requests to what eventually shipped

### DIFF
--- a/Octokit.Reactive/Clients/IObservablePullRequestReviewRequestsClient.cs
+++ b/Octokit.Reactive/Clients/IObservablePullRequestReviewRequestsClient.cs
@@ -18,17 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<User> GetAll(string owner, string name, int number);
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        IObservable<User> GetAll(string owner, string name, int number, ApiOptions options);
+        IObservable<RequestedReviews> Get(string owner, string name, int number);
 
         /// <summary>
         /// Gets review requests for a specified pull request.
@@ -36,16 +26,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        IObservable<User> GetAll(long repositoryId, int number);
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        IObservable<User> GetAll(long repositoryId, int number, ApiOptions options);
+        IObservable<RequestedReviews> Get(long repositoryId, int number);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.

--- a/Octokit.Reactive/Clients/ObservablePullRequestReviewRequestsClient.cs
+++ b/Octokit.Reactive/Clients/ObservablePullRequestReviewRequestsClient.cs
@@ -25,29 +25,12 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<User> GetAll(string owner, string name, int number)
+        public IObservable<RequestedReviews> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PullRequestReviewRequests(owner, name, number), null, AcceptHeaders.PullRequestReviewsApiPreview);
-        }
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        public IObservable<User> GetAll(string owner, string name, int number, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-            Ensure.ArgumentNotNull(options, nameof(options));
-
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PullRequestReviewRequests(owner, name, number), null, AcceptHeaders.PullRequestReviewsApiPreview, options);
+            return _client.Get(owner, name, number).ToObservable();
         }
 
         /// <summary>
@@ -56,23 +39,9 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        public IObservable<User> GetAll(long repositoryId, int number)
+        public IObservable<RequestedReviews> Get(long repositoryId, int number)
         {
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PullRequestReviewRequests(repositoryId, number), null, AcceptHeaders.PullRequestReviewsApiPreview);
-        }
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        public IObservable<User> GetAll(long repositoryId, int number, ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, nameof(options));
-
-            return _connection.GetAndFlattenAllPages<User>(ApiUrls.PullRequestReviewRequests(repositoryId, number), null, AcceptHeaders.PullRequestReviewsApiPreview, options);
+            return _client.Get(repositoryId, number).ToObservable();
         }
 
         /// <summary>

--- a/Octokit.Tests/Clients/PullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests/Clients/PullRequestReviewRequestsClientTests.cs
@@ -25,12 +25,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestReviewRequestsClient(connection);
 
-                await client.GetAll("owner", "name", 7);
+                await client.Get("owner", "name", 7);
 
-                connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/requested_reviewers"),
-                    null,
-                    "application/vnd.github.black-cat-preview+json");
+                connection.Received().Get<RequestedReviews>(
+                    Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/requested_reviewers"));
             }
 
             [Fact]
@@ -39,56 +37,10 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestReviewRequestsClient(connection);
 
-                await client.GetAll(42, 7);
+                await client.Get(42, 7);
 
-                connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "repositories/42/pulls/7/requested_reviewers"),
-                    null,
-                    "application/vnd.github.black-cat-preview+json");
-            }
-
-            [Fact]
-            public async Task RequestsCorrectUrlWithApiOptions()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new PullRequestReviewRequestsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                await client.GetAll("owner", "name", 7, options);
-
-                connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/7/requested_reviewers"),
-                    null,
-                    "application/vnd.github.black-cat-preview+json",
-                    options);
-            }
-
-            [Fact]
-            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
-            {
-                var connection = Substitute.For<IApiConnection>();
-                var client = new PullRequestReviewRequestsClient(connection);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                await client.GetAll(42, 7, options);
-
-                connection.Received().GetAll<User>(
-                    Arg.Is<Uri>(u => u.ToString() == "repositories/42/pulls/7/requested_reviewers"),
-                    null,
-                    "application/vnd.github.black-cat-preview+json",
-                    options);
+                connection.Received().Get<RequestedReviews>(
+                    Arg.Is<Uri>(u => u.ToString() == "repositories/42/pulls/7/requested_reviewers"));
             }
 
             [Fact]
@@ -97,21 +49,11 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestReviewRequestsClient(connection);
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get(null, "name", 1));
+                await Assert.ThrowsAsync<ArgumentNullException>(() => client.Get("owner", null, 1));
 
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
-
-
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1));
-
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
-                await Assert.ThrowsAsync<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
-
-                await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAll(42, 1, null));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("", "name", 1));
+                await Assert.ThrowsAsync<ArgumentException>(() => client.Get("owner", "", 1));
             }
         }
 
@@ -124,15 +66,13 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestReviewRequestsClient(connection);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 client.Create("fakeOwner", "fakeRepoName", 13, pullRequestReviewRequest);
 
-                connection.Connection.Received().Post<PullRequest>(
+                connection.Received().Post<PullRequest>(
                     Arg.Is<Uri>(u => u.ToString() == "repos/fakeOwner/fakeRepoName/pulls/13/requested_reviewers"),
-                    pullRequestReviewRequest,
-                    "application/vnd.github.black-cat-preview+json",
-                    null);
+                    pullRequestReviewRequest);
             }
 
             [Fact]
@@ -141,15 +81,13 @@ namespace Octokit.Tests.Clients
                 var connection = Substitute.For<IApiConnection>();
                 var client = new PullRequestReviewRequestsClient(connection);
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 client.Create(42, 13, pullRequestReviewRequest);
 
-                connection.Connection.Received().Post<PullRequest>(
+                connection.Received().Post<PullRequest>(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/42/pulls/13/requested_reviewers"),
-                    pullRequestReviewRequest,
-                    "application/vnd.github.black-cat-preview+json",
-                    null);
+                    pullRequestReviewRequest);
             }
 
             [Fact]
@@ -159,7 +97,7 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestReviewRequestsClient(connection);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create(null, "fakeRepoName", 1, pullRequestReviewRequest));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Create("fakeOwner", null, 1, pullRequestReviewRequest));
@@ -180,14 +118,13 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestReviewRequestsClient(connection);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await client.Delete("owner", "name", 13, pullRequestReviewRequest);
 
                 connection.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "repos/owner/name/pulls/13/requested_reviewers"),
-                    pullRequestReviewRequest,
-                    "application/vnd.github.black-cat-preview+json");
+                    pullRequestReviewRequest);
             }
 
             [Fact]
@@ -197,14 +134,13 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestReviewRequestsClient(connection);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await client.Delete(43, 13, pullRequestReviewRequest);
 
                 connection.Received().Delete(
                     Arg.Is<Uri>(u => u.ToString() == "repositories/43/pulls/13/requested_reviewers"),
-                    pullRequestReviewRequest,
-                    "application/vnd.github.black-cat-preview+json");
+                    pullRequestReviewRequest);
             }
 
             [Fact]
@@ -214,7 +150,7 @@ namespace Octokit.Tests.Clients
                 var client = new PullRequestReviewRequestsClient(connection);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete(null, "name", 1, pullRequestReviewRequest));
                 await Assert.ThrowsAsync<ArgumentNullException>(() => client.Delete("owner", null, 1, pullRequestReviewRequest));

--- a/Octokit.Tests/Reactive/ObservablePullRequestReviewRequestsClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservablePullRequestReviewRequestsClientTests.cs
@@ -29,9 +29,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
-                client.GetAll("owner", "name", 7);
+                client.Get("owner", "name", 7);
 
-                gitHubClient.Received().PullRequest.ReviewRequest.GetAll("owner", "name", 7);
+                gitHubClient.Received().PullRequest.ReviewRequest.Get("owner", "name", 7);
             }
 
             [Fact]
@@ -40,45 +40,9 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
-                client.GetAll(42, 7);
+                client.Get(42, 7);
 
-                gitHubClient.Received().PullRequest.ReviewRequest.GetAll(42, 7);
-            }
-
-            [Fact]
-            public async Task RequestsCorrectUrlWithApiOptions()
-            {
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                client.GetAll("owner", "name", 7, options);
-
-                gitHubClient.Received().PullRequest.ReviewRequest.GetAll("owner", "name", 7, options);
-            }
-
-            [Fact]
-            public async Task RequestsCorrectUrlWithApiOptionsWithRepositoryId()
-            {
-                var gitHubClient = Substitute.For<IGitHubClient>();
-                var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
-
-                var options = new ApiOptions
-                {
-                    StartPage = 1,
-                    PageCount = 1,
-                    PageSize = 1
-                };
-
-                client.GetAll(42, 7, options);
-
-                gitHubClient.Received().PullRequest.ReviewRequest.GetAll(42, 7, options);
+                gitHubClient.Received().PullRequest.ReviewRequest.Get(42, 7);
             }
 
             [Fact]
@@ -87,20 +51,12 @@ namespace Octokit.Tests.Reactive
                 var gitHubClient = Substitute.For<IGitHubClient>();
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1));
+                Assert.Throws<ArgumentNullException>(() => client.Get(null, "name", 1));
+                Assert.Throws<ArgumentNullException>(() => client.Get("owner", null, 1));
 
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(null, "name", 1, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", null, 1, ApiOptions.None));
-                Assert.Throws<ArgumentNullException>(() => client.GetAll("owner", "name", 1, null));
+                Assert.Throws<ArgumentException>(() => client.Get("", "name", 1));
+                Assert.Throws<ArgumentException>(() => client.Get("owner", "", 1));
 
-                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1));
-                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1));
-
-                Assert.Throws<ArgumentException>(() => client.GetAll("", "name", 1, ApiOptions.None));
-                Assert.Throws<ArgumentException>(() => client.GetAll("owner", "", 1, ApiOptions.None));
-
-                Assert.Throws<ArgumentNullException>(() => client.GetAll(42, 1, null));
             }
         }
 
@@ -113,7 +69,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 client.Create("fakeOwner", "fakeRepoName", 13, pullRequestReviewRequest);
 
@@ -127,7 +83,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 client.Create(42, 13, pullRequestReviewRequest);
 
@@ -141,7 +97,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 Assert.Throws<ArgumentNullException>(() => client.Create(null, "fakeRepoName", 1, pullRequestReviewRequest));
                 Assert.Throws<ArgumentNullException>(() => client.Create("fakeOwner", null, 1, pullRequestReviewRequest));
@@ -162,7 +118,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await client.Delete("owner", "name", 13, pullRequestReviewRequest);
 
@@ -176,7 +132,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 await client.Delete(42, 13, pullRequestReviewRequest);
 
@@ -190,7 +146,7 @@ namespace Octokit.Tests.Reactive
                 var client = new ObservablePullRequestReviewRequestsClient(gitHubClient);
 
                 IReadOnlyList<string> fakeReviewers = new List<string> { "zxc", "asd" };
-                var pullRequestReviewRequest = new PullRequestReviewRequest(fakeReviewers);
+                var pullRequestReviewRequest = PullRequestReviewRequest.ForReviewers(fakeReviewers);
 
                 Assert.Throws<ArgumentNullException>(() => client.Delete(null, "name", 1, pullRequestReviewRequest));
                 Assert.Throws<ArgumentNullException>(() => client.Delete("owner", null, 1, pullRequestReviewRequest));

--- a/Octokit/Clients/IPullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/IPullRequestReviewRequestsClient.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Octokit
 {
@@ -18,17 +17,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<User>> GetAll(string owner, string name, int number);
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<User>> GetAll(string owner, string name, int number, ApiOptions options);
+        Task<RequestedReviews> Get(string owner, string name, int number);
 
         /// <summary>
         /// Gets review requests for a specified pull request.
@@ -36,16 +25,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
-        Task<IReadOnlyList<User>> GetAll(long repositoryId, int number);
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<User>> GetAll(long repositoryId, int number, ApiOptions options);
+        Task<RequestedReviews> Get(long repositoryId, int number);
 
         /// <summary>
         /// Creates review requests on a pull request for specified users.

--- a/Octokit/Clients/PullRequestReviewRequestsClient.cs
+++ b/Octokit/Clients/PullRequestReviewRequestsClient.cs
@@ -25,30 +25,12 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="number">The pull request number</param>
         [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
-        public Task<IReadOnlyList<User>> GetAll(string owner, string name, int number)
+        public Task<RequestedReviews> Get(string owner, string name, int number)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            return ApiConnection.GetAll<User>(ApiUrls.PullRequestReviewRequests(owner, name, number), null, AcceptHeaders.PullRequestReviewsApiPreview);
-        }
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="owner">The owner of the repository</param>
-        /// <param name="name">The name of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
-        public Task<IReadOnlyList<User>> GetAll(string owner, string name, int number, ApiOptions options)
-        {
-            Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
-            Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
-            Ensure.ArgumentNotNull(options, nameof(options));
-
-            return ApiConnection.GetAll<User>(ApiUrls.PullRequestReviewRequests(owner, name, number), null, AcceptHeaders.PullRequestReviewsApiPreview, options);
+            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(owner, name, number));
         }
 
         /// <summary>
@@ -58,24 +40,9 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="number">The pull request number</param>
         [ManualRoute("GET", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public Task<IReadOnlyList<User>> GetAll(long repositoryId, int number)
+        public Task<RequestedReviews> Get(long repositoryId, int number)
         {
-            return ApiConnection.GetAll<User>(ApiUrls.PullRequestReviewRequests(repositoryId, number), null, AcceptHeaders.PullRequestReviewsApiPreview);
-        }
-
-        /// <summary>
-        /// Gets review requests for a specified pull request.
-        /// </summary>
-        /// <remarks>https://developer.github.com/v3/pulls/review_requests/#list-review-requests</remarks>
-        /// <param name="repositoryId">The Id of the repository</param>
-        /// <param name="number">The pull request number</param>
-        /// <param name="options">Options for changing the API response</param>
-        [ManualRoute("GET", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public Task<IReadOnlyList<User>> GetAll(long repositoryId, int number, ApiOptions options)
-        {
-            Ensure.ArgumentNotNull(options, nameof(options));
-
-            return ApiConnection.GetAll<User>(ApiUrls.PullRequestReviewRequests(repositoryId, number), null, AcceptHeaders.PullRequestReviewsApiPreview, options);
+            return ApiConnection.Get<RequestedReviews>(ApiUrls.PullRequestReviewRequests(repositoryId, number));
         }
 
         /// <summary>
@@ -87,21 +54,14 @@ namespace Octokit
         /// <param name="number">The Pull Request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
         [ManualRoute("POST", "/repos/{owner}/{name}/pulls/{number}/requested_reviewers")]
-        public async Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
+        public Task<PullRequest> Create(string owner, string name, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
             var endpoint = ApiUrls.PullRequestReviewRequests(owner, name, number);
-            var response = await ApiConnection.Connection.Post<PullRequest>(endpoint, users, AcceptHeaders.PullRequestReviewsApiPreview, null).ConfigureAwait(false);
-
-            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
-            }
-
-            return response.Body;
+            return ApiConnection.Post<PullRequest>(endpoint, users);
         }
 
         /// <summary>
@@ -112,19 +72,12 @@ namespace Octokit
         /// <param name="number">The Pull Request number</param>
         /// <param name="users">List of logins of user will be requested for review</param>
         [ManualRoute("POST", "/repositories/{id}/pulls/{number}/requested_reviewers")]
-        public async Task<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users)
+        public Task<PullRequest> Create(long repositoryId, int number, PullRequestReviewRequest users)
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
             var endpoint = ApiUrls.PullRequestReviewRequests(repositoryId, number);
-            var response = await ApiConnection.Connection.Post<PullRequest>(endpoint, users, AcceptHeaders.PullRequestReviewsApiPreview, null).ConfigureAwait(false);
-
-            if (response.HttpResponse.StatusCode != HttpStatusCode.Created)
-            {
-                throw new ApiException("Invalid Status Code returned. Expected a 201", response.HttpResponse.StatusCode);
-            }
-
-            return response.Body;
+            return ApiConnection.Post<PullRequest>(endpoint, users);
         }
 
         /// <summary>
@@ -142,7 +95,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(owner, name, number), users, AcceptHeaders.PullRequestReviewsApiPreview);
+            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(owner, name, number), users);
         }
 
         /// <summary>
@@ -157,7 +110,7 @@ namespace Octokit
         {
             Ensure.ArgumentNotNull(users, nameof(users));
 
-            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(repositoryId, number), users, AcceptHeaders.PullRequestReviewsApiPreview);
+            return ApiConnection.Delete(ApiUrls.PullRequestReviewRequests(repositoryId, number), users);
         }
     }
 }

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Octokit
 {
@@ -47,6 +48,7 @@ namespace Octokit
 
         public const string RepositoryTrafficApiPreview = "application/vnd.github.spiderman-preview";
 
+        [Obsolete("This API has already been graduated")]
         public const string PullRequestReviewsApiPreview = "application/vnd.github.black-cat-preview+json";
 
         public const string DraftPullRequestApiPreview = "application/vnd.github.shadow-cat-preview+json";

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -48,9 +48,6 @@ namespace Octokit
 
         public const string RepositoryTrafficApiPreview = "application/vnd.github.spiderman-preview";
 
-        [Obsolete("This API has already been graduated")]
-        public const string PullRequestReviewsApiPreview = "application/vnd.github.black-cat-preview+json";
-
         public const string DraftPullRequestApiPreview = "application/vnd.github.shadow-cat-preview+json";
 
         public const string ProjectsApiPreview = "application/vnd.github.inertia-preview+json";

--- a/Octokit/Models/Request/PullRequestReviewRequest.cs
+++ b/Octokit/Models/Request/PullRequestReviewRequest.cs
@@ -14,16 +14,28 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class PullRequestReviewRequest
     {
-        public PullRequestReviewRequest(IReadOnlyList<string> reviewers)
+        public PullRequestReviewRequest(IReadOnlyList<string> reviewers, IReadOnlyList<string> teamReviewers)
         {
             Reviewers = reviewers;
+            TeamReviewers = teamReviewers;
         }
 
-        public IReadOnlyList<string> Reviewers { get; set; }
+        public IReadOnlyList<string> Reviewers { get; private set; }
+        public IReadOnlyList<string> TeamReviewers { get; private set; }
 
         internal string DebuggerDisplay
         {
             get { return string.Format(CultureInfo.InvariantCulture, "Reviewers: {0}", string.Join(", ", Reviewers)); }
+        }
+
+        public static PullRequestReviewRequest ForReviewers(IReadOnlyList<string> reviewers)
+        {
+            return new PullRequestReviewRequest(reviewers, new List<string>());
+        }
+
+        public static PullRequestReviewRequest ForTeamReviewers(IReadOnlyList<string> teamReviewers)
+        {
+            return new PullRequestReviewRequest(new List<string>(), teamReviewers);
         }
     }
 }

--- a/Octokit/Models/Response/RequestedReviews.cs
+++ b/Octokit/Models/Response/RequestedReviews.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+
+namespace Octokit
+{
+    /// <summary>
+    /// Users and teams requested to review a pull request
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class RequestedReviews
+    {
+        public RequestedReviews()
+        {
+            Users = new List<User>();
+            Teams = new List<Team>();
+        }
+
+        public RequestedReviews(IReadOnlyList<User> users, IReadOnlyList<Team> teams)
+        {
+            Users = users;
+            Teams = teams;
+        }
+        public IReadOnlyList<User> Users { get; protected set; }
+        public IReadOnlyList<Team> Teams { get; protected set; }
+
+        internal string DebuggerDisplay
+        {
+            get
+            {
+                return string.Format(
+              CultureInfo.InvariantCulture,
+              "Users: {0}, Teams: {1}",
+              string.Join(", ", Users.Select(u => u.Login)),
+              string.Join(", ", Teams.Select(t => t.Slug)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #2122

This is a breaking change in several ways due to changes the API made while under preview:

 - requesting teams is now supported, so the response and requests payload had to change
 - pagination is no longer supported, so those overloads have been removed

To use the new API there are two static constructors to differentiate between "request users" and "request teams":

```c#
// request specific collaborators
var collaborators = new List<string> { "shiftkey", "ryangribble" };
var requestCollaborators = PullRequestReviewRequest.ForReviewers(collaborators);

// request specific teams
var teams = new List<string> { "frontend-reviewers", "backend-reviewers" };
var requestTeams = PullRequestReviewRequest.ForTeamReviewers(teams);

// request a mixture of both
var requestBothGroups = new PullRequestReviewRequest(collaborators, teams);
```

