### PR TITLE
bugfix: improve fallback when StringEnum encounters null value

### DIFF
--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -431,6 +431,13 @@ namespace Octokit.Tests
                 }
             }
 
+            // this test is the root cause of https://github.com/octokit/octokit.net/issues/2052
+            // as the API is returning a null value where the enum is expecting
+            // something like a string
+            //
+            // this should be removed once we can confirm the GitHub API is no
+            // longer returning a null for the parent Team's permission value,
+            // making the test redundant
             [Fact]
             public void ShouldDeserializeParentTeamWithNullPermission()
             {

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -430,6 +430,44 @@ namespace Octokit.Tests
                     // Test passes if no exception thrown
                 }
             }
+
+            [Fact]
+            public void ShouldDeserializeParentTeamWithNullPermission()
+            {
+                var teamJson = @"{
+                    ""id"": 1,
+                    ""node_id"": ""MDQ6VGVhbTE="",
+                    ""url"": ""https://api.github.com/teams/1"",
+                    ""html_url"": ""https://api.github.com/teams/justice-league"",
+                    ""name"": ""Justice League"",
+                    ""slug"": ""justice-league"",
+                    ""description"": ""A great team."",
+                    ""privacy"": ""closed"",
+                    ""permission"": ""admin"",
+                    ""members_url"": ""https://api.github.com/teams/1/members{/member}"",
+                    ""repositories_url"": ""https://api.github.com/teams/1/repos"",
+                    ""parent"": {
+                        ""id"": 1,
+                        ""node_id"": ""MDQ6LFJSbTE="",
+                        ""url"": ""https://api.github.com/teams/2"",
+                        ""html_url"": ""https://api.github.com/teams/super-friends"",
+                        ""name"": ""Super Friends"",
+                        ""slug"": ""super-friends"",
+                        ""description"": ""Also a great team."",
+                        ""privacy"": ""closed"",
+                        ""permission"": null,
+                        ""members_url"": ""https://api.github.com/teams/2/members{/member}"",
+                        ""repositories_url"": ""https://api.github.com/teams/2/repos"",
+                        }
+                    }
+                }";
+
+                var result = new SimpleJsonSerializer().Deserialize<Team>(teamJson);
+
+                Assert.NotNull(result.Permission);
+                Assert.NotNull(result.Parent);
+                Assert.Null(result.Parent.Permission);
+            }
         }
 
         public class Sample

--- a/Octokit.Tests/SimpleJsonSerializerTests.cs
+++ b/Octokit.Tests/SimpleJsonSerializerTests.cs
@@ -464,9 +464,14 @@ namespace Octokit.Tests
 
                 var result = new SimpleJsonSerializer().Deserialize<Team>(teamJson);
 
-                Assert.NotNull(result.Permission);
-                Assert.NotNull(result.Parent);
-                Assert.Null(result.Parent.Permission);
+                // original value works as expected
+                Assert.Equal(PermissionLevel.Admin, result.Permission.Value);
+                Assert.Equal("admin", result.Permission.StringValue);
+
+                // parent permission is marked as null and cannot be parsed
+                Assert.Equal("null", result.Parent.Permission.StringValue);
+                PermissionLevel value;
+                Assert.False(result.Parent.Permission.TryParse(out value));
             }
         }
 

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -190,6 +190,11 @@ namespace Octokit.Internal
                     return base.DeserializeObject(value, payloadType);
                 }
 
+                if (ReflectionUtils.IsStringEnumWrapper(type))
+                {
+                    return Activator.CreateInstance(type, "null");
+                }
+
                 return base.DeserializeObject(value, type);
             }
 

--- a/Octokit/Http/SimpleJsonSerializer.cs
+++ b/Octokit/Http/SimpleJsonSerializer.cs
@@ -192,6 +192,13 @@ namespace Octokit.Internal
 
                 if (ReflectionUtils.IsStringEnumWrapper(type))
                 {
+                    // this check is a workaround for https://github.com/octokit/octokit.net/issues/2052
+                    // as the API is returning a null value where the enum is
+                    // expecting something like a string
+                    //
+                    // this should be removed once we can confirm the GitHub API
+                    // is no longer returning a null for the parent Team's
+                    // permission value
                     return Activator.CreateInstance(type, "null");
                 }
 

--- a/Octokit/Models/Response/Team.cs
+++ b/Octokit/Models/Response/Team.cs
@@ -12,7 +12,7 @@ namespace Octokit
     {
         public Team() { }
 
-        public Team(string url, int id, string nodeId, string slug, string name, string description, TeamPrivacy privacy, Permission permission, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
+        public Team(string url, int id, string nodeId, string slug, string name, string description, TeamPrivacy privacy, PermissionLevel permission, int membersCount, int reposCount, Organization organization, Team parent, string ldapDistinguishedName)
         {
             Url = url;
             Id = id;
@@ -67,7 +67,7 @@ namespace Octokit
         /// <summary>
         /// permission attached to this team
         /// </summary>
-        public StringEnum<Permission> Permission { get; protected set; }
+        public StringEnum<PermissionLevel> Permission { get; protected set; }
 
         /// <summary>
         /// how many members in this team


### PR DESCRIPTION
Resolves #2052

## Testing

To aid with testing this PR, you can add a `NuGet.config` file to the root of your project that adds our beta packages feed:

```
<configuration>
    <packageSources>
        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
        <add key="Octokit beta" value=" https://ci.appveyor.com/nuget/octokit-net" />
    </packageSources>
</configuration>
```

Then, switch your version to the beta release just published, currently `0.45.0-fix-teams-deseri0005`, and try to verify the fix. I'm still working to try and reproduce this on my side, but I have an idea of where it's lurking...